### PR TITLE
feat: add upgraded stateful risk workspace gateway contracts

### DIFF
--- a/src/app/contracts/risk_workspace.py
+++ b/src/app/contracts/risk_workspace.py
@@ -37,6 +37,10 @@ class WorkbenchRiskPeriodResult(BaseModel):
     label: str
     start_date: str
     end_date: str
+    portfolio_observation_count: int = 0
+    benchmark_observation_count: int = 0
+    aligned_benchmark_observation_count: int = 0
+    benchmark_context: dict[str, Any] | None = None
     metrics: list[WorkbenchRiskMetric] = Field(default_factory=list)
 
 
@@ -44,10 +48,16 @@ class WorkbenchRiskSummaryPayload(BaseModel):
     periods: list[WorkbenchRiskPeriodResult] = Field(default_factory=list)
 
 
-class WorkbenchConcentrationRiskProxy(BaseModel):
+class WorkbenchPortfolioConcentration(BaseModel):
     hhi_current: float
     hhi_proposed: float
     hhi_delta: float
+
+
+class WorkbenchTopPositionDriver(BaseModel):
+    security_id: str | None = None
+    security_name: str | None = None
+    weight: float
 
 
 class WorkbenchSinglePositionConcentration(BaseModel):
@@ -58,6 +68,14 @@ class WorkbenchSinglePositionConcentration(BaseModel):
     top_n_cumulative_weight_proposed: float
     top_n_cumulative_weight_delta: float
     top_n: int
+    top_position_current: WorkbenchTopPositionDriver
+    top_position_proposed: WorkbenchTopPositionDriver
+
+
+class WorkbenchTopIssuerDriver(BaseModel):
+    issuer_id: str | None = None
+    issuer_name: str | None = None
+    weight: float
 
 
 class WorkbenchIssuerConcentration(BaseModel):
@@ -72,15 +90,40 @@ class WorkbenchIssuerConcentration(BaseModel):
     covered_position_count_proposed: int
     total_position_count_current: int
     total_position_count_proposed: int
+    uncovered_position_count_current: int
+    uncovered_position_count_proposed: int
+    coverage_ratio_current: float
+    coverage_ratio_proposed: float
     note: str | None = None
+    top_issuer_current: WorkbenchTopIssuerDriver
+    top_issuer_proposed: WorkbenchTopIssuerDriver
+
+
+class WorkbenchRiskConcentrationValuationContext(BaseModel):
+    portfolio_currency: str | None = None
+    reporting_currency: str | None = None
+    position_basis: str | None = None
+    weight_basis: str | None = None
+
+
+class WorkbenchRiskConcentrationExecutionContext(BaseModel):
+    as_of_date: str | None = None
+    portfolio_id: str | None = None
+    simulation_session_id: str | None = None
+    simulation_session_version: int | None = None
+    session_expires_at: str | None = None
+    issuer_grouping_level: str
+    enrichment_policy: str
+    include_cash_positions: bool | None = None
+    include_zero_quantity_positions: bool | None = None
 
 
 class WorkbenchRiskConcentrationPayload(BaseModel):
-    risk_proxy: WorkbenchConcentrationRiskProxy
+    portfolio_concentration: WorkbenchPortfolioConcentration
     single_position_concentration: WorkbenchSinglePositionConcentration
     issuer_concentration: WorkbenchIssuerConcentration
-    valuation_context: dict[str, Any] | None = None
-    risk_metadata: dict[str, Any] | None = None
+    valuation_context: WorkbenchRiskConcentrationValuationContext | None = None
+    execution_context: WorkbenchRiskConcentrationExecutionContext | None = None
 
 
 class WorkbenchRiskDrawdownSummary(BaseModel):
@@ -114,6 +157,18 @@ class WorkbenchRiskRelativeDrawdownSummary(BaseModel):
     max_drawdown: float | None = None
     max_drawdown_peak_date: str | None = None
     max_drawdown_trough_date: str | None = None
