### PR TITLE
RFC-0022: add stateful risk workspace Gateway BFF

### DIFF
--- a/src/app/clients/lotus_analytics_client.py
+++ b/src/app/clients/lotus_analytics_client.py
@@ -394,20 +394,3 @@ class LotusAnalyticsClient:
             correlation_id=correlation_id,
         )
         return status_code, response_payload
-
-    async def get_workbench_risk_proxy(
-        self,
-        payload: dict[str, Any],
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
-        url = f"{self._base_url}/analytics/workbench/risk-proxy"
-        headers = propagation_headers(correlation_id)
-        return await request_with_retry(
-            method="POST",
-            url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
-            json_body=payload,
-            headers=headers,
-        )

--- a/src/app/clients/lotus_analytics_client.py
+++ b/src/app/clients/lotus_analytics_client.py
@@ -427,3 +427,14 @@ class LotusAnalyticsClient:
             payload=payload,
             correlation_id=correlation_id,
         )
+
+    async def post_risk_rolling_metrics(
+        self,
+        payload: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post_analytics_request(
+            path="/analytics/risk/rolling-metrics",
+            payload=payload,
+            correlation_id=correlation_id,
+        )

--- a/src/app/clients/lotus_analytics_client.py
+++ b/src/app/clients/lotus_analytics_client.py
@@ -438,3 +438,14 @@ class LotusAnalyticsClient:
             payload=payload,
             correlation_id=correlation_id,
         )
+
+    async def post_risk_historical_attribution(
+        self,
+        payload: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post_analytics_request(
+            path="/analytics/risk/historical-attribution",
+            payload=payload,
+            correlation_id=correlation_id,
+        )

--- a/src/app/clients/lotus_analytics_client.py
+++ b/src/app/clients/lotus_analytics_client.py
@@ -416,3 +416,14 @@ class LotusAnalyticsClient:
             payload=payload,
             correlation_id=correlation_id,
         )
+
+    async def post_risk_drawdown(
+        self,
+        payload: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post_analytics_request(
+            path="/analytics/risk/drawdown",
+            payload=payload,
+            correlation_id=correlation_id,
+        )

--- a/src/app/clients/lotus_analytics_client.py
+++ b/src/app/clients/lotus_analytics_client.py
@@ -394,3 +394,25 @@ class LotusAnalyticsClient:
             correlation_id=correlation_id,
         )
         return status_code, response_payload
