### PR TITLE
Harden advisor brief local provider integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ internal local-runtime detail until the full RFC-0071 rollout is complete.
 - `GET /api/v1/workbench/{portfolio_id}/performance/details` (lower-canvas analytical detail contract)
 - `GET /api/v1/workbench/{portfolio_id}/performance/horizon-comparison` (compact multi-horizon comparison module)
 - `GET /api/v1/workbench/{portfolio_id}/performance/attribution-trend` (benchmark-relative attribution-over-time module)
+- `GET /api/v1/workbench/{portfolio_id}/performance/advisor-brief` (source-grounded advisor brief with evidence refs and supportability)
 - `GET /api/v1/workbench/{portfolio_id}/performance` (legacy compatibility endpoint; deprecated in favor of split Performance contracts)
 - `POST /api/v1/proposals/simulate` (proxies to lotus-manage `/rebalance/proposals/simulate`)
 - `POST /api/v1/proposals` (create draft proposal via lotus-manage lifecycle create)
@@ -107,8 +108,10 @@ The current flagship performance workstation integration is served from `lotus-g
 Required upstreams:
 
 - `lotus-core` query: `http://core-query.dev.lotus`
+- `lotus-core` control plane: `http://core-control.dev.lotus`
 - `lotus-core` ingestion: `http://core-ingestion.dev.lotus`
 - `lotus-performance`: `http://performance.dev.lotus`
+- `lotus-ai`: `http://ai.dev.lotus`
 
 Example live probes:
 
@@ -120,6 +123,8 @@ curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/det
 curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/horizon-comparison?detail_basis=NET&chart_frequency=monthly&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
 
 curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/attribution-trend?period=YTD&chart_frequency=monthly&detail_basis=NET&attribution_dimension=asset_class&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+
+curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
 ```
 
 Expected benchmark catalog for the seeded flagship mandate:

--- a/docs/documentation/experience-api-foundation-blueprint.md
+++ b/docs/documentation/experience-api-foundation-blueprint.md
@@ -33,7 +33,9 @@ The gateway should own:
 2. UI-facing aggregation,
 3. graceful partial-failure behavior,
 4. workflow-friendly action contracts,
-5. supportability and evidence access for product surfaces.
+5. supportability and evidence access for product surfaces,
+6. preserved upstream provenance for AI-authored surfaces so downstream UIs can distinguish
+   managed and local provider authorship without direct provider integration.
 
 The gateway should not own:
 

--- a/src/app/clients/lotus_ai_client.py
+++ b/src/app/clients/lotus_ai_client.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.clients.http_resilience import request_with_retry
+from app.middleware.correlation import propagation_headers
+
+
+class LotusAiClient:
+    def __init__(
+        self,
+        base_url: str,
+        timeout_seconds: float,
+        max_retries: int = 2,
+        retry_backoff_seconds: float = 0.2,
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout_seconds
+        self._max_retries = max_retries
+        self._retry_backoff_seconds = retry_backoff_seconds
+
+    async def execute_task(
+        self,
+        *,
+        task_id: str,
+        caller_app: str,
+        correlation_id: str,
+        context_summary: str,
+        context_payload: dict[str, Any],
+        source_refs: list[str],
+        expected_output_label: str | None = None,
+    ) -> tuple[int, dict[str, Any]]:
+        request_payload: dict[str, Any] = {
+            "task_id": task_id,
+            "input_mode": "STRUCTURED_CONTEXT",
+            "caller": {
+                "caller_app": caller_app,
+                "correlation_id": correlation_id,
+            },
+            "context": {
+                "summary": context_summary,
+                "payload": context_payload,
+                "source_refs": source_refs,
+            },
+        }
+        if expected_output_label:
+            request_payload["expected_output_label"] = expected_output_label
+
+        return await request_with_retry(
+            method="POST",
+            url=f"{self._base_url}/ai/tasks/execute",
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            json_body=request_payload,
+            headers=propagation_headers(correlation_id),
+            retry_timeout_exceptions=False,
+        )

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -37,6 +37,7 @@ class Settings(BaseSettings):
     upstream_max_retries: int = Field(default=2)
     upstream_retry_backoff_seconds: float = Field(default=0.2)
     portfolio_upstream_cache_ttl_seconds: float = Field(default=5.0)
+    advisor_brief_cache_ttl_seconds: float = Field(default=30.0)
 
 
 settings = Settings()

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -33,7 +33,7 @@ class Settings(BaseSettings):
     manage_split_enabled: bool = Field(default=True)
     upstream_timeout_seconds: float = Field(default=3.0)
     performance_analytics_timeout_seconds: float = Field(default=15.0)
-    ai_service_timeout_seconds: float = Field(default=15.0)
+    ai_service_timeout_seconds: float = Field(default=45.0)
     upstream_max_retries: int = Field(default=2)
     upstream_retry_backoff_seconds: float = Field(default=0.2)
     portfolio_upstream_cache_ttl_seconds: float = Field(default=5.0)

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("PORTFOLIO_DATA_INGESTION_BASE_URL"),
     )
     performance_analytics_base_url: str = Field(default="http://performance.dev.lotus")
+    ai_service_base_url: str = Field(default="http://ai.dev.lotus")
     risk_analytics_base_url: str = Field(default="http://risk.dev.lotus")
     reporting_aggregation_base_url: str = Field(default="http://report.dev.lotus")
     management_service_base_url: str = Field(default="http://manage.dev.lotus")
@@ -32,6 +33,7 @@ class Settings(BaseSettings):
     manage_split_enabled: bool = Field(default=True)
     upstream_timeout_seconds: float = Field(default=3.0)
     performance_analytics_timeout_seconds: float = Field(default=15.0)
+    ai_service_timeout_seconds: float = Field(default=15.0)
     upstream_max_retries: int = Field(default=2)
     upstream_retry_backoff_seconds: float = Field(default=0.2)
     portfolio_upstream_cache_ttl_seconds: float = Field(default=5.0)

--- a/src/app/contracts/advisor_brief.py
+++ b/src/app/contracts/advisor_brief.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.contracts.workbench import WorkbenchPartialFailure, WorkbenchPortfolioSummary
+
+
+class AdvisorBriefStatus(str, Enum):
+    READY = "ready"
+    PARTIAL = "partial"
+    UNAVAILABLE = "unavailable"
+
+
+class AdvisorBriefTone(str, Enum):
+    POSITIVE = "positive"
+    NEUTRAL = "neutral"
+    WARNING = "warning"
+
+
+class AdvisorBriefEvidenceRef(BaseModel):
+    metric_label: str
+    metric_value: str
+    source_surface: str
+    target_mode: str
+    route: str
+
+
+class AdvisorBriefNarrativeItem(BaseModel):
+    headline: str
+    detail: str
+    tone: AdvisorBriefTone
+    evidence_refs: list[AdvisorBriefEvidenceRef] = Field(default_factory=list)
+
+
+class AdvisorBriefActionItem(BaseModel):
+    label: str
+    target_mode: str
+    route: str
+
+
+class AdvisorBriefSourceMetric(BaseModel):
+    label: str
+    value: str
+    support_label: str
+    target_mode: str
+    route: str
+    state: str = "ready"
+
+
+class AdvisorBriefSupportabilityItem(BaseModel):
+    label: str
+    value: str
+    tone: str = "default"
+    reason: str | None = None
+
+
+class AdvisorBriefResponse(BaseModel):
+    correlation_id: str
+    contract_version: str = Field(default="v1")
+    portfolio_id: str
+    portfolio: WorkbenchPortfolioSummary
+    as_of_date: str
+    period: str
+    report_start_date: str
+    report_end_date: str
+    detail_basis: str
+    chart_frequency: str
+    contribution_dimension: str
+    attribution_dimension: str
+    benchmark_code: str | None = None
+    status: AdvisorBriefStatus
+    summary: str
+    talking_points: list[AdvisorBriefNarrativeItem] = Field(default_factory=list)
+    recommended_actions: list[AdvisorBriefActionItem] = Field(default_factory=list)
+    risks_and_exceptions: list[AdvisorBriefNarrativeItem] = Field(default_factory=list)
+    source_metrics: list[AdvisorBriefSourceMetric] = Field(default_factory=list)
+    supportability: list[AdvisorBriefSupportabilityItem] = Field(default_factory=list)
+    ai_audit: dict[str, Any] = Field(default_factory=dict)
+    ai_evidence: dict[str, Any] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+    partial_failures: list[WorkbenchPartialFailure] = Field(default_factory=list)

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -54,6 +54,7 @@ def _service_signature() -> tuple[object, ...]:
         settings.upstream_max_retries,
         settings.upstream_retry_backoff_seconds,
         settings.portfolio_upstream_cache_ttl_seconds,
+        settings.advisor_brief_cache_ttl_seconds,
     )
 
 
@@ -148,6 +149,7 @@ def _build_advisor_brief_service(
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
+        cache_ttl_seconds=settings.advisor_brief_cache_ttl_seconds,
     )
 
 

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter
 
 from app.clients.dpm_client import DpmClient
+from app.clients.lotus_ai_client import LotusAiClient
 from app.clients.lotus_analytics_client import LotusAnalyticsClient
 from app.clients.lotus_core_query_client import LotusCoreQueryClient
 from app.config import settings
+from app.contracts.advisor_brief import AdvisorBriefResponse
 from app.contracts.performance_workspace import (
     PerformanceAttributionTrendResponse,
     PerformanceHorizonComparisonResponse,
@@ -20,6 +22,7 @@ from app.contracts.workbench import (
     WorkbenchSandboxStateResponse,
 )
 from app.middleware.correlation import correlation_id_var
+from app.services.advisor_brief_service import AdvisorBriefService
 from app.services.performance_workspace_service import PerformanceWorkspaceService
 from app.services.workbench_service import WorkbenchService
 
@@ -30,6 +33,8 @@ _WORKBENCH_SERVICE: WorkbenchService | None = None
 _WORKBENCH_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 _PERFORMANCE_WORKSPACE_SERVICE: PerformanceWorkspaceService | None = None
 _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_ADVISOR_BRIEF_SERVICE: AdvisorBriefService | None = None
+_ADVISOR_BRIEF_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 
 
 def _service_signature() -> tuple[object, ...]:
@@ -37,6 +42,7 @@ def _service_signature() -> tuple[object, ...]:
         settings.portfolio_data_query_base_url,
         settings.portfolio_data_control_plane_base_url,
         settings.performance_analytics_base_url,
+        settings.ai_service_base_url,
         settings.management_service_base_url,
         settings.decisioning_service_base_url,
         settings.risk_analytics_base_url,
@@ -44,6 +50,7 @@ def _service_signature() -> tuple[object, ...]:
         settings.risk_split_enabled,
         settings.upstream_timeout_seconds,
         settings.performance_analytics_timeout_seconds,
+        settings.ai_service_timeout_seconds,
         settings.upstream_max_retries,
         settings.upstream_retry_backoff_seconds,
         settings.portfolio_upstream_cache_ttl_seconds,
@@ -128,6 +135,31 @@ def _performance_workspace_service() -> PerformanceWorkspaceService:
         _PERFORMANCE_WORKSPACE_SERVICE = _build_performance_workspace_service(_workbench_service())
         _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE = signature
     return _PERFORMANCE_WORKSPACE_SERVICE
+
+
+def _build_advisor_brief_service(
+    performance_workspace_service: PerformanceWorkspaceService,
+) -> AdvisorBriefService:
+    return AdvisorBriefService(
+        performance_workspace_service=performance_workspace_service,
+        lotus_ai_client=LotusAiClient(
+            base_url=settings.ai_service_base_url,
+            timeout_seconds=settings.ai_service_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+    )
+
+
+def _advisor_brief_service() -> AdvisorBriefService:
+    global _ADVISOR_BRIEF_SERVICE, _ADVISOR_BRIEF_SERVICE_SIGNATURE
+    signature = _service_signature()
+    if _ADVISOR_BRIEF_SERVICE is None or _ADVISOR_BRIEF_SERVICE_SIGNATURE != signature:
+        _ADVISOR_BRIEF_SERVICE = _build_advisor_brief_service(
+            _performance_workspace_service()
+        )
+        _ADVISOR_BRIEF_SERVICE_SIGNATURE = signature
+    return _ADVISOR_BRIEF_SERVICE
 
 
 @router.get(
@@ -366,6 +398,42 @@ async def get_performance_workspace(
     service = _performance_workspace_service()
     correlation_id = correlation_id_var.get()
     return await service.get_performance_workspace(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+        period=period,
+        chart_frequency=chart_frequency,
+        contribution_dimension=contribution_dimension,
+        attribution_dimension=attribution_dimension,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        explicit_start_date=report_start_date,
+        explicit_end_date=report_end_date,
+    )
+
+
+@router.get(
+    "/{portfolio_id}/performance/advisor-brief",
+    response_model=AdvisorBriefResponse,
+    summary="Get Performance Advisor Brief",
+    description=(
+        "Returns a source-grounded advisor brief assembled from the performance workspace "
+        "contract and narrated through lotus-ai with audit and evidence metadata preserved."
+    ),
+)
+async def get_performance_advisor_brief(
+    portfolio_id: str,
+    period: str = "YTD",
+    chart_frequency: str = "monthly",
+    contribution_dimension: str = "asset_class",
+    attribution_dimension: str = "asset_class",
+    detail_basis: str = "NET",
+    benchmark_code: str | None = None,
+    report_start_date: str | None = None,
+    report_end_date: str | None = None,
+) -> AdvisorBriefResponse:
+    service = _advisor_brief_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_performance_advisor_brief(
         portfolio_id=portfolio_id,
         correlation_id=correlation_id,
         period=period,

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -535,14 +535,15 @@ def _to_supportability_item(
     state: str,
     reason: str | None,
 ) -> AdvisorBriefSupportabilityItem:
-    if state == "ready":
+    normalized_state = state.strip().lower()
+    if normalized_state in {"ready", "supported"}:
         return AdvisorBriefSupportabilityItem(
             label=label,
             value="Ready",
             tone="success",
             reason=reason,
         )
-    if state == "partial":
+    if normalized_state == "partial":
         return AdvisorBriefSupportabilityItem(
             label=label,
             value="Partial",

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -110,7 +110,48 @@ class AdvisorBriefService:
                     expected_output_label=_EXPECTED_OUTPUT_LABEL,
                 )
             if ai_status == 200 and ai_payload.get("status") == "COMPLETED":
-                source_summary = _extract_ai_summary(ai_payload=ai_payload) or source_summary
+                result = _safe_dict(ai_payload.get("result"))
+                structured_output = _safe_dict(result.get("structured_output"))
+                source_summary = (
+                    _extract_ai_summary(ai_payload=ai_payload, structured_output=structured_output)
+                    or source_summary
+                )
+                talking_points = (
+                    _extract_ai_talking_points(
+                        structured_output=structured_output,
+                        route=_route_query(
+                            portfolio_id=workspace.portfolio_id,
+                            period=workspace.period,
+                            basis=workspace.detail_basis,
+                            benchmark_code=workspace.benchmark_code,
+                        ),
+                    )
+                    or talking_points
+                )
+                recommended_actions = (
+                    _extract_ai_recommended_actions(
+                        structured_output=structured_output,
+                        route=_route_query(
+                            portfolio_id=workspace.portfolio_id,
+                            period=workspace.period,
+                            basis=workspace.detail_basis,
+                            benchmark_code=workspace.benchmark_code,
+                        ),
+                    )
+                    or recommended_actions
+                )
+                risks_and_exceptions = (
+                    _extract_ai_risks(
+                        structured_output=structured_output,
+                        route=_route_query(
+                            portfolio_id=workspace.portfolio_id,
+                            period=workspace.period,
+                            basis=workspace.detail_basis,
+                            benchmark_code=workspace.benchmark_code,
+                        ),
+                    )
+                    or risks_and_exceptions
+                )
                 ai_audit = _safe_dict(ai_payload.get("audit"))
                 ai_evidence = _safe_dict(ai_payload.get("evidence")) or {"descriptors": []}
             else:
@@ -190,7 +231,10 @@ def _build_ai_fact_bundle(
     contribution = workspace.contribution
     attribution = workspace.attribution
     return {
-        "portfolio": workspace.portfolio.model_dump(mode="json"),
+        "portfolio": {
+            **workspace.portfolio.model_dump(mode="json"),
+            "display_label": _portfolio_display_label(workspace=workspace),
+        },
         "period": {
             "period": workspace.period,
             "report_start_date": workspace.report_start_date,
@@ -200,6 +244,7 @@ def _build_ai_fact_bundle(
         },
         "benchmark": {
             "benchmark_code": workspace.benchmark_code,
+            "benchmark_name": _benchmark_display_label(workspace=workspace),
             "benchmark_return_pct": selected_performance.benchmark_return_pct,
         },
         "performance": {
@@ -219,12 +264,18 @@ def _build_ai_fact_bundle(
                 contribution.portfolio_contribution_pct if contribution else None
             ),
             "coverage_mv_pct": contribution.coverage_mv_pct if contribution else None,
-            "top_positions": [
-                row.model_dump(mode="json")
+                "top_positions": [
+                {
+                    **row.model_dump(mode="json"),
+                    "display_label": _normalize_position_label(row.position_id),
+                }
                 for row in _positive_position_contributors(contribution=contribution)[:5]
             ],
             "bottom_positions": [
-                row.model_dump(mode="json")
+                {
+                    **row.model_dump(mode="json"),
+                    "display_label": _normalize_position_label(row.position_id),
+                }
                 for row in _negative_position_contributors(contribution=contribution)[:5]
             ],
         },
@@ -255,19 +306,178 @@ def _build_source_summary(
         return (
             "No source-backed advisor brief can be generated from the current performance "
             "selection."
-        )
+    )
     return (
-        f"{workspace.period} portfolio return is {portfolio_return} versus benchmark "
-        f"{benchmark_return}, with active return {active_return}."
+        f"{workspace.period} portfolio return for {_portfolio_display_label(workspace=workspace)} "
+        f"is {portfolio_return} versus "
+        f"{_benchmark_display_label(workspace=workspace) or 'benchmark'} {benchmark_return}, "
+        f"with active return {active_return}."
     )
 
 
-def _extract_ai_summary(*, ai_payload: dict[str, Any]) -> str | None:
+def _extract_ai_summary(
+    *,
+    ai_payload: dict[str, Any],
+    structured_output: dict[str, Any] | None = None,
+) -> str | None:
+    output_payload = structured_output or _safe_dict(
+        _safe_dict(ai_payload.get("result")).get("structured_output")
+    )
+    summary = output_payload.get("grounded_summary")
+    if isinstance(summary, str) and summary.strip():
+        return summary.strip()
     result = _safe_dict(ai_payload.get("result"))
     message = result.get("message")
     if isinstance(message, str) and message.strip():
         return message.strip()
     return None
+
+
+def _extract_ai_talking_points(
+    *,
+    structured_output: dict[str, Any],
+    route: str,
+) -> list[AdvisorBriefNarrativeItem]:
+    return [
+        item
+        for item in (
+            _parse_ai_narrative_item(value=value, route=route, default_mode="summary")
+            for value in _safe_list(structured_output.get("talking_points"))
+        )
+        if item is not None
+    ]
+
+
+def _extract_ai_risks(
+    *,
+    structured_output: dict[str, Any],
+    route: str,
+) -> list[AdvisorBriefNarrativeItem]:
+    return [
+        item
+        for item in (
+            _parse_ai_narrative_item(value=value, route=route, default_mode="analysis")
+            for value in _safe_list(structured_output.get("risks_and_exceptions"))
+        )
+        if item is not None
+    ]
+
+
+def _extract_ai_recommended_actions(
+    *,
+    structured_output: dict[str, Any],
+    route: str,
+) -> list[AdvisorBriefActionItem]:
+    actions: list[AdvisorBriefActionItem] = []
+    for value in _safe_list(structured_output.get("recommended_actions")):
+        item = _safe_dict(value)
+        label = item.get("label")
+        if not isinstance(label, str) or not label.strip():
+            continue
+        actions.append(
+            AdvisorBriefActionItem(
+                label=label.strip(),
+                target_mode=_infer_target_mode_from_text(label),
+                route=route,
+            )
+        )
+    return actions
+
+
+def _parse_ai_narrative_item(
+    *,
+    value: Any,
+    route: str,
+    default_mode: str,
+) -> AdvisorBriefNarrativeItem | None:
+    item = _safe_dict(value)
+    headline = item.get("headline")
+    detail = item.get("detail")
+    if not isinstance(headline, str) or not headline.strip():
+        return None
+    if not isinstance(detail, str) or not detail.strip():
+        return None
+    tone = _normalize_narrative_tone(item.get("tone"))
+    evidence_refs = [
+        ref
+        for ref in (
+            _parse_ai_evidence_ref(value=ref_value, route=route, default_mode=default_mode)
+            for ref_value in _safe_list(item.get("evidence_refs"))
+        )
+        if ref is not None
+    ]
+    if not evidence_refs:
+        evidence_refs = [
+            AdvisorBriefEvidenceRef(
+                metric_label="Advisor Brief",
+                metric_value="Source-Grounded",
+                source_surface="performance.advisor_brief",
+                target_mode=default_mode,
+                route=route,
+            )
+        ]
+    return AdvisorBriefNarrativeItem(
+        headline=headline.strip(),
+        detail=detail.strip(),
+        tone=tone,
+        evidence_refs=evidence_refs,
+    )
+
+
+def _parse_ai_evidence_ref(
+    *,
+    value: Any,
+    route: str,
+    default_mode: str,
+) -> AdvisorBriefEvidenceRef | None:
+    item = _safe_dict(value)
+    metric_label = item.get("metric_label")
+    metric_value = item.get("metric_value")
+    if not isinstance(metric_label, str) or not metric_label.strip():
+        return None
+    if not isinstance(metric_value, str) or not metric_value.strip():
+        return None
+    source_ref = _safe_str(item.get("source_ref")) or _safe_str(item.get("source_surface"))
+    source_surface = _infer_source_surface(source_ref) if source_ref else "performance.advisor_brief"
+    return AdvisorBriefEvidenceRef(
+        metric_label=metric_label.strip(),
+        metric_value=metric_value.strip(),
+        source_surface=source_surface,
+        target_mode=_infer_target_mode(source_surface=source_surface, default_mode=default_mode),
+        route=route,
+    )
+
+
+def _normalize_narrative_tone(value: Any) -> AdvisorBriefTone:
+    if value == AdvisorBriefTone.POSITIVE.value:
+        return AdvisorBriefTone.POSITIVE
+    if value == AdvisorBriefTone.WARNING.value:
+        return AdvisorBriefTone.WARNING
+    return AdvisorBriefTone.NEUTRAL
+
+
+def _infer_target_mode(*, source_surface: str, default_mode: str) -> str:
+    return "summary" if source_surface == "performance.return_path" else default_mode
+
+
+def _infer_target_mode_from_text(label: str) -> str:
+    normalized = label.strip().lower()
+    if "return" in normalized:
+        return "summary"
+    return "analysis"
+
+
+def _infer_source_surface(source_ref: str | None) -> str:
+    if not source_ref:
+        return "performance.advisor_brief"
+    normalized = source_ref.lower()
+    if "performance-summary" in normalized:
+        return "performance.return_path"
+    if "performance-details" in normalized or "contribution" in normalized:
+        return "performance.contribution"
+    if "benchmark" in normalized or "attribution" in normalized:
+        return "performance.attribution"
+    return "performance.advisor_brief"
 
 
 def _build_source_talking_points(
@@ -313,16 +523,20 @@ def _build_source_talking_points(
     if top_position:
         points.append(
             AdvisorBriefNarrativeItem(
-                headline=f"Top contributor is {top_position[0].position_id}.",
+                headline=(
+                    f"Top contributor is "
+                    f"{_normalize_position_label(top_position[0].position_id)}."
+                ),
                 detail=(
-                    f"Contribution is {_format_pct(top_position[0].contribution_pct)} "
-                    f"with return {_format_pct(top_position[0].total_return_pct)}."
+                    f"{_normalize_position_label(top_position[0].position_id)} contributed "
+                    f"{_format_pct(top_position[0].contribution_pct)} with return "
+                    f"{_format_pct(top_position[0].total_return_pct)}."
                 ),
                 tone=AdvisorBriefTone.POSITIVE,
                 evidence_refs=[
                     _analysis_evidence_ref(
                         label="Top Contributor",
-                        value=top_position[0].position_id,
+                        value=_normalize_position_label(top_position[0].position_id),
                         portfolio_id=workspace.portfolio_id,
                         period=workspace.period,
                         basis=workspace.detail_basis,
@@ -336,16 +550,20 @@ def _build_source_talking_points(
     if bottom_position:
         points.append(
             AdvisorBriefNarrativeItem(
-                headline=f"Top detractor is {bottom_position[0].position_id}.",
+                headline=(
+                    f"Top detractor is "
+                    f"{_normalize_position_label(bottom_position[0].position_id)}."
+                ),
                 detail=(
-                    f"Contribution is {_format_pct(bottom_position[0].contribution_pct)} "
-                    f"with return {_format_pct(bottom_position[0].total_return_pct)}."
+                    f"{_normalize_position_label(bottom_position[0].position_id)} contributed "
+                    f"{_format_pct(bottom_position[0].contribution_pct)} with return "
+                    f"{_format_pct(bottom_position[0].total_return_pct)}."
                 ),
                 tone=AdvisorBriefTone.WARNING,
                 evidence_refs=[
                     _analysis_evidence_ref(
                         label="Top Detractor",
-                        value=bottom_position[0].position_id,
+                        value=_normalize_position_label(bottom_position[0].position_id),
                         portfolio_id=workspace.portfolio_id,
                         period=workspace.period,
                         basis=workspace.detail_basis,
@@ -694,8 +912,40 @@ def _safe_dict(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _safe_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_str(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def _safe_error_detail(payload: dict[str, Any]) -> str:
     detail = payload.get("detail")
     if isinstance(detail, str) and detail.strip():
         return detail.strip()
     return "lotus-ai task execution did not return a completed advisor brief."
+
+
+def _normalize_position_label(position_id: str) -> str:
+    display_label = position_id.rsplit(":", 1)[-1].strip()
+    for prefix in ("FO_EQ_", "FO_FI_", "FO_CASH_", "FO_ALT_", "FO_FX_"):
+        if display_label.startswith(prefix):
+            display_label = display_label[len(prefix):]
+            break
+    return display_label.replace("_", " ").strip() or position_id
+
+
+def _portfolio_display_label(*, workspace: PerformanceWorkspaceResponse) -> str:
+    return _normalize_position_label(workspace.portfolio.portfolio_id)
+
+
+def _benchmark_display_label(*, workspace: PerformanceWorkspaceResponse) -> str | None:
+    if not workspace.benchmark_code:
+        return None
+    for option in workspace.benchmark_options:
+        if option.benchmark_code == workspace.benchmark_code:
+            return option.benchmark_name.strip() or workspace.benchmark_code
+    return workspace.benchmark_code

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -20,6 +20,7 @@ from app.contracts.performance_workspace import (
     PerformanceComparativeSummary,
     PerformanceWorkspaceResponse,
 )
+from app.middleware.server_timing import server_timing_span
 from app.services.performance_workspace_service import PerformanceWorkspaceService
 
 _TASK_ID = "explain.v1"
@@ -50,18 +51,21 @@ class AdvisorBriefService:
         explicit_start_date: str | None = None,
         explicit_end_date: str | None = None,
     ) -> AdvisorBriefResponse:
-        workspace = await self._performance_workspace_service.get_performance_workspace(
-            portfolio_id=portfolio_id,
-            correlation_id=correlation_id,
-            period=period,
-            chart_frequency=chart_frequency,
-            contribution_dimension=contribution_dimension,
-            attribution_dimension=attribution_dimension,
-            detail_basis=detail_basis,
-            benchmark_code=benchmark_code,
-            explicit_start_date=explicit_start_date,
-            explicit_end_date=explicit_end_date,
-        )
+        async with server_timing_span("perf-advisor-brief-source"):
+            workspace = (
+                await self._performance_workspace_service.get_performance_workspace(
+                    portfolio_id=portfolio_id,
+                    correlation_id=correlation_id,
+                    period=period,
+                    chart_frequency=chart_frequency,
+                    contribution_dimension=contribution_dimension,
+                    attribution_dimension=attribution_dimension,
+                    detail_basis=detail_basis,
+                    benchmark_code=benchmark_code,
+                    explicit_start_date=explicit_start_date,
+                    explicit_end_date=explicit_end_date,
+                )
+            )
 
         selected_performance = (
             workspace.net_performance
@@ -89,21 +93,22 @@ class AdvisorBriefService:
         ai_evidence: dict[str, Any] = {"descriptors": []}
 
         if status is not AdvisorBriefStatus.UNAVAILABLE:
-            ai_status, ai_payload = await self._lotus_ai_client.execute_task(
-                task_id=_TASK_ID,
-                caller_app="lotus-gateway",
-                correlation_id=correlation_id,
-                context_summary=(
-                    f"Advisor brief context for portfolio {workspace.portfolio_id}, "
-                    f"{workspace.period} period, basis {workspace.detail_basis}."
-                ),
-                context_payload=_build_ai_fact_bundle(
-                    workspace=workspace,
-                    selected_performance=selected_performance,
-                ),
-                source_refs=source_refs,
-                expected_output_label=_EXPECTED_OUTPUT_LABEL,
-            )
+            async with server_timing_span("perf-advisor-brief-ai"):
+                ai_status, ai_payload = await self._lotus_ai_client.execute_task(
+                    task_id=_TASK_ID,
+                    caller_app="lotus-gateway",
+                    correlation_id=correlation_id,
+                    context_summary=(
+                        f"Advisor brief context for portfolio {workspace.portfolio_id}, "
+                        f"{workspace.period} period, basis {workspace.detail_basis}."
+                    ),
+                    context_payload=_build_ai_fact_bundle(
+                        workspace=workspace,
+                        selected_performance=selected_performance,
+                    ),
+                    source_refs=source_refs,
+                    expected_output_label=_EXPECTED_OUTPUT_LABEL,
+                )
             if ai_status == 200 and ai_payload.get("status") == "COMPLETED":
                 source_summary = _extract_ai_summary(ai_payload=ai_payload) or source_summary
                 ai_audit = _safe_dict(ai_payload.get("audit"))

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -89,7 +89,7 @@ class AdvisorBriefService:
             workspace=workspace,
             supportability=supportability,
         )
-        ai_audit: dict[str, Any] = {}
+        ai_audit: dict[str, Any] = _normalize_ai_audit({})
         ai_evidence: dict[str, Any] = {"descriptors": []}
 
         if status is not AdvisorBriefStatus.UNAVAILABLE:
@@ -152,20 +152,25 @@ class AdvisorBriefService:
                     )
                     or risks_and_exceptions
                 )
-                ai_audit = _safe_dict(ai_payload.get("audit"))
+                ai_audit = _normalize_ai_audit(_safe_dict(ai_payload.get("audit")))
                 ai_evidence = _safe_dict(ai_payload.get("evidence")) or {"descriptors": []}
             else:
                 status = AdvisorBriefStatus.PARTIAL
-                ai_audit = {
-                    "task_id": _TASK_ID,
-                    "output_label": _EXPECTED_OUTPUT_LABEL,
-                    "provider_mode": "unavailable",
-                    "detail": _safe_error_detail(ai_payload),
-                }
+                ai_audit = _normalize_ai_audit(
+                    {
+                        "task_id": _TASK_ID,
+                        "output_label": _EXPECTED_OUTPUT_LABEL,
+                        "provider_mode": "unavailable",
+                        "detail": _safe_error_detail(ai_payload),
+                    }
+                )
                 risks_and_exceptions.append(
                     AdvisorBriefNarrativeItem(
                         headline="AI narrative generation is unavailable.",
-                        detail="Source-backed metrics remain available for manual review and client prep.",
+                        detail=(
+                            "Source-backed metrics remain available for manual review and "
+                            "client prep."
+                        ),
                         tone=AdvisorBriefTone.WARNING,
                         evidence_refs=[
                             _summary_evidence_ref(
@@ -209,6 +214,20 @@ class AdvisorBriefService:
             warnings=workspace.warnings,
             partial_failures=workspace.partial_failures,
         )
+
+
+def _normalize_ai_audit(audit: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(audit)
+    normalized.setdefault("task_id", _TASK_ID)
+    normalized.setdefault("output_label", _EXPECTED_OUTPUT_LABEL)
+    normalized.setdefault("provider_mode", "unknown")
+    normalized.setdefault("provider_id", None)
+    normalized.setdefault("adapter_kind", None)
+    normalized.setdefault("model_id", None)
+    normalized.setdefault("generated_at", None)
+    normalized.setdefault("stubbed", True)
+    normalized.setdefault("source_refs", [])
+    return normalized
 
 
 def _build_source_refs(*, workspace: PerformanceWorkspaceResponse) -> list[str]:
@@ -285,7 +304,10 @@ def _build_ai_fact_bundle(
             "residual_pct": attribution.residual_pct if attribution else None,
             "top_effects": _top_attribution_effects(attribution=attribution),
         },
-        "supportability": [item.model_dump(mode="json") for item in _build_supportability(workspace=workspace)],
+        "supportability": [
+            item.model_dump(mode="json")
+            for item in _build_supportability(workspace=workspace)
+        ],
         "warnings": workspace.warnings,
         "partial_failures": [item.model_dump(mode="json") for item in workspace.partial_failures],
     }
@@ -438,7 +460,9 @@ def _parse_ai_evidence_ref(
     if not isinstance(metric_value, str) or not metric_value.strip():
         return None
     source_ref = _safe_str(item.get("source_ref")) or _safe_str(item.get("source_surface"))
-    source_surface = _infer_source_surface(source_ref) if source_ref else "performance.advisor_brief"
+    source_surface = (
+        _infer_source_surface(source_ref) if source_ref else "performance.advisor_brief"
+    )
     return AdvisorBriefEvidenceRef(
         metric_label=metric_label.strip(),
         metric_value=metric_value.strip(),

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -21,6 +21,7 @@ from app.contracts.performance_workspace import (
     PerformanceWorkspaceResponse,
 )
 from app.middleware.server_timing import server_timing_span
+from app.services.async_ttl_cache import AsyncTtlCache
 from app.services.performance_workspace_service import PerformanceWorkspaceService
 
 _TASK_ID = "explain.v1"
@@ -33,9 +34,14 @@ class AdvisorBriefService:
         *,
         performance_workspace_service: PerformanceWorkspaceService,
         lotus_ai_client: LotusAiClient,
+        cache_ttl_seconds: float = 30.0,
     ):
         self._performance_workspace_service = performance_workspace_service
         self._lotus_ai_client = lotus_ai_client
+        self._response_cache = AsyncTtlCache[AdvisorBriefResponse](ttl_seconds=cache_ttl_seconds)
+
+    def clear_cache(self) -> None:
+        self._response_cache.clear()
 
     async def get_performance_advisor_brief(
         self,
@@ -51,20 +57,60 @@ class AdvisorBriefService:
         explicit_start_date: str | None = None,
         explicit_end_date: str | None = None,
     ) -> AdvisorBriefResponse:
+        cache_key = (
+            "advisor_brief",
+            portfolio_id,
+            period,
+            chart_frequency,
+            contribution_dimension,
+            attribution_dimension,
+            detail_basis,
+            benchmark_code or "",
+            explicit_start_date or "",
+            explicit_end_date or "",
+        )
+        return await self._response_cache.get_or_set(
+            key=cache_key,
+            factory=lambda: self._build_performance_advisor_brief(
+                portfolio_id=portfolio_id,
+                correlation_id=correlation_id,
+                period=period,
+                chart_frequency=chart_frequency,
+                contribution_dimension=contribution_dimension,
+                attribution_dimension=attribution_dimension,
+                detail_basis=detail_basis,
+                benchmark_code=benchmark_code,
+                explicit_start_date=explicit_start_date,
+                explicit_end_date=explicit_end_date,
+            ),
+        )
+
+    async def _build_performance_advisor_brief(
+        self,
+        *,
+        portfolio_id: str,
+        correlation_id: str,
+        period: str,
+        chart_frequency: str,
+        contribution_dimension: str,
+        attribution_dimension: str,
+        detail_basis: str,
+        benchmark_code: str | None,
+        explicit_start_date: str | None = None,
+        explicit_end_date: str | None = None,
+    ) -> AdvisorBriefResponse:
         async with server_timing_span("perf-advisor-brief-source"):
-            workspace = (
-                await self._performance_workspace_service.get_performance_workspace(
-                    portfolio_id=portfolio_id,
-                    correlation_id=correlation_id,
-                    period=period,
-                    chart_frequency=chart_frequency,
-                    contribution_dimension=contribution_dimension,
-                    attribution_dimension=attribution_dimension,
-                    detail_basis=detail_basis,
-                    benchmark_code=benchmark_code,
-                    explicit_start_date=explicit_start_date,
-                    explicit_end_date=explicit_end_date,
-                )
+            workspace = await self._performance_workspace_service.get_performance_workspace(
+                portfolio_id=portfolio_id,
+                correlation_id=correlation_id,
+                period=period,
+                chart_frequency=chart_frequency,
+                contribution_dimension=contribution_dimension,
+                attribution_dimension=attribution_dimension,
+                detail_basis=detail_basis,
+                benchmark_code=benchmark_code,
+                explicit_start_date=explicit_start_date,
+                explicit_end_date=explicit_end_date,
             )
 
         selected_performance = (

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -250,10 +250,7 @@ def _build_ai_fact_bundle(
     contribution = workspace.contribution
     attribution = workspace.attribution
     return {
-        "portfolio": {
-            **workspace.portfolio.model_dump(mode="json"),
-            "display_label": _portfolio_display_label(workspace=workspace),
-        },
+        "portfolio": _build_ai_portfolio_context(workspace=workspace),
         "period": {
             "period": workspace.period,
             "report_start_date": workspace.report_start_date,
@@ -283,18 +280,12 @@ def _build_ai_fact_bundle(
                 contribution.portfolio_contribution_pct if contribution else None
             ),
             "coverage_mv_pct": contribution.coverage_mv_pct if contribution else None,
-                "top_positions": [
-                {
-                    **row.model_dump(mode="json"),
-                    "display_label": _normalize_position_label(row.position_id),
-                }
+            "top_positions": [
+                _build_ai_contribution_position(row=row)
                 for row in _positive_position_contributors(contribution=contribution)[:5]
             ],
             "bottom_positions": [
-                {
-                    **row.model_dump(mode="json"),
-                    "display_label": _normalize_position_label(row.position_id),
-                }
+                _build_ai_contribution_position(row=row)
                 for row in _negative_position_contributors(contribution=contribution)[:5]
             ],
         },
@@ -310,6 +301,33 @@ def _build_ai_fact_bundle(
         ],
         "warnings": workspace.warnings,
         "partial_failures": [item.model_dump(mode="json") for item in workspace.partial_failures],
+    }
+
+
+def _build_ai_portfolio_context(
+    *,
+    workspace: PerformanceWorkspaceResponse,
+) -> dict[str, Any]:
+    return {
+        "portfolio_id": workspace.portfolio_id,
+        "display_label": _portfolio_display_label(workspace=workspace),
+        "base_currency": workspace.portfolio.base_currency,
+        "booking_center_code": workspace.portfolio.booking_center_code,
+        "client_id": workspace.portfolio.client_id,
+    }
+
+
+def _build_ai_contribution_position(
+    *,
+    row: ContributionPositionView,
+) -> dict[str, Any]:
+    return {
+        "display_label": _normalize_position_label(row.position_id),
+        "contribution_pct": row.contribution_pct,
+        "weight_avg_pct": row.weight_avg_pct,
+        "total_return_pct": row.total_return_pct,
+        "local_contribution_pct": row.local_contribution_pct,
+        "fx_contribution_pct": row.fx_contribution_pct,
     }
 
 
@@ -850,7 +868,17 @@ def _top_attribution_effects(
         if row.total_effect_pct is not None
     ]
     return [
-        row.model_dump(mode="json")
+        {
+            "segment_label": row.key_label,
+            "total_effect_pct": row.total_effect_pct,
+            "allocation_pct": row.allocation_pct,
+            "selection_pct": row.selection_pct,
+            "interaction_pct": row.interaction_pct,
+            "portfolio_weight_avg_pct": row.portfolio_weight_avg_pct,
+            "benchmark_weight_avg_pct": row.benchmark_weight_avg_pct,
+            "portfolio_return_pct": row.portfolio_return_pct,
+            "benchmark_return_pct": row.benchmark_return_pct,
+        }
         for row in sorted(
             rows,
             key=lambda row: abs(row.total_effect_pct),

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -1,0 +1,695 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.clients.lotus_ai_client import LotusAiClient
+from app.contracts.advisor_brief import (
+    AdvisorBriefActionItem,
+    AdvisorBriefEvidenceRef,
+    AdvisorBriefNarrativeItem,
+    AdvisorBriefResponse,
+    AdvisorBriefSourceMetric,
+    AdvisorBriefStatus,
+    AdvisorBriefSupportabilityItem,
+    AdvisorBriefTone,
+)
+from app.contracts.performance_workspace import (
+    AttributionSummaryView,
+    ContributionPositionView,
+    ContributionSummaryView,
+    PerformanceComparativeSummary,
+    PerformanceWorkspaceResponse,
+)
+from app.services.performance_workspace_service import PerformanceWorkspaceService
+
+_TASK_ID = "explain.v1"
+_EXPECTED_OUTPUT_LABEL = "EXPLANATION_ONLY"
+
+
+class AdvisorBriefService:
+    def __init__(
+        self,
+        *,
+        performance_workspace_service: PerformanceWorkspaceService,
+        lotus_ai_client: LotusAiClient,
+    ):
+        self._performance_workspace_service = performance_workspace_service
+        self._lotus_ai_client = lotus_ai_client
+
+    async def get_performance_advisor_brief(
+        self,
+        *,
+        portfolio_id: str,
+        correlation_id: str,
+        period: str,
+        chart_frequency: str,
+        contribution_dimension: str,
+        attribution_dimension: str,
+        detail_basis: str,
+        benchmark_code: str | None,
+        explicit_start_date: str | None = None,
+        explicit_end_date: str | None = None,
+    ) -> AdvisorBriefResponse:
+        workspace = await self._performance_workspace_service.get_performance_workspace(
+            portfolio_id=portfolio_id,
+            correlation_id=correlation_id,
+            period=period,
+            chart_frequency=chart_frequency,
+            contribution_dimension=contribution_dimension,
+            attribution_dimension=attribution_dimension,
+            detail_basis=detail_basis,
+            benchmark_code=benchmark_code,
+            explicit_start_date=explicit_start_date,
+            explicit_end_date=explicit_end_date,
+        )
+
+        selected_performance = (
+            workspace.net_performance
+            if detail_basis.upper() == "NET"
+            else workspace.gross_performance
+        )
+        source_refs = _build_source_refs(workspace=workspace)
+        supportability = _build_supportability(workspace=workspace)
+        status = _resolve_status(workspace=workspace, supportability=supportability)
+
+        source_summary = _build_source_summary(
+            workspace=workspace,
+            selected_performance=selected_performance,
+        )
+        talking_points = _build_source_talking_points(
+            workspace=workspace,
+            selected_performance=selected_performance,
+        )
+        recommended_actions = _build_recommended_actions(workspace=workspace)
+        risks_and_exceptions = _build_risks_and_exceptions(
+            workspace=workspace,
+            supportability=supportability,
+        )
+        ai_audit: dict[str, Any] = {}
+        ai_evidence: dict[str, Any] = {"descriptors": []}
+
+        if status is not AdvisorBriefStatus.UNAVAILABLE:
+            ai_status, ai_payload = await self._lotus_ai_client.execute_task(
+                task_id=_TASK_ID,
+                caller_app="lotus-gateway",
+                correlation_id=correlation_id,
+                context_summary=(
+                    f"Advisor brief context for portfolio {workspace.portfolio_id}, "
+                    f"{workspace.period} period, basis {workspace.detail_basis}."
+                ),
+                context_payload=_build_ai_fact_bundle(
+                    workspace=workspace,
+                    selected_performance=selected_performance,
+                ),
+                source_refs=source_refs,
+                expected_output_label=_EXPECTED_OUTPUT_LABEL,
+            )
+            if ai_status == 200 and ai_payload.get("status") == "COMPLETED":
+                source_summary = _extract_ai_summary(ai_payload=ai_payload) or source_summary
+                ai_audit = _safe_dict(ai_payload.get("audit"))
+                ai_evidence = _safe_dict(ai_payload.get("evidence")) or {"descriptors": []}
+            else:
+                status = AdvisorBriefStatus.PARTIAL
+                ai_audit = {
+                    "task_id": _TASK_ID,
+                    "output_label": _EXPECTED_OUTPUT_LABEL,
+                    "provider_mode": "unavailable",
+                    "detail": _safe_error_detail(ai_payload),
+                }
+                risks_and_exceptions.append(
+                    AdvisorBriefNarrativeItem(
+                        headline="AI narrative generation is unavailable.",
+                        detail="Source-backed metrics remain available for manual review and client prep.",
+                        tone=AdvisorBriefTone.WARNING,
+                        evidence_refs=[
+                            _summary_evidence_ref(
+                                label="Advisor Brief",
+                                value="Unavailable",
+                                portfolio_id=workspace.portfolio_id,
+                                period=workspace.period,
+                                basis=workspace.detail_basis,
+                                benchmark_code=workspace.benchmark_code,
+                            )
+                        ],
+                    )
+                )
+
+        return AdvisorBriefResponse(
+            correlation_id=correlation_id,
+            contract_version=workspace.contract_version,
+            portfolio_id=workspace.portfolio_id,
+            portfolio=workspace.portfolio,
+            as_of_date=workspace.as_of_date,
+            period=workspace.period,
+            report_start_date=workspace.report_start_date,
+            report_end_date=workspace.report_end_date,
+            detail_basis=workspace.detail_basis,
+            chart_frequency=workspace.chart_frequency,
+            contribution_dimension=workspace.contribution_dimension,
+            attribution_dimension=workspace.attribution_dimension,
+            benchmark_code=workspace.benchmark_code,
+            status=status,
+            summary=source_summary,
+            talking_points=talking_points,
+            recommended_actions=recommended_actions,
+            risks_and_exceptions=risks_and_exceptions,
+            source_metrics=_build_source_metrics(
+                workspace=workspace,
+                selected_performance=selected_performance,
+            ),
+            supportability=supportability,
+            ai_audit=ai_audit,
+            ai_evidence=ai_evidence,
+            warnings=workspace.warnings,
+            partial_failures=workspace.partial_failures,
+        )
+
+
+def _build_source_refs(*, workspace: PerformanceWorkspaceResponse) -> list[str]:
+    refs = [
+        f"lotus-gateway:workbench:{workspace.portfolio_id}:performance-summary:{workspace.period}",
+        f"lotus-gateway:workbench:{workspace.portfolio_id}:performance-details:{workspace.period}",
+    ]
+    if workspace.benchmark_code:
+        refs.append(
+            f"lotus-performance:benchmark:{workspace.portfolio_id}:{workspace.benchmark_code}:{workspace.period}"
+        )
+    return refs
+
+
+def _build_ai_fact_bundle(
+    *,
+    workspace: PerformanceWorkspaceResponse,
+    selected_performance: PerformanceComparativeSummary,
+) -> dict[str, Any]:
+    contribution = workspace.contribution
+    attribution = workspace.attribution
+    return {
+        "portfolio": workspace.portfolio.model_dump(mode="json"),
+        "period": {
+            "period": workspace.period,
+            "report_start_date": workspace.report_start_date,
+            "report_end_date": workspace.report_end_date,
+            "as_of_date": workspace.as_of_date,
+            "detail_basis": workspace.detail_basis,
+        },
+        "benchmark": {
+            "benchmark_code": workspace.benchmark_code,
+            "benchmark_return_pct": selected_performance.benchmark_return_pct,
+        },
+        "performance": {
+            "portfolio_return_pct": selected_performance.portfolio_return_pct,
+            "benchmark_return_pct": selected_performance.benchmark_return_pct,
+            "active_return_pct": selected_performance.active_return_pct,
+            "net_cash_flow": selected_performance.net_cash_flow,
+            "end_market_value": selected_performance.end_market_value,
+            "money_weighted_return_pct": (
+                workspace.money_weighted_return.money_weighted_return_pct
+                if workspace.money_weighted_return
+                else None
+            ),
+        },
+        "contribution": {
+            "portfolio_contribution_pct": (
+                contribution.portfolio_contribution_pct if contribution else None
+            ),
+            "coverage_mv_pct": contribution.coverage_mv_pct if contribution else None,
+            "top_positions": [
+                row.model_dump(mode="json")
+                for row in _positive_position_contributors(contribution=contribution)[:5]
+            ],
+            "bottom_positions": [
+                row.model_dump(mode="json")
+                for row in _negative_position_contributors(contribution=contribution)[:5]
+            ],
+        },
+        "attribution": {
+            "active_return_pct": attribution.active_return_pct if attribution else None,
+            "sum_of_effects_pct": attribution.sum_of_effects_pct if attribution else None,
+            "residual_pct": attribution.residual_pct if attribution else None,
+            "top_effects": _top_attribution_effects(attribution=attribution),
+        },
+        "supportability": [item.model_dump(mode="json") for item in _build_supportability(workspace=workspace)],
+        "warnings": workspace.warnings,
+        "partial_failures": [item.model_dump(mode="json") for item in workspace.partial_failures],
+    }
+
+
+def _build_source_summary(
+    *,
+    workspace: PerformanceWorkspaceResponse,
+    selected_performance: PerformanceComparativeSummary,
+) -> str:
+    portfolio_return = _format_pct(selected_performance.portfolio_return_pct)
+    benchmark_return = _format_pct(selected_performance.benchmark_return_pct)
+    active_return = _format_pct(selected_performance.active_return_pct)
+    if (
+        selected_performance.portfolio_return_pct is None
+        and selected_performance.benchmark_return_pct is None
+    ):
+        return (
+            "No source-backed advisor brief can be generated from the current performance "
+            "selection."
+        )
+    return (
+        f"{workspace.period} portfolio return is {portfolio_return} versus benchmark "
+        f"{benchmark_return}, with active return {active_return}."
+    )
+
+
+def _extract_ai_summary(*, ai_payload: dict[str, Any]) -> str | None:
+    result = _safe_dict(ai_payload.get("result"))
+    message = result.get("message")
+    if isinstance(message, str) and message.strip():
+        return message.strip()
+    return None
+
+
+def _build_source_talking_points(
+    *,
+    workspace: PerformanceWorkspaceResponse,
+    selected_performance: PerformanceComparativeSummary,
+) -> list[AdvisorBriefNarrativeItem]:
+    points: list[AdvisorBriefNarrativeItem] = []
+    if (
+        selected_performance.portfolio_return_pct is not None
+        or selected_performance.benchmark_return_pct is not None
+        or selected_performance.active_return_pct is not None
+    ):
+        points.append(
+            AdvisorBriefNarrativeItem(
+                headline=(
+                    f"Portfolio return is {_format_pct(selected_performance.portfolio_return_pct)} "
+                    f"versus benchmark {_format_pct(selected_performance.benchmark_return_pct)}."
+                ),
+                detail=(
+                    f"Active return is {_format_pct(selected_performance.active_return_pct)} "
+                    f"for the selected {workspace.period} period."
+                ),
+                tone=(
+                    AdvisorBriefTone.POSITIVE
+                    if (selected_performance.active_return_pct or 0) >= 0
+                    else AdvisorBriefTone.WARNING
+                ),
+                evidence_refs=[
+                    _summary_evidence_ref(
+                        label="Active Return",
+                        value=_format_pct(selected_performance.active_return_pct),
+                        portfolio_id=workspace.portfolio_id,
+                        period=workspace.period,
+                        basis=workspace.detail_basis,
+                        benchmark_code=workspace.benchmark_code,
+                    )
+                ],
+            )
+        )
+
+    top_position = _positive_position_contributors(contribution=workspace.contribution)[:1]
+    if top_position:
+        points.append(
+            AdvisorBriefNarrativeItem(
+                headline=f"Top contributor is {top_position[0].position_id}.",
+                detail=(
+                    f"Contribution is {_format_pct(top_position[0].contribution_pct)} "
+                    f"with return {_format_pct(top_position[0].total_return_pct)}."
+                ),
+                tone=AdvisorBriefTone.POSITIVE,
+                evidence_refs=[
+                    _analysis_evidence_ref(
+                        label="Top Contributor",
+                        value=top_position[0].position_id,
+                        portfolio_id=workspace.portfolio_id,
+                        period=workspace.period,
+                        basis=workspace.detail_basis,
+                        benchmark_code=workspace.benchmark_code,
+                    )
+                ],
+            )
+        )
+
+    bottom_position = _negative_position_contributors(contribution=workspace.contribution)[:1]
+    if bottom_position:
+        points.append(
+            AdvisorBriefNarrativeItem(
+                headline=f"Top detractor is {bottom_position[0].position_id}.",
+                detail=(
+                    f"Contribution is {_format_pct(bottom_position[0].contribution_pct)} "
+                    f"with return {_format_pct(bottom_position[0].total_return_pct)}."
+                ),
+                tone=AdvisorBriefTone.WARNING,
+                evidence_refs=[
+                    _analysis_evidence_ref(
+                        label="Top Detractor",
+                        value=bottom_position[0].position_id,
+                        portfolio_id=workspace.portfolio_id,
+                        period=workspace.period,
+                        basis=workspace.detail_basis,
+                        benchmark_code=workspace.benchmark_code,
+                    )
+                ],
+            )
+        )
+
+    return points
+
+
+def _build_recommended_actions(
+    *,
+    workspace: PerformanceWorkspaceResponse,
+) -> list[AdvisorBriefActionItem]:
+    return [
+        AdvisorBriefActionItem(
+            label="Open Return Path",
+            target_mode="summary",
+            route=_route_query(
+                portfolio_id=workspace.portfolio_id,
+                period=workspace.period,
+                basis=workspace.detail_basis,
+                benchmark_code=workspace.benchmark_code,
+            ),
+        ),
+        AdvisorBriefActionItem(
+            label="Open Contribution",
+            target_mode="analysis",
+            route=_route_query(
+                portfolio_id=workspace.portfolio_id,
+                period=workspace.period,
+                basis=workspace.detail_basis,
+                benchmark_code=workspace.benchmark_code,
+            ),
+        ),
+        AdvisorBriefActionItem(
+            label="Open Attribution",
+            target_mode="analysis",
+            route=_route_query(
+                portfolio_id=workspace.portfolio_id,
+                period=workspace.period,
+                basis=workspace.detail_basis,
+                benchmark_code=workspace.benchmark_code,
+            ),
+        ),
+    ]
+
+
+def _build_risks_and_exceptions(
+    *,
+    workspace: PerformanceWorkspaceResponse,
+    supportability: list[AdvisorBriefSupportabilityItem],
+) -> list[AdvisorBriefNarrativeItem]:
+    risks: list[AdvisorBriefNarrativeItem] = []
+    for item in supportability:
+        if item.tone not in {"warn", "danger"}:
+            continue
+        if item.label == "Advisor Brief":
+            continue
+        risks.append(
+            AdvisorBriefNarrativeItem(
+                headline=f"{item.label} is {item.value.lower()}.",
+                detail=item.reason or "Source detail is not fully available for this selection.",
+                tone=AdvisorBriefTone.WARNING,
+                evidence_refs=[
+                    AdvisorBriefEvidenceRef(
+                        metric_label=item.label,
+                        metric_value=item.value,
+                        source_surface=f"performance.{item.label.lower().replace(' ', '_')}",
+                        target_mode="analysis"
+                        if item.label in {"Contribution", "Attribution"}
+                        else "summary",
+                        route=_route_query(
+                            portfolio_id=workspace.portfolio_id,
+                            period=workspace.period,
+                            basis=workspace.detail_basis,
+                            benchmark_code=workspace.benchmark_code,
+                        ),
+                    )
+                ],
+            )
+        )
+    return risks
+
+
+def _build_source_metrics(
+    *,
+    workspace: PerformanceWorkspaceResponse,
+    selected_performance: PerformanceComparativeSummary,
+) -> list[AdvisorBriefSourceMetric]:
+    route = _route_query(
+        portfolio_id=workspace.portfolio_id,
+        period=workspace.period,
+        basis=workspace.detail_basis,
+        benchmark_code=workspace.benchmark_code,
+    )
+    return [
+        AdvisorBriefSourceMetric(
+            label="Portfolio Return",
+            value=_format_pct(selected_performance.portfolio_return_pct),
+            support_label=f"{workspace.period} {workspace.detail_basis}",
+            target_mode="summary",
+            route=route,
+            state=workspace.capabilities.summary_kpis.state,
+        ),
+        AdvisorBriefSourceMetric(
+            label="Benchmark Return",
+            value=_format_pct(selected_performance.benchmark_return_pct),
+            support_label=workspace.benchmark_code or "Unassigned",
+            target_mode="summary",
+            route=route,
+            state=workspace.capabilities.benchmark_comparison.state,
+        ),
+        AdvisorBriefSourceMetric(
+            label="Active Return",
+            value=_format_pct(selected_performance.active_return_pct),
+            support_label=f"{workspace.report_start_date} to {workspace.report_end_date}",
+            target_mode="summary",
+            route=route,
+            state=workspace.capabilities.benchmark_comparison.state,
+        ),
+        AdvisorBriefSourceMetric(
+            label="Net Flow",
+            value=_format_currency(selected_performance.net_cash_flow),
+            support_label=workspace.portfolio.base_currency or "Portfolio currency",
+            target_mode="summary",
+            route=route,
+            state=workspace.capabilities.summary_kpis.state,
+        ),
+        AdvisorBriefSourceMetric(
+            label="Ending MV",
+            value=_format_currency(selected_performance.end_market_value),
+            support_label=workspace.report_end_date,
+            target_mode="summary",
+            route=route,
+            state=workspace.capabilities.summary_kpis.state,
+        ),
+    ]
+
+
+def _build_supportability(
+    *,
+    workspace: PerformanceWorkspaceResponse,
+) -> list[AdvisorBriefSupportabilityItem]:
+    items = [
+        _to_supportability_item("Portfolio", workspace.capabilities.summary_kpis.state, None),
+        _to_supportability_item(
+            "Return History",
+            workspace.capabilities.return_path.state,
+            workspace.capabilities.return_path.reason,
+        ),
+        _to_supportability_item(
+            "Contribution",
+            workspace.capabilities.contribution_detail.state,
+            workspace.capabilities.contribution_detail.reason,
+        ),
+        _to_supportability_item(
+            "Attribution",
+            workspace.capabilities.attribution_detail.state,
+            workspace.capabilities.attribution_detail.reason,
+        ),
+    ]
+    advisor_brief_value = "Ready"
+    advisor_brief_tone = "success"
+    if any(item.tone == "danger" for item in items[:2]):
+        advisor_brief_value = "Unavailable"
+        advisor_brief_tone = "danger"
+    elif any(item.tone in {"warn", "danger"} for item in items):
+        advisor_brief_value = "Partial"
+        advisor_brief_tone = "warn"
+
+    items.append(
+        AdvisorBriefSupportabilityItem(
+            label="Advisor Brief",
+            value=advisor_brief_value,
+            tone=advisor_brief_tone,
+            reason=None,
+        )
+    )
+    return items
+
+
+def _to_supportability_item(
+    label: str,
+    state: str,
+    reason: str | None,
+) -> AdvisorBriefSupportabilityItem:
+    if state == "ready":
+        return AdvisorBriefSupportabilityItem(
+            label=label,
+            value="Ready",
+            tone="success",
+            reason=reason,
+        )
+    if state == "partial":
+        return AdvisorBriefSupportabilityItem(
+            label=label,
+            value="Partial",
+            tone="warn",
+            reason=reason,
+        )
+    return AdvisorBriefSupportabilityItem(
+        label=label,
+        value="Unavailable",
+        tone="danger",
+        reason=reason,
+    )
+
+
+def _resolve_status(
+    *,
+    workspace: PerformanceWorkspaceResponse,
+    supportability: list[AdvisorBriefSupportabilityItem],
+) -> AdvisorBriefStatus:
+    if workspace.capabilities.summary_kpis.state == "unavailable":
+        return AdvisorBriefStatus.UNAVAILABLE
+    if any(item.tone in {"warn", "danger"} for item in supportability):
+        return AdvisorBriefStatus.PARTIAL
+    return AdvisorBriefStatus.READY
+
+
+def _positive_position_contributors(
+    *,
+    contribution: ContributionSummaryView | None,
+) -> list[ContributionPositionView]:
+    if not contribution:
+        return []
+    return sorted(
+        [row for row in contribution.position_rows if row.contribution_pct > 0],
+        key=lambda row: row.contribution_pct,
+        reverse=True,
+    )
+
+
+def _negative_position_contributors(
+    *,
+    contribution: ContributionSummaryView | None,
+) -> list[ContributionPositionView]:
+    if not contribution:
+        return []
+    return sorted(
+        [row for row in contribution.position_rows if row.contribution_pct < 0],
+        key=lambda row: row.contribution_pct,
+    )
+
+
+def _top_attribution_effects(
+    *,
+    attribution: AttributionSummaryView | None,
+) -> list[dict[str, Any]]:
+    if not attribution:
+        return []
+    rows = [
+        row
+        for level in attribution.levels
+        for row in level.rows
+        if row.total_effect_pct is not None
+    ]
+    return [
+        row.model_dump(mode="json")
+        for row in sorted(
+            rows,
+            key=lambda row: abs(row.total_effect_pct),
+            reverse=True,
+        )[:5]
+    ]
+
+
+def _summary_evidence_ref(
+    *,
+    label: str,
+    value: str,
+    portfolio_id: str,
+    period: str,
+    basis: str,
+    benchmark_code: str | None,
+) -> AdvisorBriefEvidenceRef:
+    return AdvisorBriefEvidenceRef(
+        metric_label=label,
+        metric_value=value,
+        source_surface="performance.return_path",
+        target_mode="summary",
+        route=_route_query(
+            portfolio_id=portfolio_id,
+            period=period,
+            basis=basis,
+            benchmark_code=benchmark_code,
+        ),
+    )
+
+
+def _analysis_evidence_ref(
+    *,
+    label: str,
+    value: str,
+    portfolio_id: str,
+    period: str,
+    basis: str,
+    benchmark_code: str | None,
+) -> AdvisorBriefEvidenceRef:
+    return AdvisorBriefEvidenceRef(
+        metric_label=label,
+        metric_value=value,
+        source_surface="performance.contribution",
+        target_mode="analysis",
+        route=_route_query(
+            portfolio_id=portfolio_id,
+            period=period,
+            basis=basis,
+            benchmark_code=benchmark_code,
+        ),
+    )
+
+
+def _route_query(
+    *,
+    portfolio_id: str,
+    period: str,
+    basis: str,
+    benchmark_code: str | None,
+) -> str:
+    route = (
+        f"/performance?portfolioId={portfolio_id}&period={period}&detailBasis={basis}"
+    )
+    if benchmark_code:
+        route += f"&benchmark={benchmark_code}"
+    return route
+
+
+def _format_pct(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value:.2f}%"
+
+
+def _format_currency(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"${value:,.0f}"
+
+
+def _safe_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _safe_error_detail(payload: dict[str, Any]) -> str:
+    detail = payload.get("detail")
+    if isinstance(detail, str) and detail.strip():
+        return detail.strip()
+    return "lotus-ai task execution did not return a completed advisor brief."

--- a/tests/e2e/test_workflow_journeys.py
+++ b/tests/e2e/test_workflow_journeys.py
@@ -85,6 +85,9 @@ def test_e2e_platform_capability_aggregation_and_health(monkeypatch) -> None:
 
 
 def test_e2e_workbench_sandbox_flow(monkeypatch) -> None:
+    async def _pas_portfolio(*args, **kwargs):
+        return 200, {"portfolio_id": "PF_1001", "base_currency": "USD"}
+
     async def _pas_core(*args, **kwargs):
         return 200, {
             "portfolio": {"portfolio_id": "PF_1001", "base_currency": "USD"},
@@ -130,6 +133,7 @@ def test_e2e_workbench_sandbox_flow(monkeypatch) -> None:
     async def _dpm_simulate(*args, **kwargs):
         return 200, {"status": "COMPLETED", "gate_decision": {"status": "PASS"}}
 
+    monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio", _pas_portfolio)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_core_snapshot", _pas_core)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.create_simulation_session", _pas_create)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.add_simulation_changes", _pas_add)
@@ -335,6 +339,9 @@ def test_e2e_reporting_snapshot_maps_upstream_failure_to_gateway_error(monkeypat
 
 
 def test_e2e_sandbox_policy_feedback_unavailable_when_dpm_simulation_fails(monkeypatch) -> None:
+    async def _pas_portfolio(*args, **kwargs):
+        return 200, {"portfolio_id": "PF_1001", "base_currency": "USD"}
+
     async def _pas_core(*args, **kwargs):
         return 200, {
             "portfolio": {"portfolio_id": "PF_1001", "base_currency": "USD"},
@@ -380,6 +387,7 @@ def test_e2e_sandbox_policy_feedback_unavailable_when_dpm_simulation_fails(monke
     async def _dpm_simulate_failure(*args, **kwargs):
         return 503, {"detail": "lotus-manage policy service unavailable"}
 
+    monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio", _pas_portfolio)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_core_snapshot", _pas_core)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.create_simulation_session", _pas_create)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.add_simulation_changes", _pas_add)

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -1,5 +1,16 @@
 from fastapi.testclient import TestClient
 
+from app.contracts.advisor_brief import (
+    AdvisorBriefActionItem,
+    AdvisorBriefEvidenceRef,
+    AdvisorBriefNarrativeItem,
+    AdvisorBriefResponse,
+    AdvisorBriefSourceMetric,
+    AdvisorBriefStatus,
+    AdvisorBriefSupportabilityItem,
+    AdvisorBriefTone,
+)
+from app.contracts.workbench import WorkbenchPortfolioSummary
 from app.main import app
 from app.middleware.server_timing import append_server_timing_metric
 
@@ -791,6 +802,116 @@ def test_workbench_performance_monolithic_route_is_marked_deprecated_in_openapi(
         "Compatibility endpoint for the legacy monolithic performance workspace contract"
         in (performance_get["description"])
     )
+
+
+def test_workbench_performance_advisor_brief_router(monkeypatch):
+    captured_call = {}
+
+    async def _brief(*args, **kwargs):
+        captured_call.update(kwargs)
+        return AdvisorBriefResponse(
+            correlation_id=kwargs["correlation_id"],
+            contract_version="v1",
+            portfolio_id="PF_1001",
+            portfolio=WorkbenchPortfolioSummary(
+                portfolio_id="PF_1001",
+                client_id="CIF_1001",
+                base_currency="USD",
+                booking_center_code="SG",
+            ),
+            as_of_date="2026-04-04",
+            period="YTD",
+            report_start_date="2026-01-01",
+            report_end_date="2026-04-04",
+            detail_basis="NET",
+            chart_frequency="monthly",
+            contribution_dimension="asset_class",
+            attribution_dimension="asset_class",
+            benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+            status=AdvisorBriefStatus.READY,
+            summary="Advisor summary.",
+            talking_points=[
+                AdvisorBriefNarrativeItem(
+                    headline="Portfolio return is 1.25% versus benchmark 7.93%.",
+                    detail="Active return is -6.68% for the selected YTD period.",
+                    tone=AdvisorBriefTone.WARNING,
+                    evidence_refs=[
+                        AdvisorBriefEvidenceRef(
+                            metric_label="Active Return",
+                            metric_value="-6.68%",
+                            source_surface="performance.return_path",
+                            target_mode="summary",
+                            route=(
+                                "/performance?portfolioId=PF_1001&period=YTD"
+                                "&detailBasis=NET&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                            ),
+                        )
+                    ],
+                )
+            ],
+            recommended_actions=[
+                AdvisorBriefActionItem(
+                    label="Open Return Path",
+                    target_mode="summary",
+                    route=(
+                        "/performance?portfolioId=PF_1001&period=YTD"
+                        "&detailBasis=NET&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                    ),
+                )
+            ],
+            risks_and_exceptions=[],
+            source_metrics=[
+                AdvisorBriefSourceMetric(
+                    label="Active Return",
+                    value="-6.68%",
+                    support_label="YTD NET",
+                    target_mode="summary",
+                    route=(
+                        "/performance?portfolioId=PF_1001&period=YTD"
+                        "&detailBasis=NET&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                    ),
+                )
+            ],
+            supportability=[
+                AdvisorBriefSupportabilityItem(
+                    label="Advisor Brief",
+                    value="Ready",
+                    tone="success",
+                )
+            ],
+            ai_audit={"request_id": "req-1"},
+            ai_evidence={"descriptors": []},
+        )
+
+    monkeypatch.setattr(
+        "app.services.advisor_brief_service.AdvisorBriefService.get_performance_advisor_brief",
+        _brief,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/workbench/PF_1001/performance/advisor-brief"
+        "?period=YTD&chart_frequency=monthly&detail_basis=NET"
+        "&contribution_dimension=asset_class&attribution_dimension=asset_class"
+        "&benchmark_code=BMK_GLOBAL_BALANCED_60_40&report_start_date=2026-01-01"
+        "&report_end_date=2026-04-04"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ready"
+    assert body["summary"] == "Advisor summary."
+    assert body["talking_points"][0]["evidence_refs"][0]["target_mode"] == "summary"
+    assert body["source_metrics"][0]["label"] == "Active Return"
+    assert body["supportability"][0]["value"] == "Ready"
+    assert body["ai_audit"]["request_id"] == "req-1"
+    assert body["ai_evidence"] == {"descriptors": []}
+    assert captured_call["portfolio_id"] == "PF_1001"
+    assert captured_call["period"] == "YTD"
+    assert captured_call["detail_basis"] == "NET"
+    assert captured_call["benchmark_code"] == "BMK_GLOBAL_BALANCED_60_40"
+    assert captured_call["explicit_start_date"] == "2026-01-01"
+    assert captured_call["explicit_end_date"] == "2026-04-04"
 
 
 def test_workbench_sandbox_changes_router(monkeypatch):

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -881,7 +881,14 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
                     tone="success",
                 )
             ],
-            ai_audit={"request_id": "req-1"},
+            ai_audit={
+                "request_id": "req-1",
+                "provider_mode": "local_openai_compatible",
+                "provider_id": "text.local",
+                "adapter_kind": "OPENAI_COMPATIBLE_LOCAL",
+                "model_id": "qwen3:8b",
+                "stubbed": False,
+            },
             ai_evidence={"descriptors": []},
         )
 
@@ -910,6 +917,11 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
     assert body["source_metrics"][0]["label"] == "Active Return"
     assert body["supportability"][0]["value"] == "Ready"
     assert body["ai_audit"]["request_id"] == "req-1"
+    assert body["ai_audit"]["provider_mode"] == "local_openai_compatible"
+    assert body["ai_audit"]["provider_id"] == "text.local"
+    assert body["ai_audit"]["adapter_kind"] == "OPENAI_COMPATIBLE_LOCAL"
+    assert body["ai_audit"]["model_id"] == "qwen3:8b"
+    assert body["ai_audit"]["stubbed"] is False
     assert body["ai_evidence"] == {"descriptors": []}
     assert captured_call["portfolio_id"] == "PF_1001"
     assert captured_call["period"] == "YTD"

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -809,6 +809,8 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
 
     async def _brief(*args, **kwargs):
         captured_call.update(kwargs)
+        append_server_timing_metric("perf-advisor-brief-source", 4.0)
+        append_server_timing_metric("perf-advisor-brief-ai", 5.0)
         return AdvisorBriefResponse(
             correlation_id=kwargs["correlation_id"],
             contract_version="v1",
@@ -898,6 +900,9 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
     )
 
     assert response.status_code == 200
+    assert response.headers["Server-Timing"].startswith("app;dur=")
+    assert "perf-advisor-brief-source;dur=" in response.headers["Server-Timing"]
+    assert "perf-advisor-brief-ai;dur=" in response.headers["Server-Timing"]
     body = response.json()
     assert body["status"] == "ready"
     assert body["summary"] == "Advisor summary."

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -7,6 +7,7 @@ from app.contracts.performance_workspace import (
     ContributionPositionView,
     ContributionSummaryView,
     MoneyWeightedReturnSummary,
+    PerformanceBenchmarkOptionView,
     PerformanceComparativeSummary,
     PerformanceModuleCapability,
     PerformanceWorkspaceCapabilities,
@@ -43,7 +44,46 @@ class _StubLotusAiClient:
             "task_id": "explain.v1",
             "result": {
                 "message": "AI summary: portfolio return exceeded benchmark over the selected period.",
-                "structured_output": {},
+                "structured_output": {
+                    "grounded_summary": (
+                        "AI summary: portfolio return exceeded benchmark over the selected period."
+                    ),
+                    "talking_points": [
+                        {
+                            "headline": "AI-generated active-return summary.",
+                            "detail": "Use Return Path to explain the benchmark gap.",
+                            "tone": "warning",
+                            "evidence_refs": [
+                                {
+                                    "metric_label": "Active Return",
+                                    "metric_value": "-6.68%",
+                                    "source_ref": "lotus-gateway:workbench:PF_1001:performance-summary:YTD",
+                                }
+                            ],
+                        }
+                    ],
+                    "recommended_actions": [
+                        {
+                            "label": "Review Return Path",
+                            "detail": "Check period and flow context.",
+                            "evidence_refs": [],
+                        }
+                    ],
+                    "risks_and_exceptions": [
+                        {
+                            "headline": "Attribution evidence is partial.",
+                            "detail": "Keep the narrative constrained to available source metrics.",
+                            "tone": "warning",
+                            "evidence_refs": [
+                                {
+                                    "metric_label": "Attribution",
+                                    "metric_value": "Partial",
+                                    "source_ref": "lotus-gateway:workbench:PF_1001:performance-details:YTD",
+                                }
+                            ],
+                        }
+                    ],
+                },
             },
             "audit": {
                 "request_id": "req-1",
@@ -89,23 +129,26 @@ async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_acti
 
     assert response.status == "ready"
     assert response.summary.startswith("AI summary:")
+    assert response.talking_points[0].headline == "AI-generated active-return summary."
+    assert response.talking_points[0].evidence_refs[0].source_surface == "performance.return_path"
+    assert response.recommended_actions[0].label == "Review Return Path"
+    assert response.risks_and_exceptions[0].headline == "Attribution evidence is partial."
+    assert response.risks_and_exceptions[0].evidence_refs[0].target_mode == "analysis"
     assert response.source_metrics[0].label == "Portfolio Return"
     assert response.source_metrics[0].route == (
         "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET"
         "&benchmark=BMK_GLOBAL_BALANCED_60_40"
     )
-    assert response.talking_points[0].evidence_refs[0].source_surface == "performance.return_path"
-    assert [action.label for action in response.recommended_actions] == [
-        "Open Return Path",
-        "Open Contribution",
-        "Open Attribution",
-    ]
     assert response.ai_audit["request_id"] == "req-1"
     assert response.ai_evidence["descriptors"][0]["evidence_type"] == "source_fact_bundle"
     assert workspace_service.calls[0]["portfolio_id"] == "PF_1001"
     assert ai_client.calls[0]["task_id"] == "explain.v1"
     assert ai_client.calls[0]["expected_output_label"] == "EXPLANATION_ONLY"
     assert ai_client.calls[0]["context_payload"]["portfolio"]["portfolio_id"] == "PF_1001"
+    assert ai_client.calls[0]["context_payload"]["portfolio"]["display_label"] == "PF 1001"
+    assert ai_client.calls[0]["context_payload"]["benchmark"]["benchmark_name"] == (
+        "Private Banking Global Balanced 60/40"
+    )
     assert ai_client.calls[0]["source_refs"] == [
         "lotus-gateway:workbench:PF_1001:performance-summary:YTD",
         "lotus-gateway:workbench:PF_1001:performance-details:YTD",
@@ -247,6 +290,63 @@ async def test_advisor_brief_service_treats_supported_capabilities_as_ready():
 
 
 @pytest.mark.asyncio
+async def test_advisor_brief_service_normalizes_raw_position_ids_in_fallback_copy():
+    workspace = _build_workspace()
+    workspace.contribution.position_rows = [
+        ContributionPositionView(
+            position_id="PF_1001:FO_EQ_AAPL_US",
+            contribution_pct=0.30,
+            weight_avg_pct=7.37,
+            total_return_pct=4.31,
+        ),
+        ContributionPositionView(
+            position_id="PF_1001:FO_CASH_USD_BOOK_OPERATING",
+            contribution_pct=-0.06,
+            weight_avg_pct=9.24,
+            total_return_pct=0.00,
+        ),
+    ]
+    service = AdvisorBriefService(
+        performance_workspace_service=_StubPerformanceWorkspaceService(workspace),
+        lotus_ai_client=_StubLotusAiClient(
+            payload={
+                "status": "COMPLETED",
+                "task_id": "explain.v1",
+                "result": {
+                    "message": "Fallback summary only.",
+                    "structured_output": {
+                        "grounded_summary": "Fallback summary only.",
+                        "talking_points": [],
+                        "recommended_actions": [],
+                        "risks_and_exceptions": [],
+                    },
+                },
+                "audit": {},
+                "evidence": {"descriptors": []},
+            }
+        ),
+    )
+
+    response = await service.get_performance_advisor_brief(
+        portfolio_id="PF_1001",
+        correlation_id="corr-raw-position-id",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+    )
+
+    assert "PF_1001:" not in response.talking_points[1].headline
+    assert response.talking_points[1].headline == "Top contributor is AAPL US."
+    assert response.talking_points[2].headline == "Top detractor is USD BOOK OPERATING."
+    assert response.talking_points[2].detail == (
+        "USD BOOK OPERATING contributed -0.06% with return 0.00%."
+    )
+
+
+@pytest.mark.asyncio
 async def test_advisor_brief_service_records_source_and_ai_server_timing_spans():
     workspace_service = _StubPerformanceWorkspaceService(_build_workspace())
     ai_client = _StubLotusAiClient()
@@ -299,6 +399,13 @@ def _build_workspace(
         requested_attribution_dimension_supported=True,
         segment="asset_class",
         benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_options=[
+            PerformanceBenchmarkOptionView(
+                benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+                benchmark_name="Private Banking Global Balanced 60/40",
+                benchmark_currency="USD",
+            )
+        ],
         capabilities=PerformanceWorkspaceCapabilities(
             summary_kpis=PerformanceModuleCapability(state="ready"),
             return_path=PerformanceModuleCapability(state="ready"),

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -1,0 +1,341 @@
+import pytest
+
+from app.contracts.performance_workspace import (
+    AttributionLevelView,
+    AttributionRowView,
+    AttributionSummaryView,
+    ContributionPositionView,
+    ContributionSummaryView,
+    MoneyWeightedReturnSummary,
+    PerformanceComparativeSummary,
+    PerformanceModuleCapability,
+    PerformanceWorkspaceCapabilities,
+    PerformanceWorkspaceResponse,
+)
+from app.contracts.workbench import (
+    WorkbenchOverviewSummary,
+    WorkbenchPartialFailure,
+    WorkbenchPortfolioSummary,
+)
+from app.services.advisor_brief_service import AdvisorBriefService
+
+
+class _StubPerformanceWorkspaceService:
+    def __init__(self, workspace: PerformanceWorkspaceResponse):
+        self.workspace = workspace
+        self.calls: list[dict[str, object]] = []
+
+    async def get_performance_workspace(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.workspace
+
+
+class _StubLotusAiClient:
+    def __init__(self, *, status_code: int = 200, payload: dict | None = None):
+        self.status_code = status_code
+        self.payload = payload or {
+            "status": "COMPLETED",
+            "task_id": "explain.v1",
+            "result": {
+                "message": "AI summary: portfolio return exceeded benchmark over the selected period.",
+                "structured_output": {},
+            },
+            "audit": {
+                "request_id": "req-1",
+                "task_id": "explain.v1",
+                "provider_mode": "stub",
+            },
+            "evidence": {
+                "descriptors": [
+                    {
+                        "evidence_type": "source_fact_bundle",
+                        "summary": "Grounded in Gateway performance workspace facts.",
+                        "attributes": {"portfolio_id": "PF_1001"},
+                    }
+                ]
+            },
+        }
+        self.calls: list[dict[str, object]] = []
+
+    async def execute_task(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.status_code, self.payload
+
+
+@pytest.mark.asyncio
+async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_actions():
+    workspace_service = _StubPerformanceWorkspaceService(_build_workspace())
+    ai_client = _StubLotusAiClient()
+    service = AdvisorBriefService(
+        performance_workspace_service=workspace_service,
+        lotus_ai_client=ai_client,
+    )
+
+    response = await service.get_performance_advisor_brief(
+        portfolio_id="PF_1001",
+        correlation_id="corr-1",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+    )
+
+    assert response.status == "ready"
+    assert response.summary.startswith("AI summary:")
+    assert response.source_metrics[0].label == "Portfolio Return"
+    assert response.source_metrics[0].route == (
+        "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET"
+        "&benchmark=BMK_GLOBAL_BALANCED_60_40"
+    )
+    assert response.talking_points[0].evidence_refs[0].source_surface == "performance.return_path"
+    assert [action.label for action in response.recommended_actions] == [
+        "Open Return Path",
+        "Open Contribution",
+        "Open Attribution",
+    ]
+    assert response.ai_audit["request_id"] == "req-1"
+    assert response.ai_evidence["descriptors"][0]["evidence_type"] == "source_fact_bundle"
+    assert workspace_service.calls[0]["portfolio_id"] == "PF_1001"
+    assert ai_client.calls[0]["task_id"] == "explain.v1"
+    assert ai_client.calls[0]["expected_output_label"] == "EXPLANATION_ONLY"
+    assert ai_client.calls[0]["context_payload"]["portfolio"]["portfolio_id"] == "PF_1001"
+    assert ai_client.calls[0]["source_refs"] == [
+        "lotus-gateway:workbench:PF_1001:performance-summary:YTD",
+        "lotus-gateway:workbench:PF_1001:performance-details:YTD",
+        "lotus-performance:benchmark:PF_1001:BMK_GLOBAL_BALANCED_60_40:YTD",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_advisor_brief_service_marks_partial_when_source_slices_or_ai_generation_are_partial():
+    workspace = _build_workspace(
+        contribution_state="partial",
+        attribution_state="unavailable",
+        benchmark_state="partial",
+    )
+    service = AdvisorBriefService(
+        performance_workspace_service=_StubPerformanceWorkspaceService(workspace),
+        lotus_ai_client=_StubLotusAiClient(status_code=503, payload={"detail": "lotus-ai paused"}),
+    )
+
+    response = await service.get_performance_advisor_brief(
+        portfolio_id="PF_1001",
+        correlation_id="corr-partial",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+    )
+
+    assert response.status == "partial"
+    assert response.ai_audit["provider_mode"] == "unavailable"
+    assert response.ai_audit["detail"] == "lotus-ai paused"
+    assert [item.model_dump(mode="json") for item in response.supportability] == [
+        {"label": "Portfolio", "value": "Ready", "tone": "success", "reason": None},
+        {"label": "Return History", "value": "Ready", "tone": "success", "reason": None},
+        {
+            "label": "Contribution",
+            "value": "Partial",
+            "tone": "warn",
+            "reason": "Contribution aggregate only.",
+        },
+        {
+            "label": "Attribution",
+            "value": "Unavailable",
+            "tone": "danger",
+            "reason": "Attribution unavailable.",
+        },
+        {"label": "Advisor Brief", "value": "Partial", "tone": "warn", "reason": None},
+    ]
+    assert [item.model_dump(mode="json") for item in response.risks_and_exceptions] == [
+        {
+            "headline": "Contribution is partial.",
+            "detail": "Contribution aggregate only.",
+            "tone": "warning",
+            "evidence_refs": [
+                {
+                    "metric_label": "Contribution",
+                    "metric_value": "Partial",
+                    "source_surface": "performance.contribution",
+                    "target_mode": "analysis",
+                    "route": (
+                        "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET"
+                        "&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                    ),
+                }
+            ],
+        },
+        {
+            "headline": "Attribution is unavailable.",
+            "detail": "Attribution unavailable.",
+            "tone": "warning",
+            "evidence_refs": [
+                {
+                    "metric_label": "Attribution",
+                    "metric_value": "Unavailable",
+                    "source_surface": "performance.attribution",
+                    "target_mode": "analysis",
+                    "route": (
+                        "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET"
+                        "&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                    ),
+                }
+            ],
+        },
+        {
+            "headline": "AI narrative generation is unavailable.",
+            "detail": "Source-backed metrics remain available for manual review and client prep.",
+            "tone": "warning",
+            "evidence_refs": [
+                {
+                    "metric_label": "Advisor Brief",
+                    "metric_value": "Unavailable",
+                    "source_surface": "performance.return_path",
+                    "target_mode": "summary",
+                    "route": (
+                        "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET"
+                        "&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                    ),
+                }
+            ],
+        },
+    ]
+
+
+def _build_workspace(
+    *,
+    benchmark_state: str = "ready",
+    contribution_state: str = "ready",
+    attribution_state: str = "ready",
+) -> PerformanceWorkspaceResponse:
+    return PerformanceWorkspaceResponse(
+        correlation_id="corr-1",
+        contract_version="v1",
+        portfolio_id="PF_1001",
+        as_of_date="2026-04-04",
+        period="YTD",
+        report_start_date="2026-01-01",
+        report_end_date="2026-04-04",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        requested_chart_frequency_supported=True,
+        requested_contribution_dimension_supported=True,
+        requested_attribution_dimension_supported=True,
+        segment="asset_class",
+        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        capabilities=PerformanceWorkspaceCapabilities(
+            summary_kpis=PerformanceModuleCapability(state="ready"),
+            return_path=PerformanceModuleCapability(state="ready"),
+            benchmark_comparison=PerformanceModuleCapability(state=benchmark_state),
+            multi_horizon_returns=PerformanceModuleCapability(state="ready"),
+            contribution_ranking=PerformanceModuleCapability(state=contribution_state),
+            attribution_detail=PerformanceModuleCapability(
+                state=attribution_state,
+                reason="Attribution unavailable." if attribution_state != "ready" else None,
+            ),
+            contribution_detail=PerformanceModuleCapability(
+                state=contribution_state,
+                reason="Contribution aggregate only." if contribution_state != "ready" else None,
+            ),
+            evidence=PerformanceModuleCapability(state="ready"),
+        ),
+        portfolio=WorkbenchPortfolioSummary(
+            portfolio_id="PF_1001",
+            client_id="CIF_1001",
+            base_currency="USD",
+            booking_center_code="SG",
+        ),
+        overview=WorkbenchOverviewSummary(
+            market_value_base=1_087_461.0,
+            cash_weight_pct=8.5,
+            position_count=10,
+        ),
+        net_performance=PerformanceComparativeSummary(
+            metric_basis="NET",
+            portfolio_return_pct=1.25,
+            benchmark_return_pct=7.93,
+            active_return_pct=-6.68,
+            benchmark_id="BMK_GLOBAL_BALANCED_60_40",
+            end_market_value=1_087_461.0,
+            net_cash_flow=14_725.0,
+        ),
+        gross_performance=PerformanceComparativeSummary(
+            metric_basis="GROSS",
+            portfolio_return_pct=1.45,
+            benchmark_return_pct=7.93,
+            active_return_pct=-6.48,
+            benchmark_id="BMK_GLOBAL_BALANCED_60_40",
+            end_market_value=1_087_461.0,
+            net_cash_flow=14_725.0,
+        ),
+        money_weighted_return=MoneyWeightedReturnSummary(
+            money_weighted_return_pct=1.23,
+            method="XIRR",
+            start_date="2026-01-01",
+            end_date="2026-04-04",
+        ),
+        net_chart=[],
+        gross_chart=[],
+        contribution=ContributionSummaryView(
+            metric_basis="NET",
+            portfolio_contribution_pct=1.25,
+            coverage_mv_pct=100.0,
+            position_rows=[
+                ContributionPositionView(
+                    position_id="AAPL US",
+                    contribution_pct=0.30,
+                    weight_avg_pct=7.37,
+                    total_return_pct=4.31,
+                ),
+                ContributionPositionView(
+                    position_id="USD BOOK OPERATING",
+                    contribution_pct=-0.06,
+                    weight_avg_pct=9.24,
+                    total_return_pct=0.00,
+                ),
+            ],
+            levels=[],
+        ),
+        attribution=AttributionSummaryView(
+            metric_basis="NET",
+            model="BF",
+            linking="Carino",
+            benchmark_id="BMK_GLOBAL_BALANCED_60_40",
+            active_return_pct=-6.68,
+            sum_of_effects_pct=-6.67,
+            residual_pct=-0.01,
+            levels=[
+                AttributionLevelView(
+                    dimension="asset_class",
+                    total_effect_pct=-3.2,
+                    rows=[
+                        AttributionRowView(
+                            key_label="Equity",
+                            portfolio_weight_avg_pct=62.0,
+                            benchmark_weight_avg_pct=55.0,
+                            portfolio_return_pct=4.0,
+                            benchmark_return_pct=8.0,
+                            allocation_pct=-1.1,
+                            selection_pct=-2.0,
+                            interaction_pct=-0.1,
+                            total_effect_pct=-3.2,
+                        )
+                    ],
+                )
+            ],
+        ),
+        warnings=["FOUNDATION_WARNING"],
+        partial_failures=[
+            WorkbenchPartialFailure(
+                source_service="lotus-core",
+                error_code="FOUNDATION_WARNING",
+                detail="Foundation context has warnings.",
+            )
+        ],
+    )

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -305,6 +305,77 @@ async def test_advisor_brief_service_marks_partial_for_partial_sources_or_ai():
 
 
 @pytest.mark.asyncio
+async def test_advisor_brief_service_reuses_cached_response_for_identical_request():
+    workspace_service = _StubPerformanceWorkspaceService(_build_workspace())
+    ai_client = _StubLotusAiClient()
+    service = AdvisorBriefService(
+        performance_workspace_service=workspace_service,
+        lotus_ai_client=ai_client,
+        cache_ttl_seconds=60.0,
+    )
+
+    first = await service.get_performance_advisor_brief(
+        portfolio_id="PF_1001",
+        correlation_id="corr-cache-1",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+    )
+    second = await service.get_performance_advisor_brief(
+        portfolio_id="PF_1001",
+        correlation_id="corr-cache-2",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+    )
+
+    assert first.summary == second.summary
+    assert len(workspace_service.calls) == 1
+    assert len(ai_client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_advisor_brief_service_cache_key_changes_when_request_shape_changes():
+    workspace_service = _StubPerformanceWorkspaceService(_build_workspace())
+    ai_client = _StubLotusAiClient()
+    service = AdvisorBriefService(
+        performance_workspace_service=workspace_service,
+        lotus_ai_client=ai_client,
+        cache_ttl_seconds=60.0,
+    )
+
+    await service.get_performance_advisor_brief(
+        portfolio_id="PF_1001",
+        correlation_id="corr-cache-net",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+    )
+    await service.get_performance_advisor_brief(
+        portfolio_id="PF_1001",
+        correlation_id="corr-cache-gross",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="GROSS",
+        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+    )
+
+    assert len(workspace_service.calls) == 2
+    assert len(ai_client.calls) == 2
+
+
+@pytest.mark.asyncio
 async def test_advisor_brief_service_treats_supported_capabilities_as_ready():
     workspace = _build_workspace(
         benchmark_state="supported",

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -43,7 +43,9 @@ class _StubLotusAiClient:
             "status": "COMPLETED",
             "task_id": "explain.v1",
             "result": {
-                "message": "AI summary: portfolio return exceeded benchmark over the selected period.",
+                "message": (
+                    "AI summary: portfolio return exceeded benchmark over the selected period."
+                ),
                 "structured_output": {
                     "grounded_summary": (
                         "AI summary: portfolio return exceeded benchmark over the selected period."
@@ -57,7 +59,10 @@ class _StubLotusAiClient:
                                 {
                                     "metric_label": "Active Return",
                                     "metric_value": "-6.68%",
-                                    "source_ref": "lotus-gateway:workbench:PF_1001:performance-summary:YTD",
+                                    "source_ref": (
+                                        "lotus-gateway:workbench:PF_1001:"
+                                        "performance-summary:YTD"
+                                    ),
                                 }
                             ],
                         }
@@ -78,7 +83,10 @@ class _StubLotusAiClient:
                                 {
                                     "metric_label": "Attribution",
                                     "metric_value": "Partial",
-                                    "source_ref": "lotus-gateway:workbench:PF_1001:performance-details:YTD",
+                                    "source_ref": (
+                                        "lotus-gateway:workbench:PF_1001:"
+                                        "performance-details:YTD"
+                                    ),
                                 }
                             ],
                         }
@@ -88,7 +96,11 @@ class _StubLotusAiClient:
             "audit": {
                 "request_id": "req-1",
                 "task_id": "explain.v1",
-                "provider_mode": "stub",
+                "provider_mode": "openai",
+                "provider_id": "text.openai",
+                "adapter_kind": "OPENAI_LIVE",
+                "model_id": "gpt-5.4",
+                "stubbed": False,
             },
             "evidence": {
                 "descriptors": [
@@ -140,6 +152,11 @@ async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_acti
         "&benchmark=BMK_GLOBAL_BALANCED_60_40"
     )
     assert response.ai_audit["request_id"] == "req-1"
+    assert response.ai_audit["provider_mode"] == "openai"
+    assert response.ai_audit["provider_id"] == "text.openai"
+    assert response.ai_audit["adapter_kind"] == "OPENAI_LIVE"
+    assert response.ai_audit["model_id"] == "gpt-5.4"
+    assert response.ai_audit["stubbed"] is False
     assert response.ai_evidence["descriptors"][0]["evidence_type"] == "source_fact_bundle"
     assert workspace_service.calls[0]["portfolio_id"] == "PF_1001"
     assert ai_client.calls[0]["task_id"] == "explain.v1"
@@ -157,7 +174,7 @@ async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_acti
 
 
 @pytest.mark.asyncio
-async def test_advisor_brief_service_marks_partial_when_source_slices_or_ai_generation_are_partial():
+async def test_advisor_brief_service_marks_partial_for_partial_sources_or_ai():
     workspace = _build_workspace(
         contribution_state="partial",
         attribution_state="unavailable",
@@ -181,6 +198,10 @@ async def test_advisor_brief_service_marks_partial_when_source_slices_or_ai_gene
 
     assert response.status == "partial"
     assert response.ai_audit["provider_mode"] == "unavailable"
+    assert response.ai_audit["provider_id"] is None
+    assert response.ai_audit["adapter_kind"] is None
+    assert response.ai_audit["model_id"] is None
+    assert response.ai_audit["stubbed"] is True
     assert response.ai_audit["detail"] == "lotus-ai paused"
     assert [item.model_dump(mode="json") for item in response.supportability] == [
         {"label": "Portfolio", "value": "Ready", "tone": "success", "reason": None},

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -212,6 +212,41 @@ async def test_advisor_brief_service_marks_partial_when_source_slices_or_ai_gene
 
 
 @pytest.mark.asyncio
+async def test_advisor_brief_service_treats_supported_capabilities_as_ready():
+    workspace = _build_workspace(
+        benchmark_state="supported",
+        contribution_state="supported",
+        attribution_state="supported",
+    )
+    workspace.capabilities.summary_kpis.state = "supported"
+    workspace.capabilities.return_path.state = "supported"
+    service = AdvisorBriefService(
+        performance_workspace_service=_StubPerformanceWorkspaceService(workspace),
+        lotus_ai_client=_StubLotusAiClient(),
+    )
+
+    response = await service.get_performance_advisor_brief(
+        portfolio_id="PF_1001",
+        correlation_id="corr-supported",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+    )
+
+    assert response.status == "ready"
+    assert [item.value for item in response.supportability] == [
+        "Ready",
+        "Ready",
+        "Ready",
+        "Ready",
+        "Ready",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_advisor_brief_service_records_source_and_ai_server_timing_spans():
     workspace_service = _StubPerformanceWorkspaceService(_build_workspace())
     ai_client = _StubLotusAiClient()

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -163,9 +163,38 @@ async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_acti
     assert ai_client.calls[0]["expected_output_label"] == "EXPLANATION_ONLY"
     assert ai_client.calls[0]["context_payload"]["portfolio"]["portfolio_id"] == "PF_1001"
     assert ai_client.calls[0]["context_payload"]["portfolio"]["display_label"] == "PF 1001"
+    assert set(ai_client.calls[0]["context_payload"]["portfolio"].keys()) == {
+        "portfolio_id",
+        "display_label",
+        "base_currency",
+        "booking_center_code",
+        "client_id",
+    }
     assert ai_client.calls[0]["context_payload"]["benchmark"]["benchmark_name"] == (
         "Private Banking Global Balanced 60/40"
     )
+    top_position = ai_client.calls[0]["context_payload"]["contribution"]["top_positions"][0]
+    assert set(top_position.keys()) == {
+        "display_label",
+        "contribution_pct",
+        "weight_avg_pct",
+        "total_return_pct",
+        "local_contribution_pct",
+        "fx_contribution_pct",
+    }
+    assert top_position["display_label"] == "AAPL US"
+    top_effect = ai_client.calls[0]["context_payload"]["attribution"]["top_effects"][0]
+    assert set(top_effect.keys()) == {
+        "segment_label",
+        "total_effect_pct",
+        "allocation_pct",
+        "selection_pct",
+        "interaction_pct",
+        "portfolio_weight_avg_pct",
+        "benchmark_weight_avg_pct",
+        "portfolio_return_pct",
+        "benchmark_return_pct",
+    }
     assert ai_client.calls[0]["source_refs"] == [
         "lotus-gateway:workbench:PF_1001:performance-summary:YTD",
         "lotus-gateway:workbench:PF_1001:performance-details:YTD",

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -17,6 +17,11 @@ from app.contracts.workbench import (
     WorkbenchPartialFailure,
     WorkbenchPortfolioSummary,
 )
+from app.middleware.server_timing import (
+    format_server_timing_header,
+    reset_server_timing_metrics,
+    restore_server_timing_metrics,
+)
 from app.services.advisor_brief_service import AdvisorBriefService
 
 
@@ -204,6 +209,36 @@ async def test_advisor_brief_service_marks_partial_when_source_slices_or_ai_gene
             ],
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_advisor_brief_service_records_source_and_ai_server_timing_spans():
+    workspace_service = _StubPerformanceWorkspaceService(_build_workspace())
+    ai_client = _StubLotusAiClient()
+    service = AdvisorBriefService(
+        performance_workspace_service=workspace_service,
+        lotus_ai_client=ai_client,
+    )
+    token = reset_server_timing_metrics()
+
+    try:
+        await service.get_performance_advisor_brief(
+            portfolio_id="PF_1001",
+            correlation_id="corr-1",
+            period="YTD",
+            chart_frequency="monthly",
+            contribution_dimension="asset_class",
+            attribution_dimension="asset_class",
+            detail_basis="NET",
+            benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        )
+
+        server_timing = format_server_timing_header(1.0)
+    finally:
+        restore_server_timing_metrics(token)
+
+    assert "perf-advisor-brief-source;dur=" in server_timing
+    assert "perf-advisor-brief-ai;dur=" in server_timing
 
 
 def _build_workspace(

--- a/tests/unit/test_config_defaults.py
+++ b/tests/unit/test_config_defaults.py
@@ -15,6 +15,7 @@ def test_settings_default_to_canonical_dev_service_identities():
     assert settings.portfolio_data_ingestion_base_url == "http://core-ingestion.dev.lotus"
     assert settings.performance_analytics_base_url == "http://performance.dev.lotus"
     assert settings.ai_service_base_url == "http://ai.dev.lotus"
+    assert settings.ai_service_timeout_seconds == 45.0
     assert settings.risk_analytics_base_url == "http://risk.dev.lotus"
     assert settings.reporting_aggregation_base_url == "http://report.dev.lotus"
     assert settings.management_service_base_url == "http://manage.dev.lotus"

--- a/tests/unit/test_config_defaults.py
+++ b/tests/unit/test_config_defaults.py
@@ -14,6 +14,7 @@ def test_settings_default_to_canonical_dev_service_identities():
     assert settings.portfolio_data_control_plane_base_url == "http://core-control.dev.lotus"
     assert settings.portfolio_data_ingestion_base_url == "http://core-ingestion.dev.lotus"
     assert settings.performance_analytics_base_url == "http://performance.dev.lotus"
+    assert settings.ai_service_base_url == "http://ai.dev.lotus"
     assert settings.risk_analytics_base_url == "http://risk.dev.lotus"
     assert settings.reporting_aggregation_base_url == "http://report.dev.lotus"
     assert settings.management_service_base_url == "http://manage.dev.lotus"

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 from app.clients.dpm_client import DpmClient
+from app.clients.lotus_ai_client import LotusAiClient
 from app.clients.lotus_analytics_client import LotusAnalyticsClient
 from app.clients.lotus_core_ingestion_client import LotusCoreIngestionClient
 from app.clients.lotus_core_query_client import LotusCoreQueryClient
@@ -265,6 +266,51 @@ async def test_lotus_analytics_client_performance_workspace_requests_use_owned_c
     assert attribution_post["json"]["stateful_input"]["benchmark_id"] == "MODEL_60_40"
     assert "calculation_id" not in attribution_post["json"]
 
+
+@pytest.mark.asyncio
+async def test_lotus_ai_client_calls_task_execution_contract_with_correlation_headers():
+    client = LotusAiClient(base_url="http://ai", timeout_seconds=3.0)
+    _FakeAsyncClient.queue_json(
+        200,
+        {
+            "status": "COMPLETED",
+            "task_id": "explain.v1",
+            "category": "explain",
+            "output_label": "EXPLANATION_ONLY",
+            "result": {"message": "Advisor summary.", "structured_output": {}},
+            "audit": {"request_id": "req-1"},
+            "evidence": {"descriptors": []},
+        },
+    )
+
+    status, payload = await client.execute_task(
+        task_id="explain.v1",
+        caller_app="lotus-gateway",
+        correlation_id="corr-ai-1",
+        context_summary="Advisor brief context",
+        context_payload={"portfolio_id": "PF_1001"},
+        source_refs=["lotus-gateway:workbench:PF_1001:performance-summary:YTD"],
+        expected_output_label="EXPLANATION_ONLY",
+    )
+
+    assert status == 200
+    assert payload["status"] == "COMPLETED"
+    assert _FakeAsyncClient.calls[-1]["url"] == "http://ai/ai/tasks/execute"
+    assert _FakeAsyncClient.calls[-1]["headers"]["X-Correlation-Id"] == "corr-ai-1"
+    assert _FakeAsyncClient.calls[-1]["json"] == {
+        "task_id": "explain.v1",
+        "input_mode": "STRUCTURED_CONTEXT",
+        "caller": {
+            "caller_app": "lotus-gateway",
+            "correlation_id": "corr-ai-1",
+        },
+        "context": {
+            "summary": "Advisor brief context",
+            "payload": {"portfolio_id": "PF_1001"},
+            "source_refs": ["lotus-gateway:workbench:PF_1001:performance-summary:YTD"],
+        },
+        "expected_output_label": "EXPLANATION_ONLY",
+    }
 
 @pytest.mark.asyncio
 async def test_lotus_analytics_client_twr_request_omits_benchmark_when_not_requested():


### PR DESCRIPTION
## Summary
- slim the advisor-brief AI fact bundle to business-relevant fields only
- add short-lived advisor-brief response caching for repeated workstation requests
- keep provider provenance and advisor-brief behavior aligned with RFC-0027

## Validation
- python -m ruff check src tests
- python -m pytest tests/unit/test_advisor_brief_service.py tests/integration/test_workbench_router.py -q