### PR TITLE
docs: standardize lotus-gateway readme and wiki

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,142 @@
+# Lotus Agent Operating Contract
+
+This is the governed operating contract for Lotus agent work.
+
+Repo-root `AGENTS.md` files across Lotus repositories and the deployed local `AGENTS.md` should
+remain synchronized copies of this file.
+
+Use `automation/Sync-AgentOperatingContract.ps1` to synchronize or verify that deployed copy.
+
+## Mandatory Reading Order
+
+Before doing substantial work, load context in this order:
+
+1. `AGENTS.md`
+2. `lotus-platform/context/LOTUS-QUICKSTART-CONTEXT.md`
+3. `lotus-platform/context/LOTUS-ENGINEERING-CONTEXT.md`
+4. the target repository's `REPOSITORY-ENGINEERING-CONTEXT.md`
+5. `lotus-platform/context/CONTEXT-REFERENCE-MAP.md`
+6. `lotus-platform/context/PROCEDURAL-MEMORY-INDEX.md` when the task is primarily about how work should be executed
+
+Use the smallest correct working set. Do not load broad context blindly if the task is narrow.
+
+## Mandatory Operating Rules
+
+Always:
+
+1. reduce complexity where possible,
+2. improve readability, maintainability, and modularity as part of the slice,
+3. make code and test improvements that materially improve reliability and maintainability,
+4. update documentation when platform or repository truth changes,
+5. leave the codebase cleaner than you found it,
+6. write meaningful, high-value tests and avoid superficial coverage,
+7. keep commits small, meaningful, and truthful,
+8. remove dead code, duplicate logic, and stale non-standard handling when encountered,
+9. ensure every UI feature is genuinely backed by supported backend functionality.
+
+## Delivery Posture
+
+Operate as a banking-grade engineer, not a generic coding assistant.
+
+That means:
+
+1. prefer truthful implementation over cosmetic output,
+2. prefer reusable patterns over local hacks,
+3. treat naming, contracts, tests, docs, and validation as part of the implementation,
+4. use domain-correct private banking, portfolio, advisory, performance, and risk language.
+
+## Skills, Automation, And Async Execution
+
+When the task matches an available Lotus skill, use it.
+
+Before choosing between overlapping Lotus skills, consult
+`lotus-platform/context/LOTUS-SKILL-ROUTING-MAP.md`.
+
+Prefer:
+
+1. standards, validators, and runbooks before inventing a new pattern,
+2. repo-native commands before ad hoc command sequences,
+3. targeted local checks for quick proof,
+4. GitHub-backed heavy execution for expensive full validation,
+5. async monitoring and fix-forward work rather than blocking on long reruns.
+
+When a task is explicitly about canonical populated Workbench surfaces, demo screenshots, or
+`PB_SG_GLOBAL_BAL_001`, choose `lotus-front-office-runtime` first and use broader QA or delivery
+skills only as supporting guidance.
+
+## Front-Office Runtime Routing Rule
+
+When the task is about:
+
+1. local front-office runtime bring-up,
+2. populated Workbench screens,
+3. panel validation,
+4. demo screenshots,
+5. canonical UI proof,
+
+use the governed `lotus-workbench` runtime and validation flow first:
+
+1. `lotus-workbench/docs/operations/canonical-front-office-local-runtime.md`
+2. `npm run live:stack:up`
+3. `npm run live:validate`
+4. `npm run live:stack:down`
+5. `lotus-platform/automation/Invoke-Canonical-FrontOffice-QA.ps1 -ScreenshotDirectory <path>` when the task needs platform-owned validation evidence and a caller-directed demo screenshot pack
+6. `lotus-platform/context/contracts/canonical-front-office-demo-data-contract.json`
+7. `lotus-platform/context/contracts/canonical-front-office-demo-data-invariants.json`
+
+Use `PB_SG_GLOBAL_BAL_001` as the governed seeded front-office portfolio unless the task explicitly requires another dataset.
+
+Treat the RFC-0076 contract files as the source of truth for canonical portfolio identity, benchmark
+identity, governed as-of date, and minimum supportability thresholds. Runtime evidence should carry
+contract provenance instead of relying on implicit repo convention.
+
+Do not treat `lotus-platform/platform-stack` as the canonical front-office product bring-up path. It owns shared ingress and infrastructure support, not the full governed product-surface flow.
+
+Do not capture or share demo-ready screenshots before canonical API, calculation, and panel validation pass. If a pre-validation capture is necessary for diagnosis, label it with a `diagnostic-` prefix and keep it separate from demo evidence.
+
+## Context Maintenance Rule
+
+Keep the context system up to date as Lotus changes.
+
+Update the relevant context artifacts when:
+
+1. platform architecture changes,
+2. repository responsibilities change,
+3. canonical commands or validation flows change,
+4. CI or governance expectations change,
+5. a repeatable pattern should become durable guidance,
+6. domain vocabulary or operating assumptions materially change.
+
+If the change is platform-wide:
+
+1. update the central context system in `lotus-platform/context/`.
+2. update `LOTUS-SKILL-ROUTING-MAP.md` if task routing expectations changed.
+
+If the change is repository-local:
+
+1. update that repository's `REPOSITORY-ENGINEERING-CONTEXT.md`.
+
+If both changed:
+
+1. update both in the same slice.
+
+## Cross-Links
+
+Central context system:
+
+1. `<lotus-platform>/context/LOTUS-QUICKSTART-CONTEXT.md`
+2. `<lotus-platform>/context/LOTUS-ENGINEERING-CONTEXT.md`
+3. `<lotus-platform>/context/CONTEXT-REFERENCE-MAP.md`
+4. `<lotus-platform>/context/PROCEDURAL-MEMORY-INDEX.md`
+5. `<lotus-platform>/context/LOTUS-SKILL-ROUTING-MAP.md`
+6. `<lotus-platform>/context/lotus-context-manifest.json`
+7. `<lotus-platform>/context/platform-engineering-ledger.md`
+8. `<lotus-platform>/context/recent-architectural-decisions-digest.md`
+9. `<lotus-platform>/docs/onboarding/LOTUS-DEVELOPER-ONBOARDING.md`
+10. `<lotus-platform>/docs/onboarding/LOTUS-AGENT-RAMP-UP.md`
+
+Repository-local context:
+
+1. `REPOSITORY-ENGINEERING-CONTEXT.md` in the repository you are changing
+
+When the central contract changes, keep both this source file and the deployed `AGENTS.md` synchronized.

