### PR TITLE
feat: expose source policy versions in platform capabilities

### DIFF
--- a/src/app/contracts/platform_capabilities.py
+++ b/src/app/contracts/platform_capabilities.py
@@ -15,6 +15,7 @@ class PlatformCapabilitiesNormalized(BaseModel):
     input_modes_by_source: dict[str, list[str]] = Field(alias="inputModesBySource")
     input_modes_union: list[str] = Field(alias="inputModesUnion")
     module_health: dict[str, str] = Field(alias="moduleHealth")
+    policy_versions_by_source: dict[str, str] = Field(alias="policyVersionsBySource")
 
     model_config = {"populate_by_name": True}
 

--- a/src/app/services/platform_capabilities_service.py
+++ b/src/app/services/platform_capabilities_service.py
@@ -101,15 +101,21 @@ class PlatformCapabilitiesService:
     ) -> PlatformCapabilitiesNormalized:
         input_modes_by_source: dict[str, list[str]] = {}
         input_modes_union: list[str] = []
+        policy_versions_by_source: dict[str, str] = {}
         for source_name, source_payload in sources.items():
             source_modes = source_payload.get("supportedInputModes", [])
             if not isinstance(source_modes, list):
                 source_modes = []
             normalized_modes = [str(mode) for mode in source_modes]
             input_modes_by_source[source_name] = normalized_modes
+            policy_versions_by_source[source_name] = str(
+                source_payload.get("policyVersion", "unknown")
+            )
             for mode in normalized_modes:
                 if mode not in input_modes_union:
                     input_modes_union.append(mode)
