### PR TITLE
Split gateway upstream routing for advise/manage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ make ci-local-docker-down
 Live platform-capabilities E2E (BFF + PAS + PA + DPM):
 
 ```bash
-export DPM_REPO_PATH=/c/Users/sande/dev/lotus-advise
+export ADVISE_REPO_PATH=/c/Users/sande/dev/lotus-advise
+export MANAGE_REPO_PATH=/c/Users/sande/dev/lotus-manage
 export PAS_REPO_PATH=/c/Users/sande/dev/lotus-core
 export PA_REPO_PATH=/c/Users/sande/dev/lotus-performance
 make e2e-up
@@ -87,4 +88,11 @@ Standards documentation:
 
 - `docs/standards/migration-contract.md`
 - `docs/standards/data-model-ownership.md`
+
+
+
+Split routing notes:
+- Advisory lifecycle APIs (/api/v1/proposals/*) use DECISIONING_SERVICE_BASE_URL (lotus-advise).
+- DPM/workbench APIs use MANAGEMENT_SERVICE_BASE_URL (lotus-manage) when MANAGE_SPLIT_ENABLED=true.
+
 

--- a/docker-compose.ci-local.yml
+++ b/docker-compose.ci-local.yml
@@ -15,6 +15,7 @@ services:
       ]
     environment:
       - DECISIONING_SERVICE_BASE_URL=http://host.docker.internal:8000
+      - MANAGEMENT_SERVICE_BASE_URL=http://host.docker.internal:8140
+      - MANAGE_SPLIT_ENABLED=true
       - UPSTREAM_TIMEOUT_SECONDS=30
       - CONTRACT_VERSION=v1
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - "8100:8100"
     environment:
       - DECISIONING_SERVICE_BASE_URL=${DECISIONING_SERVICE_BASE_URL:-http://host.docker.internal:8000}
+      - MANAGEMENT_SERVICE_BASE_URL=${MANAGEMENT_SERVICE_BASE_URL:-http://host.docker.internal:8140}
+      - MANAGE_SPLIT_ENABLED=${MANAGE_SPLIT_ENABLED:-true}
       - PORTFOLIO_DATA_PLATFORM_BASE_URL=${PORTFOLIO_DATA_PLATFORM_BASE_URL:-http://host.docker.internal:8201}
       - PORTFOLIO_DATA_INGESTION_BASE_URL=${PORTFOLIO_DATA_INGESTION_BASE_URL:-http://host.docker.internal:8200}
       - PERFORMANCE_ANALYTICS_BASE_URL=${PERFORMANCE_ANALYTICS_BASE_URL:-http://host.docker.internal:8002}
@@ -25,5 +27,3 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
-
-

--- a/src/app/routers/platform.py
+++ b/src/app/routers/platform.py
@@ -44,11 +44,15 @@ def _platform_capabilities_service() -> PlatformCapabilitiesService:
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
-        manage_client=DpmClient(
-            base_url=settings.management_service_base_url,
-            timeout_seconds=settings.upstream_timeout_seconds,
-            max_retries=settings.upstream_max_retries,
-            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        manage_client=(
+            DpmClient(
+                base_url=settings.management_service_base_url,
+                timeout_seconds=settings.upstream_timeout_seconds,
+                max_retries=settings.upstream_max_retries,
+                retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+            )
+            if settings.manage_split_enabled
+            else None
         ),
         contract_version=settings.contract_version,
     )

--- a/src/app/routers/proposals.py
+++ b/src/app/routers/proposals.py
@@ -18,11 +18,7 @@ router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
 def _proposal_service() -> ProposalService:
-    base_url = (
-        settings.management_service_base_url
-        if settings.manage_split_enabled
-        else settings.decisioning_service_base_url
-    )
+    base_url = settings.decisioning_service_base_url
     return ProposalService(
         dpm_client=DpmClient(
             base_url=base_url,

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -19,6 +19,11 @@ router = APIRouter(prefix="/api/v1/workbench", tags=["workbench"])
 
 
 def _workbench_service() -> WorkbenchService:
+    dpm_base_url = (
+        settings.management_service_base_url
+        if settings.manage_split_enabled
+        else settings.decisioning_service_base_url
+    )
     return WorkbenchService(
         pas_client=PasClient(
             base_url=settings.portfolio_data_platform_base_url,
@@ -33,7 +38,7 @@ def _workbench_service() -> WorkbenchService:
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
         dpm_client=DpmClient(
-            base_url=settings.decisioning_service_base_url,
+            base_url=dpm_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,

--- a/tests/unit/test_router_upstream_selection.py
+++ b/tests/unit/test_router_upstream_selection.py
@@ -1,0 +1,52 @@
+from app.routers.platform import _platform_capabilities_service
+from app.routers.proposals import _proposal_service
+from app.routers.workbench import _workbench_service
+
+
+def test_proposals_router_targets_advisory_base_url(monkeypatch):
+    monkeypatch.setattr(
+        "app.routers.proposals.settings.decisioning_service_base_url", "http://advise:8000"
+    )
+    monkeypatch.setattr(
+        "app.routers.proposals.settings.management_service_base_url", "http://manage:8000"
+    )
+    monkeypatch.setattr("app.routers.proposals.settings.manage_split_enabled", True)
+
+    service = _proposal_service()
+    assert service._dpm_client._base_url == "http://advise:8000"
+
+
+def test_workbench_router_targets_manage_when_split_enabled(monkeypatch):
+    monkeypatch.setattr(
+        "app.routers.workbench.settings.decisioning_service_base_url", "http://advise:8000"
+    )
+    monkeypatch.setattr(
+        "app.routers.workbench.settings.management_service_base_url", "http://manage:8000"
+    )
+    monkeypatch.setattr("app.routers.workbench.settings.manage_split_enabled", True)
+
+    service = _workbench_service()
+    assert service._dpm_client._base_url == "http://manage:8000"
+
+
+def test_workbench_router_targets_advisory_when_split_disabled(monkeypatch):
+    monkeypatch.setattr(
+        "app.routers.workbench.settings.decisioning_service_base_url", "http://advise:8000"
+    )
+    monkeypatch.setattr(
+        "app.routers.workbench.settings.management_service_base_url", "http://manage:8000"
+    )
+    monkeypatch.setattr("app.routers.workbench.settings.manage_split_enabled", False)
+
+    service = _workbench_service()
+    assert service._dpm_client._base_url == "http://advise:8000"
+
+
+def test_platform_capabilities_manage_client_obeys_split_flag(monkeypatch):
+    monkeypatch.setattr("app.routers.platform.settings.manage_split_enabled", True)
+    service = _platform_capabilities_service()
+    assert service._manage_client is not None
+
+    monkeypatch.setattr("app.routers.platform.settings.manage_split_enabled", False)
+    service = _platform_capabilities_service()
+    assert service._manage_client is None


### PR DESCRIPTION
## Summary
- route proposal lifecycle APIs to advisory service base URL
- route workbench DPM paths to manage service when split enabled
- gate optional manage capability aggregation behind manage_split_enabled
- add router-level tests for upstream selection
- expose MANAGEMENT_SERVICE_BASE_URL and MANAGE_SPLIT_ENABLED in local docker compose files

## Validation
- python -m ruff check src tests
- python -m ruff format --check src tests
- python -m mypy src
- python -m pytest tests/unit tests/integration -q