--- a/README.md
+++ b/README.md
@@ -1,188 +1,238 @@
 # lotus-gateway
 
-FastAPI experience API for `lotus-workbench`, evolving from proposal-first aggregation and
-pass-through routes into the primary BFF layer for Lotus workspace applications.
+Experience API and composition boundary for Lotus product clients, primarily
+`lotus-workbench`.
 
-## Contribution Standards
+Repository-local engineering context:
+[REPOSITORY-ENGINEERING-CONTEXT.md](REPOSITORY-ENGINEERING-CONTEXT.md)
 
-- Contribution process: `CONTRIBUTING.md`
-- Repository-local engineering context: `REPOSITORY-ENGINEERING-CONTEXT.md`
-- Docs-with-code standard: `docs/documentation/implementation-documentation-standard.md`
-- PR checklist template: `.github/pull_request_template.md`
-- Platform-wide architecture governance source: `https://github.com/sgajbi/lotus-platform`
+Experience-API blueprint:
+[docs/documentation/experience-api-foundation-blueprint.md](docs/documentation/experience-api-foundation-blueprint.md)
 
-## Architecture Direction
+Upstream contract-family map:
+[docs/standards/RFC-0082-upstream-contract-family-map.md](docs/standards/RFC-0082-upstream-contract-family-map.md)
 
-- Experience API foundation blueprint:
-  `docs/documentation/experience-api-foundation-blueprint.md`
-- RFC-0082 upstream contract-family conformance map:
-  `docs/standards/RFC-0082-upstream-contract-family-map.md`
-- Current RFC history:
-  `docs/rfcs/README.md`
+## Purpose And Scope
 
-## Quickstart
+`lotus-gateway` owns product-facing API composition for Lotus.
 
-```bash
-python -m venv .venv
-. .venv/Scripts/activate
-pip install -e ".[dev]"
-make run
-```
+It is responsible for:
 
-API docs: `http://gateway.dev.lotus/docs`
+- experience-oriented payload shaping for `lotus-workbench`
+- partial-readiness-aware aggregation across upstream services
+- gateway-level contract governance
+- product-safe routing, evidence mediation, and degraded-state handling
 
-Preferred environment-scoped service identity:
+It does not own portfolio domain truth, analytics methodology, reporting methodology, advisory
+workflow truth, management workflow truth, or AI output truth. Those remain upstream.
 
-- Gateway: `http://gateway.dev.lotus`
+## Ownership And Boundaries
 
-Canonical local host runtime:
+`lotus-gateway` is the primary backend contract for `lotus-workbench`.
 
-```powershell
-powershell -ExecutionPolicy Bypass -File scripts/Start-CanonicalGateway.ps1
-```
+It depends on:
 
-This is the preferred local operator command when Workbench is expected to call the current
-checkout through `http://gateway.dev.lotus`.
+- `lotus-core`
+  portfolio, booking, lookup, ingestion, simulation, and supportability inputs
+- `lotus-performance`
+  performance workspace analytics and evidence lineage
+- `lotus-risk`
+  stateful risk workspace analytics
+- `lotus-advise`
+  proposal and advisory workflow capability
+- `lotus-manage`
+  management workflow capability when split routing is enabled
+- `lotus-report`
+  reporting snapshot, summary, and review payloads
+- `lotus-ai`
+  evidence-grounded advisor-brief support
 
-Important:
+Boundary rules that matter:
 
-- local Gateway startup on port `8111` must include `--app-dir src`
-- otherwise Windows can resolve a different installed `app` package and serve a misleading
-  health-only process that returns `200` for `/health/ready` but `404` for current Workbench routes
+1. gateway contracts should be product-oriented, not thin mirrors of every upstream route
+2. domain authority stays upstream
+3. partial-failure and supportability signals must survive composition when the UI depends on them
+4. canonical local service identity for product and cross-app validation is `http://gateway.dev.lotus`
 