+        for source_name in ("pas", "pa", "dpm"):
+            policy_versions_by_source.setdefault(source_name, "unknown")
 
         feature_enabled = {
             "pas_core_snapshot": self._feature_enabled(
@@ -169,6 +175,7 @@ class PlatformCapabilitiesService:
             inputModesBySource=input_modes_by_source,
             inputModesUnion=input_modes_union,
             moduleHealth=module_health,
+            policyVersionsBySource=policy_versions_by_source,
         )
 
     def _feature_enabled(

--- a/tests/contract/test_platform_capabilities_contract.py
+++ b/tests/contract/test_platform_capabilities_contract.py
@@ -8,6 +8,7 @@ def test_platform_capabilities_contract_shape(monkeypatch):
         return 200, {
             "contractVersion": "v1",
             "sourceService": "portfolio-analytics-system",
+            "policyVersion": "pas-default-v1",
             "features": [],
             "workflows": [],
         }
@@ -16,6 +17,7 @@ def test_platform_capabilities_contract_shape(monkeypatch):
         return 200, {
             "contractVersion": "v1",
             "sourceService": "performance-analytics",
+            "policyVersion": "pa-default-v1",
             "features": [],
             "workflows": [],
         }
@@ -24,6 +26,7 @@ def test_platform_capabilities_contract_shape(monkeypatch):
         return 200, {
             "contractVersion": "v1",
             "sourceService": "dpm-rebalance-engine",
+            "policyVersion": "dpm-default-v1",
             "features": [],
             "workflows": [],
         }
@@ -45,6 +48,7 @@ def test_platform_capabilities_contract_shape(monkeypatch):
     assert "navigation" in payload["normalized"]
     assert "workflowFlags" in payload["normalized"]
     assert "moduleHealth" in payload["normalized"]
+    assert "policyVersionsBySource" in payload["normalized"]
 
     for service_name in ("pas", "pa", "dpm"):
         source = payload["sources"][service_name]

--- a/tests/integration/test_platform_capabilities_router.py
+++ b/tests/integration/test_platform_capabilities_router.py
@@ -8,6 +8,7 @@ def test_platform_capabilities_router_success(monkeypatch):
         return 200, {
             "sourceService": "portfolio-analytics-system",
             "contractVersion": "v1",
+            "policyVersion": "pas-default-v1",
             "features": [
                 {"key": "pas.integration.core_snapshot", "enabled": True},
                 {"key": "pas.ingestion.bulk_upload", "enabled": True},
@@ -20,6 +21,7 @@ def test_platform_capabilities_router_success(monkeypatch):
         return 200, {
             "sourceService": "performance-analytics",
             "contractVersion": "v1",
+            "policyVersion": "pa-default-v1",
             "features": [{"key": "pa.analytics.twr", "enabled": True}],
             "workflows": [{"workflow_key": "performance_snapshot", "enabled": True}],
             "supportedInputModes": ["pas_ref", "inline_bundle"],
@@ -29,6 +31,7 @@ def test_platform_capabilities_router_success(monkeypatch):
         return 200, {
             "sourceService": "dpm-rebalance-engine",
             "contractVersion": "v1",
+            "policyVersion": "dpm-default-v1",
             "features": [
                 {"key": "dpm.proposals.lifecycle", "enabled": True},
                 {"key": "dpm.support.run_apis", "enabled": True},
@@ -50,6 +53,11 @@ def test_platform_capabilities_router_success(monkeypatch):
     assert set(body["sources"].keys()) == {"pas", "pa", "dpm"}
     assert body["normalized"]["navigation"]["decision_console"] is True
     assert body["normalized"]["workflowFlags"]["proposal_lifecycle"] is True
+    assert body["normalized"]["policyVersionsBySource"] == {
+        "pas": "pas-default-v1",
+        "pa": "pa-default-v1",
+        "dpm": "dpm-default-v1",
+    }
 
 
 def test_platform_capabilities_router_partial_failure(monkeypatch):
@@ -57,6 +65,7 @@ def test_platform_capabilities_router_partial_failure(monkeypatch):
         return 200, {
             "sourceService": "portfolio-analytics-system",
             "contractVersion": "v1",
+            "policyVersion": "pas-default-v1",
             "features": [{"key": "pas.integration.core_snapshot", "enabled": True}],
             "workflows": [],
             "supportedInputModes": ["pas_ref"],
@@ -82,3 +91,5 @@ def test_platform_capabilities_router_partial_failure(monkeypatch):
     assert len(body["errors"]) == 2
     assert body["normalized"]["navigation"]["analytics_studio"] is False
     assert body["normalized"]["moduleHealth"]["pa"] == "unavailable"
+    assert body["normalized"]["policyVersionsBySource"]["pas"] == "pas-default-v1"
+    assert body["normalized"]["policyVersionsBySource"]["pa"] == "unknown"

--- a/tests/unit/test_platform_capabilities_service.py
+++ b/tests/unit/test_platform_capabilities_service.py
@@ -34,6 +34,7 @@ async def test_platform_capabilities_all_sources_success():
             200,
             {
                 "sourceService": "dpm",
+                "policyVersion": "dpm-tenant-a-v2",
                 "supportedInputModes": ["pas_ref", "inline_bundle"],
                 "features": [
                     {"key": "dpm.proposals.lifecycle", "enabled": True},
@@ -46,6 +47,7 @@ async def test_platform_capabilities_all_sources_success():
             200,
             {
                 "sourceService": "pas",
+                "policyVersion": "pas-tenant-a-v3",
                 "supportedInputModes": ["pas_ref"],
                 "features": [
                     {"key": "pas.integration.core_snapshot", "enabled": True},
@@ -58,6 +60,7 @@ async def test_platform_capabilities_all_sources_success():
             200,
             {
                 "sourceService": "pa",
+                "policyVersion": "pa-tenant-a-v4",
                 "supportedInputModes": ["pas_ref", "inline_bundle"],
                 "features": [{"key": "pa.analytics.twr", "enabled": True}],
                 "workflows": [{"workflow_key": "performance_snapshot", "enabled": True}],
@@ -81,6 +84,11 @@ async def test_platform_capabilities_all_sources_success():
     assert response.data.normalized.workflow_flags["proposal_lifecycle"] is True
     assert "inline_bundle" in response.data.normalized.input_modes_union
     assert response.data.normalized.module_health["pas"] == "available"
+    assert response.data.normalized.policy_versions_by_source == {
+        "pas": "pas-tenant-a-v3",
+        "pa": "pa-tenant-a-v4",
+        "dpm": "dpm-tenant-a-v2",
+    }
 
 
 @pytest.mark.asyncio
@@ -91,6 +99,7 @@ async def test_platform_capabilities_partial_failure_on_error():
             200,
             {
                 "sourceService": "pas",
+                "policyVersion": "pas-tenant-default-v1",
                 "features": [{"key": "pas.integration.core_snapshot", "enabled": True}],
                 "workflows": [],
             },
@@ -112,3 +121,8 @@ async def test_platform_capabilities_partial_failure_on_error():
     assert response.data.normalized.navigation["advisory_pipeline"] is False
     assert response.data.normalized.module_health["pa"] == "unavailable"
     assert response.data.normalized.module_health["dpm"] == "unavailable"
+    assert response.data.normalized.policy_versions_by_source == {
+        "pas": "pas-tenant-default-v1",
+        "pa": "unknown",
+        "dpm": "unknown",
+    }


### PR DESCRIPTION
## Summary
- extend normalized platform capability contract with policyVersionsBySource
- provide stable unknown defaults for missing source policy versions
- update unit/integration/contract tests

## Validation
- make lint
- pytest