### PR TITLE
feat(workbench): position valuation fields in portfolio-360

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -18,3 +18,4 @@ Governance boundary:
 | RFC-0010 | Lifecycle-Oriented BFF Contract for Portfolio Foundation, Advisory Iteration, and DPM Iteration | PROPOSED | `docs/rfcs/RFC-0010-lifecycle-oriented-bff-contract-for-portfolio-advisory-and-dpm.md` |
 | RFC-0011 | Workbench Portfolio 360 and Live Sandbox Contract | IMPLEMENTED | `docs/rfcs/RFC-0011-workbench-portfolio-360-and-live-sandbox-contract.md` |
 | RFC-0012 | Workbench Analytics Delta API | IMPLEMENTED | `docs/rfcs/RFC-0012-workbench-analytics-delta-api.md` |
+| RFC-0013 | Workbench Position Valuation Fields | IMPLEMENTED | `docs/rfcs/RFC-0013-workbench-position-valuation-fields.md` |

--- a/docs/rfcs/RFC-0013-workbench-position-valuation-fields.md
+++ b/docs/rfcs/RFC-0013-workbench-position-valuation-fields.md
@@ -1,0 +1,30 @@
+# RFC-0013: Workbench Position Valuation Fields
+
+## Problem Statement
+Workbench baseline holdings lacked per-position valuation and weight fields, limiting portfolio review quality and making the UI appear incomplete even when positions were present.
+
+## Root Cause
+`WorkbenchPositionView` only exposed security, instrument, asset class, and quantity. Position-level valuation data from PAS holdings payload was not propagated through BFF contracts.
+
+## Proposed Solution
+- Extend `WorkbenchPositionView` with:
+  - `market_value_base: float | None`
+  - `weight_pct: float | None`
+- Parse these fields from PAS holdings payload where available.
+- If `weight_pct` is absent but `market_value_base` and total market value are available, derive weight in BFF.
+
+## Architectural Impact
+- Backward-compatible additive contract update.
+- Improves backend-driven UI composition and avoids duplicating valuation derivation logic in frontend.
+
+## Risks and Trade-offs
+- Some portfolios may still return `None` for valuation fields if upstream PAS pricing/valuation is incomplete.
+- Field mapping relies on known PAS payload key aliases; additional aliases may be required if upstream payload variations expand.
+
+## High-Level Implementation Approach
+1. Update BFF contract model with optional valuation fields.
+2. Update holdings extraction logic to map and derive valuation context.
+3. Add/adjust unit and integration tests.
+
+## Status
+IMPLEMENTED

--- a/src/app/contracts/workbench.py
+++ b/src/app/contracts/workbench.py
@@ -49,6 +49,8 @@ class WorkbenchPositionView(BaseModel):
     instrument_name: str
     asset_class: str | None = None
     quantity: float
+    market_value_base: float | None = None
+    weight_pct: float | None = None
 
 
 class WorkbenchProjectedPositionView(BaseModel):

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -86,7 +86,12 @@ def test_workbench_portfolio_360_router(monkeypatch):
                 "holdings": {
                     "holdingsByAssetClass": {
                         "Equity": [
-                            {"instrument_id": "EQ_1", "instrument_name": "Equity 1", "quantity": 10}
+                            {
+                                "instrument_id": "EQ_1",
+                                "instrument_name": "Equity 1",
+                                "quantity": 10,
+                                "market_value_base": 500.0,
+                            }
                         ]
                     }
                 },
@@ -109,6 +114,7 @@ def test_workbench_portfolio_360_router(monkeypatch):
     body = response.json()
     assert body["portfolio"]["portfolio_id"] == "PF_1001"
     assert len(body["current_positions"]) == 1
+    assert body["current_positions"][0]["market_value_base"] == 500.0
 
 
 def test_workbench_analytics_router(monkeypatch):

--- a/tests/unit/test_workbench_service.py
+++ b/tests/unit/test_workbench_service.py
@@ -202,6 +202,7 @@ async def test_workbench_portfolio_360_with_projected_state():
                                     "instrument_id": "EQ_1",
                                     "instrument_name": "Equity 1",
                                     "quantity": 10,
+                                    "valuation": {"market_value": 420.5},
                                 }
                             ]
                         }
@@ -219,6 +220,8 @@ async def test_workbench_portfolio_360_with_projected_state():
     )
     assert response.active_session_id == "sess_1"
     assert len(response.current_positions) == 1
+    assert response.current_positions[0].market_value_base == 420.5
+    assert response.current_positions[0].weight_pct == pytest.approx(42.05)
     assert len(response.projected_positions) == 1
     assert response.projected_summary is not None
     assert response.projected_summary.net_delta_quantity == 5.0
@@ -273,6 +276,7 @@ async def test_workbench_analytics_response():
                                     "instrument_id": "EQ_1",
                                     "instrument_name": "Equity 1",
                                     "quantity": 10,
+                                    "market_value_base": 300.0,
                                 }
                             ]
                         }


### PR DESCRIPTION
## Summary
- add optional market_value_base and weight_pct to workbench position contract
- map nested PAS aluation.market_value and derive weight when total market value exists
- add RFC-0013 and update RFC index
- extend unit/integration coverage for valuation mapping

## Why
UI portfolio review needs backend valuation context per position; avoid frontend-derived drift.

## Validation
- targeted unit/integration tests updated
- consumed by advisor-workbench workbench holdings table