### PR TITLE
docs(gateway): align RFC-0082 upstream contract posture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,15 @@ install:
 	python -m pip install -e ".[dev]"
 
 lint:
-	ruff check .
-	ruff format --check .
+	python -m ruff check .
+	python -m ruff format --check .
 	$(MAKE) monetary-float-guard
 
 monetary-float-guard:
 	python scripts/check_monetary_float_usage.py
 
 typecheck:
-	mypy src
+	python -m mypy src
 
 openapi-gate:
 	python -m pytest tests/contract/test_workbench_contract.py -q

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ pass-through routes into the primary BFF layer for Lotus workspace applications.
 
 - Experience API foundation blueprint:
   `docs/documentation/experience-api-foundation-blueprint.md`
+- RFC-0082 upstream contract-family conformance map:
+  `docs/standards/RFC-0082-upstream-contract-family-map.md`
 - Current RFC history:
   `docs/rfcs/README.md`
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -32,7 +32,8 @@ Current repository posture:
 1. `lotus-gateway` is the primary backend contract for `lotus-workbench`,
 2. the repository is moving from thin pass-through behavior to a cleaner experience-API posture,
 3. performance, proposal, foundation, reporting, and capability aggregation routes are active,
-4. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
+4. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
+5. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
 
 ## Architecture And Module Map
 
@@ -64,7 +65,9 @@ Boundary rules:
 1. gateway payloads should be product-oriented and governed,
 2. domain ownership must remain upstream,
 3. route contracts should prefer replacement and cleanup over versioned clutter while pre-live,
-4. canonical service identity is part of the operational contract.
+4. gateway must not become the authority for portfolio source data, performance analytics, risk analytics, advisory workflow, management workflow, reporting, or AI outputs,
+5. REST/OpenAPI remains the canonical integration contract; gRPC is not justified for current gateway upstream calls,
+6. canonical service identity is part of the operational contract.
 
 ## Repo-Native Commands
 
@@ -111,13 +114,16 @@ Most relevant current governance:
 4. `../lotus-platform/rfcs/RFC-0071-centralized-environment-scoped-service-addressing-and-ingress-governance.md`
 5. `../lotus-platform/rfcs/RFC-0072-platform-wide-multi-lane-ci-validation-and-release-governance.md`
 6. `../lotus-platform/rfcs/RFC-0073-lotus-ecosystem-engineering-context-and-agent-guidance-system.md`
+7. `../lotus-platform/rfcs/RFC-0082-lotus-core-domain-authority-and-analytics-serving-boundary-hardening.md`
+8. `docs/standards/RFC-0082-upstream-contract-family-map.md`
 
 ## Known Constraints And Implementation Notes
 
 1. Windows startup can serve a misleading health-only process if `--app-dir src` is omitted,
 2. stale thin-pass-through routes should be retired as better experience contracts replace them,
 3. gateway fixes should not smuggle domain logic out of authoritative upstream services,
-4. integration drift is most dangerous here because it directly affects the product UI.
+4. reporting query, cashflow projection, projected summary, and benchmark catalog upstream calls remain RFC-0082 watchlist surfaces,
+5. integration drift is most dangerous here because it directly affects the product UI.
 
 ## Context Maintenance Rule
 
@@ -127,7 +133,8 @@ Update this document when:
 2. canonical startup commands or CI expectations change,
 3. upstream dependency boundaries change,
 4. gateway composition patterns or partial-readiness behavior change materially,
-5. current-state architectural direction changes.
+5. RFC-0082 contract-family classification changes,
+6. current-state architectural direction changes.
 
 ## Cross-Links
 

