### PR TITLE
feat: add manage split routing toggle for proposals

### DIFF
--- a/src/app/config.py
+++ b/src/app/config.py
@@ -12,6 +12,8 @@ class Settings(BaseSettings):
     risk_analytics_base_url: str = Field(default="http://localhost:8130")
     reporting_aggregation_base_url: str = Field(default="http://localhost:8300")
     management_service_base_url: str = Field(default="http://localhost:8140")
+    risk_split_enabled: bool = Field(default=False)
+    manage_split_enabled: bool = Field(default=False)
     upstream_timeout_seconds: float = Field(default=3.0)
     upstream_max_retries: int = Field(default=2)
     upstream_retry_backoff_seconds: float = Field(default=0.2)

--- a/src/app/routers/proposals.py
+++ b/src/app/routers/proposals.py
@@ -18,9 +18,14 @@ router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
 def _proposal_service() -> ProposalService:
+    base_url = (
+        settings.management_service_base_url
+        if settings.manage_split_enabled
+        else settings.decisioning_service_base_url
+    )
     return ProposalService(
         dpm_client=DpmClient(
-            base_url=settings.decisioning_service_base_url,
+            base_url=base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,


### PR DESCRIPTION
Adds manage_split_enabled flag and routes proposal workflows to lotus-manage base URL when enabled.