-Public-entry repos should depend on the stable service identity above. Raw port mappings remain an
-internal local-runtime detail until the full RFC-0071 rollout is complete.
+## Current Operational Posture
 
-## Current endpoints
+1. `lotus-gateway` is the primary experience API for `lotus-workbench`.
+2. Foundation, platform capabilities, proposals, reporting, intake/lookups, portfolio, and workbench
+   route families are active.
+3. The repository is still moving from thin pass-through behavior toward cleaner experience-API
+   contracts.
+4. Canonical local startup relies on `--app-dir src`; omitting it on Windows can start the wrong
+   `app` package and yield a misleading health-only process.
 
-- `GET /api/v1/foundation/portfolios` (selector-ready Foundation portfolio catalog)
-- `GET /api/v1/foundation/portfolios/{portfolio_id}/workspace` (Foundation workspace entry payload with readiness and partial-failure-aware upstream context)
-- `GET /api/v1/workbench/{portfolio_id}/performance/summary` (first-paint benchmark-aware performance summary with gateway-owned `evidence_view`)
-- `GET /api/v1/workbench/{portfolio_id}/performance/details` (lower-canvas analytical detail contract with gateway-owned `evidence_view`)
-- `GET /api/v1/workbench/{portfolio_id}/performance/evidence/artifacts/{calculation_id}/{artifact_name}` (gateway-owned proxy for lotus-performance lineage artifacts)
-- `GET /api/v1/workbench/{portfolio_id}/performance/horizon-comparison` (compact MTD/QTD/YTD comparison module)
-- `GET /api/v1/workbench/{portfolio_id}/performance/attribution-trend` (benchmark-relative attribution-over-time module)
-- `GET /api/v1/workbench/{portfolio_id}/performance/advisor-brief` (source-grounded advisor brief with evidence refs and supportability)
-- `POST /api/v1/proposals/simulate` (proxies to lotus-manage `/rebalance/proposals/simulate`)
-- `POST /api/v1/proposals` (create draft proposal via lotus-manage lifecycle create)
-- `GET /api/v1/proposals` (list proposals)
-- `GET /api/v1/proposals/{proposal_id}` (proposal detail)
-- `GET /api/v1/proposals/{proposal_id}/versions/{version_no}` (immutable proposal version detail)
-- `POST /api/v1/proposals/{proposal_id}/versions` (create proposal version `N+1`)
-- `POST /api/v1/proposals/{proposal_id}/submit` (submit draft for review via lotus-manage transition)
-- `POST /api/v1/proposals/{proposal_id}/approve-risk` (risk approval action)
-- `POST /api/v1/proposals/{proposal_id}/approve-compliance` (compliance approval action)
-- `POST /api/v1/proposals/{proposal_id}/record-client-consent` (client consent action)
-- `GET /api/v1/proposals/{proposal_id}/workflow-events` (workflow timeline)
-- `GET /api/v1/proposals/{proposal_id}/approvals` (approval records)
-- `GET /api/v1/platform/capabilities` (aggregated shell/workspace capability contract across lotus-core, lotus-performance, lotus-risk publication, lotus-manage, and lotus-report for UI gating)
-- `GET /api/v1/workbench/{portfolio_id}/overview` (aggregated lotus-core+lotus-performance+lotus-manage decision-console overview)
-- `GET /api/v1/reports/{portfolio_id}/snapshot` (report-ready aggregation rows from lotus-report)
-- `POST /api/v1/reports/{portfolio_id}/summary` (lotus-report-owned summary payload for one reporting date)
-- `POST /api/v1/reports/{portfolio_id}/review` (lotus-report-owned review payload for one reporting date)
-- `POST /api/v1/intake/portfolio-bundle` (lotus-core ingestion bundle pass-through)
-- `POST /api/v1/intake/uploads/preview` (lotus-core upload preview pass-through)
-- `POST /api/v1/intake/uploads/commit` (lotus-core upload commit pass-through)
-- `GET /api/v1/lookups/portfolios` (lotus-core-backed portfolio selector values)
-- `GET /api/v1/lookups/instruments` (lotus-core-backed instrument selector values)
-- `GET /api/v1/lookups/currencies` (lotus-core-backed currency selector values)
+## Architecture At A Glance
 
-These are the current endpoints. Because the project is pre-live, the target future direction is a
-clean replacement-first experience-API model organized around workspace journeys rather than thin
-upstream parity. Stale routes should be replaced and removed instead of being preserved by default
-under versioned duplication, as described in
-`docs/documentation/experience-api-foundation-blueprint.md`.
+Main runtime surfaces come from [src/app/main.py](src/app/main.py):
 
-## Docker
+- `foundation`
+  `/api/v1/foundation/*`
+- `platform`
+  `/api/v1/platform/*`
+- `proposals`
+  `/api/v1/proposals/*`
+- `intake` and `lookups`
+  `/api/v1/intake/*`, `/api/v1/lookups/*`
+- `portfolio`
+  `/api/v1/portfolio/*`
+- `workbench`
+  `/api/v1/workbench/*`
+- `reporting`
+  `/api/v1/reports/*`
+- platform surfaces
+  `/health`, `/health/live`, `/health/ready`, `/metrics`, `/docs`
 
