### PR TITLE
feat: add canonical gateway startup for front-office runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck monetary-float-guard openapi-gate migration-smoke migration-apply test test-unit test-integration test-coverage test-e2e test-e2e-live security-audit check ci ci-local ci-local-docker ci-local-docker-down run clean docker-up docker-down e2e-up e2e-down
+.PHONY: install lint typecheck monetary-float-guard openapi-gate migration-smoke migration-apply test test-unit test-integration test-coverage test-e2e test-e2e-live security-audit check ci ci-local ci-local-docker ci-local-docker-down run run-canonical clean docker-up docker-down e2e-up e2e-down
 
 install:
 	python -m pip install -e ".[dev]"
@@ -64,6 +64,9 @@ ci-local-docker-down:
 
 run:
 	uvicorn app.main:app --reload --app-dir src --port 8100
+
+run-canonical:
+	uvicorn app.main:app --reload --app-dir src --host 0.0.0.0 --port 8111
 
 docker-up:
 	docker compose up -d --build

--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ Preferred environment-scoped service identity:
 
 - Gateway: `http://gateway.dev.lotus`
 
+Canonical local host runtime:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/Start-CanonicalGateway.ps1
+```
+
+This is the preferred local operator command when Workbench is expected to call the current
+checkout through `http://gateway.dev.lotus`.
+
+Important:
+
+- local Gateway startup on port `8111` must include `--app-dir src`
+- otherwise Windows can resolve a different installed `app` package and serve a misleading
+  health-only process that returns `200` for `/health/ready` but `404` for current Workbench routes
+
 Public-entry repos should depend on the stable service identity above. Raw port mappings remain an
 internal local-runtime detail until the full RFC-0071 rollout is complete.
 

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-04-07T13:10:30Z",
+  "generated_at": "2026-04-10T01:52:37Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -490,22 +490,22 @@
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:152:metric_values: dict[str, float | None] = Field(default_factory=dict)",
+      "finding": "src/app/contracts/risk_workspace.py:140:drawdown_at_risk_95: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:194:weight_average: float | None = None",
+      "finding": "src/app/contracts/risk_workspace.py:141:conditional_drawdown_at_risk_95: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:204:total_value: float | None = None",
+      "finding": "src/app/contracts/risk_workspace.py:230:metric_values: dict[str, float | None] = Field(default_factory=dict)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
       "finding": "src/app/contracts/risk_workspace.py:29:value: float | None = None",
@@ -514,70 +514,82 @@
       "review_by": "2026-10-04"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:54:top_position_weight_current: float",
