### PR TITLE
test(aea): coverage hardening wave 2 and RFC-0002

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,3 +1,4 @@
 # RFC Index
 
 - `RFC-0001-aea-coverage-hardening-wave-1.md`
+- `RFC-0002-aea-coverage-hardening-wave-2.md`

--- a/rfcs/RFC-0002-aea-coverage-hardening-wave-2.md
+++ b/rfcs/RFC-0002-aea-coverage-hardening-wave-2.md
@@ -1,0 +1,39 @@
+# RFC-0002: AEA Coverage Hardening Wave 2
+
+- Status: Implemented
+- Authors: Codex
+- Date: 2026-02-24
+
+## Context
+
+AEA had strong coverage after wave 1 but still had untested branch paths in middleware and service normalization logic.
+
+## Problem
+
+- Overall coverage was below the platform target.
+- Several defensive branches in correlation resolution and platform/workbench normalization were not exercised.
+
+## Decision
+
+Add focused unit tests for:
+
+- Valid `traceparent` parsing in correlation middleware.
+- PAS policy exception handling and malformed list item handling in platform capabilities normalization.
+- Module health fallback to `unknown` when a source is neither available nor errored.
+- Workbench holdings extraction when asset-class entries are non-list values.
+
+## Validation
+
+- `python -m pytest -q` passes (`132 passed`).
+- `python -m pytest --cov=src/app --cov-report=term-missing -q` reports:
+  - Total coverage: `99.39%`.
+  - `platform_capabilities_service.py`: `100%`.
+  - `workbench_service.py`: `99%` (remaining branch-only edges).
+
+## Risks and Trade-offs
+
+- Additional private-method coverage increases coupling to internal structures, accepted to lock down critical normalization/guard behavior.
+
+## Follow-ups
+
+- Cover remaining branch-only edge paths in router/service boolean guards where practical without reducing test clarity.

--- a/tests/unit/test_correlation_middleware.py
+++ b/tests/unit/test_correlation_middleware.py
@@ -53,3 +53,20 @@ def test_resolve_trace_id_uses_generated_value_for_invalid_traceparent_without_f
 
     resolved = resolve_trace_id(_FakeRequest())
     assert len(resolved) == 32
+
+
+def test_resolve_trace_id_prefers_valid_traceparent():
+    class _FakeHeaders:
+        def __init__(self, values: dict[str, str]):
+            self._values = values
+
+        def get(self, key: str):
+            return self._values.get(key)
+
+    class _FakeRequest:
+        headers = _FakeHeaders(
+            {"traceparent": "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"}
+        )
+
+    resolved = resolve_trace_id(_FakeRequest())
+    assert resolved == "0123456789abcdef0123456789abcdef"

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -477,6 +477,16 @@ def test_extract_current_positions_skips_invalid_item_shapes():
     assert rows[0].security_id == "EQ_1"
 
 
+def test_extract_current_positions_skips_asset_class_with_non_list_items():
+    service, _, _, _ = _build_service()
+    payload = {
+        "overview": {"total_market_value": 100.0},
+        "holdings": {"holdingsByAssetClass": {"Equity": {"instrument_id": "EQ_1"}}},
+    }
+    rows = service._extract_current_positions(payload)
+    assert rows == []
+
+
 def test_parse_position_market_value_skips_non_numeric_in_flat_keys():
     service, _, _, _ = _build_service()
     assert (


### PR DESCRIPTION
## Summary
- add RFC-0002 for AEA coverage hardening wave-2
- add branch-focused tests for correlation traceparent parsing
- add platform capabilities tests for policy exception handling, malformed list entries, and unknown module health
- add workbench position extraction guard test for non-list asset-class buckets

## Validation
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m pytest -q` (132 passed)
- `python -m pytest --cov=src/app --cov-report=term-missing -q` (99.39%)

## Governance
- RFC: `rfcs/RFC-0002-aea-coverage-hardening-wave-2.md`
- RFC index updated: `rfcs/README.md`