-```bash
-make docker-up
-make docker-down
+Key code areas:
 
-make ci-local-docker
-make ci-local-docker-down
-```
+- `src/app/routers/`
+  public HTTP route families
+- `src/app/services/`
+  gateway composition, partial-readiness handling, and upstream orchestration
+- `src/app/contracts/`
+  workbench-facing gateway contracts
+- `src/app/clients/`
+  upstream client integrations
+- `docs/documentation/`
+  experience-API architecture and implementation guidance
+- `docs/standards/`
+  ownership, migration, durability, and RFC-0082 integration guidance
 
-Live platform-capabilities E2E (lotus-gateway + lotus-core + lotus-performance + lotus-manage):
+## Repository Layout
 
-```bash
-export ADVISE_REPO_PATH=/c/Users/sande/dev/lotus-advise
-export LOTUS_MANAGE_REPO_PATH=/c/Users/sande/dev/lotus-manage
-export LOTUS_CORE_REPO_PATH=/c/Users/sande/dev/lotus-core
-export LOTUS_PERFORMANCE_REPO_PATH=/c/Users/sande/dev/lotus-performance
-make e2e-up
-make test-e2e-live
-make e2e-down
-```
+- `src/app/main.py`
+  FastAPI entrypoint and router registration
+- `src/app/routers/`
+  gateway route families by product surface
+- `src/app/services/`
+  composition and orchestration logic
+- `src/app/contracts/`
+  workbench-facing response and request contracts
+- `tests/contract/`
+  contract proof for workbench-facing surfaces
+- `tests/integration/`
+  composed behavior checks
+- `tests/e2e/`
+  workflow and live integration checks
+- `scripts/`
+  quality gates, migration checks, and canonical startup helpers
+- `wiki/`
+  canonical authored source for GitHub wiki publication
 
-Coverage gate (local parity with CI threshold):
+## Quick Start
 
-```bash
-make test-coverage
-```
-
-## Live Performance Demo Contracts
-
-The current flagship performance workstation integration is served from `lotus-gateway`.
-
-Required upstreams:
-
-- `lotus-core` query: `http://core-query.dev.lotus`
-- `lotus-core` control plane: `http://core-control.dev.lotus`
-- `lotus-core` ingestion: `http://core-ingestion.dev.lotus`
-- `lotus-performance`: `http://performance.dev.lotus`
-- `lotus-ai`: `http://ai.dev.lotus`
-
-Example live probes:
+Install dependencies:
 
 ```bash
-curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
-
-curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/details?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
-
-curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/evidence/artifacts/calc-workspace-summary/request.json"
-
-curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/horizon-comparison?detail_basis=NET&chart_frequency=monthly&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
-
-curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/attribution-trend?period=YTD&chart_frequency=monthly&detail_basis=NET&attribution_dimension=asset_class&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
-
-curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+make install
 ```
 
-Expected benchmark catalog for the seeded flagship mandate:
+Preferred direct local run:
 
-- `BMK_GLOBAL_BALANCED_60_40` (`Global Balanced 60/40`)
-- `BMK_GLOBAL_GROWTH_80_20` (`Global Growth 80/20`)
+```bash
+make run-canonical
+```
 
-Performance evidence posture:
+Canonical local identities:
 
-- `performance/summary` and `performance/details` now expose `capabilities.evidence` plus `evidence_view`
-- `evidence_view.calculations[]` carries calculation-scoped execution status, lineage status, stage state, upstream snapshot summaries, and gateway-owned artifact URLs
-- downstream UI clients should use the gateway artifact route above instead of calling `lotus-performance` lineage URLs directly
-- `performance/horizon-comparison` is intentionally limited to `MTD`, `QTD`, and `YTD`; gateway does not present longer TWR windows as front-office-safe until supportability gating is available
+- cross-app and product validation: `http://gateway.dev.lotus`
+- direct process debugging: `http://127.0.0.1:8111`
 
-## Demo Pack
+Quick probes:
 
-- `docs/demo/README.md`
-- `docs/demo/payloads/proposal-create.json`
-- `docs/demo/scripts/demo-approval-chain.sh`
+```bash
+curl http://127.0.0.1:8111/health
+curl "http://127.0.0.1:8111/api/v1/platform/capabilities?consumerSystem=lotus-workbench&tenantId=default"
+```
 
-## Platform Foundation Commands
+## Common Commands
 
-- `make migration-smoke`
-- `make migration-apply`
-- `make security-audit`
+- `make install`
+  install dependencies
+- `make lint`
+  lint, format check, and monetary-float guard
+- `make typecheck`
+  mypy on `src/`
+- `make check`
+  contract and unit gate
+- `make ci`
+  PR-grade local proof with migration smoke, integration, coverage, and security audit
+- `make ci-local-docker`
+  dockerized parity check
+- `make run-canonical`
+  canonical local gateway runtime on port `8111`
 
-Standards documentation:
+## Validation And CI Lanes
 
-- `docs/standards/migration-contract.md`
-- `docs/standards/data-model-ownership.md`
+`lotus-gateway` follows the Lotus multi-lane model:
 
+1. `Remote Feature Lane`
+2. `Pull Request Merge Gate`
+3. `Main Releasability Gate`
+4. platform-facing validation when cross-app experience contracts change
 