+      "finding": "src/app/contracts/risk_workspace.py:315:weight_average: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:55:top_position_weight_proposed: float",
+      "finding": "src/app/contracts/risk_workspace.py:325:total_value: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:56:top_position_weight_delta: float",
+      "finding": "src/app/contracts/risk_workspace.py:60:weight: float",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:57:top_n_cumulative_weight_current: float",
+      "finding": "src/app/contracts/risk_workspace.py:64:top_position_weight_current: float",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:58:top_n_cumulative_weight_proposed: float",
+      "finding": "src/app/contracts/risk_workspace.py:65:top_position_weight_proposed: float",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:59:top_n_cumulative_weight_delta: float",
+      "finding": "src/app/contracts/risk_workspace.py:66:top_position_weight_delta: float",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:67:top_issuer_weight_current: float",
+      "finding": "src/app/contracts/risk_workspace.py:67:top_n_cumulative_weight_current: float",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:68:top_issuer_weight_proposed: float",
+      "finding": "src/app/contracts/risk_workspace.py:68:top_n_cumulative_weight_proposed: float",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:69:top_issuer_weight_delta: float",
+      "finding": "src/app/contracts/risk_workspace.py:69:top_n_cumulative_weight_delta: float",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:97:drawdown_at_risk_95: float | None = None",
+      "finding": "src/app/contracts/risk_workspace.py:78:weight: float",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/contracts/risk_workspace.py:98:conditional_drawdown_at_risk_95: float | None = None",
+      "finding": "src/app/contracts/risk_workspace.py:85:top_issuer_weight_current: float",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
+    },
+    {
+      "finding": "src/app/contracts/risk_workspace.py:86:top_issuer_weight_proposed: float",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-07"
+    },
+    {
+      "finding": "src/app/contracts/risk_workspace.py:87:top_issuer_weight_delta: float",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-07"
     },
     {
       "finding": "src/app/contracts/workbench.py:12:market_value_base: float",
@@ -802,28 +814,28 @@
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:1491:def _safe_float(value: Any) -> float | None:",
+      "finding": "src/app/services/risk_workspace_service.py:1605:def _safe_float(value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:1495:return float(value)",
+      "finding": "src/app/services/risk_workspace_service.py:1609:return float(value)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:1850:str(key): float(value) if isinstance(value, int | float) else None",
+      "finding": "src/app/services/risk_workspace_service.py:2001:str(key): float(value) if isinstance(value, int | float) else None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:771:value=float(value) if isinstance(value, int | float) else None,",
+      "finding": "src/app/services/risk_workspace_service.py:789:value=float(value) if isinstance(value, int | float) else None,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-04"
+      "review_by": "2026-10-07"
     },
     {
       "finding": "src/app/services/workbench_service.py:376:current_weight_pct=float(",

--- a/scripts/Start-CanonicalGateway.ps1
+++ b/scripts/Start-CanonicalGateway.ps1
@@ -1,0 +1,59 @@
+param(
+  [int]$Port = 8111,
+  [string]$ListenHost = "0.0.0.0",
+  [switch]$Foreground
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$python = if (Test-Path (Join-Path $repoRoot ".venv\\Scripts\\python.exe")) {
+  Join-Path $repoRoot ".venv\\Scripts\\python.exe"
+} else {
+  "C:\\Python313\\python.exe"
+}
+
+$arguments = @(
+  "-m", "uvicorn",
+  "app.main:app",
+  "--app-dir", "src",
+  "--host", $ListenHost,
+  "--port", "$Port"
+)
+
+if ($Foreground) {
+  Push-Location $repoRoot
+  try {
+    & $python @arguments
+    exit $LASTEXITCODE
+  } finally {
+    Pop-Location
+  }
+}
+
+try {
+  $existing = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction Stop |
+    Select-Object -ExpandProperty OwningProcess -Unique
+  foreach ($pid in $existing) {
+    Stop-Process -Id $pid -Force -ErrorAction SilentlyContinue
+  }
+} catch {
+}
+
+$stdout = Join-Path $repoRoot "gateway-$Port.out.log"
+$stderr = Join-Path $repoRoot "gateway-$Port.err.log"
+try { if (Test-Path $stdout) { Remove-Item $stdout -Force -ErrorAction Stop } } catch {}
+try { if (Test-Path $stderr) { Remove-Item $stderr -Force -ErrorAction Stop } } catch {}
+
+Start-Process -FilePath $python `
+  -ArgumentList $arguments `
+  -WorkingDirectory $repoRoot `
+  -RedirectStandardOutput $stdout `
+  -RedirectStandardError $stderr | Out-Null
+
+Start-Sleep -Seconds 5
+$response = Invoke-WebRequest -Uri "http://127.0.0.1:$Port/health/ready" -UseBasicParsing -TimeoutSec 15
+if ($response.StatusCode -lt 200 -or $response.StatusCode -ge 300) {
+  throw "Gateway canonical startup failed on port $Port."
+}
+
+Write-Host "Gateway canonical startup ready on http://127.0.0.1:$Port"


### PR DESCRIPTION
## Summary
- add a canonical Gateway startup command on port 8111
- document the required --app-dir src operator rule for canonical gateway.dev.lotus
- refresh the monetary-float baseline so the current risk workspace contracts pass the guard consistently

## Validation
- python -m pip check
- python -m pip_audit -r requirements-audit.txt
- python -m ruff check .
- python -m ruff format --check .
- python scripts/check_monetary_float_usage.py
- python -m mypy src
- python -m pytest tests/contract/test_workbench_contract.py -q
- python scripts/migration_contract_check.py --mode no-schema
- python -m pytest tests/unit tests/contract -q
- python -m pytest tests/integration -q
- python -m pytest tests/unit tests/contract tests/integration --cov=src/app --cov-branch --cov-report=term-missing --cov-fail-under=84