+    max_drawdown_recovery_date: str | None = None
+    is_recovered: bool = False
+    days_to_trough: int | None = None
+    days_to_recovery: int | None = None
+    time_under_water_days: int = 0
+
+
+class WorkbenchRiskRelativeDrawdownContext(BaseModel):
+    requested: bool = False
+    applied: bool = False
+    reason: str = "NOT_REQUESTED"
+    aligned_observation_count: int = 0
 
 
 class WorkbenchRiskUnderwaterPoint(BaseModel):
@@ -126,18 +181,41 @@ class WorkbenchRiskDrawdownPeriodResult(BaseModel):
     label: str
     start_date: str
     end_date: str
+    portfolio_observation_count: int = 0
+    benchmark_observation_count: int = 0
     summary: WorkbenchRiskDrawdownSummary | None = None
     episodes: list[WorkbenchRiskDrawdownEpisode] = Field(default_factory=list)
     relative_to_benchmark: WorkbenchRiskRelativeDrawdownSummary | None = None
+    relative_to_benchmark_context: WorkbenchRiskRelativeDrawdownContext | None = None
     underwater_series: list[WorkbenchRiskUnderwaterPoint] | None = None
     error: str | None = None
 
 
+class WorkbenchRiskDrawdownAnalysisContext(BaseModel):
+    include_underwater_series: bool = False
+    include_episode_list: bool = True
+    top_n_episodes: int = 5
+    cdar_alpha: float = 0.95
+    minimum_episode_depth_bps: float = 0.0
+    duration_unit: str = "BUSINESS_DAYS"
+    include_benchmark: bool | None = None
+    missing_benchmark_policy: str | None = None
+
+
 class WorkbenchRiskDrawdownPayload(BaseModel):
     periods: list[WorkbenchRiskDrawdownPeriodResult] = Field(default_factory=list)
+    analysis_context: WorkbenchRiskDrawdownAnalysisContext | None = None
 
 
 class WorkbenchRiskRollingMetricSummary(BaseModel):
+    total_point_count: int = 0
+    computed_point_count: int = 0
+    coverage_ratio: float = 0.0
+    min_observations_required: int = 0
+    warmup_point_count: int = 0
+    non_computed_point_count: int = 0
+    post_warmup_gap_point_count: int = 0
+    latest_observation_date: str | None = None
     latest: float | None = None
     average: float | None = None
     minimum: float | None = None
@@ -152,10 +230,30 @@ class WorkbenchRiskRollingMetricSeriesPoint(BaseModel):
     metric_values: dict[str, float | None] = Field(default_factory=dict)
 
 
+class WorkbenchRiskRollingMetricSeriesContext(BaseModel):
+    requested: bool
+    included: bool
+    emitted_point_count: int = 0
+    reason: str
+
+
 class WorkbenchRiskRollingWindowResult(BaseModel):
     window_length: int
     metric_summaries: dict[str, WorkbenchRiskRollingMetricSummary] = Field(default_factory=dict)
     metric_series: list[WorkbenchRiskRollingMetricSeriesPoint] | None = None
+    metric_series_context: WorkbenchRiskRollingMetricSeriesContext | None = None
+
+
+class WorkbenchRiskRollingDependencyContext(BaseModel):
+    requested: bool
+    available: bool
+    aligned: bool
+    reason: str
+
+
+class WorkbenchRiskRollingRequestDependencyContext(BaseModel):
+    requested: bool
+    requested_metrics: list[str] = Field(default_factory=list)
 
 
 class WorkbenchRiskRollingPeriodResult(BaseModel):
@@ -164,13 +262,36 @@ class WorkbenchRiskRollingPeriodResult(BaseModel):
     start_date: str
     end_date: str
     series_count: int