+Repo-native gate mapping:
 
-Split routing notes:
-- Advisory lifecycle APIs (/api/v1/proposals/*) use DECISIONING_SERVICE_BASE_URL (lotus-advise).
-- lotus-manage/workbench APIs use MANAGEMENT_SERVICE_BASE_URL (lotus-manage) when MANAGE_SPLIT_ENABLED=true.
+- `make check`
+  lint, typecheck, OpenAPI contract proof, unit tests
+- `make ci`
+  migration smoke, integration tests, coverage, and security audit
+- `make ci-local`
+  local feature-lane style validation
+- `make ci-local-docker`
+  Docker parity for the live integration boundary
 
+## API Contract Notes
 
+Important current parameter conventions:
 
+1. `GET /api/v1/platform/capabilities` uses camelCase query parameters `consumerSystem` and
+   `tenantId`
+2. reporting snapshot and reporting portfolio requests use `asOfDate`
+3. intake upload routes accept camelCase multipart aliases such as `entityType`, `sampleSize`, and
+   `allowPartial`
+4. some lookup filters intentionally remain snake_case, such as `cif_id`, `booking_center`,
+   `product_type`, and `instrument_page_limit`
+5. proposal write routes require `Idempotency-Key`
+
+Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
+
+## Integration Boundaries
+
+- primary downstream consumer:
+  `lotus-workbench`
+- key upstreams:
+  `lotus-core`, `lotus-performance`, `lotus-risk`, `lotus-advise`, `lotus-manage`, `lotus-report`,
+  `lotus-ai`
+- contract rule:
+  gateway may reshape, aggregate, and annotate upstream data for product use, but must not assume
+  upstream business authority
+
+## Operations And Runtime Posture
+
+- use `gateway.dev.lotus` for canonical product and cross-app validation
+- use `127.0.0.1:8111` for direct local debugging only
+- if startup appears healthy but product routes 404 on Windows, verify `--app-dir src`
+- treat degraded responses as composition issues first: inspect upstream supportability, readiness,
+  and parameter shape before changing the gateway response contract
+
+## Documentation Map
+
+- architecture direction:
+  [docs/documentation/experience-api-foundation-blueprint.md](docs/documentation/experience-api-foundation-blueprint.md)
+- upstream integration governance:
+  [docs/standards/RFC-0082-upstream-contract-family-map.md](docs/standards/RFC-0082-upstream-contract-family-map.md)
+- demo material:
+  [docs/demo/README.md](docs/demo/README.md)
+- RFC inventory:
+  [docs/rfcs/README.md](docs/rfcs/README.md)
+- wiki home:
+  [wiki/Home.md](wiki/Home.md)
+
+## Wiki Source
+
+Repository-authored wiki pages live under [wiki/](wiki). If the GitHub wiki is published later,
+keep `wiki/` as the canonical source and treat any separate `*.wiki.git` clone as publication
+plumbing only.

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -51,6 +51,8 @@ Primary areas:
    Experience-API architecture and standards documentation.
 6. `scripts/`
    quality gates, migration checks, and canonical startup helpers.
+7. `wiki/`
+   canonical authored source for GitHub wiki publication and operator-facing gateway summaries.
 
 ## Runtime And Integration Boundaries
 
@@ -102,7 +104,9 @@ Important validation expectations:
 1. OpenAPI and workbench contract quality are part of the gate,
 2. migration smoke remains required,
 3. security audit and monetary-float governance remain active,
-4. Docker parity matters because the gateway is a live integration boundary.
+4. Docker parity matters because the gateway is a live integration boundary,
+5. README and wiki updates should preserve truthful endpoint-specific parameter conventions, and
+   mixed query, body, or multipart shapes should be backed by executable examples in the wiki.
 
 ## Standards And RFCs That Govern This Repository
 
@@ -124,6 +128,8 @@ Most relevant current governance:
 3. gateway fixes should not smuggle domain logic out of authoritative upstream services,
 4. reporting query, cashflow projection, projected summary, and benchmark catalog upstream calls remain RFC-0082 watchlist surfaces,
 5. integration drift is most dangerous here because it directly affects the product UI.
+6. repo-local `wiki/` content should summarize route families and operator flows without duplicating
+   the full `docs/` tree.
 
 ## Context Maintenance Rule
 
@@ -134,7 +140,8 @@ Update this document when:
 3. upstream dependency boundaries change,
 4. gateway composition patterns or partial-readiness behavior change materially,
 5. RFC-0082 contract-family classification changes,
-6. current-state architectural direction changes.
+6. current endpoint-specific parameter conventions or canonical startup guidance changes,
+7. current-state architectural direction changes.
 
 ## Cross-Links
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -1,0 +1,64 @@
+# API Surface
+
+## Route families
+
+- `GET /api/v1/foundation/portfolios`
+- `GET /api/v1/foundation/portfolios/{portfolio_id}/workspace`
+- `GET /api/v1/platform/capabilities`
+- `POST /api/v1/proposals/*` and `GET /api/v1/proposals/*`
+- `POST /api/v1/intake/*`
+- `GET /api/v1/lookups/*`
+- `GET /api/v1/portfolio/*`
+- `GET` and `POST /api/v1/workbench/*`
+- `GET` and `POST /api/v1/reports/*`
+- `/health`, `/health/live`, `/health/ready`, `/metrics`, `/docs`
+
+## Current contract notes
+
+- platform capabilities uses camelCase query parameters `consumerSystem` and `tenantId`
+- reporting snapshot and reporting request payloads use `asOfDate`
+- intake upload routes accept camelCase multipart aliases such as `entityType`, `sampleSize`, and
+  `allowPartial`
+- selected lookup filters remain snake_case, such as `cif_id`, `booking_center`, `product_type`,
+  and `instrument_page_limit`
+- proposal writes require `Idempotency-Key`
+
+## Request examples
+
+Platform capabilities:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/platform/capabilities?consumerSystem=lotus-workbench&tenantId=default"
+```
+
+Foundation workspace:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/foundation/portfolios/PF_1001/workspace"
+```
+
+Performance summary:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/workbench/DEMO_ADV_USD_001/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+```
+
+Reporting summary:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/reports/DEMO_DPM_EUR_001/summary" \
+  -H "Content-Type: application/json" \
+  -d "{\"asOfDate\":\"2026-02-24\",\"sections\":[\"WEALTH\",\"ALLOCATION\"],\"allocationDimensions\":[\"asset_class\"]}"
+```
+
+Proposal creation:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/proposals" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: idem-create-1" \
+  -d @docs/demo/payloads/proposal-create.json
+```
+
+Use these examples to preserve the current gateway-facing parameter shapes until a contract is
+intentionally changed.

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,33 @@
+# Architecture
+
+## Runtime model
+
+- FastAPI experience API
+- route families under `src/app/routers/`
+- composition logic under `src/app/services/`
+- upstream integrations under `src/app/clients/`
+- workbench-facing contracts under `src/app/contracts/`
+
+## Route-family map
+
+- `foundation`
+  first-paint workspace entry and selector-ready catalog
+- `platform`
+  aggregated capability posture for shell bootstrap and gating
+- `proposals`
+  advisory proposal lifecycle and approvals
+- `intake` and `lookups`
+  ingress handoff and selector catalog surfaces
+- `portfolio`
+  portfolio page workspace, readiness, book, liquidity, activity, and transactions
+- `workbench`
+  overview, portfolio-360, sandbox, performance, risk, and advisor brief surfaces
+- `reporting`
+  report snapshot, summary, and review payloads
+
+## Boundary notes
+
+1. product composition belongs here
+2. domain calculations stay upstream
+3. gateway must preserve supportability, readiness, and partial-failure state
+4. RFC-0082 classification governs how new upstream dependencies are justified

--- a/wiki/Development-Workflow.md
+++ b/wiki/Development-Workflow.md
@@ -1,0 +1,27 @@
+# Development Workflow
+
+## Branching and slice model
+
+- branch from `main`
+- keep one branch per RFC or documentation slice
+- use PR-first delivery
+
+## Repo-native commands
+
+- `make lint`
+  formatting, linting, and monetary-float guard
+- `make typecheck`
+  mypy on `src/`
+- `make check`
+  contract and unit gate
+- `make ci`
+  PR-grade local proof
+- `make ci-local-docker`
+  docker parity check
+
+## Documentation workflow
+
+- keep `README.md` concise and repo-front-door focused
+- keep `wiki/` as the authored wiki source
+- keep route-family detail and request examples in the wiki, not in the README
+- keep deep architecture and RFC detail in `docs/`

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,35 @@
+# Getting Started
+
+## Install
+
+```bash
+make install
+```
+
+## Run locally
+
+```bash
+make run-canonical
+```
+
+Canonical identities:
+
+- cross-app and product validation: `http://gateway.dev.lotus`
+- direct process debugging: `http://127.0.0.1:8111`
+
+## First checks
+
+```powershell
+curl http://127.0.0.1:8111/health
+curl "http://127.0.0.1:8111/api/v1/platform/capabilities?consumerSystem=lotus-workbench&tenantId=default"
+```
+
+If health is green but product routes still 404 on Windows, verify startup used `--app-dir src`
+before debugging gateway contracts.
+
+## First docs to read
+
+- [README.md](../README.md)
+- [REPOSITORY-ENGINEERING-CONTEXT.md](../REPOSITORY-ENGINEERING-CONTEXT.md)
+- [docs/documentation/experience-api-foundation-blueprint.md](../docs/documentation/experience-api-foundation-blueprint.md)
+- [docs/standards/RFC-0082-upstream-contract-family-map.md](../docs/standards/RFC-0082-upstream-contract-family-map.md)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,42 @@
+# lotus-gateway wiki
+
+`lotus-gateway` is the Lotus experience API and product-facing composition boundary.
+
+## Start here
+
+- Repo entrypoint: [README.md](../README.md)
+- Repo context: [REPOSITORY-ENGINEERING-CONTEXT.md](../REPOSITORY-ENGINEERING-CONTEXT.md)
+- Experience-API blueprint:
+  [docs/documentation/experience-api-foundation-blueprint.md](../docs/documentation/experience-api-foundation-blueprint.md)
+- Upstream contract-family map:
+  [docs/standards/RFC-0082-upstream-contract-family-map.md](../docs/standards/RFC-0082-upstream-contract-family-map.md)
+
+## Current phase
+
+- primary backend contract for `lotus-workbench`
+- active route families across foundation, workbench, platform capabilities, proposals, reporting,
+  portfolio, and intake/lookups
+- still replacing thin pass-through patterns with cleaner experience-API contracts
+
+## Most important commands
+
+- `make install`
+- `make check`
+- `make ci`
+- `make ci-local-docker`
+- `make run-canonical`
+
+## Navigation
+
+- [Overview](Overview)
+- [Architecture](Architecture)
+- [API Surface](API-Surface)
+- [Getting Started](Getting-Started)
+- [Development Workflow](Development-Workflow)
+- [Validation and CI](Validation-and-CI)
+- [Operations Runbook](Operations-Runbook)
+- [Integrations](Integrations)
+- [Security and Governance](Security-and-Governance)
+- [RFC Index](RFC-Index)
+- [Roadmap](Roadmap)
+- [Troubleshooting](Troubleshooting)

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -1,0 +1,48 @@
+# Integrations
+
+## Downstream posture
+
+- primary product consumer:
+  `lotus-workbench`
+
+## Upstream posture
+
+- `lotus-core`
+  portfolio, lookups, ingestion, simulation, and supportability
+- `lotus-performance`
+  performance workspace analytics and evidence lineage
+- `lotus-risk`
+  stateful risk workspace analytics
+- `lotus-advise`
+  proposal and advisory workflow
+- `lotus-manage`
+  split-routing management workflows when enabled
+- `lotus-report`
+  reporting snapshot, summary, and review payloads
+- `lotus-ai`
+  evidence-grounded advisor brief narration
+
+## Canonical local identities
+
+- `lotus-gateway`
+  `http://gateway.dev.lotus`
+- `lotus-core query`
+  `http://core-query.dev.lotus`
+- `lotus-core control`
+  `http://core-control.dev.lotus`
+- `lotus-core ingestion`
+  `http://core-ingestion.dev.lotus`
+- `lotus-performance`
+  `http://performance.dev.lotus`
+- `lotus-risk`
+  `http://risk.dev.lotus`
+- `lotus-report`
+  `http://report.dev.lotus`
+- `lotus-ai`
+  `http://ai.dev.lotus`
+
+## Contract notes
+
+1. gateway contracts are product-facing and may differ intentionally from upstream parameter shapes
+2. RFC-0082 governs how upstream dependency families are classified
+3. supportability, readiness, and partial-failure metadata should survive composition

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -1,0 +1,33 @@
+# Operations Runbook
+
+## Important operational checks
+
+- confirm canonical gateway identity is `gateway.dev.lotus` before product validation
+- if Windows startup looks healthy but routes fail, verify `--app-dir src`
+- treat partial-failure and supportability signals as contract data, not as noise to suppress
+- use repo-native gates before inventing custom checks
+
+## Health and readiness surfaces
+
+- `/health`
+  broad service-health probe
+- `/health/live`
+  liveness probe
+- `/health/ready`
+  readiness probe
+- `/metrics`
+  observability surface for runtime monitoring
+
+## Practical probes
+
+```powershell
+curl http://127.0.0.1:8111/health/ready
+curl "http://127.0.0.1:8111/api/v1/foundation/portfolios/PF_1001/workspace"
+curl "http://127.0.0.1:8111/api/v1/platform/capabilities?consumerSystem=lotus-workbench&tenantId=default"
+```
+
+## Key references
+
+- [docs/documentation/experience-api-foundation-blueprint.md](../docs/documentation/experience-api-foundation-blueprint.md)
+- [docs/standards/RFC-0082-upstream-contract-family-map.md](../docs/standards/RFC-0082-upstream-contract-family-map.md)
+- [docs/demo/README.md](../docs/demo/README.md)

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -1,0 +1,33 @@
+# Overview
+
+## Business role
+
+`lotus-gateway` is the governed experience API for Lotus product clients, primarily
+`lotus-workbench`.
+
+It shapes product-facing contracts from upstream domain services without becoming the authority for
+their business truth.
+
+## Ownership boundaries
+
+This repo owns:
+
+1. product-facing API composition
+2. partial-readiness-aware aggregation
+3. gateway-level routing and contract governance
+4. experience-oriented payload shaping and degraded-state handling
+
+This repo does not own:
+
+1. portfolio source truth, which belongs to `lotus-core`
+2. performance methodology, which belongs to `lotus-performance`
+3. risk methodology, which belongs to `lotus-risk`
+4. reporting methodology, which belongs to `lotus-report`
+5. advisory and management workflow truth, which belong upstream
+
+## Current posture
+
+- primary backend contract for `lotus-workbench`
+- canonical local service identity is `gateway.dev.lotus`
+- live integration boundary where Docker parity matters
+- high drift risk because gateway changes directly affect the product UI

--- a/wiki/RFC-Index.md
+++ b/wiki/RFC-Index.md
@@ -1,0 +1,24 @@
+# RFC Index
+
+## Most relevant local RFCs
+
+- RFC-0007
+  gateway as the BFF and UI-facing integration contract
+- RFC-0041
+  platform integration architecture governance
+- RFC-0067
+  OpenAPI and vocabulary governance
+- RFC-0071
+  environment-scoped service identity
+- RFC-0072
+  CI and release governance
+- RFC-0073
+  context and agent guidance system
+- RFC-0082
+  upstream contract-family classification and boundary hardening
+
+## Local references
+
+- [docs/rfcs/README.md](../docs/rfcs/README.md)
+- [docs/standards/RFC-0082-upstream-contract-family-map.md](../docs/standards/RFC-0082-upstream-contract-family-map.md)
+- [docs/documentation/experience-api-foundation-blueprint.md](../docs/documentation/experience-api-foundation-blueprint.md)

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -1,0 +1,18 @@
+# Roadmap
+
+## Current phase
+
+- active experience API for `lotus-workbench`
+- foundation, workbench, reporting, proposal, and platform capability contracts are live
+
+## Intentional limitations
+
+- some thin pass-through and transitional route shapes still exist
+- parameter conventions are not fully uniform across all route families
+- gateway is not the authority for upstream domain methodology
+
+## Next priorities
+
+1. keep replacing thin pass-through surfaces with clearer product contracts
+2. preserve RFC-0082 boundary discipline as integrations evolve
+3. keep request-convention and runtime guidance explicit for operators and future agents

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -1,0 +1,31 @@
+# Security and Governance
+
+## Current governance
+
+- RFC-0007
+  BFF integration contract for the UI platform
+- RFC-0041
+  platform integration architecture governance
+- RFC-0067
+  centralized OpenAPI and vocabulary governance
+- RFC-0071
+  environment-scoped service identity and ingress posture
+- RFC-0072
+  multi-lane CI and release governance
+- RFC-0073
+  ecosystem context and agent guidance system
+- RFC-0082
+  upstream contract-family boundary hardening
+
+## Repo-specific guardrails
+
+- OpenAPI contract proof is active
+- migration smoke, monetary-float guard, and security audit remain active
+- Docker parity matters because this is a live integration boundary
+- gateway must not smuggle domain logic out of authoritative upstream services
+
+## Operational discipline
+
+- preserve correlation, evidence, supportability, and degraded-state signals
+- keep gateway contracts product-oriented instead of accreting thin pass-through clutter
+- document endpoint-specific parameter conventions explicitly when they differ by route family

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,22 @@
+# Troubleshooting
+
+## Common checks
+
+- if startup looks healthy but routes 404, verify `--app-dir src`
+- if the UI gets partial or degraded payloads, inspect upstream readiness and supportability first
+- if platform capabilities look wrong, verify `consumerSystem` and `tenantId` query shape
+- if intake upload requests fail, verify the camelCase multipart aliases expected by gateway
+- if proposal writes fail, verify `Idempotency-Key`
+
+## Useful commands
+
+```bash
+make check
+make ci
+make ci-local-docker
+```
+
+## References
+
+- [docs/documentation/experience-api-foundation-blueprint.md](../docs/documentation/experience-api-foundation-blueprint.md)
+- [docs/standards/RFC-0082-upstream-contract-family-map.md](../docs/standards/RFC-0082-upstream-contract-family-map.md)

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -1,0 +1,28 @@
+# Validation and CI
+
+## Lane model
+
+`lotus-gateway` uses:
+
+1. `Remote Feature Lane`
+2. `Pull Request Merge Gate`
+3. `Main Releasability Gate`
+4. platform-facing validation for cross-app experience changes
+
+## Local command mapping
+
+- `make check`
+  lint, typecheck, OpenAPI contract proof, unit tests
+- `make ci`
+  migration smoke, integration tests, coverage, security audit
+- `make ci-local`
+  local feature-lane validation
+- `make ci-local-docker`
+  Docker parity for the integration boundary
+
+## What the gates protect
+
+- workbench-facing contract integrity
+- startup and migration truth
+- upstream composition safety
+- live integration-boundary parity

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,19 @@
+[Home](Home)
+
+### Orientation
+- [Overview](Overview)
+- [Architecture](Architecture)
+- [API Surface](API-Surface)
+- [Getting Started](Getting-Started)
+
+### Delivery
+- [Development Workflow](Development-Workflow)
+- [Validation and CI](Validation-and-CI)
+- [Operations Runbook](Operations-Runbook)
+- [Troubleshooting](Troubleshooting)
+
+### Boundaries
+- [Integrations](Integrations)
+- [Security and Governance](Security-and-Governance)
+- [RFC Index](RFC-Index)
+- [Roadmap](Roadmap)


### PR DESCRIPTION
## Summary
- add the repo-root `AGENTS.md` operating contract
- rewrite the README into a proper experience-API front door with boundaries, runtime posture, command mapping, and parameter-convention notes
- add authored wiki source pages for route families, request examples, setup, validation, operations, integrations, governance, RFCs, troubleshooting, and roadmap
- update `REPOSITORY-ENGINEERING-CONTEXT.md` so future agents keep wiki content concise and preserve executable examples for mixed gateway parameter shapes

## Validation
- `python -m pytest tests/contract/test_workbench_contract.py -q`
- `python scripts/check_monetary_float_usage.py`
- `python -m pytest tests/integration/test_platform_capabilities_router.py tests/integration/test_reporting_router.py -q`