### PR TITLE
fix: docker ci-local parity test discovery

### DIFF
--- a/docker-compose.ci-local.yml
+++ b/docker-compose.ci-local.yml
@@ -5,6 +5,8 @@ services:
       dockerfile: Dockerfile
     image: advisor-experience-api:ci-local
     working_dir: /app
+    volumes:
+      - ./:/app
     command:
       [
         "sh",


### PR DESCRIPTION
## Summary
- mount repository into the ci-local container in docker parity compose
- ensure pytest paths (tests/unit, tests/contract, tests/integration) exist in container runtime

## Validation
- make ci-local