### PR TITLE
Fix BFF live E2E CI env scope and retry robustness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,10 @@ jobs:
     name: E2E Platform Capabilities (Live Upstreams)
     needs: [integration]
     runs-on: ubuntu-latest
+    env:
+      DPM_REPO_PATH: ../dpm-rebalance-engine
+      PAS_REPO_PATH: ../portfolio-analytics-system
+      PA_REPO_PATH: ../performanceAnalytics
     steps:
       - uses: actions/checkout@v4
 
@@ -91,10 +95,6 @@ jobs:
           git clone https://github.com/sgajbi/performanceAnalytics.git ../performanceAnalytics
 
       - name: Start live E2E stack
-        env:
-          DPM_REPO_PATH: ../dpm-rebalance-engine
-          PAS_REPO_PATH: ../portfolio-analytics-system
-          PA_REPO_PATH: ../performanceAnalytics
         run: make e2e-up
 
       - name: Validate BFF aggregation against live upstreams

--- a/tests/e2e/test_platform_capabilities_live.py
+++ b/tests/e2e/test_platform_capabilities_live.py
@@ -1,4 +1,5 @@
 import json
+import socket
 import time
 import urllib.error
 import urllib.parse
@@ -43,7 +44,16 @@ def main() -> None:
             _assert_payload(payload)
             print("E2E platform capabilities assertion passed")
             return
-        except (AssertionError, urllib.error.URLError, TimeoutError, ValueError) as exc:
+        except (
+            AssertionError,
+            urllib.error.URLError,
+            TimeoutError,
+            ValueError,
+            ConnectionResetError,
+            ConnectionRefusedError,
+            socket.timeout,
+            socket.error,
+        ) as exc:
             last_error = exc
             time.sleep(2)
 


### PR DESCRIPTION
## Problem\nThe main pipeline failed in the live E2E job because compose path env vars were only set for one step, then missing for logs/cleanup. Also, startup race caused transient connection resets during the first probe.\n\n## Changes\n- move DPM_REPO_PATH, PAS_REPO_PATH, PA_REPO_PATH to job-level env in .github/workflows/ci.yml\n- extend live E2E retry exceptions to include transient connection/socket errors\n\n## Validation\n- make lint\n- make typecheck\n- make test-unit\n- make test-integration