### PR TITLE
docs(rfc): RFC-0010 lifecycle-oriented BFF contract

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -15,3 +15,4 @@ Governance boundary:
 | RFC-0007 | BFF Lookup Delegation to PAS Canonical Lookup APIs | IMPLEMENTED | `docs/rfcs/RFC-0007-bff-lookup-delegation-to-pas-canonical-apis.md` |
 | RFC-0008 | BFF PAS Lookup Compatibility Contract Gate | IMPLEMENTED | `docs/rfcs/RFC-0008-bff-pas-lookup-compatibility-contract-gate.md` |
 | RFC-0009 | Workbench Overview Aggregation Contract | IMPLEMENTED | `docs/rfcs/RFC-0009-workbench-overview-aggregation-contract.md` |
+| RFC-0010 | Lifecycle-Oriented BFF Contract for Portfolio Foundation, Advisory Iteration, and DPM Iteration | PROPOSED | `docs/rfcs/RFC-0010-lifecycle-oriented-bff-contract-for-portfolio-advisory-and-dpm.md` |

--- a/docs/rfcs/RFC-0010-lifecycle-oriented-bff-contract-for-portfolio-advisory-and-dpm.md
+++ b/docs/rfcs/RFC-0010-lifecycle-oriented-bff-contract-for-portfolio-advisory-and-dpm.md
@@ -1,0 +1,52 @@
+# RFC-0010: Lifecycle-Oriented BFF Contract for Portfolio Foundation, Advisory Iteration, and DPM Iteration
+
+- Status: PROPOSED
+- Date: 2026-02-24
+- Owners: Advisor Experience API
+
+## Problem Statement
+
+Frontend lifecycle experiences require cohesive domain data and iterative simulation feedback, but BFF contracts are currently optimized for point-in-time feature surfaces rather than end-to-end lifecycle orchestration.
+
+## Root Cause
+
+- BFF endpoints are mostly feature-specific aggregations.
+- No single lifecycle session contract for iterative edits and impact refresh.
+- Limited first-class abstraction for universal portfolio foundation views.
+
+## Proposed Solution
+
+Introduce lifecycle-oriented BFF surfaces:
+
+1. Portfolio Foundation APIs
+   - Unified portfolio list/detail payloads with positions, transactions, health, and analytics summaries.
+2. Advisory Iteration Session APIs
+   - Session-scoped endpoints for delta updates (trade/cash changes) and immediate impact snapshots.
+3. DPM Iteration Session APIs
+   - Parallel session model with DPM-specific controls and governance states.
+4. Lifecycle Progression APIs
+   - Proposal generation, consent state transitions, and execution handoff orchestration.
+
+## Architectural Impact
+
+- BFF becomes explicit orchestration layer for lifecycle UX.
+- Clearer service boundary: UI consumes product contracts; domain systems remain system-of-record engines.
+- Enables responsive iterative frontend with stable schema and correlation tracing.
+
+## Risks and Trade-offs
+
+- More orchestration logic in BFF increases contract ownership burden.
+- Session semantics require clear idempotency and timeout policies.
+- Additional integration tests required for cross-service consistency.
+
+## High-Level Implementation Approach
+
+1. Define canonical lifecycle payload schemas and error model.
+2. Add foundation endpoints first, then iteration session endpoints.
+3. Integrate PAS/PA/DPM responses under deterministic correlation IDs.
+4. Add contract and e2e-live tests for iterative loop latency and correctness.
+
+## Downstream/Upstream Dependencies
+
+- Upstream: PAS RFC-046, PA RFC-032, DPM RFC-0029
+- Downstream: AW RFC-0007


### PR DESCRIPTION
## Summary\n- adds RFC-0010 for lifecycle-oriented BFF orchestration contracts\n- covers foundation read models, advisory/dpm iteration sessions, and lifecycle progression surfaces\n- updates RFC index