### PR TITLE
Delegate BFF lookups to PAS canonical lookup APIs

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -8,3 +8,4 @@
 | RFC-0004 | Platform Capabilities Aggregation Contract | IMPLEMENTED | `docs/rfcs/RFC-0004-platform-capabilities-aggregation-contract.md` |
 | RFC-0005 | Live Multi-Service E2E for Platform Capabilities | IMPLEMENTED | `docs/rfcs/RFC-0005-live-multi-service-e2e-platform-capabilities.md` |
 | RFC-0006 | PAS Intake and Lookup Pass-Through in BFF | IMPLEMENTED | `docs/rfcs/RFC-0006-pas-intake-and-lookup-pass-through.md` |
+| RFC-0007 | BFF Lookup Delegation to PAS Canonical Lookup APIs | IMPLEMENTED | `docs/rfcs/RFC-0007-bff-lookup-delegation-to-pas-canonical-apis.md` |

--- a/docs/rfcs/RFC-0007-bff-lookup-delegation-to-pas-canonical-apis.md
+++ b/docs/rfcs/RFC-0007-bff-lookup-delegation-to-pas-canonical-apis.md
@@ -1,0 +1,38 @@
+# RFC-0007: BFF Lookup Delegation to PAS Canonical Lookup APIs
+
+- Status: IMPLEMENTED
+- Date: 2026-02-23
+- Owner: advisor-experience-api
+
+## Context
+
+Initial BFF intake implementation translated PAS reference APIs (`/portfolios`, `/instruments`) into lookup contracts and derived currency lists inside BFF. PAS now provides canonical lookup endpoints.
+
+## Decision
+
+Refactor BFF lookup paths to call PAS lookup APIs directly:
+
+- `GET /api/v1/lookups/portfolios` -> PAS `GET /lookups/portfolios`
+- `GET /api/v1/lookups/instruments` -> PAS `GET /lookups/instruments`
+- `GET /api/v1/lookups/currencies` -> PAS `GET /lookups/currencies`
+
+BFF now preserves the PAS `items` list shape and only wraps with BFF envelope metadata (`correlation_id`, `contract_version`).
+
+## Rationale
+
+- Reduces mapping/derivation logic in BFF.
+- Keeps lookup vocabulary ownership in PAS.
+- Improves consistency between PAS and BFF selector catalogs.
+
+## Consequences
+
+Positive:
+- Lower BFF complexity and lower risk of lookup drift.
+- Clearer backend boundary (PAS owns reference catalog semantics).
+
+Trade-offs:
+- BFF depends on PAS lookup endpoint availability and contract stability.
+
+## Follow-ups
+
+- Add PAS lookup contract smoke checks to BFF live E2E suite.

--- a/src/app/clients/pas_client.py
+++ b/src/app/clients/pas_client.py
@@ -43,6 +43,45 @@ class PasClient:
             response = await client.get(url, params=params, headers=headers)
             return response.status_code, self._response_payload(response)
 
+    async def get_portfolio_lookups(
+        self,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get_lookup(
+            path="/lookups/portfolios", params={}, correlation_id=correlation_id
+        )
+
+    async def get_instrument_lookups(
+        self,
+        limit: int,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get_lookup(
+            path="/lookups/instruments",
+            params={"limit": limit},
+            correlation_id=correlation_id,
+        )
+
+    async def get_currency_lookups(
+        self,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get_lookup(
+            path="/lookups/currencies", params={}, correlation_id=correlation_id
+        )
+
+    async def _get_lookup(
+        self,
+        path: str,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}{path}"
+        headers = {"X-Correlation-Id": correlation_id}
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(url, params=params, headers=headers)
+            return response.status_code, self._response_payload(response)
+
     def _response_payload(self, response: httpx.Response) -> dict[str, Any]:
         try:
             payload = response.json()

--- a/tests/integration/test_intake_router.py
+++ b/tests/integration/test_intake_router.py
@@ -64,13 +64,19 @@ def test_commit_upload_success(monkeypatch):
 
 def test_lookups_success(monkeypatch):
     async def _fake_portfolios(*args, **kwargs):
-        return 200, {"portfolios": [{"portfolio_id": "PF_1"}]}
+        return 200, {"items": [{"id": "PF_1", "label": "PF_1"}]}
 
     async def _fake_instruments(*args, **kwargs):
-        return 200, {"instruments": [{"security_id": "SEC_1", "currency": "USD"}]}
+        return 200, {"items": [{"id": "SEC_1", "label": "SEC_1 | Apple Inc."}]}
 
-    monkeypatch.setattr("app.clients.pas_client.PasClient.list_portfolios", _fake_portfolios)
-    monkeypatch.setattr("app.clients.pas_client.PasClient.list_instruments", _fake_instruments)
+    async def _fake_currencies(*args, **kwargs):
+        return 200, {"items": [{"id": "USD", "label": "USD"}]}
+
+    monkeypatch.setattr("app.clients.pas_client.PasClient.get_portfolio_lookups", _fake_portfolios)
+    monkeypatch.setattr(
+        "app.clients.pas_client.PasClient.get_instrument_lookups", _fake_instruments
+    )
+    monkeypatch.setattr("app.clients.pas_client.PasClient.get_currency_lookups", _fake_currencies)
 
     client = TestClient(app)
 

--- a/tests/unit/test_intake_service.py
+++ b/tests/unit/test_intake_service.py
@@ -19,13 +19,17 @@ class _PasIngestionStub:
 
 
 class _PasQueryStub:
-    async def list_portfolios(self, correlation_id):  # noqa: ANN001
+    async def get_portfolio_lookups(self, correlation_id):  # noqa: ANN001
         _ = correlation_id
-        return 200, {"portfolios": [{"portfolio_id": "PF_1", "base_currency": "USD"}]}
+        return 200, {"items": [{"id": "PF_1", "label": "PF_1"}]}
 
-    async def list_instruments(self, limit, correlation_id):  # noqa: ANN001
+    async def get_instrument_lookups(self, limit, correlation_id):  # noqa: ANN001
         _ = limit, correlation_id
-        return 200, {"instruments": [{"security_id": "SEC_1", "currency": "EUR"}]}
+        return 200, {"items": [{"id": "SEC_1", "label": "SEC_1 | Apple Inc."}]}
+
+    async def get_currency_lookups(self, correlation_id):  # noqa: ANN001
+        _ = correlation_id
+        return 200, {"items": [{"id": "EUR", "label": "EUR"}, {"id": "USD", "label": "USD"}]}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- refactor BFF intake lookup service to call PAS /lookups/* endpoints directly\n- remove BFF-side currency derivation and low-level reference mapping\n- add RFC-0007 documenting boundary refinement\n- update unit/integration tests for the canonical lookup contract path\n\n## Validation\n- make lint\n- make typecheck\n- make test-unit\n- make test-integration