### PR TITLE
refactor(bff): migrate PA integration to pas-input vocabulary

### DIFF
--- a/docs/rfcs/RFC-0014-workbench-pas-core-snapshot-minimal-sections.md
+++ b/docs/rfcs/RFC-0014-workbench-pas-core-snapshot-minimal-sections.md
@@ -1,0 +1,19 @@
+# RFC-0014 Workbench PAS Core Snapshot Minimal Sections
+
+## Problem
+Workbench overview currently requests `PERFORMANCE` from PAS core snapshot even though performance is owned by PA.
+
+## Decision
+- BFF workbench should request only PAS core data sections needed for overview composition:
+  - `OVERVIEW`
+  - `HOLDINGS`
+- Performance snapshot remains sourced from PA.
+
+## Architectural Impact
+- Cleaner PAS/PA boundaries in the BFF orchestration layer.
+- Reduced coupling to deprecated PAS analytics sections in `core-snapshot`.
+
+## Implementation
+1. Update workbench overview PAS request to remove `PERFORMANCE`.
+2. Keep PA performance call as the single performance source for the response contract.
+

--- a/src/app/clients/pa_client.py
+++ b/src/app/clients/pa_client.py
@@ -21,7 +21,7 @@ class PaClient:
             response = await client.get(url, params=params, headers=headers)
             return response.status_code, self._response_payload(response)
 
-    async def get_pas_snapshot_twr(
+    async def get_pas_input_twr(
         self,
         portfolio_id: str,
         as_of_date: str,
@@ -29,14 +29,13 @@ class PaClient:
         consumer_system: str,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        url = f"{self._base_url}/performance/twr/pas-snapshot"
+        url = f"{self._base_url}/performance/twr/pas-input"
         headers = {"X-Correlation-Id": correlation_id}
         payload = {
             "portfolioId": portfolio_id,
             "asOfDate": as_of_date,
             "periods": periods,
             "consumerSystem": consumer_system,
-            "includeSections": ["PERFORMANCE"],
         }
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             response = await client.post(url, json=payload, headers=headers)

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -54,7 +54,7 @@ class WorkbenchService:
         pas_status, pas_payload = await self._pas_client.get_core_snapshot(
             portfolio_id=portfolio_id,
             as_of_date=as_of_date,
-            include_sections=["OVERVIEW", "PERFORMANCE", "HOLDINGS"],
+            include_sections=["OVERVIEW", "HOLDINGS"],
             consumer_system="BFF",
             correlation_id=correlation_id,
         )
@@ -66,7 +66,7 @@ class WorkbenchService:
             fallback_as_of_date=as_of_date,
         )
 
-        pa_task = self._pa_client.get_pas_snapshot_twr(
+        pa_task = self._pa_client.get_pas_input_twr(
             portfolio_id=portfolio_id,
             as_of_date=as_of_date,
             periods=["YTD"],

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -34,7 +34,7 @@ def test_workbench_router_success(monkeypatch):
         }
 
     monkeypatch.setattr("app.clients.pas_client.PasClient.get_core_snapshot", _pas)
-    monkeypatch.setattr("app.clients.pa_client.PaClient.get_pas_snapshot_twr", _pa)
+    monkeypatch.setattr("app.clients.pa_client.PaClient.get_pas_input_twr", _pa)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm)
 
     client = TestClient(app)
@@ -64,7 +64,7 @@ def test_workbench_router_partial_failure(monkeypatch):
         return 503, {"detail": "paused"}
 
     monkeypatch.setattr("app.clients.pas_client.PasClient.get_core_snapshot", _pas)
-    monkeypatch.setattr("app.clients.pa_client.PaClient.get_pas_snapshot_twr", _pa)
+    monkeypatch.setattr("app.clients.pa_client.PaClient.get_pas_input_twr", _pa)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm)
 
     client = TestClient(app)
@@ -105,7 +105,7 @@ def test_workbench_portfolio_360_router(monkeypatch):
         return 200, {"items": []}
 
     monkeypatch.setattr("app.clients.pas_client.PasClient.get_core_snapshot", _pas_core)
-    monkeypatch.setattr("app.clients.pa_client.PaClient.get_pas_snapshot_twr", _pa)
+    monkeypatch.setattr("app.clients.pa_client.PaClient.get_pas_input_twr", _pa)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
 
     client = TestClient(app)
@@ -164,7 +164,7 @@ def test_workbench_analytics_router(monkeypatch):
     monkeypatch.setattr("app.clients.pas_client.PasClient.get_core_snapshot", _pas_core)
     monkeypatch.setattr("app.clients.pas_client.PasClient.get_projected_positions", _pas_positions)
     monkeypatch.setattr("app.clients.pas_client.PasClient.get_projected_summary", _pas_summary)
-    monkeypatch.setattr("app.clients.pa_client.PaClient.get_pas_snapshot_twr", _pa)
+    monkeypatch.setattr("app.clients.pa_client.PaClient.get_pas_input_twr", _pa)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
 
     client = TestClient(app)
@@ -230,7 +230,7 @@ def test_workbench_sandbox_changes_router(monkeypatch):
     monkeypatch.setattr("app.clients.pas_client.PasClient.add_simulation_changes", _pas_add)
     monkeypatch.setattr("app.clients.pas_client.PasClient.get_projected_positions", _pas_positions)
     monkeypatch.setattr("app.clients.pas_client.PasClient.get_projected_summary", _pas_summary)
-    monkeypatch.setattr("app.clients.pa_client.PaClient.get_pas_snapshot_twr", _pa)
+    monkeypatch.setattr("app.clients.pa_client.PaClient.get_pas_input_twr", _pa)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.simulate_proposal", _dpm_simulate)
 

--- a/tests/unit/test_workbench_service.py
+++ b/tests/unit/test_workbench_service.py
@@ -62,7 +62,7 @@ class _StubPaClient:
         self.status_code = status_code
         self.payload = payload
 
-    async def get_pas_snapshot_twr(
+    async def get_pas_input_twr(
         self,
         portfolio_id: str,
         as_of_date: str,


### PR DESCRIPTION
## Summary\n- rename BFF->PA contract call from pas-snapshot to pas-input\n- update workbench orchestration to use PA pas-input endpoint\n- align integration and unit tests with new naming\n- include RFC-0014 documenting boundary alignment\n\n## Validation\n- python -m pytest tests/unit/test_workbench_service.py tests/integration/test_workbench_router.py -q\n\n## Architecture\n- keeps PAS as core data source and PA as analytics authority\n- removes ambiguous analytics ownership language from BFF contracts