### PR TITLE
Add BFF PAS lookup compatibility contract gate

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -9,3 +9,4 @@
 | RFC-0005 | Live Multi-Service E2E for Platform Capabilities | IMPLEMENTED | `docs/rfcs/RFC-0005-live-multi-service-e2e-platform-capabilities.md` |
 | RFC-0006 | PAS Intake and Lookup Pass-Through in BFF | IMPLEMENTED | `docs/rfcs/RFC-0006-pas-intake-and-lookup-pass-through.md` |
 | RFC-0007 | BFF Lookup Delegation to PAS Canonical Lookup APIs | IMPLEMENTED | `docs/rfcs/RFC-0007-bff-lookup-delegation-to-pas-canonical-apis.md` |
+| RFC-0008 | BFF PAS Lookup Compatibility Contract Gate | IMPLEMENTED | `docs/rfcs/RFC-0008-bff-pas-lookup-compatibility-contract-gate.md` |

--- a/docs/rfcs/RFC-0008-bff-pas-lookup-compatibility-contract-gate.md
+++ b/docs/rfcs/RFC-0008-bff-pas-lookup-compatibility-contract-gate.md
@@ -1,0 +1,34 @@
+# RFC-0008: BFF PAS Lookup Compatibility Contract Gate
+
+- Status: IMPLEMENTED
+- Date: 2026-02-23
+- Owner: advisor-experience-api
+
+## Context
+
+BFF lookup endpoints now delegate to PAS canonical `/lookups/*` APIs. If PAS payload shape drifts (for example invalid `id`/`label` types), UI selectors can fail silently unless BFF validates and gates this contract.
+
+## Decision
+
+- Add contract tests for BFF lookup endpoints:
+  - `tests/contract/test_lookup_contract.py`
+- Validate passthrough contract shape for:
+  - `/api/v1/lookups/portfolios`
+  - `/api/v1/lookups/instruments`
+  - `/api/v1/lookups/currencies`
+- Harden `IntakeService` lookup mapping to return `502 Bad Gateway` when PAS lookup payload fails schema validation.
+
+## Rationale
+
+- Fails fast on upstream contract violations.
+- Protects UI from malformed selector payloads.
+- Keeps BFF behavior explicit at integration boundaries.
+
+## Consequences
+
+Positive:
+- Clearer observability for contract drift (502 vs latent UI runtime errors).
+- Stronger CI signal through existing unit+contract stage.
+
+Trade-offs:
+- Stricter compatibility checks may surface integration issues earlier, requiring coordinated PAS/BFF updates.

--- a/tests/contract/test_lookup_contract.py
+++ b/tests/contract/test_lookup_contract.py
@@ -1,0 +1,60 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_lookup_contract_shape_passthrough(monkeypatch):
+    async def _fake_portfolio_lookups(*args, **kwargs):
+        return 200, {"items": [{"id": "PF_1", "label": "PF_1"}]}
+
+    async def _fake_instrument_lookups(*args, **kwargs):
+        return 200, {"items": [{"id": "SEC_1", "label": "SEC_1 | Apple Inc."}]}
+
+    async def _fake_currency_lookups(*args, **kwargs):
+        return 200, {"items": [{"id": "USD", "label": "USD"}]}
+
+    monkeypatch.setattr(
+        "app.clients.pas_client.PasClient.get_portfolio_lookups",
+        _fake_portfolio_lookups,
+    )
+    monkeypatch.setattr(
+        "app.clients.pas_client.PasClient.get_instrument_lookups",
+        _fake_instrument_lookups,
+    )
+    monkeypatch.setattr(
+        "app.clients.pas_client.PasClient.get_currency_lookups",
+        _fake_currency_lookups,
+    )
+
+    client = TestClient(app)
+
+    portfolio_response = client.get("/api/v1/lookups/portfolios")
+    instrument_response = client.get("/api/v1/lookups/instruments?limit=200")
+    currency_response = client.get("/api/v1/lookups/currencies")
+
+    assert portfolio_response.status_code == 200
+    assert instrument_response.status_code == 200
+    assert currency_response.status_code == 200
+
+    for response in [portfolio_response, instrument_response, currency_response]:
+        payload = response.json()
+        assert payload["contract_version"] == "v1"
+        assert isinstance(payload["correlation_id"], str)
+        assert payload["correlation_id"] != ""
+        assert isinstance(payload["items"], list)
+        assert isinstance(payload["items"][0]["id"], str)
+        assert isinstance(payload["items"][0]["label"], str)
+
+
+def test_lookup_contract_invalid_upstream_payload_maps_to_502(monkeypatch):
+    async def _bad_payload(*args, **kwargs):
+        return 200, {"items": [{"id": 100, "label": None}]}
+
+    monkeypatch.setattr(
+        "app.clients.pas_client.PasClient.get_portfolio_lookups",
+        _bad_payload,
+    )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/lookups/portfolios")
+    assert response.status_code == 502


### PR DESCRIPTION
## Summary\n- add contract smoke tests for BFF lookup endpoints backed by PAS canonical lookup APIs\n- harden intake lookup response mapping to return 502 on invalid PAS lookup payload shape\n- add RFC-0008 documenting compatibility gate rationale\n\n## Validation\n- make lint\n- make typecheck\n- make test-unit\n- make test-integration