### PR TITLE
Close scalability gap: availability baseline evidence

### DIFF
--- a/docs/standards/scalability-availability.md
+++ b/docs/standards/scalability-availability.md
@@ -16,6 +16,13 @@ This repository adopts the platform-wide standard defined in pbwm-platform-docs/
 - Compliance matrix entry in pbwm-platform-docs/output/scalability-availability-compliance.md.
 - Service-specific tests covering resilience and concurrency-critical paths.
 
+## Availability Baseline
+
+- Internal SLO baseline: p95 response latency < 300 ms for health and capability endpoints; error rate < 1%.
+- Recovery assumptions: RTO 30 minutes, RPO 15 minutes for dependent platform data recovery.
+- Backup and restore: persistence-owning upstream services are required to expose validated backup/restore runbooks;
+  AEA validates readiness through `/health/ready` and dependency checks during platform startup.
+
 ## Deviation Rule
 
 Any deviation from this standard requires ADR/RFC with remediation timeline.


### PR DESCRIPTION
Adds explicit availability baseline (SLO/RTO/RPO/backup-restore) guidance to complete Do-Now evidence.