### PR TITLE
AEA: E2E pyramid wave 2 (resilience and failure paths)

### DIFF
--- a/docs/rfcs/RFC-0015-e2e-pyramid-wave-2-resilience-and-failure-paths.md
+++ b/docs/rfcs/RFC-0015-e2e-pyramid-wave-2-resilience-and-failure-paths.md
@@ -1,0 +1,28 @@
+# RFC-0015 E2E Pyramid Wave 2 - Resilience and Failure Paths
+
+## Problem Statement
+AEA E2E test count is below target pyramid distribution and does not sufficiently validate failure-path orchestration behavior for key BFF contracts.
+
+## Root Cause
+Existing E2E journeys primarily cover happy-path workflows, with limited checks for:
+- partial upstream capability aggregation failures
+- reporting upstream outage mapping
+- sandbox policy evaluation degradation behavior
+
+## Proposed Solution
+Add E2E journey tests for:
+1. Platform capabilities aggregation with one upstream error (`partialFailure` behavior).
+2. Reporting snapshot upstream failure mapped to BFF gateway error.
+3. Workbench sandbox apply-changes flow where DPM policy simulation is unavailable but PAS changes succeed.
+
+## Architectural Impact
+No runtime or API contract changes. This is verification-depth improvement for existing orchestrated contracts.
+
+## Risks and Trade-offs
+- Low runtime risk (tests only).
+- Slight CI runtime increase due to additional E2E journeys.
+
+## High-Level Implementation Approach
+1. Extend `tests/e2e/test_workflow_journeys.py` with resilience-path tests.
+2. Validate with targeted E2E execution.
+3. Merge and re-measure pyramid distribution.


### PR DESCRIPTION
## Summary\n- add RFC-0015 for AEA E2E pyramid wave 2\n- add E2E test for platform capabilities partial failure handling\n- add E2E test for reporting snapshot upstream failure mapping\n- add E2E test for sandbox policy feedback degradation when DPM policy simulation is unavailable\n\n## Validation\n- python -m pytest tests/e2e/test_workflow_journeys.py\n  - 7 passed\n- python -m pytest tests/e2e --collect-only -q\n  - e2e collected: 8 (was 5)\n\n## Impact\n- tests only, no runtime/API contract changes