### PR TITLE
Add live multi-service platform capabilities E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,34 @@ jobs:
       - name: Cleanup
         if: always()
         run: make ci-local-docker-down
+
+  e2e-platform-capabilities-live:
+    name: E2E Platform Capabilities (Live Upstreams)
+    needs: [integration]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone upstream repos
+        run: |
+          git clone https://github.com/sgajbi/dpm-rebalance-engine.git ../dpm-rebalance-engine
+          git clone https://github.com/sgajbi/portfolio-analytics-system.git ../portfolio-analytics-system
+          git clone https://github.com/sgajbi/performanceAnalytics.git ../performanceAnalytics
+
+      - name: Start live E2E stack
+        env:
+          DPM_REPO_PATH: ../dpm-rebalance-engine
+          PAS_REPO_PATH: ../portfolio-analytics-system
+          PA_REPO_PATH: ../performanceAnalytics
+        run: make e2e-up
+
+      - name: Validate BFF aggregation against live upstreams
+        run: make test-e2e-live
+
+      - name: Stack logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.e2e.yml logs --no-color
+
+      - name: Cleanup live E2E stack
+        if: always()
+        run: make e2e-down

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck test test-unit test-integration check ci-local ci-local-docker ci-local-docker-down run clean docker-up docker-down
+.PHONY: install lint typecheck test test-unit test-integration test-e2e-live check ci-local ci-local-docker ci-local-docker-down run clean docker-up docker-down e2e-up e2e-down
 
 install:
 	python -m pip install -e ".[dev]"
@@ -18,6 +18,15 @@ test-unit:
 
 test-integration:
 	python -m pytest tests/integration