+    benchmark_series_count: int = 0
+    aligned_benchmark_series_count: int = 0
+    risk_free_series_count: int = 0
+    aligned_risk_free_series_count: int = 0
+    window_lengths_requested: list[int] = Field(default_factory=list)
+    window_count_requested: int = 0
+    window_lengths_emitted: list[int] = Field(default_factory=list)
+    window_count_emitted: int = 0
+    benchmark_context: WorkbenchRiskRollingDependencyContext | None = None
+    risk_free_context: WorkbenchRiskRollingDependencyContext | None = None
     window_results: list[WorkbenchRiskRollingWindowResult] = Field(default_factory=list)
     quality_flags: list[str] = Field(default_factory=list)
     error: str | None = None
 
 
+class WorkbenchRiskRollingRequestContext(BaseModel):
+    annualization_basis: int = 252
+    requested_metrics: list[str] = Field(default_factory=list)
+    window_lengths_requested: list[int] = Field(default_factory=list)
+    window_count_requested: int = 0
+    alignment_policy: str = "INNER_JOIN"
+    min_observations_policy: str = "STRICT"
+    include_time_series: bool = False
+    benchmark_context: WorkbenchRiskRollingRequestDependencyContext | None = None
+    risk_free_context: WorkbenchRiskRollingRequestDependencyContext | None = None
+
+
 class WorkbenchRiskRollingPayload(BaseModel):
     periods: list[WorkbenchRiskRollingPeriodResult] = Field(default_factory=list)
+    request_context: WorkbenchRiskRollingRequestContext | None = None
 
 
 class WorkbenchRiskAttributionTypeOption(BaseModel):
@@ -224,9 +345,22 @@ class WorkbenchRiskAttributionControls(BaseModel):
     selected_grouping_dimension: str
 
 
+class WorkbenchRiskAttributionMethodologyContext(BaseModel):
+    covariance_method: str | None = None
+    annualization_basis: int | None = None
+    requested_attribution_types: list[str] = Field(default_factory=list)
+    requested_metrics: list[str] = Field(default_factory=list)
+    requested_grouping_dimensions: list[str] = Field(default_factory=list)
+    min_observations_policy: str | None = None
+    stateful_active_risk_supported_grouping_dimensions: list[str] = Field(default_factory=list)
+    stateful_active_risk_gated_grouping_dimensions: list[str] = Field(default_factory=list)
+    stateful_active_risk_gate_reason: str | None = None
+
+
 class WorkbenchRiskAttributionPayload(BaseModel):
     controls: WorkbenchRiskAttributionControls
     periods: list[WorkbenchRiskAttributionPeriodResult] = Field(default_factory=list)
