### PR TITLE
chore: enforce canonical correlation header handling

### DIFF
--- a/src/app/middleware/correlation.py
+++ b/src/app/middleware/correlation.py
@@ -43,7 +43,7 @@ def setup_logging() -> None:
 
 
 def resolve_correlation_id(request: Request) -> str:
-    incoming = request.headers.get("X-Correlation-Id") or request.headers.get("X-Correlation-ID")
+    incoming = request.headers.get("X-Correlation-Id")
     return incoming if incoming else f"corr_{uuid4().hex[:12]}"
 
 

--- a/tests/unit/test_correlation_middleware.py
+++ b/tests/unit/test_correlation_middleware.py
@@ -13,7 +13,7 @@ def test_correlation_header_is_returned():
     assert response.headers.get("X-Trace-Id")
 
 
-def test_legacy_correlation_header_alias_is_supported():
+def test_correlation_header_casing_variants_are_equivalent():
     client = TestClient(app)
     response = client.get("/health", headers={"X-Correlation-ID": "corr_test_legacy"})
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- remove redundant fallback lookup for X-Correlation-ID alias in middleware
- keep canonical X-Correlation-Id propagation behavior explicit
- update middleware test naming to reflect HTTP header case-insensitive semantics

## Validation
- python -m ruff check src/app/middleware/correlation.py tests/unit/test_correlation_middleware.py
- python -m pytest tests/unit/test_correlation_middleware.py -q
- python -m pytest tests/unit -q
