### PR TITLE
feat: orchestrate PAS effective policy diagnostics in BFF

### DIFF
--- a/src/app/clients/pas_client.py
+++ b/src/app/clients/pas_client.py
@@ -21,6 +21,19 @@ class PasClient:
             response = await client.get(url, params=params, headers=headers)
             return response.status_code, self._response_payload(response)
 
+    async def get_effective_policy(
+        self,
+        consumer_system: str,
+        tenant_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/integration/policy/effective"
+        params = {"consumerSystem": consumer_system, "tenantId": tenant_id}
+        headers = {"X-Correlation-Id": correlation_id}
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(url, params=params, headers=headers)
+            return response.status_code, self._response_payload(response)
+
     async def list_portfolios(
         self,
         correlation_id: str,

--- a/src/app/contracts/platform_capabilities.py
+++ b/src/app/contracts/platform_capabilities.py
@@ -16,6 +16,7 @@ class PlatformCapabilitiesNormalized(BaseModel):
     input_modes_union: list[str] = Field(alias="inputModesUnion")
     module_health: dict[str, str] = Field(alias="moduleHealth")
     policy_versions_by_source: dict[str, str] = Field(alias="policyVersionsBySource")
+    pas_policy_diagnostics: dict[str, Any] = Field(alias="pasPolicyDiagnostics")
 
     model_config = {"populate_by_name": True}
 

--- a/tests/contract/test_platform_capabilities_contract.py
+++ b/tests/contract/test_platform_capabilities_contract.py
@@ -31,7 +31,20 @@ def test_platform_capabilities_contract_shape(monkeypatch):
             "workflows": [],
         }
 
+    async def _pas_policy(*args, **kwargs):
+        return 200, {
+            "policyProvenance": {
+                "policyVersion": "pas-default-v1",
+                "policySource": "default",
+                "matchedRuleId": "default",
+                "strictMode": False,
+            },
+            "allowedSections": ["OVERVIEW"],
+            "warnings": [],
+        }
+
     monkeypatch.setattr("app.clients.pas_client.PasClient.get_capabilities", _pas)
+    monkeypatch.setattr("app.clients.pas_client.PasClient.get_effective_policy", _pas_policy)
     monkeypatch.setattr("app.clients.pa_client.PaClient.get_capabilities", _pa)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.get_capabilities", _dpm)
 
@@ -49,6 +62,7 @@ def test_platform_capabilities_contract_shape(monkeypatch):
     assert "workflowFlags" in payload["normalized"]
     assert "moduleHealth" in payload["normalized"]
     assert "policyVersionsBySource" in payload["normalized"]
+    assert "pasPolicyDiagnostics" in payload["normalized"]
 
     for service_name in ("pas", "pa", "dpm"):
         source = payload["sources"][service_name]


### PR DESCRIPTION
## Summary
- add PAS client integration for /integration/policy/effective
- include pasPolicyDiagnostics in normalized platform capabilities
- return deterministic fallback diagnostics and warning on PAS policy endpoint degradation
- update unit/integration/contract tests

## Validation
- make lint
- pytest