+    methodology_context: WorkbenchRiskAttributionMethodologyContext | None = None
 
 
 class WorkbenchRiskModuleEnvelope(BaseModel):

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -8,18 +8,22 @@ from app.config import settings
 from app.contracts.risk_workspace import (
     RiskModuleState,
     RiskSupportabilityState,
-    WorkbenchConcentrationRiskProxy,
     WorkbenchIssuerConcentration,
+    WorkbenchPortfolioConcentration,
     WorkbenchRiskAttributionContributor,
     WorkbenchRiskAttributionControls,
     WorkbenchRiskAttributionGroupingOption,
+    WorkbenchRiskAttributionMethodologyContext,
     WorkbenchRiskAttributionPayload,
     WorkbenchRiskAttributionPeriodResult,
     WorkbenchRiskAttributionResponse,
     WorkbenchRiskAttributionSet,
     WorkbenchRiskAttributionTypeOption,
+    WorkbenchRiskConcentrationExecutionContext,
     WorkbenchRiskConcentrationPayload,
     WorkbenchRiskConcentrationResponse,
+    WorkbenchRiskConcentrationValuationContext,
+    WorkbenchRiskDrawdownAnalysisContext,
     WorkbenchRiskDrawdownEpisode,
     WorkbenchRiskDrawdownPayload,
     WorkbenchRiskDrawdownPeriodResult,
@@ -28,11 +32,15 @@ from app.contracts.risk_workspace import (
     WorkbenchRiskMetadata,
     WorkbenchRiskMetric,
     WorkbenchRiskPeriodResult,
+    WorkbenchRiskRelativeDrawdownContext,
     WorkbenchRiskRelativeDrawdownSummary,
+    WorkbenchRiskRollingDependencyContext,
+    WorkbenchRiskRollingMetricSeriesContext,
     WorkbenchRiskRollingMetricSeriesPoint,
     WorkbenchRiskRollingMetricSummary,
     WorkbenchRiskRollingPayload,
     WorkbenchRiskRollingPeriodResult,
+    WorkbenchRiskRollingRequestContext,
     WorkbenchRiskRollingResponse,
     WorkbenchRiskRollingWindowResult,
     WorkbenchRiskSummaryPayload,
@@ -714,6 +722,16 @@ def _map_summary_response(
                     label=str(key),
                     start_date=str(value.get("start_date", "")),
                     end_date=str(value.get("end_date", "")),
+                    portfolio_observation_count=int(value.get("portfolio_observation_count", 0)),
+                    benchmark_observation_count=int(value.get("benchmark_observation_count", 0)),
+                    aligned_benchmark_observation_count=int(
+                        value.get("aligned_benchmark_observation_count", 0)
+                    ),
+                    benchmark_context=(
+                        cast(dict[str, Any], value.get("benchmark_context"))
+                        if isinstance(value.get("benchmark_context"), dict)
+                        else None
+                    ),
                     metrics=metrics,
                 )
             )
@@ -827,7 +845,7 @@ def _map_concentration_response(
     upstream_payload: dict[str, Any],
 ) -> WorkbenchRiskConcentrationResponse:
     required_blocks = {
-        "risk_proxy": upstream_payload.get("risk_proxy"),
+        "portfolio_concentration": upstream_payload.get("risk_proxy"),
         "single_position_concentration": upstream_payload.get("single_position_concentration"),
         "issuer_concentration": upstream_payload.get("issuer_concentration"),
     }
@@ -857,6 +875,20 @@ def _map_concentration_response(
             reason=_issuer_supportability_reason(issuer_payload),
             source_service="lotus-risk",
         ),
+        WorkbenchRiskSupportabilityItem(
+            key="issuer_grouping",
+            label="Issuer grouping",
+            state="ready",
+            reason=_issuer_grouping_reason(upstream_payload.get("metadata")),
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="valuation_basis",
+            label="Valuation basis",
+            state="ready",
+            reason=_valuation_context_reason(upstream_payload.get("valuation_context")),
+            source_service="lotus-risk",
+        ),
     ]
     return WorkbenchRiskConcentrationResponse(
         correlation_id=correlation_id,
@@ -866,8 +898,8 @@ def _map_concentration_response(
         benchmark_code=benchmark_code,
         state="ready" if issuer_state == "ready" else "partial",
         payload=WorkbenchRiskConcentrationPayload(
-            risk_proxy=WorkbenchConcentrationRiskProxy.model_validate(
-                required_blocks["risk_proxy"]
+            portfolio_concentration=WorkbenchPortfolioConcentration.model_validate(
+                required_blocks["portfolio_concentration"]
             ),
             single_position_concentration=WorkbenchSinglePositionConcentration.model_validate(
                 required_blocks["single_position_concentration"]
@@ -875,10 +907,14 @@ def _map_concentration_response(
             issuer_concentration=WorkbenchIssuerConcentration.model_validate(
                 required_blocks["issuer_concentration"]
             ),
-            valuation_context=upstream_payload.get("valuation_context")
+            valuation_context=WorkbenchRiskConcentrationValuationContext.model_validate(
+                upstream_payload.get("valuation_context")
+            )
             if isinstance(upstream_payload.get("valuation_context"), dict)
             else None,
-            risk_metadata=upstream_payload.get("metadata")
+            execution_context=WorkbenchRiskConcentrationExecutionContext.model_validate(
+                upstream_payload.get("metadata")
+            )
             if isinstance(upstream_payload.get("metadata"), dict)
             else None,
         ),
@@ -994,9 +1030,18 @@ def _map_drawdown_response(
                     label=str(key),
                     start_date=str(value.get("start_date", "")),
                     end_date=str(value.get("end_date", "")),
+                    portfolio_observation_count=int(value.get("portfolio_observation_count", 0)),
+                    benchmark_observation_count=int(value.get("benchmark_observation_count", 0)),
                     summary=summary,
                     episodes=episodes,
                     relative_to_benchmark=relative_to_benchmark,
+                    relative_to_benchmark_context=(
+                        WorkbenchRiskRelativeDrawdownContext.model_validate(
+                            value.get("relative_to_benchmark_context")
+                        )
+                        if isinstance(value.get("relative_to_benchmark_context"), dict)
+                        else None
+                    ),
                     underwater_series=underwater_series,
                     error=str(error) if isinstance(error, str) and error.strip() else None,
                 )
@@ -1044,6 +1089,19 @@ def _map_drawdown_response(
         if isinstance(methodology_version, str) and methodology_version.strip():
             metadata = metadata.model_copy(update={"methodology_version": methodology_version})
 
+    drawdown_payload = (
+        WorkbenchRiskDrawdownPayload(
+            periods=period_results,
+            analysis_context=(
+                WorkbenchRiskDrawdownAnalysisContext.model_validate(upstream_metadata)
+                if isinstance(upstream_metadata, dict)
+                else None
+            ),
+        )
+        if period_results
+        else None
+    )
+
     return WorkbenchRiskDrawdownResponse(
         correlation_id=correlation_id,
         portfolio_id=portfolio_id,
@@ -1051,7 +1109,7 @@ def _map_drawdown_response(
         as_of_date=as_of_date,
         benchmark_code=benchmark_code,
         state=state,
-        payload=WorkbenchRiskDrawdownPayload(periods=period_results) if period_results else None,
+        payload=drawdown_payload,
         supportability=supportability,
         warnings=sorted(set(warnings)),
         partial_failures=partial_failures,
@@ -1140,6 +1198,40 @@ def _map_rolling_response(
                     start_date=str(value.get("start_date", "")),
                     end_date=str(value.get("end_date", "")),
                     series_count=int(value.get("series_count", 0)),
+                    benchmark_series_count=int(value.get("benchmark_series_count", 0)),
+                    aligned_benchmark_series_count=int(
+                        value.get("aligned_benchmark_series_count", 0)
+                    ),
+                    risk_free_series_count=int(value.get("risk_free_series_count", 0)),
+                    aligned_risk_free_series_count=int(
+                        value.get("aligned_risk_free_series_count", 0)
+                    ),
+                    window_lengths_requested=[
+                        int(window)
+                        for window in value.get("window_lengths_requested", [])
+                        if isinstance(window, int | float)
+                    ],
+                    window_count_requested=int(value.get("window_count_requested", 0)),
+                    window_lengths_emitted=[
+                        int(window)
+                        for window in value.get("window_lengths_emitted", [])
+                        if isinstance(window, int | float)
+                    ],
+                    window_count_emitted=int(value.get("window_count_emitted", 0)),
+                    benchmark_context=(
+                        WorkbenchRiskRollingDependencyContext.model_validate(
+                            value.get("benchmark_context")
+                        )
+                        if isinstance(value.get("benchmark_context"), dict)
+                        else None
+                    ),
+                    risk_free_context=(
+                        WorkbenchRiskRollingDependencyContext.model_validate(
+                            value.get("risk_free_context")
+                        )
+                        if isinstance(value.get("risk_free_context"), dict)
+                        else None
+                    ),
                     window_results=_map_rolling_window_results(value.get("window_results")),
                     quality_flags=quality_flags,
                     error=str(error) if isinstance(error, str) and error.strip() else None,
@@ -1179,6 +1271,19 @@ def _map_rolling_response(
         )
         warnings.append("RISK_ROLLING_SHARPE_PARTIAL")
 
+    rolling_payload = (
+        WorkbenchRiskRollingPayload(
+            periods=period_results,
+            request_context=(
+                WorkbenchRiskRollingRequestContext.model_validate(upstream_metadata)
+                if isinstance(upstream_metadata, dict)
+                else None
+            ),
+        )
+        if period_results
+        else None
+    )
+
     return WorkbenchRiskRollingResponse(
         correlation_id=correlation_id,
         portfolio_id=portfolio_id,
@@ -1186,7 +1291,7 @@ def _map_rolling_response(
         as_of_date=as_of_date,
         benchmark_code=benchmark_code,
         state=state,
-        payload=WorkbenchRiskRollingPayload(periods=period_results) if period_results else None,
+        payload=rolling_payload,
         supportability=supportability,
         warnings=sorted(set(warnings)),
         partial_failures=partial_failures,
@@ -1297,6 +1402,24 @@ def _map_attribution_response(
         if isinstance(methodology_version, str) and methodology_version.strip():
             metadata = metadata.model_copy(update={"methodology_version": methodology_version})
 
+    attribution_payload = (
+        WorkbenchRiskAttributionPayload(
+            controls=_build_attribution_controls(
+                benchmark_code=benchmark_code,
+                attribution_type=attribution_type,
+                grouping_dimension=grouping_dimension,
+            ),
+            periods=period_results,
+            methodology_context=(
+                WorkbenchRiskAttributionMethodologyContext.model_validate(upstream_metadata)
+                if isinstance(upstream_metadata, dict)
+                else None
+            ),
+        )
+        if period_results
+        else None
+    )
+
     return WorkbenchRiskAttributionResponse(
         correlation_id=correlation_id,
         portfolio_id=portfolio_id,
@@ -1304,16 +1427,7 @@ def _map_attribution_response(
         as_of_date=as_of_date,
         benchmark_code=benchmark_code,
         state=state,
-        payload=WorkbenchRiskAttributionPayload(
-            controls=_build_attribution_controls(
-                benchmark_code=benchmark_code,
-                attribution_type=attribution_type,
-                grouping_dimension=grouping_dimension,
-            ),
-            periods=period_results,
-        )
-        if period_results
-        else None,
+        payload=attribution_payload,
         supportability=supportability,
         warnings=sorted(set(warnings)),
         partial_failures=partial_failures,
@@ -1517,6 +1631,36 @@ def _issuer_supportability_reason(payload: Any) -> str | None:
     if str(payload.get("coverage_status", "")).lower() != "complete":
         return "Issuer coverage is not complete for the selected portfolio context."
     return None
+
+
+def _issuer_grouping_reason(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return "Issuer grouping metadata was not returned by lotus-risk."
+    grouping = payload.get("issuer_grouping_level")
+    policy = payload.get("enrichment_policy")
+    grouping_label = str(grouping).replace("_", " ") if grouping else "unspecified grouping"
+    policy_label = str(policy).replace("_", " ") if policy else "unspecified policy"
+    return f"{grouping_label.title()} grouping with {policy_label} enrichment policy."
+
+
+def _valuation_context_reason(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return "Valuation context was not returned by lotus-risk."
+    reporting_currency = payload.get("reporting_currency")
+    portfolio_currency = payload.get("portfolio_currency")
+    weight_basis = payload.get("weight_basis")
+    basis_label = str(weight_basis).replace("_", " ") if weight_basis else "reported weights"
+    currency_context = " / ".join(
+        part
+        for part in [
+            str(reporting_currency) if reporting_currency else None,
+            str(portfolio_currency) if portfolio_currency else None,
+        ]
+        if part
+    )
+    if currency_context:
+        return f"{basis_label.title()} in {currency_context} context."
+    return f"{basis_label.title()} context."
 
 
 def _unavailable_summary(
@@ -1831,6 +1975,13 @@ def _map_rolling_window_results(window_payload: Any) -> list[WorkbenchRiskRollin
                 window_length=int(entry.get("window_length", 0)),
                 metric_summaries=metric_summaries,
                 metric_series=metric_series,
+                metric_series_context=(
+                    WorkbenchRiskRollingMetricSeriesContext.model_validate(
+                        entry.get("metric_series_context")
+                    )
+                    if isinstance(entry.get("metric_series_context"), dict)
+                    else None
+                ),
             )
         )
     results.sort(key=lambda item: item.window_length)

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -530,6 +530,16 @@ def test_workbench_risk_concentration_router_maps_stateful_concentration(monkeyp
                 "top_n_cumulative_weight_proposed": 0.52,
                 "top_n_cumulative_weight_delta": 0.02,
                 "top_n": 10,
+                "top_position_current": {
+                    "security_id": "FO_FUND_PIMCO_INC",
+                    "security_name": "PIMCO GIS Income Fund",
+                    "weight": 0.2,
+                },
+                "top_position_proposed": {
+                    "security_id": "FO_FUND_PIMCO_INC",
+                    "security_name": "PIMCO GIS Income Fund",
+                    "weight": 0.21,
+                },
             },
             "issuer_concentration": {
                 "hhi_current": 1500.0,
@@ -543,10 +553,36 @@ def test_workbench_risk_concentration_router_maps_stateful_concentration(monkeyp
                 "covered_position_count_proposed": 10,
                 "total_position_count_current": 10,
                 "total_position_count_proposed": 10,
+                "uncovered_position_count_current": 0,
+                "uncovered_position_count_proposed": 0,
+                "coverage_ratio_current": 1.0,
+                "coverage_ratio_proposed": 1.0,
                 "note": None,
+                "top_issuer_current": {
+                    "issuer_id": "ULTIMATE_PIMCO",
+                    "issuer_name": "Pacific Investment Management Company LLC",
+                    "weight": 0.25,
+                },
+                "top_issuer_proposed": {
+                    "issuer_id": "ULTIMATE_PIMCO",
+                    "issuer_name": "Pacific Investment Management Company LLC",
+                    "weight": 0.27,
+                },
             },
-            "valuation_context": {"reporting_currency": "USD"},
-            "metadata": {"as_of_date": "2026-04-04", "portfolio_id": "PF_RISK_CONC"},
+            "valuation_context": {
+                "portfolio_currency": "USD",
+                "reporting_currency": "USD",
+                "position_basis": "market_value_base",
+                "weight_basis": "total_market_value_base",
+            },
+            "metadata": {
+                "as_of_date": "2026-04-04",
+                "portfolio_id": "PF_RISK_CONC",
+                "issuer_grouping_level": "ultimate_parent",
+                "enrichment_policy": "merge_caller_then_core",
+                "include_cash_positions": True,
+                "include_zero_quantity_positions": False,
+            },
         }
 
     monkeypatch.setattr(
@@ -565,10 +601,17 @@ def test_workbench_risk_concentration_router_maps_stateful_concentration(monkeyp
     body = response.json()
     assert body["contract_version"] == "risk-workspace.v1"
     assert body["state"] == "ready"
-    assert body["payload"]["risk_proxy"]["hhi_current"] == 1200.0
+    assert body["payload"]["portfolio_concentration"]["hhi_current"] == 1200.0
+    assert (
+        body["payload"]["single_position_concentration"]["top_position_current"]["security_name"]
+        == "PIMCO GIS Income Fund"
+    )
+    assert body["payload"]["execution_context"]["issuer_grouping_level"] == "ultimate_parent"
     assert {item["key"]: item["state"] for item in body["supportability"]} == {
         "portfolio_positions": "ready",
         "issuer_enrichment": "ready",
+        "issuer_grouping": "ready",
+        "valuation_basis": "ready",
     }
 
 

--- a/tests/unit/test_risk_workspace_service.py
+++ b/tests/unit/test_risk_workspace_service.py
@@ -49,6 +49,16 @@ class _StubRiskClient:
                 "top_n_cumulative_weight_proposed": 0.42,
                 "top_n_cumulative_weight_delta": 0.0,
                 "top_n": 10,
+                "top_position_current": {
+                    "security_id": "FO_FUND_PIMCO_INC",
+                    "security_name": "PIMCO GIS Income Fund",
+                    "weight": 0.18,
+                },
+                "top_position_proposed": {
+                    "security_id": "FO_FUND_PIMCO_INC",
+                    "security_name": "PIMCO GIS Income Fund",
+                    "weight": 0.18,
+                },
             },
             "issuer_concentration": {
                 "hhi_current": 1400.0,
@@ -62,10 +72,36 @@ class _StubRiskClient:
                 "covered_position_count_proposed": 8,
                 "total_position_count_current": 10,
                 "total_position_count_proposed": 10,
+                "uncovered_position_count_current": 2,
+                "uncovered_position_count_proposed": 2,
+                "coverage_ratio_current": 0.8,
+                "coverage_ratio_proposed": 0.8,
                 "note": "Two positions have no issuer enrichment.",
+                "top_issuer_current": {
+                    "issuer_id": "ULTIMATE_PIMCO",
+                    "issuer_name": "Pacific Investment Management Company LLC",
+                    "weight": 0.2,
+                },
+                "top_issuer_proposed": {
+                    "issuer_id": "ULTIMATE_PIMCO",
+                    "issuer_name": "Pacific Investment Management Company LLC",
+                    "weight": 0.21,
+                },
             },
-            "valuation_context": {"reporting_currency": "USD"},
-            "metadata": {"as_of_date": "2026-04-04", "portfolio_id": "PF_1"},
+            "valuation_context": {
+                "portfolio_currency": "USD",
+                "reporting_currency": "USD",
+                "position_basis": "market_value_base",
+                "weight_basis": "total_market_value_base",
+            },
+            "metadata": {
+                "as_of_date": "2026-04-04",
+                "portfolio_id": "PF_1",
+                "issuer_grouping_level": "ultimate_parent",
+                "enrichment_policy": "merge_caller_then_core",
+                "include_cash_positions": True,
+                "include_zero_quantity_positions": False,
+            },
         }
         self.drawdown_payload: dict = {
             "source_service": "lotus-risk",
@@ -331,10 +367,18 @@ async def test_risk_concentration_uses_stateful_request_and_maps_issuer_supporta
     assert request["enrichment_policy"] == "merge_caller_then_core"
     assert response.state == "partial"
     assert response.payload is not None
-    assert response.payload.risk_proxy.hhi_current == 1200.0
+    assert response.payload.portfolio_concentration.hhi_current == 1200.0
+    assert response.payload.single_position_concentration.top_position_current.security_name == (
+        "PIMCO GIS Income Fund"
+    )
+    assert response.payload.issuer_concentration.coverage_ratio_current == 0.8
+    assert response.payload.execution_context is not None
+    assert response.payload.execution_context.issuer_grouping_level == "ultimate_parent"
     assert {item.key: item.state for item in response.supportability} == {
         "portfolio_positions": "ready",
         "issuer_enrichment": "partial",
+        "issuer_grouping": "ready",
+        "valuation_basis": "ready",
     }
 
 


### PR DESCRIPTION
## Summary
- expose upgraded stateful risk workspace BFF contracts for summary, concentration, drawdown, rolling, and attribution
- keep request building aligned with lotus-risk stateful analytics contracts
- cover the upgraded mapping with contract, unit, and integration tests

## Validation
- python -m ruff check .
- python -m ruff format --check .
- python -m mypy src
- python -m pytest tests/contract/test_workbench_contract.py tests/unit/test_risk_workspace_service.py tests/integration/test_workbench_router.py -q
- live lotus-risk vs lotus-gateway endpoint comparison for summary, concentration, drawdown, rolling, and attribution on 2026-04-08