--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -1,0 +1,99 @@
+# RFC-0082 Upstream Contract Family Map
+
+This document records how `lotus-gateway` consumes upstream Lotus services under
+`lotus-platform` RFC-0082.
+
+`lotus-gateway` is an experience API. It may compose, filter, reshape, and annotate product-facing
+payloads for `lotus-workbench`, but it must not become the domain authority for portfolio source
+data, performance analytics, risk analytics, advisory workflow, management workflow, reporting, or AI
+outputs.
+
+## Current Integration Posture
+
+1. REST/OpenAPI remains the governed integration contract for current `lotus-gateway` upstream calls.
+2. No current `lotus-gateway` integration requires or justifies gRPC.
+3. Domain calculations stay in their authoritative upstream services.
+4. Gateway services preserve upstream supportability, readiness, and partial-failure state rather than
+   hiding it behind synthetic success.
+
+## `lotus-core` Contract Family Map
+
+| Gateway client surface | Upstream route family | RFC-0082 family | Gateway use | Boundary rule |
+| --- | --- | --- | --- | --- |
+| `get_capabilities` | `GET /integration/capabilities` | Control-plane and policy | expose supported upstream capability posture | do not infer unsupported capabilities locally |
+| `get_effective_policy` | `GET /integration/policy/effective` | Control-plane and policy | expose effective policy context | preserve policy provenance |
+| `list_portfolios`, `get_portfolio`, `get_portfolio_positions`, `get_portfolio_transactions` | `/portfolios`, `/portfolios/{portfolio_id}`, `/positions`, `/transactions` | Operational Read | product-facing portfolio and activity views | do not convert convenience reads into analytics source truth |
+| `list_instruments`, lookup calls | `/instruments`, `/lookups/*` | Operational Read | selector and reference-data payloads | maintain source-service attribution |
+| reporting query calls | `/reporting/*/query` | Operational Read watchlist | reporting-oriented workspace summaries | keep as read-model consumption; do not define new reporting semantics in gateway |
+| `get_cashflow_projection` | `/portfolios/{portfolio_id}/cashflow-projection` | Operational Read watchlist | front-office cashflow projection panel | preserve upstream methodology and supportability |
+| `get_core_snapshot` | `/integration/portfolios/{portfolio_id}/core-snapshot` | Snapshot and simulation | simulation and workspace state bundle | do not add performance or risk analytics sections locally |
+| simulation session calls | `/simulation-sessions/*` | Snapshot and simulation | create and mutate projected state | gateway only brokers product flow; simulation semantics remain upstream |
+| projected-state calls | `/simulation-sessions/*/projected-*` | Snapshot and simulation watchlist | projected position and summary views | watch for semantics that should move to a governed analytics service |
+| `get_portfolio_analytics_reference` | `/integration/portfolios/{portfolio_id}/analytics/reference` | Analytics Input | upstream source context for analytics consumers | do not compute analytics conclusions in gateway |
+| `get_benchmark_assignment` | `/integration/portfolios/{portfolio_id}/benchmark-assignment` | Analytics Input | benchmark context for workspace composition | benchmark meaning remains core-governed input |
+| `get_benchmark_catalog` | `/integration/benchmarks/catalog` | Analytics Input watchlist | selector and catalog composition | keep catalog interpretation out of gateway |
+| support overview and readiness calls | `/support/portfolios/{portfolio_id}/*` | Control-plane and support metadata | show supportability and readiness | preserve partial readiness and gap details |
+
+## Domain Analytics Upstream Map
+
+| Upstream service | Consumed surface | Gateway use | Boundary rule |
+| --- | --- | --- | --- |
+| `lotus-performance` | performance summary, TWR, MWR, contribution, attribution, workspace summary, benchmark exposure context | performance workspace and first-paint modules | performance calculations and benchmark-relative interpretation remain in `lotus-performance` |
+| `lotus-risk` | calculate risk, concentration, drawdown, rolling metrics, historical attribution | risk workspace modules and risk panels | risk methodology, concentration, drawdown, and attribution semantics remain in `lotus-risk` |
+| `lotus-advise` | proposal lifecycle and advisory workflow surfaces | proposal workflow composition | advisory decision workflow remains in `lotus-advise` |
+| `lotus-manage` | management workflow surfaces where split routing still applies | management workflow composition | discretionary management operations remain in `lotus-manage` |
+| `lotus-report` | report snapshot rows | report-ready experience payloads | report generation and report row semantics remain in `lotus-report` |
+| `lotus-ai` | advisor-brief and AI-supported surfaces | evidence-grounded narrative support | gateway must not invent unsupported evidence or model outputs |
+
+## Conformance Rules
+
+1. Gateway routes should be product-oriented contracts, not one-to-one mirrors of every upstream route.
+2. Thin pass-through routes are tolerated only while a replacement-first product contract is being
+   prepared.
+3. Gateway services must not perform authoritative portfolio valuation, performance attribution, risk
+   concentration, advisory suitability, or reporting methodology calculations.
+4. `source_service`, supportability, readiness, and partial-failure metadata must survive composition
+   when the product surface depends on it.
+5. Any new upstream dependency must be classified into an RFC-0082 family before becoming a stable
+   Workbench-facing contract.
+6. Transport optimization discussions start with query shape, payload shape, caching, export semantics,
+   and contract boundaries. gRPC is not a default answer for gateway integration.
+
+## Current Evidence
+
+Existing tests that cover this posture include:
+
+1. `tests/unit/test_upstream_clients.py`
+2. `tests/unit/test_workbench_service.py`
+3. `tests/unit/test_workbench_service_additional.py`
+4. `tests/unit/test_performance_workspace_service.py`
+5. `tests/unit/test_risk_workspace_service.py`
+6. `tests/unit/test_foundation_service.py`
+7. `tests/unit/test_portfolio_service.py`
+8. `tests/contract/test_platform_capabilities_contract.py`
+9. `tests/contract/test_lookup_contract.py`
+10. `tests/integration/test_workbench_router.py`
+11. `tests/integration/test_portfolio_router.py`
+12. `tests/integration/test_foundation_router.py`
+13. `tests/integration/test_platform_capabilities_router.py`
+14. `tests/e2e/test_workflow_journeys.py`
+
+This RFC-0082 documentation slice did not change runtime behavior, OpenAPI output, or upstream
+request/response contracts.
+
+## Gap Register
+
+1. Reporting query and cashflow projection consumption remain watchlist surfaces because they can drift
+   into hidden methodology ownership if gateway starts interpreting the payloads.
+2. Projected-summary consumption should stay aligned with governed simulation semantics and should not
+   become a gateway-owned analytics summary.
+3. Thin pass-through routes should continue to be replaced by product-oriented experience contracts
+   before first production release.
+4. If Workbench performance or risk panels become latency-constrained, the first hardening step is
+   contract and retrieval-shape optimization in the authoritative upstream service, not a gateway-local
+   gRPC path.
+
+## Validation Lane
+
+This document is governed as Feature Lane documentation and contract proof. Escalate to PR Merge Gate
+only when a future slice changes gateway runtime behavior, public API contracts, or upstream coupling.


### PR DESCRIPTION
## Summary
- map `lotus-gateway` upstream consumption under RFC-0082
- keep the gateway startup and tooling contract portable on Windows by invoking Python tooling explicitly
- preserve gateway as an experience API that consumes governed upstream contracts instead of absorbing domain logic

## Validation
- `make check`
- `git diff --check`

## Notes
- draft first so CI can run while the broader cross-repo RFC-0082 boundary hardening work remains active