+
+e2e-up:
+	docker compose -f docker-compose.e2e.yml up -d --build
+
+e2e-down:
+	docker compose -f docker-compose.e2e.yml down -v --remove-orphans
+
+test-e2e-live:
+	python tests/e2e/test_platform_capabilities_live.py
 
 check: lint typecheck test
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ make ci-local-docker
 make ci-local-docker-down
 ```
 
+Live platform-capabilities E2E (BFF + PAS + PA + DPM):
+
+```bash
+export DPM_REPO_PATH=/c/Users/sande/dev/dpm-rebalance-engine
+export PAS_REPO_PATH=/c/Users/sande/dev/portfolio-analytics-system
+export PA_REPO_PATH=/c/Users/sande/dev/performanceAnalytics
+make e2e-up
+make test-e2e-live
+make e2e-down
+```
+
 ## Demo Pack
 
 - `docs/demo/README.md`

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,146 @@
+services:
+  dpm-postgres:
+    image: postgres:17.6
+    environment:
+      POSTGRES_DB: dpm_supportability
+      POSTGRES_USER: dpm
+      POSTGRES_PASSWORD: dpm
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dpm -d dpm_supportability"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  dpm:
+    build:
+      context: ${DPM_REPO_PATH}
+      dockerfile: Dockerfile
+    environment:
+      ENVIRONMENT: production
+      APP_PERSISTENCE_PROFILE: PRODUCTION
+      DPM_SUPPORTABILITY_STORE_BACKEND: POSTGRES
+      DPM_SUPPORTABILITY_POSTGRES_DSN: postgresql://dpm:dpm@dpm-postgres:5432/dpm_supportability
+      PROPOSAL_STORE_BACKEND: POSTGRES
+      PROPOSAL_POSTGRES_DSN: postgresql://dpm:dpm@dpm-postgres:5432/dpm_supportability
+      DPM_POLICY_PACK_CATALOG_BACKEND: POSTGRES
+      DPM_POLICY_PACK_POSTGRES_DSN: postgresql://dpm:dpm@dpm-postgres:5432/dpm_supportability
+    depends_on:
+      dpm-postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/integration/capabilities?consumerSystem=BFF&tenantId=default', timeout=5)"
+        ]
+      interval: 20s
+      timeout: 5s
+      retries: 15
+      start_period: 20s
+
+  pas-postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: portfolio_db
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d portfolio_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  pas-migration-runner:
+    build:
+      context: ${PAS_REPO_PATH}
+      dockerfile: ./src/services/persistence_service/Dockerfile
+    environment:
+      DATABASE_URL: postgresql://user:password@pas-postgres:5432/portfolio_db
+    depends_on:
+      pas-postgres:
+        condition: service_healthy
+    command: ["alembic", "upgrade", "head"]
+    restart: "no"
+
+  pas-query:
+    build:
+      context: ${PAS_REPO_PATH}
+      dockerfile: ./src/services/query_service/Dockerfile
+    environment:
+      DATABASE_URL: postgresql://user:password@pas-postgres:5432/portfolio_db
+    depends_on:
+      pas-migration-runner:
+        condition: service_completed_successfully
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8001/integration/capabilities?consumerSystem=BFF&tenantId=default', timeout=5)"
+        ]
+      interval: 20s
+      timeout: 5s
+      retries: 15
+      start_period: 20s
+
+  pa:
+    image: python:3.12-slim
+    working_dir: /app
+    volumes:
+      - ${PA_REPO_PATH}:/app
+    command:
+      [
+        "sh",
+        "-lc",
+        "pip install --no-cache-dir -r requirements.txt && uvicorn main:app --host 0.0.0.0 --port 8000"
+      ]
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/integration/capabilities?consumerSystem=BFF&tenantId=default', timeout=5)"
+        ]
+      interval: 20s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+  bff:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      DECISIONING_SERVICE_BASE_URL: http://dpm:8000
+      PORTFOLIO_DATA_PLATFORM_BASE_URL: http://pas-query:8001
+      PERFORMANCE_ANALYTICS_BASE_URL: http://pa:8000
+      UPSTREAM_TIMEOUT_SECONDS: 10
+      CONTRACT_VERSION: v1
+    ports:
+      - "8100:8100"
+    depends_on:
+      dpm:
+        condition: service_healthy
+      pas-query:
+        condition: service_healthy
+      pa:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8100/health', timeout=5)"
+        ]
+      interval: 20s
+      timeout: 5s
+      retries: 15
+      start_period: 15s

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -6,3 +6,4 @@
 | RFC-0002 | BFF Proposal Workspace v1 (Create/List/Detail/Submit) | IMPLEMENTED | `docs/rfcs/RFC-0002-bff-proposal-workspace-v1.md` |
 | RFC-0003 | BFF Approval Chain v1 and Supportability Pass-Through | IMPLEMENTED | `docs/rfcs/RFC-0003-bff-approval-chain-and-supportability-pass-through.md` |
 | RFC-0004 | Platform Capabilities Aggregation Contract | IMPLEMENTED | `docs/rfcs/RFC-0004-platform-capabilities-aggregation-contract.md` |
+| RFC-0005 | Live Multi-Service E2E for Platform Capabilities | IMPLEMENTED | `docs/rfcs/RFC-0005-live-multi-service-e2e-platform-capabilities.md` |

--- a/docs/rfcs/RFC-0005-live-multi-service-e2e-platform-capabilities.md
+++ b/docs/rfcs/RFC-0005-live-multi-service-e2e-platform-capabilities.md
@@ -1,0 +1,46 @@
+# RFC-0005: Live Multi-Service E2E for Platform Capabilities
+
+- Status: IMPLEMENTED
+- Date: 2026-02-23
+- Owner: advisor-experience-api
+
+## Context
+
+`GET /api/v1/platform/capabilities` is an aggregation API that depends on three upstream services:
+- DPM: `dpm-rebalance-engine`
+- PAS: `portfolio-analytics-system`
+- PA: `performanceAnalytics`
+
+Unit and local integration tests validated orchestration logic, but they did not validate runtime wiring to live upstream containers.
+
+## Decision
+
+Introduce a containerized live E2E validation path in `advisor-experience-api`:
+- Add `docker-compose.e2e.yml` to start DPM + PAS query stack + PA + BFF on one Docker network.
+- Add `tests/e2e/test_platform_capabilities_live.py` to assert BFF returns non-partial aggregation with PAS/PA/DPM sources.
+- Add Make targets:
+  - `make e2e-up`
+  - `make test-e2e-live`
+  - `make e2e-down`
+- Add CI job `E2E Platform Capabilities (Live Upstreams)` to clone upstream repos, start stack, execute assertions, and teardown.
+
+## Rationale
+
+- Detects real integration regressions (routing, env wiring, network contracts, startup dependencies).
+- Keeps BFF business behavior validated against actual upstream contract implementations.
+- Aligns with platform strategy where BFF is thin orchestration and backend services own domain complexity.
+
+## Consequences
+
+Positive:
+- Higher confidence in cross-service integration before merge.
+- Explicitly validated `PAS + PA + DPM -> BFF` capability path.
+
+Trade-offs:
+- CI runtime increases due to multi-repo clone/build.
+- PAS stack startup remains the slowest stage because query service requires DB migration bootstrapping.
+
+## Follow-ups
+
+- Add a nightly, broader E2E suite for proposal lifecycle paths once PAS and PA expose additional integrated APIs needed by UI workflows.
+- Consider publishing versioned upstream Docker images to reduce CI build time.

--- a/tests/e2e/test_platform_capabilities_live.py
+++ b/tests/e2e/test_platform_capabilities_live.py
@@ -1,0 +1,54 @@
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+BFF_URL = "http://127.0.0.1:8100/api/v1/platform/capabilities"
+
+
+def _fetch() -> dict:
+    query = urllib.parse.urlencode({"consumerSystem": "BFF", "tenantId": "default"})
+    with urllib.request.urlopen(f"{BFF_URL}?{query}", timeout=8) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _assert_payload(payload: dict) -> None:
+    if payload.get("data", {}).get("partialFailure"):
+        raise AssertionError(f"Expected no partial failure, got: {payload}")
+
+    sources = payload.get("data", {}).get("sources", {})
+    expected = {"pas", "pa", "dpm"}
+    if set(sources.keys()) != expected:
+        raise AssertionError(f"Expected sources {expected}, got {set(sources.keys())}")
+
+    passthrough = {
+        "pas": "portfolio-analytics-system",
+        "pa": "performance-analytics",
+        "dpm": "dpm-rebalance-engine",
+    }
+    for key, source_name in passthrough.items():
+        actual = sources[key].get("sourceService")
+        if actual != source_name:
+            raise AssertionError(f"Expected {key}.sourceService={source_name}, got {actual}")
+
+
+def main() -> None:
+    deadline = time.time() + 120
+    last_error: Exception | None = None
+
+    while time.time() < deadline:
+        try:
+            payload = _fetch()
+            _assert_payload(payload)
+            print("E2E platform capabilities assertion passed")
+            return
+        except (AssertionError, urllib.error.URLError, TimeoutError, ValueError) as exc:
+            last_error = exc
+            time.sleep(2)
+
+    raise SystemExit(f"E2E validation failed: {last_error}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary\n- add docker-compose.e2e.yml to run BFF with live PAS, PA, DPM upstreams\n- add live E2E assertion test for /api/v1/platform/capabilities\n- add CI job to clone upstream repos and run live E2E stack\n- add RFC-0005 and README/runbook updates\n\n## Validation\n- make lint\n- make typecheck\n- make test-unit\n- make test-integration