### PR TITLE
Add resilient upstream communication baseline for scalability

### DIFF
--- a/docs/standards/scalability-availability.md
+++ b/docs/standards/scalability-availability.md
@@ -1,0 +1,21 @@
+# Scalability and Availability Standard Alignment
+
+Service: AEA (BFF)
+
+This repository adopts the platform-wide standard defined in pbwm-platform-docs/Scalability and Availability Standard.md.
+
+## Implemented Baseline
+
+- Stateless service behavior with externalized durable state.
+- Explicit timeout and bounded retry/backoff for inter-service communication where applicable.
+- Health/liveness/readiness endpoints for runtime orchestration.
+- Observability instrumentation for latency/error/throughput diagnostics.
+
+## Required Evidence
+
+- Compliance matrix entry in pbwm-platform-docs/output/scalability-availability-compliance.md.
+- Service-specific tests covering resilience and concurrency-critical paths.
+
+## Deviation Rule
+
+Any deviation from this standard requires ADR/RFC with remediation timeline.

--- a/src/app/clients/http_resilience.py
+++ b/src/app/clients/http_resilience.py
@@ -1,0 +1,56 @@
+import asyncio
+from typing import Any
+
+import httpx
+
+
+def _response_payload(response: httpx.Response) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {"detail": response.text}
+    if isinstance(payload, dict):
+        return payload
+    return {"detail": payload}
+
+
+async def request_with_retry(
+    *,
+    method: str,
+    url: str,
+    timeout_seconds: float,
+    max_retries: int = 2,
+    backoff_seconds: float = 0.2,
+    retry_status_codes: set[int] | None = None,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    json_body: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None,
+    files: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    attempts = max_retries + 1
+    for attempt in range(attempts):
+        try:
+            async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+                if method.upper() == "GET":
+                    response = await client.get(url, params=params, headers=headers)
+                else:
+                    response = await client.post(
+                        url,
+                        headers=headers,
+                        json=json_body,
+                        data=data,
+                        files=files,
+                    )
+
+            should_retry_status = retry_status_codes and response.status_code in retry_status_codes
+            if should_retry_status and attempt < max_retries:
+                await asyncio.sleep(backoff_seconds * (2**attempt))
+                continue
+            return response.status_code, _response_payload(response)
+        except (httpx.TimeoutException, httpx.NetworkError) as exc:
+            if attempt >= max_retries:
+                return 503, {"detail": f"upstream communication failure: {exc.__class__.__name__}"}
+            await asyncio.sleep(backoff_seconds * (2**attempt))
+
+    return 503, {"detail": "upstream communication failure: exhausted retries"}

--- a/src/app/clients/pa_client.py
+++ b/src/app/clients/pa_client.py
@@ -1,14 +1,21 @@
 from typing import Any
 
-import httpx
-
+from app.clients.http_resilience import request_with_retry
 from app.middleware.correlation import propagation_headers
 
 
 class PaClient:
-    def __init__(self, base_url: str, timeout_seconds: float):
+    def __init__(
+        self,
+        base_url: str,
+        timeout_seconds: float,
+        max_retries: int = 2,
+        retry_backoff_seconds: float = 0.2,
+    ):
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout_seconds
+        self._max_retries = max_retries
+        self._retry_backoff_seconds = retry_backoff_seconds
 
     async def get_capabilities(
         self,
@@ -19,9 +26,15 @@ class PaClient:
         url = f"{self._base_url}/integration/capabilities"
         params = {"consumerSystem": consumer_system, "tenantId": tenant_id}
         headers = propagation_headers(correlation_id)
-        async with httpx.AsyncClient(timeout=self._timeout) as client:
-            response = await client.get(url, params=params, headers=headers)
-            return response.status_code, self._response_payload(response)
+        return await request_with_retry(
+            method="GET",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            params=params,
+            headers=headers,
+        )
 
     async def get_pas_input_twr(
         self,
@@ -39,9 +52,15 @@ class PaClient:
             "periods": periods,
             "consumerSystem": consumer_system,
         }
-        async with httpx.AsyncClient(timeout=self._timeout) as client:
-            response = await client.post(url, json=payload, headers=headers)
-            return response.status_code, self._response_payload(response)
+        return await request_with_retry(
+            method="POST",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            json_body=payload,
+            headers=headers,
+        )
 
     async def get_workbench_analytics(
         self,
@@ -50,15 +69,12 @@ class PaClient:
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/analytics/workbench"
         headers = propagation_headers(correlation_id)
-        async with httpx.AsyncClient(timeout=self._timeout) as client:
-            response = await client.post(url, json=payload, headers=headers)
-            return response.status_code, self._response_payload(response)
-
-    def _response_payload(self, response: httpx.Response) -> dict[str, Any]:
-        try:
-            payload = response.json()
-        except ValueError:
-            payload = {"detail": response.text}
-        if isinstance(payload, dict):
-            return payload
-        return {"detail": payload}
+        return await request_with_retry(
+            method="POST",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            json_body=payload,
+            headers=headers,
+        )

--- a/src/app/clients/pas_ingestion_client.py
+++ b/src/app/clients/pas_ingestion_client.py
@@ -1,14 +1,21 @@
 from typing import Any
 
-import httpx
-
+from app.clients.http_resilience import request_with_retry
 from app.middleware.correlation import propagation_headers
 
 
 class PasIngestionClient:
-    def __init__(self, base_url: str, timeout_seconds: float):
+    def __init__(
+        self,
+        base_url: str,
+        timeout_seconds: float,
+        max_retries: int = 2,
+        retry_backoff_seconds: float = 0.2,
+    ):
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout_seconds
+        self._max_retries = max_retries
+        self._retry_backoff_seconds = retry_backoff_seconds
 
     async def ingest_portfolio_bundle(
         self,
@@ -17,9 +24,15 @@ class PasIngestionClient:
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/ingest/portfolio-bundle"
         headers = propagation_headers(correlation_id)
-        async with httpx.AsyncClient(timeout=self._timeout) as client:
-            response = await client.post(url, json=body, headers=headers)
-            return response.status_code, self._response_payload(response)
+        return await request_with_retry(
+            method="POST",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            json_body=body,
+            headers=headers,
+        )
 
     async def preview_upload(
         self,
@@ -68,15 +81,13 @@ class PasIngestionClient:
         headers = propagation_headers(correlation_id)
         form_data = {"entityType": entity_type, **extra_data}
         files = {"file": (filename, content)}
-        async with httpx.AsyncClient(timeout=self._timeout) as client:
-            response = await client.post(url, data=form_data, files=files, headers=headers)
-            return response.status_code, self._response_payload(response)
-
-    def _response_payload(self, response: httpx.Response) -> dict[str, Any]:
-        try:
-            payload = response.json()
-        except ValueError:
-            payload = {"detail": response.text}
-        if isinstance(payload, dict):
-            return payload
-        return {"detail": payload}
+        return await request_with_retry(
+            method="POST",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            data=form_data,
+            files=files,
+            headers=headers,
+        )

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -11,6 +11,8 @@ class Settings(BaseSettings):
     performance_analytics_base_url: str = Field(default="http://localhost:8002")
     reporting_aggregation_base_url: str = Field(default="http://localhost:8300")
     upstream_timeout_seconds: float = Field(default=3.0)
+    upstream_max_retries: int = Field(default=2)
+    upstream_retry_backoff_seconds: float = Field(default=0.2)
 
 
 settings = Settings()

--- a/src/app/routers/intake.py
+++ b/src/app/routers/intake.py
@@ -15,10 +15,14 @@ def _intake_service() -> IntakeService:
         pas_ingestion_client=PasIngestionClient(
             base_url=settings.portfolio_data_ingestion_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
         pas_query_client=PasClient(
             base_url=settings.portfolio_data_platform_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
     )
 

--- a/src/app/routers/platform.py
+++ b/src/app/routers/platform.py
@@ -17,18 +17,26 @@ def _platform_capabilities_service() -> PlatformCapabilitiesService:
         dpm_client=DpmClient(
             base_url=settings.decisioning_service_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
         pas_client=PasClient(
             base_url=settings.portfolio_data_platform_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
         pa_client=PaClient(
             base_url=settings.performance_analytics_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
         reporting_client=ReportingClient(
             base_url=settings.reporting_aggregation_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
         contract_version=settings.contract_version,
     )

--- a/src/app/routers/proposals.py
+++ b/src/app/routers/proposals.py
@@ -24,6 +24,8 @@ def _proposal_service() -> ProposalService:
         dpm_client=DpmClient(
             base_url=settings.decisioning_service_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         )
     )
 

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -40,6 +40,8 @@ async def get_reporting_snapshot(
     client = ReportingClient(
         base_url=settings.reporting_aggregation_base_url,
         timeout_seconds=settings.upstream_timeout_seconds,
+        max_retries=settings.upstream_max_retries,
+        retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
     )
     correlation_id = correlation_id_var.get()
     status_code, payload = await client.get_portfolio_snapshot(
@@ -94,6 +96,8 @@ async def get_reporting_summary(
     client = ReportingClient(
         base_url=settings.reporting_aggregation_base_url,
         timeout_seconds=settings.upstream_timeout_seconds,
+        max_retries=settings.upstream_max_retries,
+        retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
     )
     correlation_id = correlation_id_var.get()
     status_code, payload = await client.post_portfolio_summary(
@@ -139,6 +143,8 @@ async def get_reporting_review(
     client = ReportingClient(
         base_url=settings.reporting_aggregation_base_url,
         timeout_seconds=settings.upstream_timeout_seconds,
+        max_retries=settings.upstream_max_retries,
+        retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
     )
     correlation_id = correlation_id_var.get()
     status_code, payload = await client.post_portfolio_review(

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -23,14 +23,20 @@ def _workbench_service() -> WorkbenchService:
         pas_client=PasClient(
             base_url=settings.portfolio_data_platform_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
         pa_client=PaClient(
             base_url=settings.performance_analytics_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
         dpm_client=DpmClient(
             base_url=settings.decisioning_service_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
     )
 

--- a/tests/unit/test_http_resilience.py
+++ b/tests/unit/test_http_resilience.py
@@ -1,0 +1,49 @@
+import json
+
+import httpx
+import pytest
+
+from app.clients.http_resilience import request_with_retry
+
+
+class _FlakyAsyncClient:
+    calls = 0
+
+    def __init__(self, timeout: float):
+        _ = timeout
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, params=None, headers=None):
+        _ = url, params, headers
+        _FlakyAsyncClient.calls += 1
+        if _FlakyAsyncClient.calls == 1:
+            raise httpx.TimeoutException("timed out")
+        return httpx.Response(
+            200,
+            content=json.dumps({"ok": True}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            request=httpx.Request("GET", "http://test"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_request_with_retry_retries_on_timeout(monkeypatch):
+    _FlakyAsyncClient.calls = 0
+    monkeypatch.setattr("httpx.AsyncClient", _FlakyAsyncClient)
+
+    status, payload = await request_with_retry(
+        method="GET",
+        url="http://service/health",
+        timeout_seconds=1.0,
+        max_retries=2,
+        backoff_seconds=0.0,
+    )
+
+    assert status == 200
+    assert payload == {"ok": True}
+    assert _FlakyAsyncClient.calls == 2


### PR DESCRIPTION
Adds bounded retry/backoff + timeout helper for PAS/PA/DPM/RAS clients, configurable defaults, tests, and service standard doc alignment.