### PR TITLE
docs(mesh): document mesh wiki posture

### DIFF
--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -1,0 +1,20 @@
+# Mesh Data Products
+
+## Mesh role
+
+`lotus-gateway` is the read-only API publication face for Lotus mesh discovery and trust posture.
+
+## Governed API surface
+
+- `GET /api/v1/domain-products/catalog`
+- `GET /api/v1/domain-products/products/{producer_repository}/{product_name}/{product_version}`
+- `GET /api/v1/domain-products/dependency-graph`
+- `GET /api/v1/domain-products/trust-certification`
+
+## Platform relationship
+
+Gateway reads platform-generated catalog, dependency graph, and live trust certification artifacts. It does not own domain-product declarations, trust telemetry, access policy, SLO policy, evidence policy, maturity matrix, or operating reports.
+
+## Operating rule
+
+Gateway must preserve platform product IDs, producer repositories, approved consumers, dependency edges, and degraded trust states exactly. If platform evidence is unavailable, gateway should return explicit unavailable/degraded posture rather than inventing trust.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -17,3 +17,5 @@
 - [Security and Governance](Security-and-Governance)
 - [RFC Index](RFC-Index)
 - [Roadmap](Roadmap)
+
+- [Mesh Data Products](Mesh-Data-Products)


### PR DESCRIPTION
Updates the authored repo wiki with an explicit Mesh Data Products page and sidebar link so the repo's published wiki can reflect the implemented Lotus mesh RFC posture. This is documentation-only; no runtime or API behavior changes.