### PR TITLE
feat(aea): add reporting snapshot endpoint

### DIFF
--- a/src/app/clients/reporting_client.py
+++ b/src/app/clients/reporting_client.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+import httpx
+
+
+class ReportingClient:
+    def __init__(self, base_url: str, timeout_seconds: float):
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout_seconds
+
+    async def get_portfolio_snapshot(
+        self,
+        portfolio_id: str,
+        as_of_date: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/aggregations/portfolios/{portfolio_id}"
+        params = {"asOfDate": as_of_date, "live": "true"}
+        headers = {"X-Correlation-Id": correlation_id}
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(url, params=params, headers=headers)
+            return response.status_code, self._response_payload(response)
+
+    def _response_payload(self, response: httpx.Response) -> dict[str, Any]:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {"detail": response.text}
+        if isinstance(payload, dict):
+            return payload
+        return {"detail": payload}

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     portfolio_data_platform_base_url: str = Field(default="http://localhost:8201")
     portfolio_data_ingestion_base_url: str = Field(default="http://localhost:8200")
     performance_analytics_base_url: str = Field(default="http://localhost:8002")
+    reporting_aggregation_base_url: str = Field(default="http://localhost:8300")
     upstream_timeout_seconds: float = Field(default=3.0)
 
 

--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ReportingSnapshotResponse(BaseModel):
+    correlation_id: str = Field(..., alias="correlationId")
+    contract_version: str = Field(..., alias="contractVersion")
+    source_service: str = Field(..., alias="sourceService")
+    portfolio_id: str = Field(..., alias="portfolioId")
+    as_of_date: str = Field(..., alias="asOfDate")
+    generated_at: datetime = Field(..., alias="generatedAt")
+    rows: list[dict]
+
+    model_config = {"populate_by_name": True}

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -6,6 +6,7 @@ from app.middleware.correlation import correlation_id_var, correlation_middlewar
 from app.routers.intake import router as intake_router
 from app.routers.platform import router as platform_router
 from app.routers.proposals import router as proposals_router
+from app.routers.reporting import router as reporting_router
 from app.routers.workbench import router as workbench_router
 
 app = FastAPI(title="Advisor Experience API", version="0.1.0")
@@ -14,6 +15,7 @@ app.include_router(proposals_router)
 app.include_router(platform_router)
 app.include_router(intake_router)
 app.include_router(workbench_router)
+app.include_router(reporting_router)
 
 
 @app.get("/health")

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -1,0 +1,60 @@
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Path, Query, status
+
+from app.clients.reporting_client import ReportingClient
+from app.config import settings
+from app.contracts.reporting import ReportingSnapshotResponse
+from app.middleware.correlation import correlation_id_var
+
+router = APIRouter(prefix="/api/v1/reports", tags=["Reporting"])
+
+
+@router.get(
+    "/{portfolio_id}/snapshot",
+    response_model=ReportingSnapshotResponse,
+    summary="Get reporting snapshot",
+    description=(
+        "Fetches report-ready aggregated snapshot rows from reporting-aggregation-service "
+        "for one portfolio and as-of date."
+    ),
+)
+async def get_reporting_snapshot(
+    portfolio_id: Annotated[
+        str,
+        Path(
+            description="Canonical portfolio identifier.",
+            examples=["DEMO_DPM_EUR_001"],
+        ),
+    ],
+    as_of_date: Annotated[
+        str,
+        Query(alias="asOfDate", description="Business as-of date (YYYY-MM-DD)."),
+    ],
+) -> ReportingSnapshotResponse:
+    client = ReportingClient(
+        base_url=settings.reporting_aggregation_base_url,
+        timeout_seconds=settings.upstream_timeout_seconds,
+    )
+    correlation_id = correlation_id_var.get()
+    status_code, payload = await client.get_portfolio_snapshot(
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        correlation_id=correlation_id,
+    )
+    if status_code >= status.HTTP_400_BAD_REQUEST:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Reporting snapshot unavailable: {payload}",
+        )
+
+    return ReportingSnapshotResponse(
+        correlationId=correlation_id,
+        contractVersion=settings.contract_version,
+        sourceService="reporting-aggregation-service",
+        portfolioId=portfolio_id,
+        asOfDate=as_of_date,
+        generatedAt=datetime.now(UTC),
+        rows=payload.get("rows", []),
+    )

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_reporting_snapshot_success(monkeypatch):
+    async def _mock_get_portfolio_snapshot(self, portfolio_id, as_of_date, correlation_id):  # noqa: ARG001
+        return (
+            200,
+            {
+                "rows": [
+                    {"bucket": "TOTAL", "metric": "market_value_base", "value": 1250000.0},
+                    {"bucket": "TOTAL", "metric": "return_ytd_pct", "value": 4.2},
+                ]
+            },
+        )
+
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_portfolio_snapshot",
+        _mock_get_portfolio_snapshot,
+    )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/reports/DEMO_DPM_EUR_001/snapshot?asOfDate=2026-02-24")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["portfolioId"] == "DEMO_DPM_EUR_001"
+    assert len(body["rows"]) == 2
+
+
+def test_reporting_snapshot_upstream_error(monkeypatch):
+    async def _mock_get_portfolio_snapshot(self, portfolio_id, as_of_date, correlation_id):  # noqa: ARG001
+        return 503, {"detail": "upstream unavailable"}
+
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_portfolio_snapshot",
+        _mock_get_portfolio_snapshot,
+    )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/reports/DEMO_DPM_EUR_001/snapshot?asOfDate=2026-02-24")
+    assert response.status_code == 502


### PR DESCRIPTION
## Summary
- add reporting-aggregation-service client in AEA
- add /api/v1/reports/{portfolioId}/snapshot endpoint
- wire router and config for reporting service base URL
- add integration tests for success and upstream failure

## Validation
- python -m pytest tests/integration/test_reporting_router.py -q
- python -m pytest -q