+
+    async def post_risk_calculate(
+        self,
+        payload: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post_analytics_request(
+            path="/analytics/risk/calculate",
+            payload=payload,
+            correlation_id=correlation_id,
+        )
+
+    async def post_risk_concentration(
+        self,
+        payload: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post_analytics_request(
+            path="/analytics/risk/concentration",
+            payload=payload,
+            correlation_id=correlation_id,
+        )

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -1,4 +1,6 @@
-from pydantic import AliasChoices, Field
+from urllib.parse import urlparse
+
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -38,6 +40,31 @@ class Settings(BaseSettings):
     portfolio_upstream_cache_ttl_seconds: float = Field(default=5.0)
     advisor_brief_cache_ttl_seconds: float = Field(default=30.0)
     risk_bff_cache_ttl_seconds: float = Field(default=15.0)
+
+    @field_validator(
+        "decisioning_service_base_url",
+        "portfolio_data_query_base_url",
+        "portfolio_data_control_plane_base_url",
+        "portfolio_data_ingestion_base_url",
+        "performance_analytics_base_url",
+        "ai_service_base_url",
+        "risk_analytics_base_url",
+        "reporting_aggregation_base_url",
+        "management_service_base_url",
+        mode="before",
+    )
+    @classmethod
+    def normalize_upstream_base_url(cls, value: str) -> str:
+        normalized = str(value).strip().rstrip("/")
+        hostname = urlparse(normalized).hostname
+
+        if hostname and hostname.lower() in {"localhost", "127.0.0.1", "0.0.0.0"}:
+            raise ValueError(
+                "Gateway upstream base URLs must use canonical service hostnames, "
+                f"not local loopback ({hostname})."
+            )
+
+        return normalized
 
 
 settings = Settings()

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -37,6 +37,7 @@ class Settings(BaseSettings):
     upstream_retry_backoff_seconds: float = Field(default=0.2)
     portfolio_upstream_cache_ttl_seconds: float = Field(default=5.0)
     advisor_brief_cache_ttl_seconds: float = Field(default=30.0)
+    risk_bff_cache_ttl_seconds: float = Field(default=15.0)
 
 
 settings = Settings()

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -29,7 +29,6 @@ class Settings(BaseSettings):
     risk_analytics_base_url: str = Field(default="http://risk.dev.lotus")
     reporting_aggregation_base_url: str = Field(default="http://report.dev.lotus")
     management_service_base_url: str = Field(default="http://manage.dev.lotus")
-    risk_split_enabled: bool = Field(default=True)
     manage_split_enabled: bool = Field(default=True)
     upstream_timeout_seconds: float = Field(default=3.0)
     performance_analytics_timeout_seconds: float = Field(default=15.0)

--- a/src/app/contracts/risk_workspace.py
+++ b/src/app/contracts/risk_workspace.py
@@ -173,6 +173,62 @@ class WorkbenchRiskRollingPayload(BaseModel):
     periods: list[WorkbenchRiskRollingPeriodResult] = Field(default_factory=list)
 
 
+class WorkbenchRiskAttributionTypeOption(BaseModel):
+    key: str
+    label: str
+    state: RiskSupportabilityState
+    reason: str | None = None
+
+
+class WorkbenchRiskAttributionGroupingOption(BaseModel):
+    key: str
+    label: str
+    state: RiskSupportabilityState
+    reason: str | None = None
+    supported_attribution_types: list[str] = Field(default_factory=list)
+
+
+class WorkbenchRiskAttributionContributor(BaseModel):
+    group_key: str
+    group_label: str
+    weight_average: float | None = None
+    marginal_contribution: float | None = None
+    component_contribution: float | None = None
+    percent_contribution: float | None = None
+
+
+class WorkbenchRiskAttributionSet(BaseModel):
+    attribution_type: str
+    metric: str
+    grouping_dimension: str
+    total_value: float | None = None
+    reconciled_sum: float | None = None
+    residual: float | None = None
+    contributors: list[WorkbenchRiskAttributionContributor] = Field(default_factory=list)
+    quality_flags: list[str] = Field(default_factory=list)
+
+
+class WorkbenchRiskAttributionPeriodResult(BaseModel):
+    key: str
+    label: str
+    start_date: str
+    end_date: str
+    attribution_sets: list[WorkbenchRiskAttributionSet] = Field(default_factory=list)
+    error: str | None = None
+
+
+class WorkbenchRiskAttributionControls(BaseModel):
+    attribution_types: list[WorkbenchRiskAttributionTypeOption] = Field(default_factory=list)
+    grouping_dimensions: list[WorkbenchRiskAttributionGroupingOption] = Field(default_factory=list)
+    selected_attribution_type: str
+    selected_grouping_dimension: str
+
+
+class WorkbenchRiskAttributionPayload(BaseModel):
+    controls: WorkbenchRiskAttributionControls
+    periods: list[WorkbenchRiskAttributionPeriodResult] = Field(default_factory=list)
+
+
 class WorkbenchRiskModuleEnvelope(BaseModel):
     correlation_id: str
     contract_version: str = "risk-workspace.v1"
@@ -203,3 +259,7 @@ class WorkbenchRiskDrawdownResponse(WorkbenchRiskModuleEnvelope):
 
 class WorkbenchRiskRollingResponse(WorkbenchRiskModuleEnvelope):
     payload: WorkbenchRiskRollingPayload | None = None
+
+
+class WorkbenchRiskAttributionResponse(WorkbenchRiskModuleEnvelope):
+    payload: WorkbenchRiskAttributionPayload | None = None

--- a/src/app/contracts/risk_workspace.py
+++ b/src/app/contracts/risk_workspace.py
@@ -137,6 +137,42 @@ class WorkbenchRiskDrawdownPayload(BaseModel):
     periods: list[WorkbenchRiskDrawdownPeriodResult] = Field(default_factory=list)
 
 
+class WorkbenchRiskRollingMetricSummary(BaseModel):
+    latest: float | None = None
+    average: float | None = None
+    minimum: float | None = None
+    maximum: float | None = None
+    p05: float | None = None
+    p50: float | None = None
+    p95: float | None = None
+
+
+class WorkbenchRiskRollingMetricSeriesPoint(BaseModel):
+    date: str
+    metric_values: dict[str, float | None] = Field(default_factory=dict)
+
+
+class WorkbenchRiskRollingWindowResult(BaseModel):
+    window_length: int
+    metric_summaries: dict[str, WorkbenchRiskRollingMetricSummary] = Field(default_factory=dict)
+    metric_series: list[WorkbenchRiskRollingMetricSeriesPoint] | None = None
+
+
+class WorkbenchRiskRollingPeriodResult(BaseModel):
+    key: str
+    label: str
+    start_date: str
+    end_date: str
+    series_count: int
+    window_results: list[WorkbenchRiskRollingWindowResult] = Field(default_factory=list)
+    quality_flags: list[str] = Field(default_factory=list)
+    error: str | None = None
+
+
+class WorkbenchRiskRollingPayload(BaseModel):
+    periods: list[WorkbenchRiskRollingPeriodResult] = Field(default_factory=list)
+
+
 class WorkbenchRiskModuleEnvelope(BaseModel):
     correlation_id: str
     contract_version: str = "risk-workspace.v1"
@@ -163,3 +199,7 @@ class WorkbenchRiskConcentrationResponse(WorkbenchRiskModuleEnvelope):
 
 class WorkbenchRiskDrawdownResponse(WorkbenchRiskModuleEnvelope):
     payload: WorkbenchRiskDrawdownPayload | None = None
+
+
+class WorkbenchRiskRollingResponse(WorkbenchRiskModuleEnvelope):
+    payload: WorkbenchRiskRollingPayload | None = None

--- a/src/app/contracts/risk_workspace.py
+++ b/src/app/contracts/risk_workspace.py
@@ -83,6 +83,60 @@ class WorkbenchRiskConcentrationPayload(BaseModel):
     risk_metadata: dict[str, Any] | None = None
 
 
+class WorkbenchRiskDrawdownSummary(BaseModel):
+    max_drawdown: float | None = None
+    max_drawdown_peak_date: str | None = None
+    max_drawdown_trough_date: str | None = None
+    max_drawdown_recovery_date: str | None = None
+    is_recovered: bool
+    days_to_trough: int | None = None
+    days_to_recovery: int | None = None
+    time_under_water_days: int
+    average_drawdown: float | None = None
+    ulcer_index: float | None = None
+    drawdown_at_risk_95: float | None = None
+    conditional_drawdown_at_risk_95: float | None = None
+
+
+class WorkbenchRiskDrawdownEpisode(BaseModel):
+    episode_id: str
+    peak_date: str
+    trough_date: str
+    recovery_date: str | None = None
+    depth: float
+    days_to_trough: int
+    days_to_recovery: int | None = None
+    total_days: int
+    is_recovered: bool
+
+
+class WorkbenchRiskRelativeDrawdownSummary(BaseModel):
+    max_drawdown: float | None = None
+    max_drawdown_peak_date: str | None = None
+    max_drawdown_trough_date: str | None = None
+
+
+class WorkbenchRiskUnderwaterPoint(BaseModel):
+    date: str
+    drawdown: float
+
+
+class WorkbenchRiskDrawdownPeriodResult(BaseModel):
+    key: str
+    label: str
+    start_date: str
+    end_date: str
+    summary: WorkbenchRiskDrawdownSummary | None = None
+    episodes: list[WorkbenchRiskDrawdownEpisode] = Field(default_factory=list)
+    relative_to_benchmark: WorkbenchRiskRelativeDrawdownSummary | None = None
+    underwater_series: list[WorkbenchRiskUnderwaterPoint] | None = None
+    error: str | None = None
+
+
+class WorkbenchRiskDrawdownPayload(BaseModel):
+    periods: list[WorkbenchRiskDrawdownPeriodResult] = Field(default_factory=list)
+
+
 class WorkbenchRiskModuleEnvelope(BaseModel):
     correlation_id: str
     contract_version: str = "risk-workspace.v1"
@@ -105,3 +159,7 @@ class WorkbenchRiskSummaryResponse(WorkbenchRiskModuleEnvelope):
 
 class WorkbenchRiskConcentrationResponse(WorkbenchRiskModuleEnvelope):
     payload: WorkbenchRiskConcentrationPayload | None = None
+
+
+class WorkbenchRiskDrawdownResponse(WorkbenchRiskModuleEnvelope):
+    payload: WorkbenchRiskDrawdownPayload | None = None

--- a/src/app/contracts/risk_workspace.py
+++ b/src/app/contracts/risk_workspace.py
@@ -1,0 +1,107 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from app.contracts.workbench import WorkbenchPartialFailure
+
+RiskModuleState = Literal["ready", "partial", "unavailable", "blocked"]
+RiskSupportabilityState = Literal["ready", "partial", "unavailable", "blocked"]
+
+
+class WorkbenchRiskSupportabilityItem(BaseModel):
+    key: str
+    label: str
+    state: RiskSupportabilityState
+    reason: str | None = None
+    source_service: str | None = None
+
+
+class WorkbenchRiskMetadata(BaseModel):
+    generated_at: str
+    input_mode: Literal["stateful", "simulation"] = "stateful"
+    methodology_version: str | None = None
+    cache_status: Literal["hit", "miss", "bypass"] | None = None
+
+
+class WorkbenchRiskMetric(BaseModel):
+    key: str
+    label: str
+    value: float | None = None
+    state: RiskModuleState = "ready"
+    reason: str | None = None
+    details: dict[str, Any] | None = None
+
+
+class WorkbenchRiskPeriodResult(BaseModel):
+    key: str
+    label: str
+    start_date: str
+    end_date: str
+    metrics: list[WorkbenchRiskMetric] = Field(default_factory=list)
+
+
+class WorkbenchRiskSummaryPayload(BaseModel):
+    periods: list[WorkbenchRiskPeriodResult] = Field(default_factory=list)
+
+
+class WorkbenchConcentrationRiskProxy(BaseModel):
+    hhi_current: float
+    hhi_proposed: float
+    hhi_delta: float
+
+
+class WorkbenchSinglePositionConcentration(BaseModel):
+    top_position_weight_current: float
+    top_position_weight_proposed: float
+    top_position_weight_delta: float
+    top_n_cumulative_weight_current: float
+    top_n_cumulative_weight_proposed: float
+    top_n_cumulative_weight_delta: float
+    top_n: int
+
+
+class WorkbenchIssuerConcentration(BaseModel):
+    hhi_current: float
+    hhi_proposed: float
+    hhi_delta: float
+    top_issuer_weight_current: float
+    top_issuer_weight_proposed: float
+    top_issuer_weight_delta: float
+    coverage_status: str
+    covered_position_count_current: int
+    covered_position_count_proposed: int
+    total_position_count_current: int
+    total_position_count_proposed: int
+    note: str | None = None
+
+
+class WorkbenchRiskConcentrationPayload(BaseModel):
+    risk_proxy: WorkbenchConcentrationRiskProxy
+    single_position_concentration: WorkbenchSinglePositionConcentration
+    issuer_concentration: WorkbenchIssuerConcentration
+    valuation_context: dict[str, Any] | None = None
+    risk_metadata: dict[str, Any] | None = None
+
+
+class WorkbenchRiskModuleEnvelope(BaseModel):
+    correlation_id: str
+    contract_version: str = "risk-workspace.v1"
+    portfolio_id: str
+    period: str
+    as_of_date: str
+    benchmark_code: str | None = None
+    source_service: str = "lotus-risk"
+    state: RiskModuleState
+    payload: dict[str, Any] | None = None
+    supportability: list[WorkbenchRiskSupportabilityItem] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    partial_failures: list[WorkbenchPartialFailure] = Field(default_factory=list)
+    metadata: WorkbenchRiskMetadata
+
+
+class WorkbenchRiskSummaryResponse(WorkbenchRiskModuleEnvelope):
+    payload: WorkbenchRiskSummaryPayload | None = None
+
+
+class WorkbenchRiskConcentrationResponse(WorkbenchRiskModuleEnvelope):
+    payload: WorkbenchRiskConcentrationPayload | None = None

--- a/src/app/contracts/workbench.py
+++ b/src/app/contracts/workbench.py
@@ -160,6 +160,6 @@ class WorkbenchAnalyticsResponse(BaseModel):
     active_return_pct: float | None = None
     allocation_buckets: list[WorkbenchAnalyticsBucket] = Field(default_factory=list)
     top_changes: list[WorkbenchTopChange] = Field(default_factory=list)
-    risk_proxy: WorkbenchRiskProxy
+    risk_proxy: WorkbenchRiskProxy | None = None
     warnings: list[str] = Field(default_factory=list)
     partial_failures: list[WorkbenchPartialFailure] = Field(default_factory=list)

--- a/src/app/contracts/workbench.py
+++ b/src/app/contracts/workbench.py
@@ -141,12 +141,6 @@ class WorkbenchTopChange(BaseModel):
     direction: str
 
 
-class WorkbenchRiskProxy(BaseModel):
-    hhi_current: float
-    hhi_proposed: float
-    hhi_delta: float
-
-
 class WorkbenchAnalyticsResponse(BaseModel):
     correlation_id: str
     contract_version: str = Field(default="v1")
@@ -160,6 +154,5 @@ class WorkbenchAnalyticsResponse(BaseModel):
     active_return_pct: float | None = None
     allocation_buckets: list[WorkbenchAnalyticsBucket] = Field(default_factory=list)
     top_changes: list[WorkbenchTopChange] = Field(default_factory=list)
-    risk_proxy: WorkbenchRiskProxy | None = None
     warnings: list[str] = Field(default_factory=list)
     partial_failures: list[WorkbenchPartialFailure] = Field(default_factory=list)

--- a/src/app/routers/portfolio.py
+++ b/src/app/routers/portfolio.py
@@ -48,9 +48,7 @@ def _service_signature() -> tuple[object, ...]:
         settings.performance_analytics_base_url,
         settings.management_service_base_url,
         settings.decisioning_service_base_url,
-        settings.risk_analytics_base_url,
         settings.manage_split_enabled,
-        settings.risk_split_enabled,
         settings.upstream_timeout_seconds,
         settings.performance_analytics_timeout_seconds,
         settings.upstream_max_retries,
@@ -84,16 +82,6 @@ def _build_performance_workspace_service() -> PerformanceWorkspaceService:
                 timeout_seconds=settings.upstream_timeout_seconds,
                 max_retries=settings.upstream_max_retries,
                 retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
-            ),
-            risk_client=(
-                LotusAnalyticsClient(
-                    base_url=settings.risk_analytics_base_url,
-                    timeout_seconds=settings.upstream_timeout_seconds,
-                    max_retries=settings.upstream_max_retries,
-                    retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
-                )
-                if settings.risk_split_enabled
-                else None
             ),
         ),
         analytics_client=LotusAnalyticsClient(

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -16,6 +16,7 @@ from app.contracts.performance_workspace import (
 from app.contracts.risk_workspace import (
     WorkbenchRiskConcentrationResponse,
     WorkbenchRiskDrawdownResponse,
+    WorkbenchRiskRollingResponse,
     WorkbenchRiskSummaryResponse,
 )
 from app.contracts.workbench import (
@@ -345,6 +346,38 @@ async def get_workbench_risk_drawdown(
         as_of_date=as_of_date,
         reporting_currency=reporting_currency,
         include_underwater_series=include_underwater_series,
+    )
+
+
+@router.get(
+    "/{portfolio_id}/risk/rolling",
+    response_model=WorkbenchRiskRollingResponse,
+    summary="Get Workbench Risk Rolling Metrics",
+    description=(
+        "Returns Gateway-shaped, stateful lotus-risk rolling metrics for Workbench. "
+        "Rolling series detail is optional and requested on demand to keep first paint lean."
+    ),
+)
+async def get_workbench_risk_rolling(
+    portfolio_id: str,
+    period: str = "YTD",
+    detail_basis: str = "NET",
+    benchmark_code: str | None = None,
+    as_of_date: str | None = None,
+    reporting_currency: str | None = None,
+    include_time_series: bool = False,
+) -> WorkbenchRiskRollingResponse:
+    service = _risk_workspace_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_rolling(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+        period=period,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        as_of_date=as_of_date,
+        reporting_currency=reporting_currency,
+        include_time_series=include_time_series,
     )
 
 

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -45,9 +45,7 @@ def _service_signature() -> tuple[object, ...]:
         settings.ai_service_base_url,
         settings.management_service_base_url,
         settings.decisioning_service_base_url,
-        settings.risk_analytics_base_url,
         settings.manage_split_enabled,
-        settings.risk_split_enabled,
         settings.upstream_timeout_seconds,
         settings.performance_analytics_timeout_seconds,
         settings.ai_service_timeout_seconds,
@@ -82,16 +80,6 @@ def _build_workbench_service() -> WorkbenchService:
             timeout_seconds=settings.upstream_timeout_seconds,
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
-        ),
-        risk_client=(
-            LotusAnalyticsClient(
-                base_url=settings.risk_analytics_base_url,
-                timeout_seconds=settings.upstream_timeout_seconds,
-                max_retries=settings.upstream_max_retries,
-                retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
-            )
-            if settings.risk_split_enabled
-            else None
         ),
     )
 
@@ -213,9 +201,10 @@ async def get_portfolio_360(
     description=(
         "Returns lotus-performance-owned analytics for current vs "
         "projected portfolio state, including grouped allocation "
-        "deltas, top changes, active return, and concentration "
-        "risk proxy. lotus-gateway orchestrates inputs and "
-        "delegates analytics computation to lotus-performance."
+        "deltas, top changes, and active return. Stateful risk "
+        "analytics are intentionally excluded from this legacy "
+        "Workbench analytics route and will be served by the "
+        "RFC-0022 Risk BFF."
     ),
 )
 async def get_workbench_analytics(

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -13,6 +13,10 @@ from app.contracts.performance_workspace import (
     PerformanceWorkspaceResponse,
     PerformanceWorkspaceSummaryResponse,
 )
+from app.contracts.risk_workspace import (
+    WorkbenchRiskConcentrationResponse,
+    WorkbenchRiskSummaryResponse,
+)
 from app.contracts.workbench import (
     WorkbenchAnalyticsResponse,
     WorkbenchOverviewResponse,
@@ -24,6 +28,7 @@ from app.contracts.workbench import (
 from app.middleware.correlation import correlation_id_var
 from app.services.advisor_brief_service import AdvisorBriefService
 from app.services.performance_workspace_service import PerformanceWorkspaceService
+from app.services.risk_workspace_service import RiskWorkspaceService
 from app.services.workbench_service import WorkbenchService
 
 router = APIRouter(prefix="/api/v1/workbench", tags=["workbench"])
@@ -35,6 +40,8 @@ _PERFORMANCE_WORKSPACE_SERVICE: PerformanceWorkspaceService | None = None
 _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 _ADVISOR_BRIEF_SERVICE: AdvisorBriefService | None = None
 _ADVISOR_BRIEF_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_RISK_WORKSPACE_SERVICE: RiskWorkspaceService | None = None
+_RISK_WORKSPACE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 
 
 def _service_signature() -> tuple[object, ...]:
@@ -42,6 +49,7 @@ def _service_signature() -> tuple[object, ...]:
         settings.portfolio_data_query_base_url,
         settings.portfolio_data_control_plane_base_url,
         settings.performance_analytics_base_url,
+        settings.risk_analytics_base_url,
         settings.ai_service_base_url,
         settings.management_service_base_url,
         settings.decisioning_service_base_url,
@@ -53,6 +61,7 @@ def _service_signature() -> tuple[object, ...]:
         settings.upstream_retry_backoff_seconds,
         settings.portfolio_upstream_cache_ttl_seconds,
         settings.advisor_brief_cache_ttl_seconds,
+        settings.risk_bff_cache_ttl_seconds,
     )
 
 
@@ -152,6 +161,27 @@ def _advisor_brief_service() -> AdvisorBriefService:
     return _ADVISOR_BRIEF_SERVICE
 
 
+def _build_risk_workspace_service() -> RiskWorkspaceService:
+    return RiskWorkspaceService(
+        risk_client=LotusAnalyticsClient(
+            base_url=settings.risk_analytics_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+        cache_ttl_seconds=settings.risk_bff_cache_ttl_seconds,
+    )
+
+
+def _risk_workspace_service() -> RiskWorkspaceService:
+    global _RISK_WORKSPACE_SERVICE, _RISK_WORKSPACE_SERVICE_SIGNATURE
+    signature = _service_signature()
+    if _RISK_WORKSPACE_SERVICE is None or _RISK_WORKSPACE_SERVICE_SIGNATURE != signature:
+        _RISK_WORKSPACE_SERVICE = _build_risk_workspace_service()
+        _RISK_WORKSPACE_SERVICE_SIGNATURE = signature
+    return _RISK_WORKSPACE_SERVICE
+
+
 @router.get(
     "/{portfolio_id}/overview",
     response_model=WorkbenchOverviewResponse,
@@ -223,6 +253,65 @@ async def get_workbench_analytics(
         group_by=group_by,
         benchmark_code=benchmark_code,
         session_id=session_id,
+    )
+
+
+@router.get(
+    "/{portfolio_id}/risk/summary",
+    response_model=WorkbenchRiskSummaryResponse,
+    summary="Get Workbench Risk Summary",
+    description=(
+        "Returns Gateway-shaped, stateful lotus-risk summary metrics for Workbench. "
+        "This endpoint uses the RFC-0022 Risk BFF contract and does not expose stateless "
+        "risk execution to the UI."
+    ),
+)
+async def get_workbench_risk_summary(
+    portfolio_id: str,
+    period: str = "YTD",
+    detail_basis: str = "NET",
+    benchmark_code: str | None = None,
+    as_of_date: str | None = None,
+    reporting_currency: str | None = None,
+) -> WorkbenchRiskSummaryResponse:
+    service = _risk_workspace_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_summary(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+        period=period,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        as_of_date=as_of_date,
+        reporting_currency=reporting_currency,
+    )
+
+
+@router.get(
+    "/{portfolio_id}/risk/concentration",
+    response_model=WorkbenchRiskConcentrationResponse,
+    summary="Get Workbench Risk Concentration",
+    description=(
+        "Returns Gateway-shaped, stateful lotus-risk concentration analytics for Workbench. "
+        "Simulation concentration remains gated to a future sandbox-aware slice."
+    ),
+)
+async def get_workbench_risk_concentration(
+    portfolio_id: str,
+    period: str = "YTD",
+    benchmark_code: str | None = None,
+    as_of_date: str | None = None,
+    reporting_currency: str | None = None,
+) -> WorkbenchRiskConcentrationResponse:
+    service = _risk_workspace_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_concentration(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+        period=period,
+        as_of_date=as_of_date,
+        reporting_currency=reporting_currency,
+        benchmark_code=benchmark_code,
     )
 
 

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -15,6 +15,7 @@ from app.contracts.performance_workspace import (
 )
 from app.contracts.risk_workspace import (
     WorkbenchRiskConcentrationResponse,
+    WorkbenchRiskDrawdownResponse,
     WorkbenchRiskSummaryResponse,
 )
 from app.contracts.workbench import (
@@ -312,6 +313,38 @@ async def get_workbench_risk_concentration(
         as_of_date=as_of_date,
         reporting_currency=reporting_currency,
         benchmark_code=benchmark_code,
+    )
+
+
+@router.get(
+    "/{portfolio_id}/risk/drawdown",
+    response_model=WorkbenchRiskDrawdownResponse,
+    summary="Get Workbench Risk Drawdown",
+    description=(
+        "Returns Gateway-shaped, stateful lotus-risk drawdown analytics for Workbench. "
+        "Underwater series detail is optional and requested on demand to keep first paint lean."
+    ),
+)
+async def get_workbench_risk_drawdown(
+    portfolio_id: str,
+    period: str = "YTD",
+    detail_basis: str = "NET",
+    benchmark_code: str | None = None,
+    as_of_date: str | None = None,
+    reporting_currency: str | None = None,
+    include_underwater_series: bool = False,
+) -> WorkbenchRiskDrawdownResponse:
+    service = _risk_workspace_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_drawdown(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+        period=period,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        as_of_date=as_of_date,
+        reporting_currency=reporting_currency,
+        include_underwater_series=include_underwater_series,
     )
 
 

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -14,6 +14,7 @@ from app.contracts.performance_workspace import (
     PerformanceWorkspaceSummaryResponse,
 )
 from app.contracts.risk_workspace import (
+    WorkbenchRiskAttributionResponse,
     WorkbenchRiskConcentrationResponse,
     WorkbenchRiskDrawdownResponse,
     WorkbenchRiskRollingResponse,
@@ -378,6 +379,40 @@ async def get_workbench_risk_rolling(
         as_of_date=as_of_date,
         reporting_currency=reporting_currency,
         include_time_series=include_time_series,
+    )
+
+
+@router.get(
+    "/{portfolio_id}/risk/attribution",
+    response_model=WorkbenchRiskAttributionResponse,
+    summary="Get Workbench Risk Attribution",
+    description=(
+        "Returns Gateway-shaped, stateful lotus-risk historical risk attribution for Workbench. "
+        "Only supported stateful attribution combinations are surfaced to the UI."
+    ),
+)
+async def get_workbench_risk_attribution(
+    portfolio_id: str,
+    period: str = "YTD",
+    detail_basis: str = "NET",
+    benchmark_code: str | None = None,
+    as_of_date: str | None = None,
+    reporting_currency: str | None = None,
+    attribution_type: str = "TOTAL_RISK",
+    grouping_dimension: str = "SECTOR",
+) -> WorkbenchRiskAttributionResponse:
+    service = _risk_workspace_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_attribution(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+        period=period,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        as_of_date=as_of_date,
+        reporting_currency=reporting_currency,
+        attribution_type=attribution_type,
+        grouping_dimension=grouping_dimension,
     )
 
 

--- a/src/app/services/async_ttl_cache.py
+++ b/src/app/services/async_ttl_cache.py
@@ -18,11 +18,19 @@ class AsyncTtlCache(Generic[T]):
         key: tuple[object, ...],
         factory: Callable[[], Awaitable[T]],
     ) -> T:
+        value, _ = await self.get_or_set_with_status(key=key, factory=factory)
+        return value
+
+    async def get_or_set_with_status(
+        self,
+        key: tuple[object, ...],
+        factory: Callable[[], Awaitable[T]],
+    ) -> tuple[T, bool]:
         now = monotonic()
         async with self._lock:
             entry = self._entries.get(key)
             if entry and entry[0] > now:
-                return entry[1]
+                return entry[1], True
 
             task = self._inflight.get(key)
             if task is None:
@@ -43,7 +51,7 @@ class AsyncTtlCache(Generic[T]):
             current = self._inflight.get(key)
             if current is task:
                 self._inflight.pop(key, None)
-        return value
+        return value, False
 
     def clear(self) -> None:
         self._entries.clear()

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -19,6 +19,12 @@ from app.contracts.risk_workspace import (
     WorkbenchRiskMetric,
     WorkbenchRiskPeriodResult,
     WorkbenchRiskRelativeDrawdownSummary,
+    WorkbenchRiskRollingMetricSeriesPoint,
+    WorkbenchRiskRollingMetricSummary,
+    WorkbenchRiskRollingPayload,
+    WorkbenchRiskRollingPeriodResult,
+    WorkbenchRiskRollingResponse,
+    WorkbenchRiskRollingWindowResult,
     WorkbenchRiskSummaryPayload,
     WorkbenchRiskSummaryResponse,
     WorkbenchRiskSupportabilityItem,
@@ -40,6 +46,22 @@ _SUMMARY_METRICS = [
 _BENCHMARK_DEPENDENT_METRICS = {"BETA", "TRACKING_ERROR", "INFORMATION_RATIO"}
 _RISK_FREE_DEPENDENT_METRICS = {"SHARPE"}
 _DRAWDOWN_SUPPORTABILITY_KEY_BENCHMARK = "benchmark_relative_drawdown"
+_ROLLING_METRIC_LABELS = {
+    "ROLLING_VOLATILITY": "Rolling Volatility",
+    "ROLLING_SHARPE": "Rolling Sharpe",
+    "ROLLING_BETA": "Rolling Beta",
+    "ROLLING_TRACKING_ERROR": "Rolling Tracking Error",
+    "ROLLING_INFORMATION_RATIO": "Rolling Information Ratio",
+    "ROLLING_MAX_DRAWDOWN": "Rolling Max Drawdown",
+}
+_ROLLING_PORTFOLIO_METRICS = ["ROLLING_VOLATILITY", "ROLLING_MAX_DRAWDOWN"]
+_ROLLING_BENCHMARK_METRICS = [
+    "ROLLING_BETA",
+    "ROLLING_TRACKING_ERROR",
+    "ROLLING_INFORMATION_RATIO",
+]
+_ROLLING_SHARPE_METRIC = "ROLLING_SHARPE"
+_ROLLING_DEFAULT_WINDOWS = [21, 63, 126, 252]
 _METRIC_LABELS = {
     "VOLATILITY": "Volatility",
     "DRAWDOWN": "Drawdown",
@@ -64,6 +86,7 @@ class RiskWorkspaceService:
             WorkbenchRiskSummaryResponse
             | WorkbenchRiskConcentrationResponse
             | WorkbenchRiskDrawdownResponse
+            | WorkbenchRiskRollingResponse
         ](ttl_seconds=cache_ttl_seconds or settings.risk_bff_cache_ttl_seconds)
 
     def clear_cache(self) -> None:
@@ -278,6 +301,107 @@ class RiskWorkspaceService:
             deep=True,
         )
 
+    async def get_rolling(
+        self,
+        *,
+        portfolio_id: str,
+        correlation_id: str,
+        period: str,
+        detail_basis: str,
+        benchmark_code: str | None,
+        as_of_date: str | None,
+        reporting_currency: str | None,
+        include_time_series: bool,
+    ) -> WorkbenchRiskRollingResponse:
+        resolved_as_of_date = _resolve_as_of_date(as_of_date)
+        cache_key = (
+            "rolling",
+            portfolio_id,
+            period,
+            detail_basis,
+            benchmark_code or "",
+            resolved_as_of_date,
+            reporting_currency or "",
+            include_time_series,
+        )
+
+        async def _load() -> WorkbenchRiskRollingResponse:
+            initial_payload = _build_rolling_request(
+                portfolio_id=portfolio_id,
+                period=period,
+                detail_basis=detail_basis,
+                benchmark_code=benchmark_code,
+                as_of_date=resolved_as_of_date,
+                reporting_currency=reporting_currency,
+                include_time_series=include_time_series,
+                include_sharpe=True,
+            )
+            upstream_status, upstream_payload = await self._risk_client.post_risk_rolling_metrics(
+                payload=initial_payload,
+                correlation_id=correlation_id,
+            )
+            sharpe_fallback_reason: str | None = None
+            if _should_retry_rolling_without_sharpe(
+                upstream_status=upstream_status,
+                upstream_payload=upstream_payload,
+            ):
+                sharpe_fallback_reason = _rolling_sharpe_failure_reason(upstream_payload)
+                fallback_payload = _build_rolling_request(
+                    portfolio_id=portfolio_id,
+                    period=period,
+                    detail_basis=detail_basis,
+                    benchmark_code=benchmark_code,
+                    as_of_date=resolved_as_of_date,
+                    reporting_currency=reporting_currency,
+                    include_time_series=include_time_series,
+                    include_sharpe=False,
+                )
+                upstream_status, upstream_payload = (
+                    await self._risk_client.post_risk_rolling_metrics(
+                        payload=fallback_payload,
+                        correlation_id=correlation_id,
+                    )
+                )
+
+            if upstream_status >= status.HTTP_400_BAD_REQUEST or not isinstance(
+                upstream_payload, dict
+            ):
+                return _unavailable_rolling(
+                    correlation_id=correlation_id,
+                    portfolio_id=portfolio_id,
+                    period=period,
+                    as_of_date=resolved_as_of_date,
+                    benchmark_code=benchmark_code,
+                    include_time_series=include_time_series,
+                    upstream_status=upstream_status,
+                    upstream_payload=upstream_payload,
+                )
+
+            return _map_rolling_response(
+                correlation_id=correlation_id,
+                portfolio_id=portfolio_id,
+                period=period,
+                as_of_date=resolved_as_of_date,
+                benchmark_code=benchmark_code,
+                include_time_series=include_time_series,
+                sharpe_fallback_reason=sharpe_fallback_reason,
+                upstream_payload=upstream_payload,
+            )
+
+        response, cache_hit = await self._cache.get_or_set_with_status(
+            key=cache_key, factory=_load
+        )
+        typed_response = cast(WorkbenchRiskRollingResponse, response)
+        return typed_response.model_copy(
+            update={
+                "correlation_id": correlation_id,
+                "metadata": typed_response.metadata.model_copy(
+                    update={"cache_status": "hit" if cache_hit else "miss"}
+                ),
+            },
+            deep=True,
+        )
+
 
 def _build_summary_request(
     *,
@@ -366,6 +490,41 @@ def _build_drawdown_request(
             "duration_unit": "BUSINESS_DAYS",
         },
     }
+
+
+def _build_rolling_request(
+    *,
+    portfolio_id: str,
+    period: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    as_of_date: str,
+    reporting_currency: str | None,
+    include_time_series: bool,
+    include_sharpe: bool,
+) -> dict[str, Any]:
+    metrics = list(_ROLLING_PORTFOLIO_METRICS)
+    if include_sharpe:
+        metrics.append(_ROLLING_SHARPE_METRIC)
+    if benchmark_code:
+        metrics.extend(_ROLLING_BENCHMARK_METRICS)
+    stateful_input: dict[str, Any] = {
+        "portfolio_id": portfolio_id,
+        "as_of_date": as_of_date,
+        "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
+        "periods": [{"type": _normalize_period(period), "name": period.upper()}],
+        "rolling_options": {
+            "window_lengths": _ROLLING_DEFAULT_WINDOWS,
+            "metrics": metrics,
+            "annualization_basis": 252,
+            "min_observations_policy": "STRICT",
+            "alignment_policy": "INNER_JOIN",
+            "include_time_series": include_time_series,
+        },
+    }
+    if reporting_currency:
+        stateful_input["reporting_currency"] = reporting_currency
+    return {"input_mode": "stateful", "stateful_input": stateful_input}
 
 
 def _map_summary_response(
@@ -741,6 +900,139 @@ def _map_drawdown_response(
     )
 
 
+def _map_rolling_response(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    include_time_series: bool,
+    sharpe_fallback_reason: str | None,
+    upstream_payload: dict[str, Any],
+) -> WorkbenchRiskRollingResponse:
+    results = upstream_payload.get("results")
+    warnings: list[str] = []
+    partial_failures: list[WorkbenchPartialFailure] = []
+    period_results: list[WorkbenchRiskRollingPeriodResult] = []
+    supportability = [
+        WorkbenchRiskSupportabilityItem(
+            key="portfolio_returns",
+            label="Portfolio returns",
+            state="ready" if isinstance(results, dict) and results else "unavailable",
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="benchmark_returns",
+            label="Benchmark returns",
+            state="ready" if benchmark_code else "partial",
+            reason=(
+                None
+                if benchmark_code
+                else "Benchmark-relative rolling metrics require benchmark context."
+            ),
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="risk_free_series",
+            label="Risk-free series",
+            state="partial" if sharpe_fallback_reason else "ready",
+            reason=sharpe_fallback_reason,
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="rolling_time_series",
+            label="Rolling time series",
+            state="ready" if include_time_series else "partial",
+            reason=(
+                None
+                if include_time_series
+                else "Rolling metric series is available on demand and excluded from first paint."
+            ),
+            source_service="lotus-risk",
+        ),
+    ]
+
+    if isinstance(results, dict):
+        for key, value in results.items():
+            if not isinstance(value, dict):
+                continue
+            quality_flags = [
+                str(flag)
+                for flag in value.get("quality_flags", [])
+                if isinstance(flag, str) and flag.strip()
+            ]
+            error = value.get("error")
+            if quality_flags:
+                warnings.append("RISK_ROLLING_QUALITY_FLAGS")
+            if isinstance(error, str) and error.strip():
+                partial_failures.append(
+                    WorkbenchPartialFailure(
+                        source_service="risk",
+                        error_code="ROLLING_PERIOD_ERROR",
+                        detail=f"{key}: {error}",
+                    )
+                )
+                warnings.append("RISK_ROLLING_PERIOD_PARTIAL")
+            period_results.append(
+                WorkbenchRiskRollingPeriodResult(
+                    key=str(key),
+                    label=str(key),
+                    start_date=str(value.get("start_date", "")),
+                    end_date=str(value.get("end_date", "")),
+                    series_count=int(value.get("series_count", 0)),
+                    window_results=_map_rolling_window_results(value.get("window_results")),
+                    quality_flags=quality_flags,
+                    error=str(error) if isinstance(error, str) and error.strip() else None,
+                )
+            )
+
+    state = "partial" if any(item.state != "ready" for item in supportability) else "ready"
+    if not period_results:
+        state = "unavailable"
+        warnings.append("RISK_ROLLING_EMPTY")
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="risk",
+                error_code="EMPTY_RISK_ROLLING",
+                detail="lotus-risk returned no rolling periods.",
+            )
+        )
+    elif all(not period.window_results for period in period_results):
+        state = "unavailable"
+
+    metadata = _metadata(input_mode="stateful", cache_status="miss")
+    upstream_metadata = upstream_payload.get("metadata")
+    if isinstance(upstream_metadata, dict):
+        methodology_version = upstream_metadata.get("methodology_version")
+        if isinstance(methodology_version, str) and methodology_version.strip():
+            metadata = metadata.model_copy(update={"methodology_version": methodology_version})
+
+    if sharpe_fallback_reason:
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="risk",
+                error_code="ROLLING_SHARPE_UNAVAILABLE",
+                detail=sharpe_fallback_reason,
+            )
+        )
+        warnings.append("RISK_ROLLING_SHARPE_PARTIAL")
+
+    return WorkbenchRiskRollingResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state=state,
+        payload=WorkbenchRiskRollingPayload(periods=period_results) if period_results else None,
+        supportability=supportability,
+        warnings=sorted(set(warnings)),
+        partial_failures=partial_failures,
+        metadata=metadata,
+    )
+
+
 def _issuer_supportability_state(payload: Any) -> str:
     if not isinstance(payload, dict):
         return "unavailable"
@@ -868,6 +1160,45 @@ def _unavailable_drawdown(
     )
 
 
+def _unavailable_rolling(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    include_time_series: bool,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> WorkbenchRiskRollingResponse:
+    reason = (
+        "lotus-risk rolling endpoint is unavailable."
+        if not include_time_series
+        else "lotus-risk rolling detail endpoint is unavailable."
+    )
+    return WorkbenchRiskRollingResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="unavailable",
+        payload=None,
+        supportability=[
+            WorkbenchRiskSupportabilityItem(
+                key="risk_service",
+                label="Risk service",
+                state="unavailable",
+                reason=reason,
+                source_service="lotus-risk",
+            )
+        ],
+        warnings=["RISK_ROLLING_UNAVAILABLE"],
+        partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
+        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
 def _malformed_concentration(
     *,
     correlation_id: str,
@@ -969,3 +1300,94 @@ def _map_underwater_series(series_payload: list[Any]) -> list[WorkbenchRiskUnder
             continue
         points.append(WorkbenchRiskUnderwaterPoint.model_validate(payload))
     return points
+
+
+def _map_rolling_window_results(window_payload: Any) -> list[WorkbenchRiskRollingWindowResult]:
+    if not isinstance(window_payload, list):
+        return []
+    results: list[WorkbenchRiskRollingWindowResult] = []
+    for entry in window_payload:
+        if not isinstance(entry, dict):
+            continue
+        metric_summaries_payload = entry.get("metric_summaries")
+        metric_series_payload = entry.get("metric_series")
+        metric_summaries = (
+            {
+                str(key): WorkbenchRiskRollingMetricSummary.model_validate(value)
+                for key, value in metric_summaries_payload.items()
+                if isinstance(key, str) and isinstance(value, dict)
+            }
+            if isinstance(metric_summaries_payload, dict)
+            else {}
+        )
+        metric_series = (
+            _map_rolling_metric_series(metric_series_payload)
+            if isinstance(metric_series_payload, list)
+            else None
+        )
+        results.append(
+            WorkbenchRiskRollingWindowResult(
+                window_length=int(entry.get("window_length", 0)),
+                metric_summaries=metric_summaries,
+                metric_series=metric_series,
+            )
+        )
+    results.sort(key=lambda item: item.window_length)
+    return results
+
+
+def _map_rolling_metric_series(
+    series_payload: list[Any],
+) -> list[WorkbenchRiskRollingMetricSeriesPoint]:
+    series: list[WorkbenchRiskRollingMetricSeriesPoint] = []
+    for entry in series_payload:
+        if not isinstance(entry, dict):
+            continue
+        metric_values_payload = entry.get("metric_values")
+        metric_values = (
+            {
+                str(key): float(value) if isinstance(value, int | float) else None
+                for key, value in metric_values_payload.items()
+                if isinstance(key, str)
+            }
+            if isinstance(metric_values_payload, dict)
+            else {}
+        )
+        series.append(
+            WorkbenchRiskRollingMetricSeriesPoint(
+                date=str(entry.get("date", "")),
+                metric_values=metric_values,
+            )
+        )
+    return series
+
+
+def _should_retry_rolling_without_sharpe(
+    *,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> bool:
+    if upstream_status != status.HTTP_424_FAILED_DEPENDENCY:
+        return False
+    if isinstance(upstream_payload, dict):
+        detail = upstream_payload.get("detail")
+        if isinstance(detail, dict):
+            message = detail.get("message")
+            if isinstance(message, str) and "risk-free" in message.lower():
+                return True
+        text = str(upstream_payload.get("detail", "")).lower()
+        return "risk-free" in text
+    return "risk-free" in str(upstream_payload).lower()
+
+
+def _rolling_sharpe_failure_reason(upstream_payload: Any) -> str:
+    if isinstance(upstream_payload, dict):
+        detail = upstream_payload.get("detail")
+        if isinstance(detail, dict):
+            message = detail.get("message")
+            if isinstance(message, str) and message.strip():
+                return message
+        text = upstream_payload.get("detail")
+        if isinstance(text, str) and text.strip():
+            return text
+    return "Rolling Sharpe is unavailable because the risk-free series could not be sourced."

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -1,0 +1,620 @@
+from datetime import UTC, date, datetime
+from typing import Any, cast
+
+from fastapi import status
+
+from app.clients.lotus_analytics_client import LotusAnalyticsClient
+from app.config import settings
+from app.contracts.risk_workspace import (
+    WorkbenchConcentrationRiskProxy,
+    WorkbenchIssuerConcentration,
+    WorkbenchRiskConcentrationPayload,
+    WorkbenchRiskConcentrationResponse,
+    WorkbenchRiskMetadata,
+    WorkbenchRiskMetric,
+    WorkbenchRiskPeriodResult,
+    WorkbenchRiskSummaryPayload,
+    WorkbenchRiskSummaryResponse,
+    WorkbenchRiskSupportabilityItem,
+    WorkbenchSinglePositionConcentration,
+)
+from app.contracts.workbench import WorkbenchPartialFailure
+from app.services.async_ttl_cache import AsyncTtlCache
+
+_SUMMARY_METRICS = [
+    "VOLATILITY",
+    "SHARPE",
+    "SORTINO",
+    "BETA",
+    "TRACKING_ERROR",
+    "INFORMATION_RATIO",
+    "VAR",
+]
+_BENCHMARK_DEPENDENT_METRICS = {"BETA", "TRACKING_ERROR", "INFORMATION_RATIO"}
+_RISK_FREE_DEPENDENT_METRICS = {"SHARPE"}
+_METRIC_LABELS = {
+    "VOLATILITY": "Volatility",
+    "DRAWDOWN": "Drawdown",
+    "SHARPE": "Sharpe",
+    "SORTINO": "Sortino",
+    "BETA": "Beta",
+    "TRACKING_ERROR": "Tracking Error",
+    "INFORMATION_RATIO": "Information Ratio",
+    "VAR": "Value at Risk",
+}
+
+
+class RiskWorkspaceService:
+    def __init__(
+        self,
+        risk_client: LotusAnalyticsClient,
+        *,
+        cache_ttl_seconds: float | None = None,
+    ) -> None:
+        self._risk_client = risk_client
+        self._cache = AsyncTtlCache[
+            WorkbenchRiskSummaryResponse | WorkbenchRiskConcentrationResponse
+        ](ttl_seconds=cache_ttl_seconds or settings.risk_bff_cache_ttl_seconds)
+
+    def clear_cache(self) -> None:
+        self._cache.clear()
+
+    async def get_summary(
+        self,
+        *,
+        portfolio_id: str,
+        correlation_id: str,
+        period: str,
+        detail_basis: str,
+        benchmark_code: str | None,
+        as_of_date: str | None,
+        reporting_currency: str | None,
+    ) -> WorkbenchRiskSummaryResponse:
+        resolved_as_of_date = _resolve_as_of_date(as_of_date)
+        cache_key = (
+            "summary",
+            portfolio_id,
+            period,
+            detail_basis,
+            benchmark_code or "",
+            resolved_as_of_date,
+            reporting_currency or "",
+        )
+
+        async def _load() -> WorkbenchRiskSummaryResponse:
+            payload = _build_summary_request(
+                portfolio_id=portfolio_id,
+                period=period,
+                detail_basis=detail_basis,
+                as_of_date=resolved_as_of_date,
+                reporting_currency=reporting_currency,
+            )
+            upstream_status, upstream_payload = await self._risk_client.post_risk_calculate(
+                payload=payload,
+                correlation_id=correlation_id,
+            )
+            if upstream_status >= status.HTTP_400_BAD_REQUEST or not isinstance(
+                upstream_payload, dict
+            ):
+                return _unavailable_summary(
+                    correlation_id=correlation_id,
+                    portfolio_id=portfolio_id,
+                    period=period,
+                    as_of_date=resolved_as_of_date,
+                    benchmark_code=benchmark_code,
+                    upstream_status=upstream_status,
+                    upstream_payload=upstream_payload,
+                )
+            return _map_summary_response(
+                correlation_id=correlation_id,
+                portfolio_id=portfolio_id,
+                period=period,
+                as_of_date=resolved_as_of_date,
+                benchmark_code=benchmark_code,
+                upstream_payload=upstream_payload,
+            )
+
+        response, cache_hit = await self._cache.get_or_set_with_status(
+            key=cache_key, factory=_load
+        )
+        typed_response = cast(WorkbenchRiskSummaryResponse, response)
+        return typed_response.model_copy(
+            update={
+                "correlation_id": correlation_id,
+                "metadata": typed_response.metadata.model_copy(
+                    update={"cache_status": "hit" if cache_hit else "miss"}
+                ),
+            },
+            deep=True,
+        )
+
+    async def get_concentration(
+        self,
+        *,
+        portfolio_id: str,
+        correlation_id: str,
+        period: str,
+        as_of_date: str | None,
+        reporting_currency: str | None,
+        benchmark_code: str | None,
+    ) -> WorkbenchRiskConcentrationResponse:
+        resolved_as_of_date = _resolve_as_of_date(as_of_date)
+        cache_key = (
+            "concentration",
+            portfolio_id,
+            period,
+            resolved_as_of_date,
+            reporting_currency or "",
+            benchmark_code or "",
+        )
+
+        async def _load() -> WorkbenchRiskConcentrationResponse:
+            payload = _build_concentration_request(
+                portfolio_id=portfolio_id,
+                as_of_date=resolved_as_of_date,
+                reporting_currency=reporting_currency,
+            )
+            upstream_status, upstream_payload = await self._risk_client.post_risk_concentration(
+                payload=payload,
+                correlation_id=correlation_id,
+            )
+            if upstream_status >= status.HTTP_400_BAD_REQUEST or not isinstance(
+                upstream_payload, dict
+            ):
+                return _unavailable_concentration(
+                    correlation_id=correlation_id,
+                    portfolio_id=portfolio_id,
+                    period=period,
+                    as_of_date=resolved_as_of_date,
+                    benchmark_code=benchmark_code,
+                    upstream_status=upstream_status,
+                    upstream_payload=upstream_payload,
+                )
+            return _map_concentration_response(
+                correlation_id=correlation_id,
+                portfolio_id=portfolio_id,
+                period=period,
+                as_of_date=resolved_as_of_date,
+                benchmark_code=benchmark_code,
+                upstream_payload=upstream_payload,
+            )
+
+        response, cache_hit = await self._cache.get_or_set_with_status(
+            key=cache_key, factory=_load
+        )
+        typed_response = cast(WorkbenchRiskConcentrationResponse, response)
+        return typed_response.model_copy(
+            update={
+                "correlation_id": correlation_id,
+                "metadata": typed_response.metadata.model_copy(
+                    update={"cache_status": "hit" if cache_hit else "miss"}
+                ),
+            },
+            deep=True,
+        )
+
+
+def _build_summary_request(
+    *,
+    portfolio_id: str,
+    period: str,
+    detail_basis: str,
+    as_of_date: str,
+    reporting_currency: str | None,
+) -> dict[str, Any]:
+    stateful_input: dict[str, Any] = {
+        "portfolio_id": portfolio_id,
+        "as_of_date": as_of_date,
+        "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
+        "periods": [{"type": _normalize_period(period), "name": period.upper()}],
+        "metrics": _SUMMARY_METRICS,
+        "options": {
+            "frequency": "DAILY",
+            "risk_free_mode": "ZERO",
+            "var": {
+                "method": "HISTORICAL",
+                "confidence": 0.95,
+                "horizon_days": 1,
+                "include_expected_shortfall": True,
+            },
+        },
+    }
+    if reporting_currency:
+        stateful_input["reporting_currency"] = reporting_currency
+    return {"input_mode": "stateful", "stateful_input": stateful_input}
+
+
+def _build_concentration_request(
+    *,
+    portfolio_id: str,
+    as_of_date: str,
+    reporting_currency: str | None,
+) -> dict[str, Any]:
+    stateful_input: dict[str, Any] = {
+        "portfolio_id": portfolio_id,
+        "as_of_date": as_of_date,
+        "include_cash_positions": True,
+        "include_zero_quantity_positions": False,
+        "top_n": 10,
+    }
+    if reporting_currency:
+        stateful_input["reporting_currency"] = reporting_currency
+    return {
+        "input_mode": "stateful",
+        "stateful_input": stateful_input,
+        "issuer_grouping_level": "ultimate_parent",
+        "enrichment_policy": "merge_caller_then_core",
+    }
+
+
+def _map_summary_response(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    upstream_payload: dict[str, Any],
+) -> WorkbenchRiskSummaryResponse:
+    results = upstream_payload.get("results")
+    warnings: list[str] = []
+    partial_failures: list[WorkbenchPartialFailure] = []
+    period_results: list[WorkbenchRiskPeriodResult] = []
+    supportability = [
+        WorkbenchRiskSupportabilityItem(
+            key="portfolio_returns",
+            label="Portfolio returns",
+            state="ready" if isinstance(results, dict) and results else "unavailable",
+            source_service="lotus-risk",
+        )
+    ]
+    metric_states: dict[str, str] = {}
+    if isinstance(results, dict):
+        for key, value in results.items():
+            if not isinstance(value, dict):
+                continue
+            metrics_payload = value.get("metrics")
+            metrics = _map_metrics(metrics_payload if isinstance(metrics_payload, dict) else {})
+            for metric in metrics:
+                metric_states[metric.key] = metric.state
+            period_results.append(
+                WorkbenchRiskPeriodResult(
+                    key=str(key),
+                    label=str(key),
+                    start_date=str(value.get("start_date", "")),
+                    end_date=str(value.get("end_date", "")),
+                    metrics=metrics,
+                )
+            )
+    supportability.extend(_metric_dependency_supportability(metric_states, benchmark_code))
+    state = "partial" if any(item.state != "ready" for item in supportability) else "ready"
+    if not period_results:
+        state = "unavailable"
+        warnings.append("RISK_SUMMARY_EMPTY")
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="risk",
+                error_code="EMPTY_RISK_SUMMARY",
+                detail="lotus-risk returned no risk summary periods.",
+            )
+        )
+    return WorkbenchRiskSummaryResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state=state,
+        payload=WorkbenchRiskSummaryPayload(periods=period_results) if period_results else None,
+        supportability=supportability,
+        warnings=warnings,
+        partial_failures=partial_failures,
+        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def _map_metrics(metrics_payload: dict[str, Any]) -> list[WorkbenchRiskMetric]:
+    metrics: list[WorkbenchRiskMetric] = []
+    for key in _SUMMARY_METRICS:
+        raw_value = metrics_payload.get(key)
+        if not isinstance(raw_value, dict):
+            metrics.append(
+                WorkbenchRiskMetric(
+                    key=key,
+                    label=_METRIC_LABELS.get(key, key),
+                    value=None,
+                    state="unavailable",
+                    reason="Metric was not returned by lotus-risk.",
+                )
+            )
+            continue
+        value = raw_value.get("value")
+        details = raw_value.get("details") if isinstance(raw_value.get("details"), dict) else None
+        error = details.get("error") if isinstance(details, dict) else None
+        metrics.append(
+            WorkbenchRiskMetric(
+                key=key,
+                label=_METRIC_LABELS.get(key, key),
+                value=float(value) if isinstance(value, int | float) else None,
+                state="partial" if error else "ready",
+                reason=str(error) if error else None,
+                details=details,
+            )
+        )
+    return metrics
+
+
+def _metric_dependency_supportability(
+    metric_states: dict[str, str], benchmark_code: str | None
+) -> list[WorkbenchRiskSupportabilityItem]:
+    benchmark_metric_states = [
+        metric_states.get(metric, "unavailable") for metric in _BENCHMARK_DEPENDENT_METRICS
+    ]
+    risk_free_metric_states = [
+        metric_states.get(metric, "unavailable") for metric in _RISK_FREE_DEPENDENT_METRICS
+    ]
+    benchmark_ready = bool(benchmark_code) and benchmark_metric_states and all(
+        state == "ready" for state in benchmark_metric_states
+    )
+    risk_free_ready = bool(risk_free_metric_states) and all(
+        state == "ready" for state in risk_free_metric_states
+    )
+    return [
+        WorkbenchRiskSupportabilityItem(
+            key="benchmark_returns",
+            label="Benchmark returns",
+            state="ready" if benchmark_ready else "partial",
+            reason=None
+            if benchmark_code
+            else "Benchmark-relative metrics require benchmark context.",
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="risk_free_series",
+            label="Risk-free series",
+            state="ready" if risk_free_ready else "partial",
+            reason=(
+                "Sharpe may use default zero risk-free assumption when no risk-free "
+                "series is available."
+            ),
+            source_service="lotus-risk",
+        ),
+    ]
+
+
+def _map_concentration_response(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    upstream_payload: dict[str, Any],
+) -> WorkbenchRiskConcentrationResponse:
+    required_blocks = {
+        "risk_proxy": upstream_payload.get("risk_proxy"),
+        "single_position_concentration": upstream_payload.get("single_position_concentration"),
+        "issuer_concentration": upstream_payload.get("issuer_concentration"),
+    }
+    missing_blocks = [key for key, value in required_blocks.items() if not isinstance(value, dict)]
+    if missing_blocks:
+        return _malformed_concentration(
+            correlation_id=correlation_id,
+            portfolio_id=portfolio_id,
+            period=period,
+            as_of_date=as_of_date,
+            benchmark_code=benchmark_code,
+            missing_blocks=missing_blocks,
+        )
+    issuer_payload = upstream_payload.get("issuer_concentration")
+    issuer_state = _issuer_supportability_state(issuer_payload)
+    supportability = [
+        WorkbenchRiskSupportabilityItem(
+            key="portfolio_positions",
+            label="Portfolio positions",
+            state="ready",
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="issuer_enrichment",
+            label="Issuer enrichment",
+            state=issuer_state,
+            reason=_issuer_supportability_reason(issuer_payload),
+            source_service="lotus-risk",
+        ),
+    ]
+    return WorkbenchRiskConcentrationResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="ready" if issuer_state == "ready" else "partial",
+        payload=WorkbenchRiskConcentrationPayload(
+            risk_proxy=WorkbenchConcentrationRiskProxy.model_validate(
+                required_blocks["risk_proxy"]
+            ),
+            single_position_concentration=WorkbenchSinglePositionConcentration.model_validate(
+                required_blocks["single_position_concentration"]
+            ),
+            issuer_concentration=WorkbenchIssuerConcentration.model_validate(
+                required_blocks["issuer_concentration"]
+            ),
+            valuation_context=upstream_payload.get("valuation_context")
+            if isinstance(upstream_payload.get("valuation_context"), dict)
+            else None,
+            risk_metadata=upstream_payload.get("metadata")
+            if isinstance(upstream_payload.get("metadata"), dict)
+            else None,
+        ),
+        supportability=supportability,
+        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def _issuer_supportability_state(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return "unavailable"
+    status_value = str(payload.get("coverage_status", "")).lower()
+    if status_value == "complete":
+        return "ready"
+    if status_value == "partial":
+        return "partial"
+    return "unavailable"
+
+
+def _issuer_supportability_reason(payload: Any) -> str | None:
+    if not isinstance(payload, dict):
+        return "Issuer concentration block was not returned by lotus-risk."
+    note = payload.get("note")
+    if isinstance(note, str) and note.strip():
+        return note
+    if str(payload.get("coverage_status", "")).lower() != "complete":
+        return "Issuer coverage is not complete for the selected portfolio context."
+    return None
+
+
+def _unavailable_summary(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> WorkbenchRiskSummaryResponse:
+    return WorkbenchRiskSummaryResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="unavailable",
+        payload=None,
+        supportability=[
+            WorkbenchRiskSupportabilityItem(
+                key="risk_service",
+                label="Risk service",
+                state="unavailable",
+                reason="lotus-risk summary endpoint is unavailable.",
+                source_service="lotus-risk",
+            )
+        ],
+        warnings=["RISK_SUMMARY_UNAVAILABLE"],
+        partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
+        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def _unavailable_concentration(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> WorkbenchRiskConcentrationResponse:
+    return WorkbenchRiskConcentrationResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="unavailable",
+        payload=None,
+        supportability=[
+            WorkbenchRiskSupportabilityItem(
+                key="risk_service",
+                label="Risk service",
+                state="unavailable",
+                reason="lotus-risk concentration endpoint is unavailable.",
+                source_service="lotus-risk",
+            )
+        ],
+        warnings=["RISK_CONCENTRATION_UNAVAILABLE"],
+        partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
+        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def _malformed_concentration(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    missing_blocks: list[str],
+) -> WorkbenchRiskConcentrationResponse:
+    detail = (
+        "lotus-risk concentration response omitted required blocks: "
+        + ", ".join(missing_blocks)
+    )
+    return WorkbenchRiskConcentrationResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="unavailable",
+        payload=None,
+        supportability=[
+            WorkbenchRiskSupportabilityItem(
+                key="risk_service_contract",
+                label="Risk service contract",
+                state="unavailable",
+                reason=detail,
+                source_service="lotus-risk",
+            )
+        ],
+        warnings=["RISK_CONCENTRATION_CONTRACT_INVALID"],
+        partial_failures=[
+            WorkbenchPartialFailure(
+                source_service="risk",
+                error_code="MALFORMED_RISK_CONCENTRATION",
+                detail=detail,
+            )
+        ],
+        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def _upstream_failure(upstream_status: int, upstream_payload: Any) -> WorkbenchPartialFailure:
+    detail = (
+        str(upstream_payload.get("detail", upstream_payload))
+        if isinstance(upstream_payload, dict)
+        else str(upstream_payload)
+    )
+    return WorkbenchPartialFailure(
+        source_service="risk",
+        error_code=f"HTTP_{upstream_status}",
+        detail=detail,
+    )
+
+
+def _metadata(*, input_mode: str, cache_status: str) -> WorkbenchRiskMetadata:
+    return WorkbenchRiskMetadata(
+        generated_at=datetime.now(tz=UTC).isoformat(),
+        input_mode=cast(Any, input_mode),
+        cache_status=cast(Any, cache_status),
+    )
+
+
+def _resolve_as_of_date(value: str | None) -> str:
+    return value or date.today().isoformat()
+
+
+def _normalize_period(value: str) -> str:
+    normalized = value.upper()
+    if normalized in {"MTD", "QTD", "YTD", "SI"}:
+        return normalized
+    if normalized in {"1Y", "ONE_YEAR"}:
+        return "ONE_YEAR"
+    if normalized in {"3Y", "THREE_YEAR"}:
+        return "THREE_YEAR"
+    if normalized in {"5Y", "FIVE_YEAR"}:
+        return "FIVE_YEAR"
+    return "YTD"

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -10,12 +10,19 @@ from app.contracts.risk_workspace import (
     WorkbenchIssuerConcentration,
     WorkbenchRiskConcentrationPayload,
     WorkbenchRiskConcentrationResponse,
+    WorkbenchRiskDrawdownEpisode,
+    WorkbenchRiskDrawdownPayload,
+    WorkbenchRiskDrawdownPeriodResult,
+    WorkbenchRiskDrawdownResponse,
+    WorkbenchRiskDrawdownSummary,
     WorkbenchRiskMetadata,
     WorkbenchRiskMetric,
     WorkbenchRiskPeriodResult,
+    WorkbenchRiskRelativeDrawdownSummary,
     WorkbenchRiskSummaryPayload,
     WorkbenchRiskSummaryResponse,
     WorkbenchRiskSupportabilityItem,
+    WorkbenchRiskUnderwaterPoint,
     WorkbenchSinglePositionConcentration,
 )
 from app.contracts.workbench import WorkbenchPartialFailure
@@ -32,6 +39,7 @@ _SUMMARY_METRICS = [
 ]
 _BENCHMARK_DEPENDENT_METRICS = {"BETA", "TRACKING_ERROR", "INFORMATION_RATIO"}
 _RISK_FREE_DEPENDENT_METRICS = {"SHARPE"}
+_DRAWDOWN_SUPPORTABILITY_KEY_BENCHMARK = "benchmark_relative_drawdown"
 _METRIC_LABELS = {
     "VOLATILITY": "Volatility",
     "DRAWDOWN": "Drawdown",
@@ -53,7 +61,9 @@ class RiskWorkspaceService:
     ) -> None:
         self._risk_client = risk_client
         self._cache = AsyncTtlCache[
-            WorkbenchRiskSummaryResponse | WorkbenchRiskConcentrationResponse
+            WorkbenchRiskSummaryResponse
+            | WorkbenchRiskConcentrationResponse
+            | WorkbenchRiskDrawdownResponse
         ](ttl_seconds=cache_ttl_seconds or settings.risk_bff_cache_ttl_seconds)
 
     def clear_cache(self) -> None:
@@ -193,6 +203,81 @@ class RiskWorkspaceService:
             deep=True,
         )
 
+    async def get_drawdown(
+        self,
+        *,
+        portfolio_id: str,
+        correlation_id: str,
+        period: str,
+        detail_basis: str,
+        benchmark_code: str | None,
+        as_of_date: str | None,
+        reporting_currency: str | None,
+        include_underwater_series: bool,
+    ) -> WorkbenchRiskDrawdownResponse:
+        resolved_as_of_date = _resolve_as_of_date(as_of_date)
+        cache_key = (
+            "drawdown",
+            portfolio_id,
+            period,
+            detail_basis,
+            benchmark_code or "",
+            resolved_as_of_date,
+            reporting_currency or "",
+            include_underwater_series,
+        )
+
+        async def _load() -> WorkbenchRiskDrawdownResponse:
+            payload = _build_drawdown_request(
+                portfolio_id=portfolio_id,
+                period=period,
+                detail_basis=detail_basis,
+                benchmark_code=benchmark_code,
+                as_of_date=resolved_as_of_date,
+                reporting_currency=reporting_currency,
+                include_underwater_series=include_underwater_series,
+            )
+            upstream_status, upstream_payload = await self._risk_client.post_risk_drawdown(
+                payload=payload,
+                correlation_id=correlation_id,
+            )
+            if upstream_status >= status.HTTP_400_BAD_REQUEST or not isinstance(
+                upstream_payload, dict
+            ):
+                return _unavailable_drawdown(
+                    correlation_id=correlation_id,
+                    portfolio_id=portfolio_id,
+                    period=period,
+                    as_of_date=resolved_as_of_date,
+                    benchmark_code=benchmark_code,
+                    include_underwater_series=include_underwater_series,
+                    upstream_status=upstream_status,
+                    upstream_payload=upstream_payload,
+                )
+            return _map_drawdown_response(
+                correlation_id=correlation_id,
+                portfolio_id=portfolio_id,
+                period=period,
+                as_of_date=resolved_as_of_date,
+                benchmark_code=benchmark_code,
+                include_underwater_series=include_underwater_series,
+                upstream_payload=upstream_payload,
+            )
+
+        response, cache_hit = await self._cache.get_or_set_with_status(
+            key=cache_key, factory=_load
+        )
+        typed_response = cast(WorkbenchRiskDrawdownResponse, response)
+        return typed_response.model_copy(
+            update={
+                "correlation_id": correlation_id,
+                "metadata": typed_response.metadata.model_copy(
+                    update={"cache_status": "hit" if cache_hit else "miss"}
+                ),
+            },
+            deep=True,
+        )
+
 
 def _build_summary_request(
     *,
@@ -244,6 +329,42 @@ def _build_concentration_request(
         "stateful_input": stateful_input,
         "issuer_grouping_level": "ultimate_parent",
         "enrichment_policy": "merge_caller_then_core",
+    }
+
+
+def _build_drawdown_request(
+    *,
+    portfolio_id: str,
+    period: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    as_of_date: str,
+    reporting_currency: str | None,
+    include_underwater_series: bool,
+) -> dict[str, Any]:
+    stateful_input: dict[str, Any] = {
+        "portfolio_id": portfolio_id,
+        "as_of_date": as_of_date,
+        "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
+        "periods": [{"type": _normalize_period(period), "name": period.upper()}],
+        "benchmark_policy": {
+            "include_benchmark": bool(benchmark_code),
+            "missing_benchmark_policy": "IGNORE",
+        },
+    }
+    if reporting_currency:
+        stateful_input["reporting_currency"] = reporting_currency
+    return {
+        "input_mode": "stateful",
+        "stateful_input": stateful_input,
+        "analysis_options": {
+            "include_underwater_series": include_underwater_series,
+            "include_episode_list": True,
+            "top_n_episodes": 5,
+            "cdar_alpha": 0.95,
+            "minimum_episode_depth_bps": 0,
+            "duration_unit": "BUSINESS_DAYS",
+        },
     }
 
 
@@ -452,6 +573,174 @@ def _map_concentration_response(
     )
 
 
+def _map_drawdown_response(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    include_underwater_series: bool,
+    upstream_payload: dict[str, Any],
+) -> WorkbenchRiskDrawdownResponse:
+    results = upstream_payload.get("results")
+    warnings: list[str] = []
+    partial_failures: list[WorkbenchPartialFailure] = []
+    period_results: list[WorkbenchRiskDrawdownPeriodResult] = []
+    supportability = [
+        WorkbenchRiskSupportabilityItem(
+            key="portfolio_returns",
+            label="Portfolio returns",
+            state="ready" if isinstance(results, dict) and results else "unavailable",
+            source_service="lotus-risk",
+        )
+    ]
+    benchmark_supportability_state = "unavailable"
+    benchmark_supportability_reason: str | None = None
+    underwater_supportability_state = "partial" if not include_underwater_series else "unavailable"
+    underwater_supportability_reason = (
+        "Underwater series is available on demand and is not included in first paint."
+        if not include_underwater_series
+        else None
+    )
+
+    if isinstance(results, dict):
+        for key, value in results.items():
+            if not isinstance(value, dict):
+                continue
+            summary_payload = value.get("summary")
+            episodes_payload = value.get("episodes")
+            relative_payload = value.get("relative_to_benchmark")
+            underwater_payload = value.get("underwater_series")
+            error = value.get("error")
+
+            summary = (
+                _map_drawdown_summary(summary_payload)
+                if isinstance(summary_payload, dict)
+                else None
+            )
+            episodes = (
+                _map_drawdown_episodes(episodes_payload)
+                if isinstance(episodes_payload, list)
+                else []
+            )
+            relative_to_benchmark = (
+                WorkbenchRiskRelativeDrawdownSummary.model_validate(relative_payload)
+                if isinstance(relative_payload, dict)
+                else None
+            )
+            underwater_series = (
+                _map_underwater_series(underwater_payload)
+                if isinstance(underwater_payload, list)
+                else None
+            )
+
+            if benchmark_code:
+                if relative_to_benchmark is not None:
+                    benchmark_supportability_state = "ready"
+                elif isinstance(error, str) and error.strip():
+                    benchmark_supportability_state = "partial"
+                    benchmark_supportability_reason = error
+                else:
+                    benchmark_supportability_state = "partial"
+                    benchmark_supportability_reason = (
+                        "Benchmark-relative drawdown was not returned by lotus-risk."
+                    )
+            else:
+                benchmark_supportability_state = "partial"
+                benchmark_supportability_reason = (
+                    "Benchmark-relative drawdown requires benchmark context."
+                )
+
+            if include_underwater_series:
+                if underwater_series is not None:
+                    underwater_supportability_state = "ready"
+                    underwater_supportability_reason = None
+                else:
+                    underwater_supportability_state = "partial"
+                    underwater_supportability_reason = (
+                        "Underwater series detail was requested but not returned by lotus-risk."
+                    )
+
+            if isinstance(error, str) and error.strip():
+                partial_failures.append(
+                    WorkbenchPartialFailure(
+                        source_service="risk",
+                        error_code="DRAWDOWN_PERIOD_ERROR",
+                        detail=f"{key}: {error}",
+                    )
+                )
+                warnings.append("RISK_DRAWDOWN_PERIOD_PARTIAL")
+
+            period_results.append(
+                WorkbenchRiskDrawdownPeriodResult(
+                    key=str(key),
+                    label=str(key),
+                    start_date=str(value.get("start_date", "")),
+                    end_date=str(value.get("end_date", "")),
+                    summary=summary,
+                    episodes=episodes,
+                    relative_to_benchmark=relative_to_benchmark,
+                    underwater_series=underwater_series,
+                    error=str(error) if isinstance(error, str) and error.strip() else None,
+                )
+            )
+
+    supportability.extend(
+        [
+            WorkbenchRiskSupportabilityItem(
+                key=_DRAWDOWN_SUPPORTABILITY_KEY_BENCHMARK,
+                label="Benchmark-relative drawdown",
+                state=cast(Any, benchmark_supportability_state),
+                reason=benchmark_supportability_reason,
+                source_service="lotus-risk",
+            ),
+            WorkbenchRiskSupportabilityItem(
+                key="underwater_series",
+                label="Underwater series",
+                state=cast(Any, underwater_supportability_state),
+                reason=underwater_supportability_reason,
+                source_service="lotus-risk",
+            ),
+        ]
+    )
+
+    state = "partial" if any(item.state != "ready" for item in supportability) else "ready"
+    if not period_results:
+        state = "unavailable"
+        warnings.append("RISK_DRAWDOWN_EMPTY")
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="risk",
+                error_code="EMPTY_RISK_DRAWDOWN",
+                detail="lotus-risk returned no drawdown periods.",
+            )
+        )
+    elif all(period.summary is None for period in period_results):
+        state = "unavailable"
+
+    metadata = _metadata(input_mode="stateful", cache_status="miss")
+    upstream_metadata = upstream_payload.get("metadata")
+    if isinstance(upstream_metadata, dict):
+        methodology_version = upstream_metadata.get("methodology_version")
+        if isinstance(methodology_version, str) and methodology_version.strip():
+            metadata = metadata.model_copy(update={"methodology_version": methodology_version})
+
+    return WorkbenchRiskDrawdownResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state=state,
+        payload=WorkbenchRiskDrawdownPayload(periods=period_results) if period_results else None,
+        supportability=supportability,
+        warnings=sorted(set(warnings)),
+        partial_failures=partial_failures,
+        metadata=metadata,
+    )
+
+
 def _issuer_supportability_state(payload: Any) -> str:
     if not isinstance(payload, dict):
         return "unavailable"
@@ -540,6 +829,45 @@ def _unavailable_concentration(
     )
 
 
+def _unavailable_drawdown(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    include_underwater_series: bool,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> WorkbenchRiskDrawdownResponse:
+    reason = (
+        "lotus-risk drawdown endpoint is unavailable."
+        if not include_underwater_series
+        else "lotus-risk drawdown detail endpoint is unavailable."
+    )
+    return WorkbenchRiskDrawdownResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="unavailable",
+        payload=None,
+        supportability=[
+            WorkbenchRiskSupportabilityItem(
+                key="risk_service",
+                label="Risk service",
+                state="unavailable",
+                reason=reason,
+                source_service="lotus-risk",
+            )
+        ],
+        warnings=["RISK_DRAWDOWN_UNAVAILABLE"],
+        partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
+        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
 def _malformed_concentration(
     *,
     correlation_id: str,
@@ -618,3 +946,26 @@ def _normalize_period(value: str) -> str:
     if normalized in {"5Y", "FIVE_YEAR"}:
         return "FIVE_YEAR"
     return "YTD"
+
+
+def _map_drawdown_summary(summary_payload: dict[str, Any]) -> WorkbenchRiskDrawdownSummary:
+    return WorkbenchRiskDrawdownSummary.model_validate(summary_payload)
+
+
+def _map_drawdown_episodes(episodes_payload: list[Any]) -> list[WorkbenchRiskDrawdownEpisode]:
+    episodes: list[WorkbenchRiskDrawdownEpisode] = []
+    for payload in episodes_payload:
+        if not isinstance(payload, dict):
+            continue
+        episodes.append(WorkbenchRiskDrawdownEpisode.model_validate(payload))
+    episodes.sort(key=lambda episode: episode.depth)
+    return episodes
+
+
+def _map_underwater_series(series_payload: list[Any]) -> list[WorkbenchRiskUnderwaterPoint]:
+    points: list[WorkbenchRiskUnderwaterPoint] = []
+    for payload in series_payload:
+        if not isinstance(payload, dict):
+            continue
+        points.append(WorkbenchRiskUnderwaterPoint.model_validate(payload))
+    return points

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -8,6 +8,14 @@ from app.config import settings
 from app.contracts.risk_workspace import (
     WorkbenchConcentrationRiskProxy,
     WorkbenchIssuerConcentration,
+    WorkbenchRiskAttributionContributor,
+    WorkbenchRiskAttributionControls,
+    WorkbenchRiskAttributionGroupingOption,
+    WorkbenchRiskAttributionPayload,
+    WorkbenchRiskAttributionPeriodResult,
+    WorkbenchRiskAttributionResponse,
+    WorkbenchRiskAttributionSet,
+    WorkbenchRiskAttributionTypeOption,
     WorkbenchRiskConcentrationPayload,
     WorkbenchRiskConcentrationResponse,
     WorkbenchRiskDrawdownEpisode,
@@ -72,6 +80,18 @@ _METRIC_LABELS = {
     "INFORMATION_RATIO": "Information Ratio",
     "VAR": "Value at Risk",
 }
+_RISK_ATTRIBUTION_TYPE_LABELS = {
+    "TOTAL_RISK": "Total Risk",
+    "ACTIVE_RISK": "Active Risk",
+}
+_RISK_ATTRIBUTION_GROUPING_LABELS = {
+    "POSITION": "Position",
+    "ISSUER": "Issuer",
+    "SECTOR": "Sector",
+    "ASSET_CLASS": "Asset Class",
+}
+_RISK_ATTRIBUTION_SUPPORTED_GROUPINGS = ("POSITION", "ISSUER", "SECTOR", "ASSET_CLASS")
+_RISK_ATTRIBUTION_ACTIVE_RISK_SUPPORTED_GROUPINGS = ("POSITION", "SECTOR", "ASSET_CLASS")
 
 
 class RiskWorkspaceService:
@@ -87,6 +107,7 @@ class RiskWorkspaceService:
             | WorkbenchRiskConcentrationResponse
             | WorkbenchRiskDrawdownResponse
             | WorkbenchRiskRollingResponse
+            | WorkbenchRiskAttributionResponse
         ](ttl_seconds=cache_ttl_seconds or settings.risk_bff_cache_ttl_seconds)
 
     def clear_cache(self) -> None:
@@ -402,6 +423,102 @@ class RiskWorkspaceService:
             deep=True,
         )
 
+    async def get_attribution(
+        self,
+        *,
+        portfolio_id: str,
+        correlation_id: str,
+        period: str,
+        detail_basis: str,
+        benchmark_code: str | None,
+        as_of_date: str | None,
+        reporting_currency: str | None,
+        attribution_type: str,
+        grouping_dimension: str,
+    ) -> WorkbenchRiskAttributionResponse:
+        resolved_as_of_date = _resolve_as_of_date(as_of_date)
+        normalized_type = _normalize_risk_attribution_type(attribution_type)
+        normalized_grouping = _normalize_risk_attribution_grouping(grouping_dimension)
+        blocked_response = _blocked_attribution_response(
+            correlation_id=correlation_id,
+            portfolio_id=portfolio_id,
+            period=period,
+            as_of_date=resolved_as_of_date,
+            benchmark_code=benchmark_code,
+            attribution_type=normalized_type,
+            grouping_dimension=normalized_grouping,
+        )
+        if blocked_response is not None:
+            return blocked_response
+
+        cache_key = (
+            "attribution",
+            portfolio_id,
+            period,
+            detail_basis,
+            benchmark_code or "",
+            resolved_as_of_date,
+            reporting_currency or "",
+            normalized_type,
+            normalized_grouping,
+        )
+
+        async def _load() -> WorkbenchRiskAttributionResponse:
+            payload = _build_attribution_request(
+                portfolio_id=portfolio_id,
+                period=period,
+                detail_basis=detail_basis,
+                benchmark_code=benchmark_code,
+                as_of_date=resolved_as_of_date,
+                reporting_currency=reporting_currency,
+                attribution_type=normalized_type,
+                grouping_dimension=normalized_grouping,
+            )
+            upstream_status, upstream_payload = (
+                await self._risk_client.post_risk_historical_attribution(
+                    payload=payload,
+                    correlation_id=correlation_id,
+                )
+            )
+            if upstream_status >= status.HTTP_400_BAD_REQUEST or not isinstance(
+                upstream_payload, dict
+            ):
+                return _unavailable_attribution(
+                    correlation_id=correlation_id,
+                    portfolio_id=portfolio_id,
+                    period=period,
+                    as_of_date=resolved_as_of_date,
+                    benchmark_code=benchmark_code,
+                    attribution_type=normalized_type,
+                    grouping_dimension=normalized_grouping,
+                    upstream_status=upstream_status,
+                    upstream_payload=upstream_payload,
+                )
+            return _map_attribution_response(
+                correlation_id=correlation_id,
+                portfolio_id=portfolio_id,
+                period=period,
+                as_of_date=resolved_as_of_date,
+                benchmark_code=benchmark_code,
+                attribution_type=normalized_type,
+                grouping_dimension=normalized_grouping,
+                upstream_payload=upstream_payload,
+            )
+
+        response, cache_hit = await self._cache.get_or_set_with_status(
+            key=cache_key, factory=_load
+        )
+        typed_response = cast(WorkbenchRiskAttributionResponse, response)
+        return typed_response.model_copy(
+            update={
+                "correlation_id": correlation_id,
+                "metadata": typed_response.metadata.model_copy(
+                    update={"cache_status": "hit" if cache_hit else "miss"}
+                ),
+            },
+            deep=True,
+        )
+
 
 def _build_summary_request(
     *,
@@ -525,6 +642,46 @@ def _build_rolling_request(
     if reporting_currency:
         stateful_input["reporting_currency"] = reporting_currency
     return {"input_mode": "stateful", "stateful_input": stateful_input}
+
+
+def _build_attribution_request(
+    *,
+    portfolio_id: str,
+    period: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    as_of_date: str,
+    reporting_currency: str | None,
+    attribution_type: str,
+    grouping_dimension: str,
+) -> dict[str, Any]:
+    stateful_input: dict[str, Any] = {
+        "portfolio_id": portfolio_id,
+        "as_of_date": as_of_date,
+        "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
+        "periods": [{"type": _normalize_period(period), "name": period.upper()}],
+        "attribution_options": {
+            "attribution_types": [attribution_type],
+            "metrics": ["TRACKING_ERROR" if attribution_type == "ACTIVE_RISK" else "VOLATILITY"],
+            "grouping_dimensions": [grouping_dimension],
+            "annualization_basis": 252,
+        },
+    }
+    if reporting_currency:
+        stateful_input["reporting_currency"] = reporting_currency
+    if benchmark_code and attribution_type == "ACTIVE_RISK":
+        stateful_input["benchmark_id"] = benchmark_code
+    return {"input_mode": "stateful", "stateful_input": stateful_input}
+
+
+def _normalize_risk_attribution_type(value: str) -> str:
+    normalized = value.upper()
+    return normalized if normalized in _RISK_ATTRIBUTION_TYPE_LABELS else "TOTAL_RISK"
+
+
+def _normalize_risk_attribution_grouping(value: str) -> str:
+    normalized = value.upper()
+    return normalized if normalized in _RISK_ATTRIBUTION_GROUPING_LABELS else "SECTOR"
 
 
 def _map_summary_response(
@@ -1033,6 +1190,307 @@ def _map_rolling_response(
     )
 
 
+def _map_attribution_response(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    attribution_type: str,
+    grouping_dimension: str,
+    upstream_payload: dict[str, Any],
+) -> WorkbenchRiskAttributionResponse:
+    results = upstream_payload.get("results")
+    warnings: list[str] = []
+    partial_failures: list[WorkbenchPartialFailure] = []
+    period_results: list[WorkbenchRiskAttributionPeriodResult] = []
+    supportability = _build_attribution_supportability(
+        benchmark_code=benchmark_code,
+        attribution_type=attribution_type,
+        grouping_dimension=grouping_dimension,
+    )
+
+    if isinstance(results, dict):
+        for key, value in results.items():
+            if not isinstance(value, dict):
+                continue
+            error = value.get("error")
+            attribution_sets_payload = value.get("attribution_sets")
+            attribution_sets: list[WorkbenchRiskAttributionSet] = []
+            if isinstance(attribution_sets_payload, list):
+                for entry in attribution_sets_payload:
+                    if not isinstance(entry, dict):
+                        continue
+                    contributors_payload = entry.get("contributors")
+                    contributors = (
+                        [
+                            WorkbenchRiskAttributionContributor.model_validate(contributor)
+                            for contributor in contributors_payload
+                            if isinstance(contributor, dict)
+                        ]
+                        if isinstance(contributors_payload, list)
+                        else []
+                    )
+                    attribution_sets.append(
+                        WorkbenchRiskAttributionSet(
+                            attribution_type=str(entry.get("attribution_type", attribution_type)),
+                            metric=str(entry.get("metric", "")),
+                            grouping_dimension=str(
+                                entry.get("grouping_dimension", grouping_dimension)
+                            ),
+                            total_value=_safe_float(entry.get("total_value")),
+                            reconciled_sum=_safe_float(entry.get("reconciled_sum")),
+                            residual=_safe_float(entry.get("residual")),
+                            contributors=contributors,
+                            quality_flags=[
+                                str(flag)
+                                for flag in entry.get("quality_flags", [])
+                                if isinstance(flag, str) and flag.strip()
+                            ],
+                        )
+                    )
+            if isinstance(error, str) and error.strip():
+                partial_failures.append(
+                    WorkbenchPartialFailure(
+                        source_service="risk",
+                        error_code="RISK_ATTRIBUTION_PERIOD_ERROR",
+                        detail=f"{key}: {error}",
+                    )
+                )
+                warnings.append("RISK_ATTRIBUTION_PERIOD_PARTIAL")
+            period_results.append(
+                WorkbenchRiskAttributionPeriodResult(
+                    key=str(key),
+                    label=str(key),
+                    start_date=str(value.get("start_date", "")),
+                    end_date=str(value.get("end_date", "")),
+                    attribution_sets=attribution_sets,
+                    error=str(error) if isinstance(error, str) and error.strip() else None,
+                )
+            )
+
+    state = "partial" if any(item.state != "ready" for item in supportability) else "ready"
+    if not period_results:
+        state = "unavailable"
+        warnings.append("RISK_ATTRIBUTION_EMPTY")
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="risk",
+                error_code="EMPTY_RISK_ATTRIBUTION",
+                detail="lotus-risk returned no attribution periods.",
+            )
+        )
+    elif all(not period.attribution_sets for period in period_results):
+        state = "unavailable"
+
+    metadata = _metadata(input_mode="stateful", cache_status="miss")
+    upstream_metadata = upstream_payload.get("metadata")
+    if isinstance(upstream_metadata, dict):
+        methodology_version = upstream_metadata.get("methodology_version")
+        if isinstance(methodology_version, str) and methodology_version.strip():
+            metadata = metadata.model_copy(update={"methodology_version": methodology_version})
+
+    return WorkbenchRiskAttributionResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state=state,
+        payload=WorkbenchRiskAttributionPayload(
+            controls=_build_attribution_controls(
+                benchmark_code=benchmark_code,
+                attribution_type=attribution_type,
+                grouping_dimension=grouping_dimension,
+            ),
+            periods=period_results,
+        )
+        if period_results
+        else None,
+        supportability=supportability,
+        warnings=sorted(set(warnings)),
+        partial_failures=partial_failures,
+        metadata=metadata,
+    )
+
+
+def _build_attribution_controls(
+    *,
+    benchmark_code: str | None,
+    attribution_type: str,
+    grouping_dimension: str,
+) -> WorkbenchRiskAttributionControls:
+    type_options = [
+        WorkbenchRiskAttributionTypeOption(
+            key="TOTAL_RISK",
+            label=_RISK_ATTRIBUTION_TYPE_LABELS["TOTAL_RISK"],
+            state="ready",
+        ),
+        WorkbenchRiskAttributionTypeOption(
+            key="ACTIVE_RISK",
+            label=_RISK_ATTRIBUTION_TYPE_LABELS["ACTIVE_RISK"],
+            state="ready" if benchmark_code else "blocked",
+            reason=None if benchmark_code else "Active risk requires benchmark context.",
+        ),
+    ]
+    grouping_options: list[WorkbenchRiskAttributionGroupingOption] = []
+    for key in _RISK_ATTRIBUTION_SUPPORTED_GROUPINGS:
+        total_risk_supported = True
+        active_risk_supported = key in _RISK_ATTRIBUTION_ACTIVE_RISK_SUPPORTED_GROUPINGS and bool(
+            benchmark_code
+        )
+        state = "ready"
+        reason: str | None = None
+        if key == "ISSUER":
+            state = "partial" if attribution_type == "TOTAL_RISK" else "blocked"
+            reason = (
+                "Issuer is supported for total risk only. Active risk by issuer remains "
+                "unavailable until benchmark issuer exposure semantics are approved."
+            )
+        elif attribution_type == "ACTIVE_RISK" and not benchmark_code:
+            state = "blocked"
+            reason = "Active risk requires benchmark context."
+        grouping_options.append(
+            WorkbenchRiskAttributionGroupingOption(
+                key=key,
+                label=_RISK_ATTRIBUTION_GROUPING_LABELS[key],
+                state=state,
+                reason=reason,
+                supported_attribution_types=[
+                    attribution_key
+                    for attribution_key, supported in (
+                        ("TOTAL_RISK", total_risk_supported),
+                        ("ACTIVE_RISK", active_risk_supported),
+                    )
+                    if supported
+                ],
+            )
+        )
+    return WorkbenchRiskAttributionControls(
+        attribution_types=type_options,
+        grouping_dimensions=grouping_options,
+        selected_attribution_type=attribution_type,
+        selected_grouping_dimension=grouping_dimension,
+    )
+
+
+def _build_attribution_supportability(
+    *,
+    benchmark_code: str | None,
+    attribution_type: str,
+    grouping_dimension: str,
+) -> list[WorkbenchRiskSupportabilityItem]:
+    supportability = [
+        WorkbenchRiskSupportabilityItem(
+            key="portfolio_returns",
+            label="Portfolio returns",
+            state="ready",
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="exposure_history",
+            label="Exposure history",
+            state="ready",
+            source_service="lotus-core",
+        ),
+    ]
+    if attribution_type == "ACTIVE_RISK":
+        supportability.extend(
+            [
+                WorkbenchRiskSupportabilityItem(
+                    key="benchmark_returns",
+                    label="Benchmark returns",
+                    state="ready" if benchmark_code else "blocked",
+                    reason=None if benchmark_code else "Active risk requires benchmark context.",
+                    source_service="lotus-performance",
+                ),
+                WorkbenchRiskSupportabilityItem(
+                    key="benchmark_exposure_context",
+                    label="Benchmark exposure context",
+                    state=(
+                        "blocked"
+                        if grouping_dimension == "ISSUER" or not benchmark_code
+                        else "ready"
+                    ),
+                    reason=(
+                        "Issuer benchmark exposure semantics are not available."
+                        if grouping_dimension == "ISSUER"
+                        else (
+                            "Active risk requires benchmark context."
+                            if not benchmark_code
+                            else None
+                        )
+                    ),
+                    source_service="lotus-performance",
+                ),
+            ]
+        )
+    else:
+        supportability.append(
+            WorkbenchRiskSupportabilityItem(
+                key="benchmark_exposure_context",
+                label="Benchmark exposure context",
+                state="partial" if grouping_dimension == "ISSUER" else "ready",
+                reason=(
+                    "Issuer benchmark exposure semantics are not required for total risk, but "
+                    "remain unavailable for active-risk decomposition."
+                    if grouping_dimension == "ISSUER"
+                    else None
+                ),
+                source_service="lotus-performance",
+            )
+        )
+    return supportability
+
+
+def _blocked_attribution_response(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    attribution_type: str,
+    grouping_dimension: str,
+) -> WorkbenchRiskAttributionResponse | None:
+    is_active_risk_without_benchmark = attribution_type == "ACTIVE_RISK" and not benchmark_code
+    is_active_risk_issuer = attribution_type == "ACTIVE_RISK" and grouping_dimension == "ISSUER"
+    if not is_active_risk_without_benchmark and not is_active_risk_issuer:
+        return None
+    controls = _build_attribution_controls(
+        benchmark_code=benchmark_code,
+        attribution_type=attribution_type,
+        grouping_dimension=grouping_dimension,
+    )
+    return WorkbenchRiskAttributionResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="blocked",
+        payload=WorkbenchRiskAttributionPayload(controls=controls, periods=[]),
+        supportability=_build_attribution_supportability(
+            benchmark_code=benchmark_code,
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+        ),
+        warnings=["RISK_ATTRIBUTION_BLOCKED"],
+        partial_failures=[],
+        metadata=_metadata(input_mode="stateful", cache_status="bypass"),
+    )
+
+
+def _safe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _issuer_supportability_state(payload: Any) -> str:
     if not isinstance(payload, dict):
         return "unavailable"
@@ -1194,6 +1652,44 @@ def _unavailable_rolling(
             )
         ],
         warnings=["RISK_ROLLING_UNAVAILABLE"],
+        partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
+        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def _unavailable_attribution(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    attribution_type: str,
+    grouping_dimension: str,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> WorkbenchRiskAttributionResponse:
+    return WorkbenchRiskAttributionResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="unavailable",
+        payload=WorkbenchRiskAttributionPayload(
+            controls=_build_attribution_controls(
+                benchmark_code=benchmark_code,
+                attribution_type=attribution_type,
+                grouping_dimension=grouping_dimension,
+            ),
+            periods=[],
+        ),
+        supportability=_build_attribution_supportability(
+            benchmark_code=benchmark_code,
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+        ),
+        warnings=["RISK_ATTRIBUTION_UNAVAILABLE"],
         partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
         metadata=_metadata(input_mode="stateful", cache_status="miss"),
     )

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -23,7 +23,6 @@ from app.contracts.workbench import (
     WorkbenchProjectedPositionView,
     WorkbenchProjectedSummary,
     WorkbenchRebalanceSnapshot,
-    WorkbenchRiskProxy,
     WorkbenchSandboxStateResponse,
     WorkbenchTopChange,
 )
@@ -31,7 +30,6 @@ from app.precision_policy import (
     quantize_money,
     quantize_performance,
     quantize_quantity,
-    quantize_risk,
 )
 
 
@@ -41,12 +39,10 @@ class WorkbenchService:
         lotus_core_query_client: LotusCoreQueryClient,
         analytics_client: LotusAnalyticsClient,
         dpm_client: DpmClient,
-        risk_client: LotusAnalyticsClient | None = None,
     ):
         self._lotus_core_query_client = lotus_core_query_client
         self._analytics_client = analytics_client
         self._dpm_client = dpm_client
-        self._risk_client = risk_client
 
     async def get_workbench_overview(
         self,
@@ -397,34 +393,22 @@ class WorkbenchService:
                 for item in analytics_response.get("topChanges", [])
                 if isinstance(item, dict)
             ]
-            risk_data = analytics_response.get("riskProxy", {})
-            if self._risk_client is not None:
-                risk_status, risk_response = await self._risk_client.get_workbench_risk_proxy(
-                    payload=analytics_payload,
-                    correlation_id=correlation_id,
+            warnings = list(portfolio_360.warnings)
+            if "RISK_BFF_PENDING" not in warnings:
+                warnings.append("RISK_BFF_PENDING")
+            partial_failures = list(portfolio_360.partial_failures)
+            partial_failures.append(
+                WorkbenchPartialFailure(
+                    source_service="risk",
+                    error_code="RISK_BFF_NOT_IMPLEMENTED",
+                    detail=(
+                        "Legacy workbench risk proxy was removed. Stateful concentration risk "
+                        "will be restored through the RFC-0022 Gateway Risk BFF."
+                    ),
                 )
-                if risk_status < status.HTTP_400_BAD_REQUEST and isinstance(risk_response, dict):
-                    risk_data = risk_response.get("riskProxy", risk_data)
-                else:
-                    warnings = list(portfolio_360.warnings)
-                    warnings.append("RISK_PROXY_FALLBACK_TO_PA")
-                    partial_failures = list(portfolio_360.partial_failures)
-                    partial_failures.append(
-                        WorkbenchPartialFailure(
-                            source_service="risk",
-                            error_code=f"HTTP_{risk_status}",
-                            detail=str(risk_response.get("detail", risk_response)),
-                        )
-                    )
-                    portfolio_360 = portfolio_360.model_copy(
-                        update={"warnings": warnings, "partial_failures": partial_failures}
-                    )
-            if not isinstance(risk_data, dict):
-                risk_data = {}
-            risk_proxy = WorkbenchRiskProxy(
-                hhi_current=float(quantize_risk(risk_data.get("hhiCurrent", 0.0))),
-                hhi_proposed=float(quantize_risk(risk_data.get("hhiProposed", 0.0))),
-                hhi_delta=float(quantize_risk(risk_data.get("hhiDelta", 0.0))),
+            )
+            portfolio_360 = portfolio_360.model_copy(
+                update={"warnings": warnings, "partial_failures": partial_failures}
             )
             portfolio_return = analytics_response.get("portfolioReturnPct")
             benchmark_return = analytics_response.get("benchmarkReturnPct")
@@ -458,7 +442,7 @@ class WorkbenchService:
             ),
             allocation_buckets=allocation_buckets,
             top_changes=top_changes,
-            risk_proxy=risk_proxy,
+            risk_proxy=None,
             warnings=portfolio_360.warnings,
             partial_failures=portfolio_360.partial_failures,
         )

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -442,7 +442,6 @@ class WorkbenchService:
             ),
             allocation_buckets=allocation_buckets,
             top_changes=top_changes,
-            risk_proxy=None,
             warnings=portfolio_360.warnings,
             partial_failures=portfolio_360.partial_failures,
         )

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -573,6 +573,93 @@ def test_workbench_risk_concentration_router_maps_stateful_concentration(monkeyp
     }
 
 
+def test_workbench_risk_drawdown_router_maps_stateful_drawdown_and_detail_flag(monkeypatch):
+    async def _risk_drawdown(self, payload, correlation_id):  # noqa: ARG001
+        assert payload["input_mode"] == "stateful"
+        assert payload["stateful_input"]["portfolio_id"] == "PF_RISK_DRAWDOWN"
+        assert payload["stateful_input"]["benchmark_policy"] == {
+            "include_benchmark": True,
+            "missing_benchmark_policy": "IGNORE",
+        }
+        assert payload["analysis_options"]["include_underwater_series"] is True
+        return 200, {
+            "source_service": "lotus-risk",
+            "input_mode": "stateful",
+            "results": {
+                "YTD": {
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-04-04",
+                    "summary": {
+                        "max_drawdown": -0.124533,
+                        "max_drawdown_peak_date": "2026-01-12",
+                        "max_drawdown_trough_date": "2026-02-03",
+                        "max_drawdown_recovery_date": None,
+                        "is_recovered": False,
+                        "days_to_trough": 16,
+                        "days_to_recovery": None,
+                        "time_under_water_days": 34,
+                        "average_drawdown": -0.041208,
+                        "ulcer_index": 0.053901,
+                        "drawdown_at_risk_95": -0.101552,
+                        "conditional_drawdown_at_risk_95": -0.117884,
+                    },
+                    "episodes": [
+                        {
+                            "episode_id": "dd_0001",
+                            "peak_date": "2026-01-12",
+                            "trough_date": "2026-02-03",
+                            "recovery_date": None,
+                            "depth": -0.124533,
+                            "days_to_trough": 16,
+                            "days_to_recovery": None,
+                            "total_days": 34,
+                            "is_recovered": False,
+                        }
+                    ],
+                    "relative_to_benchmark": {
+                        "max_drawdown": -0.0821,
+                        "max_drawdown_peak_date": "2026-01-11",
+                        "max_drawdown_trough_date": "2026-02-01",
+                    },
+                    "underwater_series": [
+                        {"date": "2026-01-20", "drawdown": -0.0521},
+                        {"date": "2026-01-21", "drawdown": -0.061},
+                    ],
+                    "error": None,
+                }
+            },
+            "metadata": {"contract_version": "v1", "methodology_version": "drawdown.v1"},
+        }
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.post_risk_drawdown",
+        _risk_drawdown,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/workbench/PF_RISK_DRAWDOWN/risk/drawdown"
+        "?period=YTD&detail_basis=NET&benchmark_code=BMK_1"
+        "&as_of_date=2026-04-04&reporting_currency=USD&include_underwater_series=true",
+        headers={"X-Correlation-Id": "corr-risk-drawdown"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["contract_version"] == "risk-workspace.v1"
+    assert body["correlation_id"] == "corr-risk-drawdown"
+    assert body["state"] == "ready"
+    assert body["metadata"]["methodology_version"] == "drawdown.v1"
+    assert body["payload"]["periods"][0]["summary"]["max_drawdown"] == -0.124533
+    assert body["payload"]["periods"][0]["episodes"][0]["episode_id"] == "dd_0001"
+    assert len(body["payload"]["periods"][0]["underwater_series"]) == 2
+    assert {item["key"]: item["state"] for item in body["supportability"]} == {
+        "portfolio_returns": "ready",
+        "benchmark_relative_drawdown": "ready",
+        "underwater_series": "ready",
+    }
+
+
 def test_workbench_performance_summary_router(monkeypatch):
     async def _performance_summary(*args, **kwargs):  # noqa: ARG001
         append_server_timing_metric("perf-reference", 1.0)

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -737,6 +737,83 @@ def test_workbench_risk_rolling_router_maps_stateful_rolling_and_detail_flag(mon
     }
 
 
+def test_workbench_risk_attribution_router_maps_stateful_attribution(monkeypatch):
+    async def _risk_attribution(self, payload, correlation_id):  # noqa: ARG001
+        assert payload["input_mode"] == "stateful"
+        assert payload["stateful_input"]["portfolio_id"] == "PF_RISK_ATTRIBUTION"
+        assert payload["stateful_input"]["benchmark_id"] == "BMK_1"
+        assert payload["stateful_input"]["attribution_options"] == {
+            "attribution_types": ["ACTIVE_RISK"],
+            "metrics": ["TRACKING_ERROR"],
+            "grouping_dimensions": ["ASSET_CLASS"],
+            "annualization_basis": 252,
+        }
+        return 200, {
+            "source_service": "lotus-risk",
+            "input_mode": "stateful",
+            "results": {
+                "YTD": {
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-04-04",
+                    "attribution_sets": [
+                        {
+                            "attribution_type": "ACTIVE_RISK",
+                            "metric": "TRACKING_ERROR",
+                            "grouping_dimension": "ASSET_CLASS",
+                            "total_value": 0.034,
+                            "reconciled_sum": 0.033,
+                            "residual": 0.001,
+                            "contributors": [
+                                {
+                                    "group_key": "EQUITY",
+                                    "group_label": "Equity",
+                                    "weight_average": 0.62,
+                                    "marginal_contribution": 0.018,
+                                    "component_contribution": 0.016,
+                                    "percent_contribution": 0.47,
+                                }
+                            ],
+                            "quality_flags": [],
+                        }
+                    ],
+                    "error": None,
+                }
+            },
+            "metadata": {
+                "contract_version": "v1",
+                "methodology_version": "historical_attribution.v1",
+            },
+        }
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.post_risk_historical_attribution",
+        _risk_attribution,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/workbench/PF_RISK_ATTRIBUTION/risk/attribution"
+        "?period=YTD&detail_basis=NET&benchmark_code=BMK_1"
+        "&as_of_date=2026-04-04&reporting_currency=USD"
+        "&attribution_type=ACTIVE_RISK&grouping_dimension=ASSET_CLASS",
+        headers={"X-Correlation-Id": "corr-risk-attribution"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["contract_version"] == "risk-workspace.v1"
+    assert body["correlation_id"] == "corr-risk-attribution"
+    assert body["state"] == "ready"
+    assert body["metadata"]["methodology_version"] == "historical_attribution.v1"
+    assert body["payload"]["controls"]["selected_attribution_type"] == "ACTIVE_RISK"
+    assert body["payload"]["controls"]["selected_grouping_dimension"] == "ASSET_CLASS"
+    assert body["payload"]["periods"][0]["attribution_sets"][0]["metric"] == "TRACKING_ERROR"
+    assert (
+        body["payload"]["periods"][0]["attribution_sets"][0]["contributors"][0]["group_label"]
+        == "Equity"
+    )
+
+
 def test_workbench_performance_summary_router(monkeypatch):
     async def _performance_summary(*args, **kwargs):  # noqa: ARG001
         append_server_timing_metric("perf-reference", 1.0)

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -463,6 +463,116 @@ def test_workbench_performance_router(monkeypatch):
     assert body["attribution"]["model"] == "BF"
 
 
+def test_workbench_risk_summary_router_uses_stateful_gateway_contract(monkeypatch):
+    async def _risk_calculate(self, payload, correlation_id):  # noqa: ARG001
+        assert payload["input_mode"] == "stateful"
+        assert "stateless_input" not in payload
+        assert payload["stateful_input"]["portfolio_id"] == "PF_RISK_SUMMARY"
+        return 200, {
+            "scope": {
+                "as_of_date": "2026-04-04",
+                "reporting_currency": "USD",
+                "net_or_gross": "NET",
+            },
+            "results": {
+                "YTD": {
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-04-04",
+                    "metrics": {
+                        "VOLATILITY": {"value": 0.12},
+                        "SHARPE": {"value": 1.2},
+                        "SORTINO": {"value": 1.4},
+                        "BETA": {"value": 0.9},
+                        "TRACKING_ERROR": {"value": 0.03},
+                        "INFORMATION_RATIO": {"value": 0.4},
+                        "VAR": {"value": -0.02},
+                    },
+                }
+            },
+        }
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.post_risk_calculate",
+        _risk_calculate,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/workbench/PF_RISK_SUMMARY/risk/summary"
+        "?period=YTD&detail_basis=NET&benchmark_code=BMK_1"
+        "&as_of_date=2026-04-04&reporting_currency=USD",
+        headers={"X-Correlation-Id": "corr-risk-summary"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["contract_version"] == "risk-workspace.v1"
+    assert body["correlation_id"] == "corr-risk-summary"
+    assert body["source_service"] == "lotus-risk"
+    assert body["state"] == "ready"
+    assert body["metadata"]["input_mode"] == "stateful"
+    assert body["payload"]["periods"][0]["metrics"][0]["label"] == "Volatility"
+
+
+def test_workbench_risk_concentration_router_maps_stateful_concentration(monkeypatch):
+    async def _risk_concentration(self, payload, correlation_id):  # noqa: ARG001
+        assert payload["input_mode"] == "stateful"
+        assert payload["stateful_input"]["portfolio_id"] == "PF_RISK_CONC"
+        assert payload["issuer_grouping_level"] == "ultimate_parent"
+        return 200, {
+            "source_service": "lotus-risk",
+            "input_mode": "stateful",
+            "risk_proxy": {"hhi_current": 1200.0, "hhi_proposed": 1225.0, "hhi_delta": 25.0},
+            "single_position_concentration": {
+                "top_position_weight_current": 0.2,
+                "top_position_weight_proposed": 0.21,
+                "top_position_weight_delta": 0.01,
+                "top_n_cumulative_weight_current": 0.5,
+                "top_n_cumulative_weight_proposed": 0.52,
+                "top_n_cumulative_weight_delta": 0.02,
+                "top_n": 10,
+            },
+            "issuer_concentration": {
+                "hhi_current": 1500.0,
+                "hhi_proposed": 1600.0,
+                "hhi_delta": 100.0,
+                "top_issuer_weight_current": 0.25,
+                "top_issuer_weight_proposed": 0.27,
+                "top_issuer_weight_delta": 0.02,
+                "coverage_status": "complete",
+                "covered_position_count_current": 10,
+                "covered_position_count_proposed": 10,
+                "total_position_count_current": 10,
+                "total_position_count_proposed": 10,
+                "note": None,
+            },
+            "valuation_context": {"reporting_currency": "USD"},
+            "metadata": {"as_of_date": "2026-04-04", "portfolio_id": "PF_RISK_CONC"},
+        }
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.post_risk_concentration",
+        _risk_concentration,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/workbench/PF_RISK_CONC/risk/concentration"
+        "?period=YTD&benchmark_code=BMK_1&as_of_date=2026-04-04&reporting_currency=USD",
+        headers={"X-Correlation-Id": "corr-risk-concentration"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["contract_version"] == "risk-workspace.v1"
+    assert body["state"] == "ready"
+    assert body["payload"]["risk_proxy"]["hhi_current"] == 1200.0
+    assert {item["key"]: item["state"] for item in body["supportability"]} == {
+        "portfolio_positions": "ready",
+        "issuer_enrichment": "ready",
+    }
+
+
 def test_workbench_performance_summary_router(monkeypatch):
     async def _performance_summary(*args, **kwargs):  # noqa: ARG001
         append_server_timing_metric("perf-reference", 1.0)

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -296,7 +296,6 @@ def test_workbench_analytics_router(monkeypatch):
                     "direction": "INCREASE",
                 }
             ],
-            "riskProxy": {"hhiCurrent": 10000.0, "hhiProposed": 10000.0, "hhiDelta": 0.0},
         }
 
     async def _dpm_runs(*args, **kwargs):
@@ -327,7 +326,7 @@ def test_workbench_analytics_router(monkeypatch):
     assert body["portfolio_id"] == "PF_1001"
     assert body["group_by"] == "ASSET_CLASS"
     assert len(body["allocation_buckets"]) >= 1
-    assert "risk_proxy" in body
+    assert "risk_proxy" not in body
 
 
 def test_workbench_performance_router(monkeypatch):

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -660,6 +660,83 @@ def test_workbench_risk_drawdown_router_maps_stateful_drawdown_and_detail_flag(m
     }
 
 
+def test_workbench_risk_rolling_router_maps_stateful_rolling_and_detail_flag(monkeypatch):
+    async def _risk_rolling(self, payload, correlation_id):  # noqa: ARG001
+        assert payload["input_mode"] == "stateful"
+        assert payload["stateful_input"]["portfolio_id"] == "PF_RISK_ROLLING"
+        assert payload["stateful_input"]["rolling_options"]["include_time_series"] is True
+        assert payload["stateful_input"]["rolling_options"]["window_lengths"] == [21, 63, 126, 252]
+        return 200, {
+            "source_service": "lotus-risk",
+            "input_mode": "stateful",
+            "results": {
+                "YTD": {
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-04-04",
+                    "series_count": 66,
+                    "window_results": [
+                        {
+                            "window_length": 21,
+                            "metric_summaries": {
+                                "ROLLING_VOLATILITY": {
+                                    "latest": 0.1374,
+                                    "average": 0.1221,
+                                    "minimum": 0.0913,
+                                    "maximum": 0.1662,
+                                    "p05": 0.0975,
+                                    "p50": 0.1218,
+                                    "p95": 0.1611,
+                                },
+                            },
+                            "metric_series": [
+                                {
+                                    "date": "2026-04-01",
+                                    "metric_values": {
+                                        "ROLLING_VOLATILITY": 0.131,
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                    "quality_flags": ["metric:ROLLING_BETA:benchmark_variance_zero"],
+                    "error": None,
+                }
+            },
+            "metadata": {"contract_version": "v1", "methodology_version": "rolling_metrics.v1"},
+        }
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.post_risk_rolling_metrics",
+        _risk_rolling,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/workbench/PF_RISK_ROLLING/risk/rolling"
+        "?period=YTD&detail_basis=NET&benchmark_code=BMK_1"
+        "&as_of_date=2026-04-04&reporting_currency=USD&include_time_series=true",
+        headers={"X-Correlation-Id": "corr-risk-rolling"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["contract_version"] == "risk-workspace.v1"
+    assert body["correlation_id"] == "corr-risk-rolling"
+    assert body["state"] == "ready"
+    assert body["metadata"]["methodology_version"] == "rolling_metrics.v1"
+    assert body["payload"]["periods"][0]["window_results"][0]["window_length"] == 21
+    assert len(body["payload"]["periods"][0]["window_results"][0]["metric_series"]) == 1
+    assert body["payload"]["periods"][0]["quality_flags"] == [
+        "metric:ROLLING_BETA:benchmark_variance_zero"
+    ]
+    assert {item["key"]: item["state"] for item in body["supportability"]} == {
+        "portfolio_returns": "ready",
+        "benchmark_returns": "ready",
+        "risk_free_series": "ready",
+        "rolling_time_series": "ready",
+    }
+
+
 def test_workbench_performance_summary_router(monkeypatch):
     async def _performance_summary(*args, **kwargs):  # noqa: ARG001
         append_server_timing_metric("perf-reference", 1.0)

--- a/tests/unit/test_async_ttl_cache.py
+++ b/tests/unit/test_async_ttl_cache.py
@@ -51,6 +51,26 @@ async def test_async_ttl_cache_caches_successful_value_until_cleared() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_ttl_cache_reports_hit_status() -> None:
+    cache = AsyncTtlCache[int](ttl_seconds=60)
+    calls = 0
+
+    async def factory() -> int:
+        nonlocal calls
+        calls += 1
+        return calls
+
+    first, first_hit = await cache.get_or_set_with_status(("portfolio", "P1"), factory)
+    second, second_hit = await cache.get_or_set_with_status(("portfolio", "P1"), factory)
+
+    assert first == 1
+    assert second == 1
+    assert first_hit is False
+    assert second_hit is True
+    assert calls == 1
+
+
+@pytest.mark.asyncio
 async def test_async_ttl_cache_retries_after_factory_exception() -> None:
     cache = AsyncTtlCache[int](ttl_seconds=60)
     call_count = 0

--- a/tests/unit/test_config_defaults.py
+++ b/tests/unit/test_config_defaults.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from app.config import Settings
 
 
@@ -54,3 +56,22 @@ def test_settings_accept_legacy_platform_stack_env_aliases():
     assert settings.portfolio_data_query_base_url == "http://lotus-core-query:8001"
     assert settings.portfolio_data_control_plane_base_url == "http://lotus-core-control:8002"
     assert settings.portfolio_data_ingestion_base_url == "http://lotus-core-ingestion:8000"
+
+
+def test_settings_reject_local_loopback_upstream_urls():
+    with pytest.raises(ValueError, match="canonical service hostnames"):
+        Settings(
+            _env_file=None,
+            _env_prefix="__LOTUS_GATEWAY_TEST_UNUSED__",
+            ai_service_base_url="http://127.0.0.1:8140/",
+        )
+
+
+def test_settings_normalize_trailing_slashes_on_upstream_urls():
+    settings = Settings(
+        _env_file=None,
+        _env_prefix="__LOTUS_GATEWAY_TEST_UNUSED__",
+        performance_analytics_base_url="http://performance.dev.lotus/",
+    )
+
+    assert settings.performance_analytics_base_url == "http://performance.dev.lotus"

--- a/tests/unit/test_rfc0022_risk_proxy_guard.py
+++ b/tests/unit/test_rfc0022_risk_proxy_guard.py
@@ -16,6 +16,7 @@ def test_removed_workbench_risk_proxy_is_not_reintroduced_in_gateway_runtime_cod
     forbidden_patterns = {
         "/analytics/workbench/risk-proxy": "removed lotus-risk compatibility endpoint",
         "get_workbench_risk_proxy": "legacy client method for the removed endpoint",
+        "WorkbenchRiskProxy": "legacy analytics contract type should stay deleted",
     }
 
     violations: list[tuple[str, str, str]] = []

--- a/tests/unit/test_rfc0022_risk_proxy_guard.py
+++ b/tests/unit/test_rfc0022_risk_proxy_guard.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_ROOT = REPO_ROOT / "src" / "app"
+
+
+def _source_files() -> list[Path]:
+    return [
+        path
+        for path in APP_ROOT.rglob("*.py")
+        if "__pycache__" not in path.parts
+    ]
+
+
+def test_removed_workbench_risk_proxy_is_not_reintroduced_in_gateway_runtime_code() -> None:
+    forbidden_patterns = {
+        "/analytics/workbench/risk-proxy": "removed lotus-risk compatibility endpoint",
+        "get_workbench_risk_proxy": "legacy client method for the removed endpoint",
+    }
+
+    violations: list[tuple[str, str, str]] = []
+    for source_file in _source_files():
+        contents = source_file.read_text(encoding="utf-8")
+        for pattern, reason in forbidden_patterns.items():
+            if pattern in contents:
+                violations.append(
+                    (str(source_file.relative_to(REPO_ROOT)), pattern, reason)
+                )
+
+    assert violations == []

--- a/tests/unit/test_risk_workspace_service.py
+++ b/tests/unit/test_risk_workspace_service.py
@@ -7,8 +7,10 @@ class _StubRiskClient:
     def __init__(self) -> None:
         self.calculate_calls: list[dict] = []
         self.concentration_calls: list[dict] = []
+        self.drawdown_calls: list[dict] = []
         self.calculate_status = 200
         self.concentration_status = 200
+        self.drawdown_status = 200
         self.calculate_payload: dict = {
             "scope": {
                 "as_of_date": "2026-04-04",
@@ -61,6 +63,62 @@ class _StubRiskClient:
             "valuation_context": {"reporting_currency": "USD"},
             "metadata": {"as_of_date": "2026-04-04", "portfolio_id": "PF_1"},
         }
+        self.drawdown_payload: dict = {
+            "source_service": "lotus-risk",
+            "input_mode": "stateful",
+            "results": {
+                "YTD": {
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-04-04",
+                    "summary": {
+                        "max_drawdown": -0.124533,
+                        "max_drawdown_peak_date": "2026-01-12",
+                        "max_drawdown_trough_date": "2026-02-03",
+                        "max_drawdown_recovery_date": None,
+                        "is_recovered": False,
+                        "days_to_trough": 16,
+                        "days_to_recovery": None,
+                        "time_under_water_days": 34,
+                        "average_drawdown": -0.041208,
+                        "ulcer_index": 0.053901,
+                        "drawdown_at_risk_95": -0.101552,
+                        "conditional_drawdown_at_risk_95": -0.117884,
+                    },
+                    "episodes": [
+                        {
+                            "episode_id": "dd_0002",
+                            "peak_date": "2026-02-12",
+                            "trough_date": "2026-02-13",
+                            "recovery_date": None,
+                            "depth": -0.055,
+                            "days_to_trough": 1,
+                            "days_to_recovery": None,
+                            "total_days": 7,
+                            "is_recovered": False,
+                        },
+                        {
+                            "episode_id": "dd_0001",
+                            "peak_date": "2026-01-12",
+                            "trough_date": "2026-02-03",
+                            "recovery_date": None,
+                            "depth": -0.124533,
+                            "days_to_trough": 16,
+                            "days_to_recovery": None,
+                            "total_days": 34,
+                            "is_recovered": False,
+                        },
+                    ],
+                    "relative_to_benchmark": {
+                        "max_drawdown": -0.0821,
+                        "max_drawdown_peak_date": "2026-01-11",
+                        "max_drawdown_trough_date": "2026-02-01",
+                    },
+                    "underwater_series": None,
+                    "error": None,
+                }
+            },
+            "metadata": {"contract_version": "v1", "methodology_version": "drawdown.v1"},
+        }
 
     async def post_risk_calculate(self, payload: dict, correlation_id: str):
         self.calculate_calls.append({"payload": payload, "correlation_id": correlation_id})
@@ -69,6 +127,10 @@ class _StubRiskClient:
     async def post_risk_concentration(self, payload: dict, correlation_id: str):
         self.concentration_calls.append({"payload": payload, "correlation_id": correlation_id})
         return self.concentration_status, self.concentration_payload
+
+    async def post_risk_drawdown(self, payload: dict, correlation_id: str):
+        self.drawdown_calls.append({"payload": payload, "correlation_id": correlation_id})
+        return self.drawdown_status, self.drawdown_payload
 
 
 @pytest.mark.asyncio
@@ -242,3 +304,145 @@ async def test_risk_concentration_returns_unavailable_envelope_on_malformed_succ
     assert response.partial_failures[0].error_code == "MALFORMED_RISK_CONCENTRATION"
     assert "single_position_concentration" in response.partial_failures[0].detail
     assert "issuer_concentration" in response.partial_failures[0].detail
+
+
+@pytest.mark.asyncio
+async def test_risk_drawdown_uses_stateful_request_and_keeps_underwater_out_of_first_paint(
+) -> None:
+    client = _StubRiskClient()
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_drawdown(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        include_underwater_series=False,
+    )
+
+    request = client.drawdown_calls[0]["payload"]
+    assert request["input_mode"] == "stateful"
+    assert request["stateful_input"]["portfolio_id"] == "PF_1"
+    assert request["stateful_input"]["benchmark_policy"] == {
+        "include_benchmark": True,
+        "missing_benchmark_policy": "IGNORE",
+    }
+    assert request["analysis_options"]["include_underwater_series"] is False
+    assert response.state == "partial"
+    assert response.payload is not None
+    assert response.payload.periods[0].summary is not None
+    assert response.payload.periods[0].underwater_series is None
+    assert response.payload.periods[0].episodes[0].episode_id == "dd_0001"
+    assert {item.key: item.state for item in response.supportability} == {
+        "portfolio_returns": "ready",
+        "benchmark_relative_drawdown": "ready",
+        "underwater_series": "partial",
+    }
+
+
+@pytest.mark.asyncio
+async def test_risk_drawdown_requests_underwater_detail_on_demand_with_distinct_cache_key() -> None:
+    client = _StubRiskClient()
+    client.drawdown_payload["results"]["YTD"]["underwater_series"] = [
+        {"date": "2026-01-20", "drawdown": -0.0521},
+        {"date": "2026-01-21", "drawdown": -0.061},
+    ]
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    first = await service.get_drawdown(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        include_underwater_series=False,
+    )
+    second = await service.get_drawdown(
+        portfolio_id="PF_1",
+        correlation_id="corr-2",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        include_underwater_series=True,
+    )
+    third = await service.get_drawdown(
+        portfolio_id="PF_1",
+        correlation_id="corr-3",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        include_underwater_series=True,
+    )
+
+    assert len(client.drawdown_calls) == 2
+    assert (
+        client.drawdown_calls[0]["payload"]["analysis_options"]["include_underwater_series"]
+        is False
+    )
+    assert (
+        client.drawdown_calls[1]["payload"]["analysis_options"]["include_underwater_series"]
+        is True
+    )
+    assert first.metadata.cache_status == "miss"
+    assert second.metadata.cache_status == "miss"
+    assert third.metadata.cache_status == "hit"
+    assert second.payload is not None
+    assert second.payload.periods[0].underwater_series is not None
+
+
+@pytest.mark.asyncio
+async def test_risk_drawdown_reports_partial_when_benchmark_relative_summary_is_missing() -> None:
+    client = _StubRiskClient()
+    client.drawdown_payload["results"]["YTD"]["relative_to_benchmark"] = None
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_drawdown(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        include_underwater_series=False,
+    )
+
+    assert response.state == "partial"
+    benchmark_support = {
+        item.key: item for item in response.supportability
+    }["benchmark_relative_drawdown"]
+    assert benchmark_support.state == "partial"
+    assert benchmark_support.reason == "Benchmark-relative drawdown was not returned by lotus-risk."
+
+
+@pytest.mark.asyncio
+async def test_risk_drawdown_returns_unavailable_envelope_on_upstream_failure() -> None:
+    client = _StubRiskClient()
+    client.drawdown_status = 503
+    client.drawdown_payload = {"detail": "drawdown unavailable"}
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_drawdown(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        include_underwater_series=False,
+    )
+
+    assert response.state == "unavailable"
+    assert response.payload is None
+    assert response.partial_failures[0].error_code == "HTTP_503"
+    assert response.partial_failures[0].detail == "drawdown unavailable"

--- a/tests/unit/test_risk_workspace_service.py
+++ b/tests/unit/test_risk_workspace_service.py
@@ -8,9 +8,11 @@ class _StubRiskClient:
         self.calculate_calls: list[dict] = []
         self.concentration_calls: list[dict] = []
         self.drawdown_calls: list[dict] = []
+        self.rolling_calls: list[dict] = []
         self.calculate_status = 200
         self.concentration_status = 200
         self.drawdown_status = 200
+        self.rolling_status = 200
         self.calculate_payload: dict = {
             "scope": {
                 "as_of_date": "2026-04-04",
@@ -119,6 +121,61 @@ class _StubRiskClient:
             },
             "metadata": {"contract_version": "v1", "methodology_version": "drawdown.v1"},
         }
+        self.rolling_payload: dict = {
+            "source_service": "lotus-risk",
+            "input_mode": "stateful",
+            "results": {
+                "YTD": {
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-04-04",
+                    "series_count": 66,
+                    "window_results": [
+                        {
+                            "window_length": 21,
+                            "metric_summaries": {
+                                "ROLLING_VOLATILITY": {
+                                    "latest": 0.1374,
+                                    "average": 0.1221,
+                                    "minimum": 0.0913,
+                                    "maximum": 0.1662,
+                                    "p05": 0.0975,
+                                    "p50": 0.1218,
+                                    "p95": 0.1611,
+                                },
+                                "ROLLING_MAX_DRAWDOWN": {
+                                    "latest": -0.034,
+                                    "average": -0.028,
+                                    "minimum": -0.051,
+                                    "maximum": -0.012,
+                                    "p05": -0.048,
+                                    "p50": -0.029,
+                                    "p95": -0.015,
+                                },
+                            },
+                            "metric_series": None,
+                        },
+                        {
+                            "window_length": 63,
+                            "metric_summaries": {
+                                "ROLLING_VOLATILITY": {
+                                    "latest": 0.142,
+                                    "average": 0.128,
+                                    "minimum": 0.104,
+                                    "maximum": 0.171,
+                                    "p05": 0.108,
+                                    "p50": 0.129,
+                                    "p95": 0.168,
+                                }
+                            },
+                            "metric_series": None,
+                        },
+                    ],
+                    "quality_flags": ["metric:ROLLING_BETA:benchmark_variance_zero"],
+                    "error": None,
+                }
+            },
+            "metadata": {"contract_version": "v1", "methodology_version": "rolling_metrics.v1"},
+        }
 
     async def post_risk_calculate(self, payload: dict, correlation_id: str):
         self.calculate_calls.append({"payload": payload, "correlation_id": correlation_id})
@@ -131,6 +188,10 @@ class _StubRiskClient:
     async def post_risk_drawdown(self, payload: dict, correlation_id: str):
         self.drawdown_calls.append({"payload": payload, "correlation_id": correlation_id})
         return self.drawdown_status, self.drawdown_payload
+
+    async def post_risk_rolling_metrics(self, payload: dict, correlation_id: str):
+        self.rolling_calls.append({"payload": payload, "correlation_id": correlation_id})
+        return self.rolling_status, self.rolling_payload
 
 
 @pytest.mark.asyncio
@@ -446,3 +507,142 @@ async def test_risk_drawdown_returns_unavailable_envelope_on_upstream_failure() 
     assert response.payload is None
     assert response.partial_failures[0].error_code == "HTTP_503"
     assert response.partial_failures[0].detail == "drawdown unavailable"
+
+
+@pytest.mark.asyncio
+async def test_risk_rolling_uses_stateful_request_and_maps_quality_flags() -> None:
+    client = _StubRiskClient()
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_rolling(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        include_time_series=False,
+    )
+
+    request = client.rolling_calls[0]["payload"]
+    assert request["input_mode"] == "stateful"
+    assert request["stateful_input"]["portfolio_id"] == "PF_1"
+    assert request["stateful_input"]["rolling_options"]["window_lengths"] == [21, 63, 126, 252]
+    assert request["stateful_input"]["rolling_options"]["include_time_series"] is False
+    assert request["stateful_input"]["rolling_options"]["metrics"] == [
+        "ROLLING_VOLATILITY",
+        "ROLLING_MAX_DRAWDOWN",
+        "ROLLING_SHARPE",
+        "ROLLING_BETA",
+        "ROLLING_TRACKING_ERROR",
+        "ROLLING_INFORMATION_RATIO",
+    ]
+    assert response.state == "partial"
+    assert response.payload is not None
+    assert response.payload.periods[0].window_results[0].window_length == 21
+    assert response.payload.periods[0].quality_flags == [
+        "metric:ROLLING_BETA:benchmark_variance_zero"
+    ]
+    assert {item.key: item.state for item in response.supportability} == {
+        "portfolio_returns": "ready",
+        "benchmark_returns": "ready",
+        "risk_free_series": "ready",
+        "rolling_time_series": "partial",
+    }
+
+
+@pytest.mark.asyncio
+async def test_risk_rolling_retries_without_sharpe_when_risk_free_dependency_fails() -> None:
+    client = _StubRiskClient()
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    async def _rolling(payload: dict, correlation_id: str):
+        client.rolling_calls.append({"payload": payload, "correlation_id": correlation_id})
+        if len(client.rolling_calls) == 1:
+            return 424, {
+                "detail": {
+                    "message": "lotus-core returned no usable risk-free returns for rolling Sharpe",
+                }
+            }
+        return client.rolling_status, client.rolling_payload
+
+    client.post_risk_rolling_metrics = _rolling  # type: ignore[method-assign]
+
+    response = await service.get_rolling(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        include_time_series=False,
+    )
+
+    assert len(client.rolling_calls) == 2
+    assert (
+        "ROLLING_SHARPE"
+        in client.rolling_calls[0]["payload"]["stateful_input"]["rolling_options"]["metrics"]
+    )
+    assert (
+        "ROLLING_SHARPE"
+        not in client.rolling_calls[1]["payload"]["stateful_input"]["rolling_options"]["metrics"]
+    )
+    risk_free_support = {item.key: item for item in response.supportability}["risk_free_series"]
+    assert risk_free_support.state == "partial"
+    assert "risk-free returns" in (risk_free_support.reason or "")
+    assert response.partial_failures[-1].error_code == "ROLLING_SHARPE_UNAVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_risk_rolling_time_series_uses_distinct_cache_key() -> None:
+    client = _StubRiskClient()
+    client.rolling_payload["results"]["YTD"]["window_results"][0]["metric_series"] = [
+        {
+            "date": "2026-04-01",
+            "metric_values": {
+                "ROLLING_VOLATILITY": 0.131,
+                "ROLLING_MAX_DRAWDOWN": -0.03,
+            },
+        }
+    ]
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    first = await service.get_rolling(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code=None,
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        include_time_series=False,
+    )
+    second = await service.get_rolling(
+        portfolio_id="PF_1",
+        correlation_id="corr-2",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code=None,
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        include_time_series=True,
+    )
+    third = await service.get_rolling(
+        portfolio_id="PF_1",
+        correlation_id="corr-3",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code=None,
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        include_time_series=True,
+    )
+
+    assert len(client.rolling_calls) == 2
+    assert first.metadata.cache_status == "miss"
+    assert second.metadata.cache_status == "miss"
+    assert third.metadata.cache_status == "hit"
+    assert second.payload is not None
+    assert second.payload.periods[0].window_results[0].metric_series is not None

--- a/tests/unit/test_risk_workspace_service.py
+++ b/tests/unit/test_risk_workspace_service.py
@@ -1,0 +1,244 @@
+import pytest
+
+from app.services.risk_workspace_service import RiskWorkspaceService
+
+
+class _StubRiskClient:
+    def __init__(self) -> None:
+        self.calculate_calls: list[dict] = []
+        self.concentration_calls: list[dict] = []
+        self.calculate_status = 200
+        self.concentration_status = 200
+        self.calculate_payload: dict = {
+            "scope": {
+                "as_of_date": "2026-04-04",
+                "reporting_currency": "USD",
+                "net_or_gross": "NET",
+            },
+            "results": {
+                "YTD": {
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-04-04",
+                    "metrics": {
+                        "VOLATILITY": {"value": 0.12},
+                        "SHARPE": {"value": 1.4},
+                        "SORTINO": {"value": 1.7},
+                        "BETA": {"value": 0.92},
+                        "TRACKING_ERROR": {"value": 0.04},
+                        "INFORMATION_RATIO": {"value": 0.3},
+                        "VAR": {"value": -0.02, "details": {"expected_shortfall": -0.03}},
+                    },
+                }
+            },
+        }
+        self.concentration_payload: dict = {
+            "source_service": "lotus-risk",
+            "input_mode": "stateful",
+            "risk_proxy": {"hhi_current": 1200.0, "hhi_proposed": 1200.0, "hhi_delta": 0.0},
+            "single_position_concentration": {
+                "top_position_weight_current": 0.18,
+                "top_position_weight_proposed": 0.18,
+                "top_position_weight_delta": 0.0,
+                "top_n_cumulative_weight_current": 0.42,
+                "top_n_cumulative_weight_proposed": 0.42,
+                "top_n_cumulative_weight_delta": 0.0,
+                "top_n": 10,
+            },
+            "issuer_concentration": {
+                "hhi_current": 1400.0,
+                "hhi_proposed": 1450.0,
+                "hhi_delta": 50.0,
+                "top_issuer_weight_current": 0.2,
+                "top_issuer_weight_proposed": 0.21,
+                "top_issuer_weight_delta": 0.01,
+                "coverage_status": "partial",
+                "covered_position_count_current": 8,
+                "covered_position_count_proposed": 8,
+                "total_position_count_current": 10,
+                "total_position_count_proposed": 10,
+                "note": "Two positions have no issuer enrichment.",
+            },
+            "valuation_context": {"reporting_currency": "USD"},
+            "metadata": {"as_of_date": "2026-04-04", "portfolio_id": "PF_1"},
+        }
+
+    async def post_risk_calculate(self, payload: dict, correlation_id: str):
+        self.calculate_calls.append({"payload": payload, "correlation_id": correlation_id})
+        return self.calculate_status, self.calculate_payload
+
+    async def post_risk_concentration(self, payload: dict, correlation_id: str):
+        self.concentration_calls.append({"payload": payload, "correlation_id": correlation_id})
+        return self.concentration_status, self.concentration_payload
+
+
+@pytest.mark.asyncio
+async def test_risk_summary_uses_stateful_request_and_maps_supportability() -> None:
+    client = _StubRiskClient()
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_summary(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+    )
+
+    request = client.calculate_calls[0]["payload"]
+    assert request["input_mode"] == "stateful"
+    assert "stateless_input" not in request
+    assert request["stateful_input"]["portfolio_id"] == "PF_1"
+    assert request["stateful_input"]["metrics"] == [
+        "VOLATILITY",
+        "SHARPE",
+        "SORTINO",
+        "BETA",
+        "TRACKING_ERROR",
+        "INFORMATION_RATIO",
+        "VAR",
+    ]
+    assert response.state == "ready"
+    assert response.payload is not None
+    assert response.payload.periods[0].metrics[0].label == "Volatility"
+    assert {item.key: item.state for item in response.supportability} == {
+        "portfolio_returns": "ready",
+        "benchmark_returns": "ready",
+        "risk_free_series": "ready",
+    }
+
+
+@pytest.mark.asyncio
+async def test_risk_summary_reports_partial_when_benchmark_metrics_have_errors() -> None:
+    client = _StubRiskClient()
+    client.calculate_payload["results"]["YTD"]["metrics"]["TRACKING_ERROR"] = {
+        "value": None,
+        "details": {"error": "benchmark returns unavailable"},
+    }
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_summary(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+    )
+
+    assert response.state == "partial"
+    assert response.payload is not None
+    tracking_error = [
+        metric
+        for metric in response.payload.periods[0].metrics
+        if metric.key == "TRACKING_ERROR"
+    ][0]
+    assert tracking_error.state == "partial"
+    assert tracking_error.reason == "benchmark returns unavailable"
+
+
+@pytest.mark.asyncio
+async def test_risk_concentration_uses_stateful_request_and_maps_issuer_supportability() -> None:
+    client = _StubRiskClient()
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_concentration(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        benchmark_code="BMK_1",
+    )
+
+    request = client.concentration_calls[0]["payload"]
+    assert request["input_mode"] == "stateful"
+    assert request["stateful_input"]["portfolio_id"] == "PF_1"
+    assert request["issuer_grouping_level"] == "ultimate_parent"
+    assert request["enrichment_policy"] == "merge_caller_then_core"
+    assert response.state == "partial"
+    assert response.payload is not None
+    assert response.payload.risk_proxy.hhi_current == 1200.0
+    assert {item.key: item.state for item in response.supportability} == {
+        "portfolio_positions": "ready",
+        "issuer_enrichment": "partial",
+    }
+
+
+@pytest.mark.asyncio
+async def test_risk_workspace_cache_reuses_identical_summary_requests() -> None:
+    client = _StubRiskClient()
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    first = await service.get_summary(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+    )
+    second = await service.get_summary(
+        portfolio_id="PF_1",
+        correlation_id="corr-2",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+    )
+
+    assert len(client.calculate_calls) == 1
+    assert first.metadata.cache_status == "miss"
+    assert second.metadata.cache_status == "hit"
+    assert second.correlation_id == "corr-2"
+
+
+@pytest.mark.asyncio
+async def test_risk_summary_returns_unavailable_envelope_on_upstream_failure() -> None:
+    client = _StubRiskClient()
+    client.calculate_status = 503
+    client.calculate_payload = {"detail": "risk unavailable"}
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_summary(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+    )
+
+    assert response.state == "unavailable"
+    assert response.payload is None
+    assert response.partial_failures[0].error_code == "HTTP_503"
+    assert response.partial_failures[0].detail == "risk unavailable"
+
+
+@pytest.mark.asyncio
+async def test_risk_concentration_returns_unavailable_envelope_on_malformed_success() -> None:
+    client = _StubRiskClient()
+    client.concentration_payload = {
+        "risk_proxy": {"hhi_current": 1200.0, "hhi_proposed": 1200.0, "hhi_delta": 0.0}
+    }
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_concentration(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        benchmark_code="BMK_1",
+    )
+
+    assert response.state == "unavailable"
+    assert response.payload is None
+    assert response.partial_failures[0].error_code == "MALFORMED_RISK_CONCENTRATION"
+    assert "single_position_concentration" in response.partial_failures[0].detail
+    assert "issuer_concentration" in response.partial_failures[0].detail

--- a/tests/unit/test_risk_workspace_service.py
+++ b/tests/unit/test_risk_workspace_service.py
@@ -9,10 +9,12 @@ class _StubRiskClient:
         self.concentration_calls: list[dict] = []
         self.drawdown_calls: list[dict] = []
         self.rolling_calls: list[dict] = []
+        self.attribution_calls: list[dict] = []
         self.calculate_status = 200
         self.concentration_status = 200
         self.drawdown_status = 200
         self.rolling_status = 200
+        self.attribution_status = 200
         self.calculate_payload: dict = {
             "scope": {
                 "as_of_date": "2026-04-04",
@@ -176,6 +178,50 @@ class _StubRiskClient:
             },
             "metadata": {"contract_version": "v1", "methodology_version": "rolling_metrics.v1"},
         }
+        self.attribution_payload: dict = {
+            "source_service": "lotus-risk",
+            "input_mode": "stateful",
+            "results": {
+                "YTD": {
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-04-04",
+                    "attribution_sets": [
+                        {
+                            "attribution_type": "TOTAL_RISK",
+                            "metric": "VOLATILITY",
+                            "grouping_dimension": "SECTOR",
+                            "total_value": 0.124,
+                            "reconciled_sum": 0.123,
+                            "residual": 0.001,
+                            "contributors": [
+                                {
+                                    "group_key": "SECTOR_TECH",
+                                    "group_label": "Technology",
+                                    "weight_average": 0.42,
+                                    "marginal_contribution": 0.051,
+                                    "component_contribution": 0.044,
+                                    "percent_contribution": 0.355,
+                                },
+                                {
+                                    "group_key": "SECTOR_HEALTH",
+                                    "group_label": "Healthcare",
+                                    "weight_average": 0.18,
+                                    "marginal_contribution": 0.022,
+                                    "component_contribution": 0.019,
+                                    "percent_contribution": 0.153,
+                                },
+                            ],
+                            "quality_flags": [],
+                        }
+                    ],
+                    "error": None,
+                }
+            },
+            "metadata": {
+                "contract_version": "v1",
+                "methodology_version": "historical_attribution.v1",
+            },
+        }
 
     async def post_risk_calculate(self, payload: dict, correlation_id: str):
         self.calculate_calls.append({"payload": payload, "correlation_id": correlation_id})
@@ -192,6 +238,10 @@ class _StubRiskClient:
     async def post_risk_rolling_metrics(self, payload: dict, correlation_id: str):
         self.rolling_calls.append({"payload": payload, "correlation_id": correlation_id})
         return self.rolling_status, self.rolling_payload
+
+    async def post_risk_historical_attribution(self, payload: dict, correlation_id: str):
+        self.attribution_calls.append({"payload": payload, "correlation_id": correlation_id})
+        return self.attribution_status, self.attribution_payload
 
 
 @pytest.mark.asyncio
@@ -646,3 +696,138 @@ async def test_risk_rolling_time_series_uses_distinct_cache_key() -> None:
     assert third.metadata.cache_status == "hit"
     assert second.payload is not None
     assert second.payload.periods[0].window_results[0].metric_series is not None
+
+
+@pytest.mark.asyncio
+async def test_risk_attribution_uses_stateful_total_risk_request_and_maps_controls() -> None:
+    client = _StubRiskClient()
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_attribution(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        attribution_type="TOTAL_RISK",
+        grouping_dimension="SECTOR",
+    )
+
+    request = client.attribution_calls[0]["payload"]
+    assert request["input_mode"] == "stateful"
+    assert request["stateful_input"]["portfolio_id"] == "PF_1"
+    assert request["stateful_input"]["attribution_options"] == {
+        "attribution_types": ["TOTAL_RISK"],
+        "metrics": ["VOLATILITY"],
+        "grouping_dimensions": ["SECTOR"],
+        "annualization_basis": 252,
+    }
+    assert response.state == "ready"
+    assert response.payload is not None
+    assert response.payload.controls.selected_attribution_type == "TOTAL_RISK"
+    assert response.payload.controls.selected_grouping_dimension == "SECTOR"
+    assert (
+        response.payload.periods[0].attribution_sets[0].contributors[0].group_label
+        == "Technology"
+    )
+    assert {item.key: item.state for item in response.supportability} == {
+        "portfolio_returns": "ready",
+        "exposure_history": "ready",
+        "benchmark_exposure_context": "ready",
+    }
+
+
+@pytest.mark.asyncio
+async def test_risk_attribution_uses_stateful_active_risk_request_for_supported_grouping() -> None:
+    client = _StubRiskClient()
+    client.attribution_payload["results"]["YTD"]["attribution_sets"][0][
+        "attribution_type"
+    ] = "ACTIVE_RISK"
+    client.attribution_payload["results"]["YTD"]["attribution_sets"][0]["metric"] = "TRACKING_ERROR"
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_attribution(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        attribution_type="ACTIVE_RISK",
+        grouping_dimension="ASSET_CLASS",
+    )
+
+    request = client.attribution_calls[0]["payload"]
+    assert request["stateful_input"]["attribution_options"] == {
+        "attribution_types": ["ACTIVE_RISK"],
+        "metrics": ["TRACKING_ERROR"],
+        "grouping_dimensions": ["ASSET_CLASS"],
+        "annualization_basis": 252,
+    }
+    assert response.state == "ready"
+    assert response.payload is not None
+    assert response.payload.controls.attribution_types[1].state == "ready"
+    assert {item.key: item.state for item in response.supportability} == {
+        "portfolio_returns": "ready",
+        "exposure_history": "ready",
+        "benchmark_returns": "ready",
+        "benchmark_exposure_context": "ready",
+    }
+
+
+@pytest.mark.asyncio
+async def test_risk_attribution_blocks_active_risk_issuer_until_supported() -> None:
+    client = _StubRiskClient()
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_attribution(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        attribution_type="ACTIVE_RISK",
+        grouping_dimension="ISSUER",
+    )
+
+    assert client.attribution_calls == []
+    assert response.state == "blocked"
+    assert response.payload is not None
+    assert response.payload.controls.selected_grouping_dimension == "ISSUER"
+    issuer_grouping = {
+        option.key: option for option in response.payload.controls.grouping_dimensions
+    }["ISSUER"]
+    assert issuer_grouping.state == "blocked"
+    assert "benchmark issuer exposure semantics" in (issuer_grouping.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_risk_attribution_blocks_active_risk_without_benchmark_context() -> None:
+    client = _StubRiskClient()
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_attribution(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code=None,
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+        attribution_type="ACTIVE_RISK",
+        grouping_dimension="SECTOR",
+    )
+
+    assert client.attribution_calls == []
+    assert response.state == "blocked"
+    assert response.payload is not None
+    active_risk = {
+        option.key: option for option in response.payload.controls.attribution_types
+    }["ACTIVE_RISK"]
+    assert active_risk.state == "blocked"
+    assert active_risk.reason == "Active risk requires benchmark context."

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -268,6 +268,27 @@ async def test_lotus_analytics_client_performance_workspace_requests_use_owned_c
 
 
 @pytest.mark.asyncio
+async def test_lotus_analytics_client_uses_canonical_risk_routes() -> None:
+    client = LotusAnalyticsClient(base_url="http://risk", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"results": {}})
+    _FakeAsyncClient.queue_json(200, {"risk_proxy": {"hhi_current": 100.0}})
+
+    status_one, _ = await client.post_risk_calculate(
+        payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
+        correlation_id="corr-risk",
+    )
+    status_two, _ = await client.post_risk_concentration(
+        payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
+        correlation_id="corr-risk",
+    )
+
+    assert status_one == 200
+    assert status_two == 200
+    assert _FakeAsyncClient.calls[-2]["url"] == "http://risk/analytics/risk/calculate"
+    assert _FakeAsyncClient.calls[-1]["url"] == "http://risk/analytics/risk/concentration"
+
+
+@pytest.mark.asyncio
 async def test_lotus_ai_client_calls_task_execution_contract_with_correlation_headers():
     client = LotusAiClient(base_url="http://ai", timeout_seconds=3.0)
     _FakeAsyncClient.queue_json(

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -272,6 +272,7 @@ async def test_lotus_analytics_client_uses_canonical_risk_routes() -> None:
     client = LotusAnalyticsClient(base_url="http://risk", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"results": {}})
     _FakeAsyncClient.queue_json(200, {"risk_proxy": {"hhi_current": 100.0}})
+    _FakeAsyncClient.queue_json(200, {"results": {}})
 
     status_one, _ = await client.post_risk_calculate(
         payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
@@ -281,11 +282,17 @@ async def test_lotus_analytics_client_uses_canonical_risk_routes() -> None:
         payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
         correlation_id="corr-risk",
     )
+    status_three, _ = await client.post_risk_drawdown(
+        payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
+        correlation_id="corr-risk",
+    )
 
     assert status_one == 200
     assert status_two == 200
-    assert _FakeAsyncClient.calls[-2]["url"] == "http://risk/analytics/risk/calculate"
-    assert _FakeAsyncClient.calls[-1]["url"] == "http://risk/analytics/risk/concentration"
+    assert status_three == 200
+    assert _FakeAsyncClient.calls[-3]["url"] == "http://risk/analytics/risk/calculate"
+    assert _FakeAsyncClient.calls[-2]["url"] == "http://risk/analytics/risk/concentration"
+    assert _FakeAsyncClient.calls[-1]["url"] == "http://risk/analytics/risk/drawdown"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -274,6 +274,7 @@ async def test_lotus_analytics_client_uses_canonical_risk_routes() -> None:
     _FakeAsyncClient.queue_json(200, {"risk_proxy": {"hhi_current": 100.0}})
     _FakeAsyncClient.queue_json(200, {"results": {}})
     _FakeAsyncClient.queue_json(200, {"results": {}})
+    _FakeAsyncClient.queue_json(200, {"results": {}})
 
     status_one, _ = await client.post_risk_calculate(
         payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
@@ -291,15 +292,21 @@ async def test_lotus_analytics_client_uses_canonical_risk_routes() -> None:
         payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
         correlation_id="corr-risk",
     )
+    status_five, _ = await client.post_risk_historical_attribution(
+        payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
+        correlation_id="corr-risk",
+    )
 
     assert status_one == 200
     assert status_two == 200
     assert status_three == 200
     assert status_four == 200
-    assert _FakeAsyncClient.calls[-4]["url"] == "http://risk/analytics/risk/calculate"
-    assert _FakeAsyncClient.calls[-3]["url"] == "http://risk/analytics/risk/concentration"
-    assert _FakeAsyncClient.calls[-2]["url"] == "http://risk/analytics/risk/drawdown"
-    assert _FakeAsyncClient.calls[-1]["url"] == "http://risk/analytics/risk/rolling-metrics"
+    assert status_five == 200
+    assert _FakeAsyncClient.calls[-5]["url"] == "http://risk/analytics/risk/calculate"
+    assert _FakeAsyncClient.calls[-4]["url"] == "http://risk/analytics/risk/concentration"
+    assert _FakeAsyncClient.calls[-3]["url"] == "http://risk/analytics/risk/drawdown"
+    assert _FakeAsyncClient.calls[-2]["url"] == "http://risk/analytics/risk/rolling-metrics"
+    assert _FakeAsyncClient.calls[-1]["url"] == "http://risk/analytics/risk/historical-attribution"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -273,6 +273,7 @@ async def test_lotus_analytics_client_uses_canonical_risk_routes() -> None:
     _FakeAsyncClient.queue_json(200, {"results": {}})
     _FakeAsyncClient.queue_json(200, {"risk_proxy": {"hhi_current": 100.0}})
     _FakeAsyncClient.queue_json(200, {"results": {}})
+    _FakeAsyncClient.queue_json(200, {"results": {}})
 
     status_one, _ = await client.post_risk_calculate(
         payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
@@ -286,13 +287,19 @@ async def test_lotus_analytics_client_uses_canonical_risk_routes() -> None:
         payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
         correlation_id="corr-risk",
     )
+    status_four, _ = await client.post_risk_rolling_metrics(
+        payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
+        correlation_id="corr-risk",
+    )
 
     assert status_one == 200
     assert status_two == 200
     assert status_three == 200
-    assert _FakeAsyncClient.calls[-3]["url"] == "http://risk/analytics/risk/calculate"
-    assert _FakeAsyncClient.calls[-2]["url"] == "http://risk/analytics/risk/concentration"
-    assert _FakeAsyncClient.calls[-1]["url"] == "http://risk/analytics/risk/drawdown"
+    assert status_four == 200
+    assert _FakeAsyncClient.calls[-4]["url"] == "http://risk/analytics/risk/calculate"
+    assert _FakeAsyncClient.calls[-3]["url"] == "http://risk/analytics/risk/concentration"
+    assert _FakeAsyncClient.calls[-2]["url"] == "http://risk/analytics/risk/drawdown"
+    assert _FakeAsyncClient.calls[-1]["url"] == "http://risk/analytics/risk/rolling-metrics"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_workbench_service.py
+++ b/tests/unit/test_workbench_service.py
@@ -112,7 +112,6 @@ class _StubLotusAnalyticsClient:
                     "direction": "INCREASE",
                 }
             ],
-            "riskProxy": {"hhiCurrent": 10000.0, "hhiProposed": 10000.0, "hhiDelta": 0.0},
         }
         self.twr_calls = 0
 
@@ -543,7 +542,7 @@ async def test_workbench_analytics_response():
     assert response.group_by == "ASSET_CLASS"
     assert len(response.allocation_buckets) == 1
     assert response.top_changes[0].security_id == "EQ_1"
-    assert response.risk_proxy is None
+    assert "risk_proxy" not in response.model_dump()
     assert "RISK_BFF_PENDING" in response.warnings
     assert any(
         failure.source_service == "risk"

--- a/tests/unit/test_workbench_service.py
+++ b/tests/unit/test_workbench_service.py
@@ -543,4 +543,10 @@ async def test_workbench_analytics_response():
     assert response.group_by == "ASSET_CLASS"
     assert len(response.allocation_buckets) == 1
     assert response.top_changes[0].security_id == "EQ_1"
-    assert response.risk_proxy.hhi_current == 10000.0
+    assert response.risk_proxy is None
+    assert "RISK_BFF_PENDING" in response.warnings
+    assert any(
+        failure.source_service == "risk"
+        and failure.error_code == "RISK_BFF_NOT_IMPLEMENTED"
+        for failure in response.partial_failures
+    )

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -475,7 +475,7 @@ async def test_get_workbench_analytics_ignores_legacy_risk_proxy_payload():
         benchmark_code="MODEL",
         session_id=None,
     )
-    assert response.risk_proxy is None
+    assert "risk_proxy" not in response.model_dump()
     assert "RISK_BFF_PENDING" in response.warnings
     assert [
         failure
@@ -632,7 +632,7 @@ async def test_workbench_analytics_reports_controlled_risk_gap_until_risk_bff_ex
         benchmark_code="MODEL_60_40",
         session_id=None,
     )
-    assert response.risk_proxy is None
+    assert "risk_proxy" not in response.model_dump()
     assert "RISK_BFF_PENDING" in response.warnings
     assert response.partial_failures[-1].source_service == "risk"
     assert response.partial_failures[-1].error_code == "RISK_BFF_NOT_IMPLEMENTED"

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -83,7 +83,6 @@ class _StubLotusAnalyticsClient:
         self.analytics_payload: dict = {
             "allocationBuckets": [],
             "topChanges": [],
-            "riskProxy": {},
             "portfolioReturnPct": 1.0,
             "benchmarkReturnPct": 0.8,
             "activeReturnPct": 0.2,
@@ -119,10 +118,6 @@ class _StubLotusAnalyticsClient:
     async def get_workbench_analytics(self, payload: dict, correlation_id: str):
         return self.analytics_status, self.analytics_payload
 
-    async def get_workbench_risk_proxy(self, payload: dict, correlation_id: str):
-        return 200, {"riskProxy": {"hhiCurrent": 1234.0, "hhiProposed": 1500.0, "hhiDelta": 266.0}}
-
-
 class _StubDpmClient:
     def __init__(self):
         self.list_runs_status = 200
@@ -151,31 +146,6 @@ def _build_service() -> tuple[
         pas,
         pa,
         dpm,
-    )
-
-
-def _build_service_with_risk_client() -> tuple[
-    WorkbenchService,
-    _StubLotusCoreQueryClient,
-    _StubLotusAnalyticsClient,
-    _StubDpmClient,
-    _StubLotusAnalyticsClient,
-]:
-    pas = _StubLotusCoreQueryClient()
-    pa = _StubLotusAnalyticsClient()
-    dpm = _StubDpmClient()
-    risk = _StubLotusAnalyticsClient()
-    return (
-        WorkbenchService(
-            lotus_core_query_client=pas,
-            analytics_client=pa,
-            dpm_client=dpm,
-            risk_client=risk,
-        ),
-        pas,
-        pa,
-        dpm,
-        risk,
     )
 
 
@@ -487,12 +457,12 @@ async def test_get_workbench_analytics_raises_on_invalid_payload_shape():
 
 
 @pytest.mark.asyncio
-async def test_get_workbench_analytics_handles_non_dict_risk_proxy():
+async def test_get_workbench_analytics_ignores_legacy_risk_proxy_payload():
     service, _, pa, _ = _build_service()
     pa.analytics_payload = {
         "allocationBuckets": [],
         "topChanges": [],
-        "riskProxy": "bad-shape",
+        "riskProxy": {"hhiCurrent": 9999.0, "hhiProposed": 9999.0, "hhiDelta": 0.0},
         "portfolioReturnPct": 1.0,
         "benchmarkReturnPct": 0.8,
         "activeReturnPct": 0.2,
@@ -505,7 +475,14 @@ async def test_get_workbench_analytics_handles_non_dict_risk_proxy():
         benchmark_code="MODEL",
         session_id=None,
     )
-    assert response.risk_proxy.hhi_current == 0.0
+    assert response.risk_proxy is None
+    assert "RISK_BFF_PENDING" in response.warnings
+    assert [
+        failure
+        for failure in response.partial_failures
+        if failure.source_service == "risk"
+        and failure.error_code == "RISK_BFF_NOT_IMPLEMENTED"
+    ]
 
 
 @pytest.mark.asyncio
@@ -637,8 +614,8 @@ def test_parse_dpm_snapshot_without_created_at_keeps_last_run_null():
 
 
 @pytest.mark.asyncio
-async def test_workbench_analytics_prefers_split_risk_proxy_when_available():
-    service, _, pa, _, _ = _build_service_with_risk_client()
+async def test_workbench_analytics_reports_controlled_risk_gap_until_risk_bff_exists():
+    service, _, pa, _ = _build_service()
     pa.analytics_payload = {
         "allocationBuckets": [],
         "topChanges": [],
@@ -655,4 +632,7 @@ async def test_workbench_analytics_prefers_split_risk_proxy_when_available():
         benchmark_code="MODEL_60_40",
         session_id=None,
     )
-    assert response.risk_proxy.hhi_current == 1234.0
+    assert response.risk_proxy is None
+    assert "RISK_BFF_PENDING" in response.warnings
+    assert response.partial_failures[-1].source_service == "risk"
+    assert response.partial_failures[-1].error_code == "RISK_BFF_NOT_IMPLEMENTED"


### PR DESCRIPTION
## Summary
- add stateful Gateway BFF endpoints for Workbench Risk mode
- remove the legacy workbench risk-proxy integration and stale analytics seam
- harden canonical upstream routing and close RFC-0022 supportability/runbook gaps

## Validation
- python -m pytest tests/unit/test_workbench_service.py tests/unit/test_workbench_service_additional.py tests/unit/test_rfc0022_risk_proxy_guard.py tests/integration/test_workbench_router.py -q
- python -m pytest tests/unit/test_risk_workspace_service.py tests/unit/test_upstream_clients.py tests/integration/test_workbench_router.py -q
- python -m pytest tests/unit/test_config_defaults.py -q
- python -m ruff check src tests
