### PR TITLE
feat: proposal version management parity endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ make run
 
 API docs: `http://localhost:8100/docs`
 
-## Current endpoint
+## Current endpoints
 
 - `POST /api/v1/proposals/simulate` (proxies to DPM `/rebalance/proposals/simulate`)
 - `POST /api/v1/proposals` (create draft proposal via DPM lifecycle create)
 - `GET /api/v1/proposals` (list proposals)
 - `GET /api/v1/proposals/{proposal_id}` (proposal detail)
+- `GET /api/v1/proposals/{proposal_id}/versions/{version_no}` (immutable proposal version detail)
+- `POST /api/v1/proposals/{proposal_id}/versions` (create proposal version `N+1`)
 - `POST /api/v1/proposals/{proposal_id}/submit` (submit draft for review via DPM transition)
 - `POST /api/v1/proposals/{proposal_id}/approve-risk` (risk approval action)
 - `POST /api/v1/proposals/{proposal_id}/approve-compliance` (compliance approval action)

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -62,6 +62,35 @@ class DpmClient:
             headers={"X-Correlation-Id": correlation_id},
         )
 
+    async def get_proposal_version(
+        self,
+        proposal_id: str,
+        version_no: int,
+        include_evidence: bool,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/rebalance/proposals/{proposal_id}/versions/{version_no}",
+            params={"include_evidence": str(include_evidence).lower()},
+            headers={"X-Correlation-Id": correlation_id},
+        )
+
+    async def create_proposal_version(
+        self,
+        proposal_id: str,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/rebalance/proposals/{proposal_id}/versions",
+            body=body,
+            headers={
+                "Idempotency-Key": idempotency_key,
+                "X-Correlation-Id": correlation_id,
+            },
+        )
+
     async def transition_proposal(
         self,
         proposal_id: str,

--- a/src/app/contracts/proposals.py
+++ b/src/app/contracts/proposals.py
@@ -21,6 +21,12 @@ class ProposalCreateRequest(BaseModel):
     )
 
 
+class ProposalVersionCreateRequest(BaseModel):
+    body: dict[str, Any] = Field(
+        description="Raw payload passed through to DPM /rebalance/proposals/{proposal_id}/versions."
+    )
+
+
 class ProposalSubmitRequest(BaseModel):
     actor_id: str = Field(description="Actor id requesting submit transition.")
     expected_state: str = Field(

--- a/src/app/services/proposal_service.py
+++ b/src/app/services/proposal_service.py
@@ -87,6 +87,46 @@ class ProposalService:
             data=upstream_payload,
         )
 
+    async def get_proposal_version(
+        self,
+        proposal_id: str,
+        version_no: int,
+        include_evidence: bool,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_proposal_version(
+            proposal_id=proposal_id,
+            version_no=version_no,
+            include_evidence=include_evidence,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return ProposalEnvelopeResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            data=upstream_payload,
+        )
+
+    async def create_proposal_version(
+        self,
+        proposal_id: str,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        upstream_status, upstream_payload = await self._dpm_client.create_proposal_version(
+            proposal_id=proposal_id,
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return ProposalEnvelopeResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            data=upstream_payload,
+        )
+
     async def submit_proposal(
         self,
         proposal_id: str,


### PR DESCRIPTION
## Summary
- add BFF endpoints for proposal version read and create
- wire service/client/contracts for DPM parity
- add integration tests for new routes
- update README endpoint list

## Validation
- python -m pytest tests/unit tests/contract -q
- python -m pytest tests/integration -q
- python -m ruff check .
- python -m mypy src