### PR TITLE
Foundation wave1: AEA security gate and standardized make ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+      - name: Verify Dependencies
+        run: python -m pip check
+      - name: Security Audit
+        run: make security-audit
       - name: Lint
         run: make lint
       - name: Typecheck

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck test test-unit test-integration test-coverage test-e2e test-e2e-live check ci-local ci-local-docker ci-local-docker-down run clean docker-up docker-down e2e-up e2e-down
+.PHONY: install lint typecheck test test-unit test-integration test-coverage test-e2e test-e2e-live security-audit check ci ci-local ci-local-docker ci-local-docker-down run clean docker-up docker-down e2e-up e2e-down
 
 install:
 	python -m pip install -e ".[dev]"
@@ -9,6 +9,9 @@ lint:
 
 typecheck:
 	mypy src
+
+security-audit:
+	python -m pip_audit
 
 test:
 	$(MAKE) test-unit
@@ -35,6 +38,8 @@ test-e2e-live:
 	python -m pytest tests/e2e/test_platform_capabilities_live.py -q
 
 check: lint typecheck test
+
+ci: lint typecheck test-integration test-coverage security-audit
 
 ci-local: check test-integration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dev = [
   "pytest-asyncio>=0.26.0",
   "pytest-cov>=6.2.1",
   "ruff>=0.15.0",
-  "mypy>=1.13.0"
+  "mypy>=1.13.0",
+  "pip-audit>=2.9.0"
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary\n- add make security-audit and make ci\n- add pip-audit to dev dependencies\n- enforce dependency pip check + security audit in CI\n\n## Validation\n- python -m ruff check src tests\n- python -m pytest tests/unit tests/contract -q