### PR TITLE
Adopt source-owned portfolio gateway contracts

### DIFF
--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-03-29T14:37:08Z",
+  "generated_at": "2026-03-29T14:43:42Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -514,55 +514,55 @@
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:2072:def _extract_return(self, payload: Any, *path: str) -> float | None:",
+      "finding": "src/app/services/performance_workspace_service.py:2075:def _extract_return(self, payload: Any, *path: str) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:2080:def _extract_nested_return(self, payload: Any, *path: str) -> float | None:",
+      "finding": "src/app/services/performance_workspace_service.py:2083:def _extract_nested_return(self, payload: Any, *path: str) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:2088:def _quantize_optional(self, value: Any) -> float | None:",
+      "finding": "src/app/services/performance_workspace_service.py:2091:def _quantize_optional(self, value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:2092:return float(quantize_performance(value))",
+      "finding": "src/app/services/performance_workspace_service.py:2095:return float(quantize_performance(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:2096:def _weight_to_pct(self, value: Any) -> float | None:",
+      "finding": "src/app/services/performance_workspace_service.py:2099:def _weight_to_pct(self, value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:2100:normalized = float(value)",
+      "finding": "src/app/services/performance_workspace_service.py:2103:normalized = float(value)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:2103:return float(quantize_performance(normalized))",
+      "finding": "src/app/services/performance_workspace_service.py:2106:return float(quantize_performance(normalized))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:2107:def _sum_optional(self, values: list[float | None]) -> float | None:",
+      "finding": "src/app/services/performance_workspace_service.py:2110:def _sum_optional(self, values: list[float | None]) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:2111:return float(quantize_performance(sum(numeric_values)))",
+      "finding": "src/app/services/performance_workspace_service.py:2114:return float(quantize_performance(sum(numeric_values)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-03-29T05:57:54Z",
+  "generated_at": "2026-03-29T14:37:08Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -226,61 +226,109 @@
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:100:cost_basis_local: float | None = None",
+      "finding": "src/app/contracts/portfolio.py:104:market_price: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:101:market_value_base: float | None = None",
+      "finding": "src/app/contracts/portfolio.py:105:cost_basis_base: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:102:market_value_local: float | None = None",
+      "finding": "src/app/contracts/portfolio.py:106:cost_basis_local: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:105:weight_pct: float | None = None",
+      "finding": "src/app/contracts/portfolio.py:107:market_value_base: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:117:price: float | None = None",
+      "finding": "src/app/contracts/portfolio.py:108:market_value_local: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:118:gross_amount: float | None = None",
+      "finding": "src/app/contracts/portfolio.py:111:weight_pct: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:120:net_cost_base: float | None = None",
+      "finding": "src/app/contracts/portfolio.py:124:price: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:146:portfolio_currency_amount: float | None = None",
+      "finding": "src/app/contracts/portfolio.py:125:gross_amount: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:147:reporting_currency_amount: float",
+      "finding": "src/app/contracts/portfolio.py:127:net_cost_base: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:194:return_pct: float | None = None",
+      "finding": "src/app/contracts/portfolio.py:153:portfolio_currency_amount: float | None = None",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-09-25"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:154:reporting_currency_amount: float",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-09-25"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:201:return_pct: float | None = None",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-09-25"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:393:portfolio_return_pct: float | None = None",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-09-25"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:394:benchmark_return_pct: float | None = None",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-09-25"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:395:excess_return_pct: float | None = None",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-09-25"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:411:portfolio_return_pct: float | None = None",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-09-25"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:412:benchmark_return_pct: float | None = None",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-09-25"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:413:excess_return_pct: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
@@ -328,31 +376,19 @@
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:83:cost_basis_base: float | None = None",
+      "finding": "src/app/contracts/portfolio.py:89:cost_basis_base: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:84:market_value_base: float | None = None",
+      "finding": "src/app/contracts/portfolio.py:90:market_value_base: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:85:weight_pct: float | None = None",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-09-25"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:98:market_price: float | None = None",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-09-25"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:99:cost_basis_base: float | None = None",
+      "finding": "src/app/contracts/portfolio.py:91:weight_pct: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
@@ -478,145 +514,145 @@
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:1942:def _extract_return(self, payload: Any, *path: str) -> float | None:",
+      "finding": "src/app/services/performance_workspace_service.py:2072:def _extract_return(self, payload: Any, *path: str) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:1950:def _extract_nested_return(self, payload: Any, *path: str) -> float | None:",
+      "finding": "src/app/services/performance_workspace_service.py:2080:def _extract_nested_return(self, payload: Any, *path: str) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:1958:def _quantize_optional(self, value: Any) -> float | None:",
+      "finding": "src/app/services/performance_workspace_service.py:2088:def _quantize_optional(self, value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:1962:return float(quantize_performance(value))",
+      "finding": "src/app/services/performance_workspace_service.py:2092:return float(quantize_performance(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:1966:def _weight_to_pct(self, value: Any) -> float | None:",
+      "finding": "src/app/services/performance_workspace_service.py:2096:def _weight_to_pct(self, value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:1970:normalized = float(value)",
+      "finding": "src/app/services/performance_workspace_service.py:2100:normalized = float(value)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:1973:return float(quantize_performance(normalized))",
+      "finding": "src/app/services/performance_workspace_service.py:2103:return float(quantize_performance(normalized))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:1977:def _sum_optional(self, values: list[float | None]) -> float | None:",
+      "finding": "src/app/services/performance_workspace_service.py:2107:def _sum_optional(self, values: list[float | None]) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/performance_workspace_service.py:1981:return float(quantize_performance(sum(numeric_values)))",
+      "finding": "src/app/services/performance_workspace_service.py:2111:return float(quantize_performance(sum(numeric_values)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1036:weight_pct=float(quantize_performance(float(item.get(\"weight\", 0)) * 100))",
+      "finding": "src/app/services/portfolio_service.py:1027:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1053:market_value_base=float(",
+      "finding": "src/app/services/portfolio_service.py:1097:market_price=float(quantize_price(item.get(\"valuation\", {}).get(\"market_price\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1056:weight_pct=float(",
+      "finding": "src/app/services/portfolio_service.py:1100:cost_basis_base=float(quantize_money(item.get(\"cost_basis\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1057:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
+      "finding": "src/app/services/portfolio_service.py:1103:cost_basis_local=float(quantize_money(item.get(\"cost_basis_local\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1117:price=float(quantize_price(item.get(\"price\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1106:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1120:gross_amount=float(quantize_money(item.get(\"gross_transaction_amount\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1118:market_value_local=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1124:net_cost_base=float(quantize_money(item.get(\"net_cost\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1156:weight_pct=float(quantize_performance(float(item.get(\"weight\", 0)) * 100))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1177:reporting_currency_amount=float(quantize_money(payload.get(reporting_key, 0))),",
+      "finding": "src/app/services/portfolio_service.py:1173:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1643:return float(",
+      "finding": "src/app/services/portfolio_service.py:1176:weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:907:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/portfolio_service.py:1177:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:977:market_price=float(quantize_price(item.get(\"valuation\", {}).get(\"market_price\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1238:price=float(quantize_price(item.get(\"price\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:980:cost_basis_base=float(quantize_money(item.get(\"cost_basis\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1241:gross_amount=float(quantize_money(item.get(\"gross_transaction_amount\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:983:cost_basis_local=float(quantize_money(item.get(\"cost_basis_local\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1245:net_cost_base=float(quantize_money(item.get(\"net_cost\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:986:market_value_base=float(",
+      "finding": "src/app/services/portfolio_service.py:1298:reporting_currency_amount=float(quantize_money(payload.get(reporting_key, 0))),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:998:market_value_local=float(",
+      "finding": "src/app/services/portfolio_service.py:1783:return float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-25"

--- a/src/app/clients/lotus_core_query_client.py
+++ b/src/app/clients/lotus_core_query_client.py
@@ -122,6 +122,7 @@ class LotusCoreQueryClient:
         as_of_date: str | None = None,
         include_projected: bool = False,
         transaction_type: str | None = None,
+        security_id: str | None = None,
         start_date: str | None = None,
         end_date: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
@@ -138,6 +139,8 @@ class LotusCoreQueryClient:
             params["as_of_date"] = as_of_date
         if transaction_type is not None:
             params["transaction_type"] = transaction_type
+        if security_id is not None:
+            params["security_id"] = security_id
         if start_date is not None:
             params["start_date"] = start_date
         if end_date is not None:
@@ -223,6 +226,7 @@ class LotusCoreQueryClient:
         dimensions: list[str],
         as_of_date: str | None = None,
         reporting_currency: str | None = None,
+        look_through_mode: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._query_base_url}/reporting/asset-allocation/query"
         headers = propagation_headers(correlation_id)
@@ -238,6 +242,8 @@ class LotusCoreQueryClient:
             payload["as_of_date"] = as_of_date
         if reporting_currency is not None:
             payload["reporting_currency"] = reporting_currency
+        if look_through_mode is not None:
+            payload["look_through_mode"] = look_through_mode
         return await request_with_retry(
             method="POST",
             url=url,
@@ -421,6 +427,27 @@ class LotusCoreQueryClient:
             timeout_seconds=self._timeout,
             max_retries=self._max_retries,
             backoff_seconds=self._retry_backoff_seconds,
+            headers=headers,
+        )
+
+    async def get_portfolio_readiness(
+        self,
+        portfolio_id: str,
+        correlation_id: str,
+        as_of_date: str | None = None,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._control_plane_base_url}/support/portfolios/{portfolio_id}/readiness"
+        headers = propagation_headers(correlation_id)
+        params: dict[str, Any] = {}
+        if as_of_date is not None:
+            params["as_of_date"] = as_of_date
+        return await request_with_retry(
+            method="GET",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            params=params,
             headers=headers,
         )
 

--- a/src/app/contracts/portfolio.py
+++ b/src/app/contracts/portfolio.py
@@ -73,6 +73,12 @@ class PortfolioAllocationView(BaseModel):
     buckets: list[PortfolioAllocationBucket] = Field(default_factory=list)
 
 
+class PortfolioAllocationLookThroughCapability(BaseModel):
+    requested_mode: str
+    effective_mode: str
+    applied: bool
+
+
 class PortfolioTopPosition(BaseModel):
     security_id: str
     instrument_name: str
@@ -109,6 +115,7 @@ class PortfolioPositionView(BaseModel):
 class PortfolioTransactionView(BaseModel):
     transaction_id: str
     transaction_date: str
+    settlement_date: str | None = None
     transaction_type: str
     component_type: str | None = None
     security_id: str
@@ -231,6 +238,16 @@ class PortfolioReadinessIndicator(BaseModel):
     href: str
 
 
+class PortfolioReadinessReason(BaseModel):
+    code: str
+    detail: str | None = None
+
+
+class PortfolioReadinessBucket(BaseModel):
+    status: str
+    reasons: list[PortfolioReadinessReason] = Field(default_factory=list)
+
+
 class PortfolioExceptionSummary(BaseModel):
     key: str
     title: str
@@ -252,6 +269,11 @@ class PortfolioReadinessResponse(BaseModel):
     contract_version: str = Field(default="v1")
     portfolio_id: str
     as_of_date: str
+    holdings: PortfolioReadinessBucket | None = None
+    pricing: PortfolioReadinessBucket | None = None
+    transactions: PortfolioReadinessBucket | None = None
+    reporting: PortfolioReadinessBucket | None = None
+    blocking_reasons: list[PortfolioReadinessReason] = Field(default_factory=list)
     indicators: list[PortfolioReadinessIndicator] = Field(default_factory=list)
 
 
@@ -326,6 +348,8 @@ class PortfolioAllocationResponse(BaseModel):
     contract_version: str = Field(default="v1")
     portfolio_id: str
     as_of_date: str
+    reporting_currency: str | None = None
+    look_through: PortfolioAllocationLookThroughCapability | None = None
     summary: PortfolioSummary
     views: list[PortfolioAllocationView] = Field(default_factory=list)
 
@@ -362,3 +386,32 @@ class PortfolioTransactionLedgerResponse(BaseModel):
     skip: int
     limit: int
     transactions: list[PortfolioTransactionView] = Field(default_factory=list)
+
+
+class PortfolioPerformanceSnapshotPoint(BaseModel):
+    as_of_date: str
+    portfolio_return_pct: float | None = None
+    benchmark_return_pct: float | None = None
+    excess_return_pct: float | None = None
+
+
+class PortfolioPerformanceSnapshotUnavailable(BaseModel):
+    title: str
+    detail: str
+    requirements: list[str] = Field(default_factory=list)
+
+
+class PortfolioPerformanceSnapshotResponse(BaseModel):
+    correlation_id: str
+    contract_version: str = Field(default="v1")
+    portfolio_id: str
+    as_of_date: str
+    period: str
+    benchmark_code: str | None = None
+    portfolio_return_pct: float | None = None
+    benchmark_return_pct: float | None = None
+    excess_return_pct: float | None = None
+    sparkline: list[PortfolioPerformanceSnapshotPoint] = Field(default_factory=list)
+    unavailable: PortfolioPerformanceSnapshotUnavailable | None = None
+    warnings: list[str] = Field(default_factory=list)
+    partial_failures: list[PortfolioPartialFailure] = Field(default_factory=list)

--- a/src/app/routers/portfolio.py
+++ b/src/app/routers/portfolio.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, Query
 
+from app.clients.dpm_client import DpmClient
+from app.clients.lotus_analytics_client import LotusAnalyticsClient
 from app.clients.lotus_core_query_client import LotusCoreQueryClient
 from app.config import settings
 from app.contracts.portfolio import (
@@ -10,6 +12,7 @@ from app.contracts.portfolio import (
     PortfolioIncomeSummaryResponse,
     PortfolioInsightsResponse,
     PortfolioLiquidityResponse,
+    PortfolioPerformanceSnapshotResponse,
     PortfolioPositionBookResponse,
     PortfolioProjectedCashflowResponse,
     PortfolioReadinessResponse,
@@ -18,7 +21,9 @@ from app.contracts.portfolio import (
     PortfolioWorkspaceResponse,
 )
 from app.middleware.correlation import correlation_id_var
+from app.services.performance_workspace_service import PerformanceWorkspaceService
 from app.services.portfolio_service import PortfolioService
+from app.services.workbench_service import WorkbenchService
 
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
@@ -35,6 +40,61 @@ _PORTFOLIO_SERVICE = PortfolioService(
 
 def _portfolio_service() -> PortfolioService:
     return _PORTFOLIO_SERVICE
+
+
+def _performance_workspace_service() -> PerformanceWorkspaceService:
+    dpm_base_url = (
+        settings.management_service_base_url
+        if settings.manage_split_enabled
+        else settings.decisioning_service_base_url
+    )
+    workbench_service = WorkbenchService(
+        lotus_core_query_client=LotusCoreQueryClient(
+            base_url=settings.portfolio_data_query_base_url,
+            control_plane_base_url=settings.portfolio_data_control_plane_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+        analytics_client=LotusAnalyticsClient(
+            base_url=settings.performance_analytics_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+        dpm_client=DpmClient(
+            base_url=dpm_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+        risk_client=(
+            LotusAnalyticsClient(
+                base_url=settings.risk_analytics_base_url,
+                timeout_seconds=settings.upstream_timeout_seconds,
+                max_retries=settings.upstream_max_retries,
+                retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+            )
+            if settings.risk_split_enabled
+            else None
+        ),
+    )
+    return PerformanceWorkspaceService(
+        workbench_service=workbench_service,
+        analytics_client=LotusAnalyticsClient(
+            base_url=settings.performance_analytics_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+        lotus_core_query_client=LotusCoreQueryClient(
+            base_url=settings.portfolio_data_query_base_url,
+            control_plane_base_url=settings.portfolio_data_control_plane_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+    )
 
 
 @router.get(
@@ -54,11 +114,13 @@ async def get_portfolios() -> PortfolioCatalogResponse:
 async def get_portfolio_workspace(
     portfolio_id: str,
     as_of_date: str | None = Query(default=None),
+    reporting_currency: str | None = Query(default=None),
 ) -> PortfolioWorkspaceResponse:
     return await _portfolio_service().get_portfolio_workspace(
         portfolio_id=portfolio_id,
         correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
+        reporting_currency=reporting_currency,
     )
 
 
@@ -136,11 +198,13 @@ async def get_portfolio_book(
 async def get_portfolio_liquidity(
     portfolio_id: str,
     as_of_date: str | None = Query(default=None),
+    reporting_currency: str | None = Query(default=None),
 ) -> PortfolioLiquidityResponse:
     return await _portfolio_service().get_portfolio_liquidity(
         portfolio_id=portfolio_id,
         correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
+        reporting_currency=reporting_currency,
     )
 
 
@@ -172,11 +236,15 @@ async def get_portfolio_projected_cashflow(
 async def get_portfolio_allocations(
     portfolio_id: str,
     as_of_date: str | None = Query(default=None),
+    reporting_currency: str | None = Query(default=None),
+    look_through_mode: str = Query(default="direct_only"),
 ) -> PortfolioAllocationResponse:
     return await _portfolio_service().get_portfolio_allocations(
         portfolio_id=portfolio_id,
         correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
+        reporting_currency=reporting_currency,
+        look_through_mode=look_through_mode,
     )
 
 
@@ -189,12 +257,14 @@ async def get_portfolio_positions(
     portfolio_id: str,
     as_of_date: str | None = Query(default=None),
     include_projected: bool = Query(default=False),
+    reporting_currency: str | None = Query(default=None),
 ) -> PortfolioPositionBookResponse:
     return await _portfolio_service().get_portfolio_positions(
         portfolio_id=portfolio_id,
         correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
         include_projected=include_projected,
+        reporting_currency=reporting_currency,
     )
 
 
@@ -205,14 +275,18 @@ async def get_portfolio_positions(
 )
 async def get_portfolio_income_summary(
     portfolio_id: str,
+    as_of_date: str | None = Query(default=None),
     start_date: str | None = Query(default=None),
     end_date: str | None = Query(default=None),
+    reporting_currency: str | None = Query(default=None),
 ) -> PortfolioIncomeSummaryResponse:
     return await _portfolio_service().get_income_summary(
         portfolio_id=portfolio_id,
         correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
         start_date=start_date,
         end_date=end_date,
+        reporting_currency=reporting_currency,
     )
 
 
@@ -223,14 +297,18 @@ async def get_portfolio_income_summary(
 )
 async def get_portfolio_activity_summary(
     portfolio_id: str,
+    as_of_date: str | None = Query(default=None),
     start_date: str | None = Query(default=None),
     end_date: str | None = Query(default=None),
+    reporting_currency: str | None = Query(default=None),
 ) -> PortfolioActivitySummaryResponse:
     return await _portfolio_service().get_activity_summary(
         portfolio_id=portfolio_id,
         correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
         start_date=start_date,
         end_date=end_date,
+        reporting_currency=reporting_currency,
     )
 
 
@@ -244,6 +322,7 @@ async def get_portfolio_transactions(
     as_of_date: str | None = Query(default=None),
     include_projected: bool = Query(default=False),
     transaction_type: str | None = Query(default=None),
+    security_id: str | None = Query(default=None),
     start_date: str | None = Query(default=None),
     end_date: str | None = Query(default=None),
     skip: int = Query(default=0, ge=0),
@@ -255,8 +334,35 @@ async def get_portfolio_transactions(
         as_of_date=as_of_date,
         include_projected=include_projected,
         transaction_type=transaction_type,
+        security_id=security_id,
         start_date=start_date,
         end_date=end_date,
         skip=skip,
         limit=limit,
+    )
+
+
+@router.get(
+    "/portfolios/{portfolio_id}/performance-snapshot",
+    response_model=PortfolioPerformanceSnapshotResponse,
+    summary="Get portfolio performance snapshot",
+)
+async def get_portfolio_performance_snapshot(
+    portfolio_id: str,
+    period: str = Query(default="YTD"),
+    chart_frequency: str = Query(default="monthly"),
+    detail_basis: str = Query(default="NET"),
+    benchmark_code: str | None = Query(default=None),
+    explicit_start_date: str | None = Query(default=None),
+    explicit_end_date: str | None = Query(default=None),
+) -> PortfolioPerformanceSnapshotResponse:
+    return await _performance_workspace_service().get_portfolio_performance_snapshot(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        period=period,
+        chart_frequency=chart_frequency,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        explicit_start_date=explicit_start_date,
+        explicit_end_date=explicit_end_date,
     )

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -27,6 +27,12 @@ from app.contracts.performance_workspace import (
     PerformanceWorkspaceResponse,
     PerformanceWorkspaceSummaryResponse,
 )
+from app.contracts.portfolio import (
+    PortfolioPartialFailure,
+    PortfolioPerformanceSnapshotPoint,
+    PortfolioPerformanceSnapshotResponse,
+    PortfolioPerformanceSnapshotUnavailable,
+)
 from app.contracts.workbench import WorkbenchPartialFailure
 from app.precision_policy import quantize_performance
 from app.services.workbench_service import WorkbenchService
@@ -140,6 +146,32 @@ class PerformanceWorkspaceService:
             explicit_end_date=explicit_end_date,
         )
         return self._project_workspace_details(workspace)
+
+    async def get_portfolio_performance_snapshot(
+        self,
+        *,
+        portfolio_id: str,
+        correlation_id: str,
+        period: str,
+        chart_frequency: str,
+        detail_basis: str,
+        benchmark_code: str | None,
+        explicit_start_date: str | None = None,
+        explicit_end_date: str | None = None,
+    ) -> PortfolioPerformanceSnapshotResponse:
+        workspace = await self._build_performance_workspace_response(
+            portfolio_id=portfolio_id,
+            correlation_id=correlation_id,
+            period=period,
+            chart_frequency=chart_frequency,
+            contribution_dimension="asset_class",
+            attribution_dimension="asset_class",
+            detail_basis=detail_basis,
+            benchmark_code=benchmark_code,
+            explicit_start_date=explicit_start_date,
+            explicit_end_date=explicit_end_date,
+        )
+        return self._project_portfolio_performance_snapshot(workspace)
 
     async def get_performance_horizon_comparison(
         self,
@@ -478,6 +510,59 @@ class PerformanceWorkspaceService:
             attribution=workspace.attribution,
             warnings=workspace.warnings,
             partial_failures=workspace.partial_failures,
+        )
+
+    def _project_portfolio_performance_snapshot(
+        self, workspace: PerformanceWorkspaceResponse
+    ) -> PortfolioPerformanceSnapshotResponse:
+        portfolio_return_pct = workspace.net_performance.portfolio_return_pct
+        benchmark_return_pct = workspace.net_performance.benchmark_return_pct
+        excess_return_pct = workspace.net_performance.active_return_pct
+        sparkline = [
+            PortfolioPerformanceSnapshotPoint(
+                as_of_date=point.as_of_date,
+                portfolio_return_pct=point.portfolio_return_pct,
+                benchmark_return_pct=point.benchmark_return_pct,
+                excess_return_pct=point.active_return_pct,
+            )
+            for point in workspace.net_chart
+        ]
+        unavailable = None
+        if (
+            portfolio_return_pct is None
+            and benchmark_return_pct is None
+            and excess_return_pct is None
+            and not sparkline
+        ):
+            unavailable = PortfolioPerformanceSnapshotUnavailable(
+                title="Performance data unavailable",
+                detail=(
+                    "Performance snapshot requires valuation history, cashflow history, "
+                    "and a selected reporting period."
+                ),
+                requirements=[
+                    "valuation history",
+                    "cashflow history",
+                    "selected reporting period",
+                ],
+            )
+        return PortfolioPerformanceSnapshotResponse(
+            correlation_id=workspace.correlation_id,
+            contract_version=workspace.contract_version,
+            portfolio_id=workspace.portfolio_id,
+            as_of_date=workspace.as_of_date,
+            period=workspace.period,
+            benchmark_code=workspace.benchmark_code,
+            portfolio_return_pct=portfolio_return_pct,
+            benchmark_return_pct=benchmark_return_pct,
+            excess_return_pct=excess_return_pct,
+            sparkline=sparkline,
+            unavailable=unavailable,
+            warnings=workspace.warnings,
+            partial_failures=[
+                PortfolioPartialFailure(**failure.model_dump())
+                for failure in workspace.partial_failures
+            ],
         )
 
     async def _determine_report_end_date(

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -520,7 +520,7 @@ class PerformanceWorkspaceService:
         excess_return_pct = workspace.net_performance.active_return_pct
         sparkline = [
             PortfolioPerformanceSnapshotPoint(
-                as_of_date=point.as_of_date,
+                as_of_date=self._snapshot_point_as_of_date(point),
                 portfolio_return_pct=point.portfolio_return_pct,
                 benchmark_return_pct=point.benchmark_return_pct,
                 excess_return_pct=point.active_return_pct,
@@ -564,6 +564,9 @@ class PerformanceWorkspaceService:
                 for failure in workspace.partial_failures
             ],
         )
+
+    def _snapshot_point_as_of_date(self, point: PerformanceChartPoint) -> str:
+        return point.period_end or point.period_start or point.label
 
     async def _determine_report_end_date(
         self,

--- a/src/app/services/platform_capabilities_service.py
+++ b/src/app/services/platform_capabilities_service.py
@@ -21,6 +21,7 @@ class PlatformCapabilitiesService:
         analytics_client: LotusAnalyticsClient,
         reporting_client: ReportingClient,
         contract_version: str,
+        source_timeout_seconds: float = 1.0,
         risk_client: LotusAnalyticsClient | None = None,
         manage_client: DpmClient | None = None,
     ):
@@ -31,6 +32,7 @@ class PlatformCapabilitiesService:
         self._risk_client = risk_client
         self._manage_client = manage_client
         self._contract_version = contract_version
+        self._source_timeout_seconds = source_timeout_seconds
 
     async def get_platform_capabilities(
         self,
@@ -39,49 +41,59 @@ class PlatformCapabilitiesService:
         correlation_id: str,
     ) -> PlatformCapabilitiesResponse:
         tasks: list[Any] = [
-            self._lotus_core_query_client.get_capabilities(
+            self._with_timeout(
+                self._lotus_core_query_client.get_capabilities(
                 consumer_system=consumer_system,
                 tenant_id=tenant_id,
                 correlation_id=correlation_id,
+                )
             ),
-            self._analytics_client.get_capabilities(
+            self._with_timeout(
+                self._analytics_client.get_capabilities(
                 consumer_system=consumer_system,
                 tenant_id=tenant_id,
                 correlation_id=correlation_id,
+                )
             ),
-            self._dpm_client.get_capabilities(
+            self._with_timeout(
+                self._dpm_client.get_capabilities(
                 consumer_system=consumer_system,
                 tenant_id=tenant_id,
                 correlation_id=correlation_id,
+                )
             ),
-            self._reporting_client.get_capabilities(
+            self._with_timeout(
+                self._reporting_client.get_capabilities(
                 consumer_system=consumer_system,
                 tenant_id=tenant_id,
                 correlation_id=correlation_id,
+                )
             ),
-            self._lotus_core_query_client.get_effective_policy(
+            self._with_timeout(
+                self._lotus_core_query_client.get_effective_policy(
                 consumer_system=consumer_system,
                 tenant_id=tenant_id,
                 correlation_id=correlation_id,
+                )
             ),
         ]
         optional_sources: list[str] = []
         if self._risk_client is not None:
             tasks.append(
-                self._risk_client.get_capabilities(
+                self._with_timeout(self._risk_client.get_capabilities(
                     consumer_system=consumer_system,
                     tenant_id=tenant_id,
                     correlation_id=correlation_id,
-                )
+                ))
             )
             optional_sources.append("risk")
         if self._manage_client is not None:
             tasks.append(
-                self._manage_client.get_capabilities(
+                self._with_timeout(self._manage_client.get_capabilities(
                     consumer_system=consumer_system,
                     tenant_id=tenant_id,
                     correlation_id=correlation_id,
-                )
+                ))
             )
             optional_sources.append("manage")
 
@@ -174,6 +186,9 @@ class PlatformCapabilitiesService:
             normalized=normalized,
         )
         return PlatformCapabilitiesResponse(data=data)
+
+    async def _with_timeout(self, coroutine: Any) -> Any:
+        return await asyncio.wait_for(coroutine, timeout=self._source_timeout_seconds)
 
     def _build_normalized_capabilities(
         self,

--- a/src/app/services/platform_capabilities_service.py
+++ b/src/app/services/platform_capabilities_service.py
@@ -43,57 +43,61 @@ class PlatformCapabilitiesService:
         tasks: list[Any] = [
             self._with_timeout(
                 self._lotus_core_query_client.get_capabilities(
-                consumer_system=consumer_system,
-                tenant_id=tenant_id,
-                correlation_id=correlation_id,
+                    consumer_system=consumer_system,
+                    tenant_id=tenant_id,
+                    correlation_id=correlation_id,
                 )
             ),
             self._with_timeout(
                 self._analytics_client.get_capabilities(
-                consumer_system=consumer_system,
-                tenant_id=tenant_id,
-                correlation_id=correlation_id,
+                    consumer_system=consumer_system,
+                    tenant_id=tenant_id,
+                    correlation_id=correlation_id,
                 )
             ),
             self._with_timeout(
                 self._dpm_client.get_capabilities(
-                consumer_system=consumer_system,
-                tenant_id=tenant_id,
-                correlation_id=correlation_id,
+                    consumer_system=consumer_system,
+                    tenant_id=tenant_id,
+                    correlation_id=correlation_id,
                 )
             ),
             self._with_timeout(
                 self._reporting_client.get_capabilities(
-                consumer_system=consumer_system,
-                tenant_id=tenant_id,
-                correlation_id=correlation_id,
+                    consumer_system=consumer_system,
+                    tenant_id=tenant_id,
+                    correlation_id=correlation_id,
                 )
             ),
             self._with_timeout(
                 self._lotus_core_query_client.get_effective_policy(
-                consumer_system=consumer_system,
-                tenant_id=tenant_id,
-                correlation_id=correlation_id,
+                    consumer_system=consumer_system,
+                    tenant_id=tenant_id,
+                    correlation_id=correlation_id,
                 )
             ),
         ]
         optional_sources: list[str] = []
         if self._risk_client is not None:
             tasks.append(
-                self._with_timeout(self._risk_client.get_capabilities(
-                    consumer_system=consumer_system,
-                    tenant_id=tenant_id,
-                    correlation_id=correlation_id,
-                ))
+                self._with_timeout(
+                    self._risk_client.get_capabilities(
+                        consumer_system=consumer_system,
+                        tenant_id=tenant_id,
+                        correlation_id=correlation_id,
+                    )
+                )
             )
             optional_sources.append("risk")
         if self._manage_client is not None:
             tasks.append(
-                self._with_timeout(self._manage_client.get_capabilities(
-                    consumer_system=consumer_system,
-                    tenant_id=tenant_id,
-                    correlation_id=correlation_id,
-                ))
+                self._with_timeout(
+                    self._manage_client.get_capabilities(
+                        consumer_system=consumer_system,
+                        tenant_id=tenant_id,
+                        correlation_id=correlation_id,
+                    )
+                )
             )
             optional_sources.append("manage")
 

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -10,6 +10,7 @@ from app.contracts.portfolio import (
     PortfolioActivityBucketSummary,
     PortfolioActivitySummaryResponse,
     PortfolioAllocationBucket,
+    PortfolioAllocationLookThroughCapability,
     PortfolioAllocationResponse,
     PortfolioAllocationView,
     PortfolioBookResponse,
@@ -33,7 +34,9 @@ from app.contracts.portfolio import (
     PortfolioPositionView,
     PortfolioProfile,
     PortfolioProjectedCashflowResponse,
+    PortfolioReadinessBucket,
     PortfolioReadinessIndicator,
+    PortfolioReadinessReason,
     PortfolioReadinessResponse,
     PortfolioSummary,
     PortfolioTopPosition,
@@ -101,13 +104,15 @@ class PortfolioService:
         portfolio_id: str,
         correlation_id: str,
         as_of_date: str | None,
+        reporting_currency: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get_cached_upstream_result(
-            ("aum", portfolio_id, as_of_date),
+            ("aum", portfolio_id, as_of_date, reporting_currency),
             lambda: self._lotus_core_query_client.query_assets_under_management(
                 correlation_id=correlation_id,
                 portfolio_id=portfolio_id,
                 as_of_date=as_of_date,
+                reporting_currency=reporting_currency,
             ),
         )
 
@@ -116,13 +121,15 @@ class PortfolioService:
         portfolio_id: str,
         correlation_id: str,
         as_of_date: str | None,
+        reporting_currency: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get_cached_upstream_result(
-            ("cash_balances", portfolio_id, as_of_date),
+            ("cash_balances", portfolio_id, as_of_date, reporting_currency),
             lambda: self._lotus_core_query_client.query_cash_balances(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 as_of_date=as_of_date,
+                reporting_currency=reporting_currency,
             ),
         )
 
@@ -157,15 +164,26 @@ class PortfolioService:
         correlation_id: str,
         as_of_date: str | None,
         dimensions: list[str],
+        reporting_currency: str | None = None,
+        look_through_mode: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
         dimensions_key = tuple(dimensions)
         return await self._get_cached_upstream_result(
-            ("asset_allocation", portfolio_id, as_of_date, dimensions_key),
+            (
+                "asset_allocation",
+                portfolio_id,
+                as_of_date,
+                dimensions_key,
+                reporting_currency,
+                look_through_mode,
+            ),
             lambda: self._lotus_core_query_client.query_asset_allocation(
                 correlation_id=correlation_id,
                 portfolio_id=portfolio_id,
                 as_of_date=as_of_date,
                 dimensions=dimensions,
+                reporting_currency=reporting_currency,
+                look_through_mode=look_through_mode,
             ),
         )
 
@@ -175,9 +193,10 @@ class PortfolioService:
         correlation_id: str,
         as_of_date: str | None,
         include_projected: bool,
+        reporting_currency: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get_cached_upstream_result(
-            ("positions", portfolio_id, as_of_date, include_projected),
+            ("positions", portfolio_id, as_of_date, include_projected, reporting_currency),
             lambda: self._lotus_core_query_client.get_portfolio_positions(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
@@ -196,6 +215,7 @@ class PortfolioService:
         skip: int,
         limit: int,
         transaction_type: str | None,
+        security_id: str | None,
         start_date: str | None,
         end_date: str | None,
     ) -> tuple[int, dict[str, Any]]:
@@ -208,6 +228,7 @@ class PortfolioService:
                 skip,
                 limit,
                 transaction_type,
+                security_id,
                 start_date,
                 end_date,
             ),
@@ -219,6 +240,7 @@ class PortfolioService:
                 skip=skip,
                 limit=limit,
                 transaction_type=transaction_type,
+                security_id=security_id,
                 start_date=start_date,
                 end_date=end_date,
             ),
@@ -230,14 +252,16 @@ class PortfolioService:
         correlation_id: str,
         start_date: str,
         end_date: str,
+        reporting_currency: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get_cached_upstream_result(
-            ("income_summary", portfolio_id, start_date, end_date),
+            ("income_summary", portfolio_id, start_date, end_date, reporting_currency),
             lambda: self._lotus_core_query_client.query_income_summary(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 start_date=start_date,
                 end_date=end_date,
+                reporting_currency=reporting_currency,
             ),
         )
 
@@ -247,14 +271,31 @@ class PortfolioService:
         correlation_id: str,
         start_date: str,
         end_date: str,
+        reporting_currency: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get_cached_upstream_result(
-            ("activity_summary", portfolio_id, start_date, end_date),
+            ("activity_summary", portfolio_id, start_date, end_date, reporting_currency),
             lambda: self._lotus_core_query_client.query_activity_summary(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 start_date=start_date,
                 end_date=end_date,
+                reporting_currency=reporting_currency,
+            ),
+        )
+
+    async def _get_portfolio_readiness_result(
+        self,
+        portfolio_id: str,
+        correlation_id: str,
+        as_of_date: str | None,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get_cached_upstream_result(
+            ("readiness", portfolio_id, as_of_date),
+            lambda: self._lotus_core_query_client.get_portfolio_readiness(
+                portfolio_id=portfolio_id,
+                correlation_id=correlation_id,
+                as_of_date=as_of_date,
             ),
         )
 
@@ -275,7 +316,11 @@ class PortfolioService:
         )
 
     async def get_portfolio_workspace(
-        self, portfolio_id: str, correlation_id: str, as_of_date: str | None = None
+        self,
+        portfolio_id: str,
+        correlation_id: str,
+        as_of_date: str | None = None,
+        reporting_currency: str | None = None,
     ) -> PortfolioWorkspaceResponse:
         effective_as_of_date = as_of_date or datetime.now(UTC).date().isoformat()
         (
@@ -284,12 +329,14 @@ class PortfolioService:
             support_result,
             cashflow_result,
             cash_balance_result,
+            readiness_result,
         ) = await asyncio.gather(
             self._get_portfolio_result(portfolio_id=portfolio_id, correlation_id=correlation_id),
             self._query_aum_result(
                 correlation_id=correlation_id,
                 portfolio_id=portfolio_id,
                 as_of_date=effective_as_of_date,
+                reporting_currency=reporting_currency,
             ),
             self._get_support_overview_result(
                 portfolio_id=portfolio_id,
@@ -303,6 +350,12 @@ class PortfolioService:
                 horizon_days=10,
             ),
             self._query_cash_balances_result(
+                portfolio_id=portfolio_id,
+                correlation_id=correlation_id,
+                as_of_date=effective_as_of_date,
+                reporting_currency=reporting_currency,
+            ),
+            self._get_portfolio_readiness_result(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 as_of_date=effective_as_of_date,
@@ -327,7 +380,7 @@ class PortfolioService:
             profile=profile,
             summary=summary,
             cashflow_outlook=cashflow_outlook,
-            reporting=self._reporting_readiness(summary),
+            reporting=self._reporting_readiness(summary, readiness_result),
             operations=operations,
             workflow_cues=self._build_workflow_cues(portfolio_id),
             warnings=warnings,
@@ -337,8 +390,13 @@ class PortfolioService:
     async def get_portfolio_readiness(
         self, portfolio_id: str, correlation_id: str, as_of_date: str | None
     ) -> PortfolioReadinessResponse:
-        workspace, positions, allocations, transactions = await asyncio.gather(
+        workspace, source_readiness, positions, allocations, transactions = await asyncio.gather(
             self.get_portfolio_workspace(
+                portfolio_id=portfolio_id,
+                correlation_id=correlation_id,
+                as_of_date=as_of_date,
+            ),
+            self._get_portfolio_readiness_result(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 as_of_date=as_of_date,
@@ -363,7 +421,17 @@ class PortfolioService:
                 limit=1,
             ),
         )
-        indicators = self._build_readiness_indicators(
+        source_payload = self._optional_payload(
+            source_readiness,
+            "lotus-core",
+            "PORTFOLIO_SOURCE_READINESS_UNAVAILABLE",
+            [],
+            [],
+        )
+        indicators = self._build_source_readiness_indicators(
+            payload=source_payload,
+            detailed_view=False,
+        ) or self._build_readiness_indicators(
             workspace=workspace,
             positions=positions.positions,
             allocation_views=allocations.views,
@@ -375,6 +443,13 @@ class PortfolioService:
             contract_version=settings.contract_version,
             portfolio_id=portfolio_id,
             as_of_date=workspace.as_of_date,
+            holdings=self._parse_readiness_bucket((source_payload or {}).get("holdings")),
+            pricing=self._parse_readiness_bucket((source_payload or {}).get("pricing")),
+            transactions=self._parse_readiness_bucket((source_payload or {}).get("transactions")),
+            reporting=self._parse_readiness_bucket((source_payload or {}).get("reporting")),
+            blocking_reasons=self._parse_readiness_reasons(
+                (source_payload or {}).get("blocking_reasons")
+            ),
             indicators=indicators,
         )
 
@@ -409,6 +484,7 @@ class PortfolioService:
             self.get_activity_summary(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
+                as_of_date=as_of_date,
                 start_date=None,
                 end_date=None,
             ),
@@ -514,6 +590,7 @@ class PortfolioService:
         portfolio_id: str,
         correlation_id: str,
         as_of_date: str | None,
+        reporting_currency: str | None = None,
     ) -> PortfolioLiquidityResponse:
         warnings: list[str] = []
         partial_failures: list[PortfolioPartialFailure] = []
@@ -523,12 +600,16 @@ class PortfolioService:
             cashflow_result,
         ) = await asyncio.gather(
             self._query_aum_result(
-                correlation_id=correlation_id, portfolio_id=portfolio_id, as_of_date=as_of_date
+                correlation_id=correlation_id,
+                portfolio_id=portfolio_id,
+                as_of_date=as_of_date,
+                reporting_currency=reporting_currency,
             ),
             self._query_cash_balances_result(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 as_of_date=as_of_date,
+                reporting_currency=reporting_currency,
             ),
             self._get_cashflow_projection_result(
                 portfolio_id=portfolio_id,
@@ -598,6 +679,8 @@ class PortfolioService:
         portfolio_id: str,
         correlation_id: str,
         as_of_date: str | None,
+        reporting_currency: str | None = None,
+        look_through_mode: str | None = "direct_only",
     ) -> PortfolioAllocationResponse:
         (
             aum_result,
@@ -605,18 +688,24 @@ class PortfolioService:
             allocation_result,
         ) = await asyncio.gather(
             self._query_aum_result(
-                correlation_id=correlation_id, portfolio_id=portfolio_id, as_of_date=as_of_date
+                correlation_id=correlation_id,
+                portfolio_id=portfolio_id,
+                as_of_date=as_of_date,
+                reporting_currency=reporting_currency,
             ),
             self._query_cash_balances_result(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 as_of_date=as_of_date,
+                reporting_currency=reporting_currency,
             ),
             self._query_asset_allocation_result(
                 correlation_id=correlation_id,
                 portfolio_id=portfolio_id,
                 as_of_date=as_of_date,
-                dimensions=["asset_class", "currency", "sector"],
+                dimensions=["asset_class", "currency", "sector", "region"],
+                reporting_currency=reporting_currency,
+                look_through_mode=look_through_mode,
             ),
         )
         aum_payload = self._require_payload(
@@ -635,6 +724,11 @@ class PortfolioService:
             as_of_date=str(
                 aum_payload.get("resolved_as_of_date") or as_of_date or datetime.now(UTC).date()
             ),
+            reporting_currency=self._optional_str(allocation_payload.get("reporting_currency"))
+            or reporting_currency,
+            look_through=self._parse_look_through_capability(
+                allocation_payload.get("look_through")
+            ),
             summary=summary,
             views=self._parse_allocation_views(allocation_payload),
         )
@@ -645,6 +739,7 @@ class PortfolioService:
         correlation_id: str,
         as_of_date: str | None,
         include_projected: bool,
+        reporting_currency: str | None = None,
     ) -> PortfolioPositionBookResponse:
         (
             aum_result,
@@ -652,18 +747,23 @@ class PortfolioService:
             positions_result,
         ) = await asyncio.gather(
             self._query_aum_result(
-                correlation_id=correlation_id, portfolio_id=portfolio_id, as_of_date=as_of_date
+                correlation_id=correlation_id,
+                portfolio_id=portfolio_id,
+                as_of_date=as_of_date,
+                reporting_currency=reporting_currency,
             ),
             self._query_cash_balances_result(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 as_of_date=as_of_date,
+                reporting_currency=reporting_currency,
             ),
             self._get_portfolio_positions_result(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 as_of_date=as_of_date,
                 include_projected=include_projected,
+                reporting_currency=reporting_currency,
             ),
         )
         aum_payload = self._require_payload(
@@ -697,6 +797,7 @@ class PortfolioService:
         skip: int,
         limit: int,
         transaction_type: str | None = None,
+        security_id: str | None = None,
         start_date: str | None = None,
         end_date: str | None = None,
     ) -> PortfolioTransactionLedgerResponse:
@@ -708,6 +809,7 @@ class PortfolioService:
             skip=skip,
             limit=limit,
             transaction_type=transaction_type,
+            security_id=security_id,
             start_date=start_date,
             end_date=end_date,
         )
@@ -740,15 +842,22 @@ class PortfolioService:
         self,
         portfolio_id: str,
         correlation_id: str,
-        start_date: str | None,
-        end_date: str | None,
+        as_of_date: str | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        reporting_currency: str | None = None,
     ) -> PortfolioIncomeSummaryResponse:
-        window_start, window_end = self._resolve_reporting_window(start_date, end_date)
+        window_start, window_end = self._resolve_reporting_window(
+            start_date,
+            end_date,
+            default_end_date=as_of_date,
+        )
         status_code, payload = await self._query_income_summary_result(
             portfolio_id=portfolio_id,
             correlation_id=correlation_id,
             start_date=window_start.isoformat(),
             end_date=window_end.isoformat(),
+            reporting_currency=reporting_currency,
         )
         result_payload = self._require_payload(
             result=(status_code, payload),
@@ -770,7 +879,9 @@ class PortfolioService:
             correlation_id=correlation_id,
             contract_version=settings.contract_version,
             portfolio_id=portfolio_id,
-            reporting_currency=str(result_payload.get("reporting_currency", "USD")),
+            reporting_currency=str(
+                result_payload.get("reporting_currency", reporting_currency or "USD")
+            ),
             window_start_date=window_start.isoformat(),
             window_end_date=window_end.isoformat(),
             totals_requested_window=self._parse_income_period_summary(
@@ -786,15 +897,22 @@ class PortfolioService:
         self,
         portfolio_id: str,
         correlation_id: str,
-        start_date: str | None,
-        end_date: str | None,
+        as_of_date: str | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        reporting_currency: str | None = None,
     ) -> PortfolioActivitySummaryResponse:
-        window_start, window_end = self._resolve_reporting_window(start_date, end_date)
+        window_start, window_end = self._resolve_reporting_window(
+            start_date,
+            end_date,
+            default_end_date=as_of_date,
+        )
         status_code, payload = await self._query_activity_summary_result(
             portfolio_id=portfolio_id,
             correlation_id=correlation_id,
             start_date=window_start.isoformat(),
             end_date=window_end.isoformat(),
+            reporting_currency=reporting_currency,
         )
         result_payload = self._require_payload(
             result=(status_code, payload),
@@ -804,7 +922,9 @@ class PortfolioService:
             correlation_id=correlation_id,
             contract_version=settings.contract_version,
             portfolio_id=portfolio_id,
-            reporting_currency=str(result_payload.get("reporting_currency", "USD")),
+            reporting_currency=str(
+                result_payload.get("reporting_currency", reporting_currency or "USD")
+            ),
             window_start_date=window_start.isoformat(),
             window_end_date=window_end.isoformat(),
             buckets=[
@@ -1109,6 +1229,7 @@ class PortfolioService:
         return PortfolioTransactionView(
             transaction_id=str(item.get("transaction_id", "")),
             transaction_date=str(item.get("transaction_date", "")),
+            settlement_date=self._optional_str(item.get("settlement_date")),
             transaction_type=str(item.get("transaction_type", "")),
             component_type=self._optional_str(item.get("component_type")),
             security_id=str(item.get("security_id", "")),
@@ -1178,9 +1299,28 @@ class PortfolioService:
             transaction_count=int(payload.get("transaction_count", 0)),
         )
 
-    def _reporting_readiness(self, summary: PortfolioSummary):
+    def _reporting_readiness(
+        self,
+        summary: PortfolioSummary,
+        readiness_result: tuple[int, dict[str, Any]] | None = None,
+    ):
         from app.contracts.portfolio import PortfolioReportingReadiness
 
+        if readiness_result is not None:
+            payload = self._optional_payload(
+                readiness_result,
+                "lotus-core",
+                "PORTFOLIO_SOURCE_READINESS_UNAVAILABLE",
+                [],
+                [],
+            )
+            if payload is not None:
+                reporting_bucket = payload.get("reporting")
+                if isinstance(reporting_bucket, dict):
+                    return PortfolioReportingReadiness(
+                        status=str(reporting_bucket.get("status", "UNKNOWN")).strip().upper(),
+                        row_count=summary.position_count,
+                    )
         return PortfolioReportingReadiness(
             status="READY" if summary.position_count > 0 else "EMPTY",
             row_count=summary.position_count,
@@ -1698,6 +1838,97 @@ class PortfolioService:
         }
         return mapping.get(key, "Open the next available workflow for this portfolio.")
 
+    def _parse_look_through_capability(
+        self, payload: Any
+    ) -> PortfolioAllocationLookThroughCapability | None:
+        if not isinstance(payload, dict):
+            return None
+        requested_mode = self._optional_str(payload.get("requested_mode"))
+        effective_mode = self._optional_str(payload.get("effective_mode"))
+        if requested_mode is None or effective_mode is None:
+            return None
+        return PortfolioAllocationLookThroughCapability(
+            requested_mode=requested_mode,
+            effective_mode=effective_mode,
+            applied=bool(payload.get("applied", False)),
+        )
+
+    def _parse_readiness_bucket(self, payload: Any) -> PortfolioReadinessBucket | None:
+        if not isinstance(payload, dict):
+            return None
+        status_value = self._optional_str(payload.get("status"))
+        if status_value is None:
+            return None
+        return PortfolioReadinessBucket(
+            status=self._map_source_readiness_status(status_value),
+            reasons=self._parse_readiness_reasons(payload.get("reasons")),
+        )
+
+    def _parse_readiness_reasons(self, payload: Any) -> list[PortfolioReadinessReason]:
+        if not isinstance(payload, list):
+            return []
+        reasons: list[PortfolioReadinessReason] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            code = self._optional_str(item.get("code"))
+            if code is None:
+                continue
+            reasons.append(
+                PortfolioReadinessReason(
+                    code=code,
+                    detail=self._optional_str(item.get("detail")),
+                )
+            )
+        return reasons
+
+    def _build_source_readiness_indicators(
+        self, payload: dict[str, Any] | None, detailed_view: bool
+    ) -> list[PortfolioReadinessIndicator]:
+        if payload is None:
+            return []
+        return [
+            PortfolioReadinessIndicator(
+                key="holdings",
+                label="Holdings",
+                status=self._map_source_readiness_status(payload.get("holdings", {}).get("status")),
+                href="#portfolio-drilldown" if detailed_view else "#portfolio-insights",
+            ),
+            PortfolioReadinessIndicator(
+                key="pricing",
+                label="Pricing",
+                status=self._map_source_readiness_status(payload.get("pricing", {}).get("status")),
+                href="#portfolio-attention",
+            ),
+            PortfolioReadinessIndicator(
+                key="transactions",
+                label="Transactions",
+                status=self._map_source_readiness_status(
+                    payload.get("transactions", {}).get("status")
+                ),
+                href="#portfolio-drilldown" if detailed_view else "#portfolio-insights",
+            ),
+            PortfolioReadinessIndicator(
+                key="reporting",
+                label="Reporting",
+                status=self._map_source_readiness_status(
+                    payload.get("reporting", {}).get("status")
+                ),
+                href="#portfolio-health",
+            ),
+        ]
+
+    def _map_source_readiness_status(self, status_value: Any) -> str:
+        normalized = str(status_value or "").strip().upper()
+        mapping = {
+            "READY": "Ready",
+            "PENDING": "Pending",
+            "BLOCKED": "Blocked",
+            "FAILED": "Blocked",
+            "EMPTY": "Empty",
+        }
+        return mapping.get(normalized, "Pending" if normalized else "Unknown")
+
     def _optional_payload(
         self,
         result: tuple[int, dict[str, Any]],
@@ -1737,8 +1968,15 @@ class PortfolioService:
         self,
         start_date: str | None,
         end_date: str | None,
+        default_end_date: str | None = None,
     ) -> tuple[date, date]:
-        window_end = date.fromisoformat(end_date) if end_date else datetime.now(UTC).date()
+        window_end = (
+            date.fromisoformat(end_date)
+            if end_date
+            else date.fromisoformat(default_end_date)
+            if default_end_date
+            else datetime.now(UTC).date()
+        )
         window_start = (
             date.fromisoformat(start_date) if start_date else window_end - timedelta(days=29)
         )

--- a/tests/integration/test_portfolio_router.py
+++ b/tests/integration/test_portfolio_router.py
@@ -40,6 +40,15 @@ def test_portfolio_workspace_router(monkeypatch):
     async def _support(*args, **kwargs):
         return 200, {"business_date": "2026-03-27", "publish_allowed": True}
 
+    async def _readiness(*args, **kwargs):
+        return 200, {
+            "holdings": {"status": "READY", "reasons": []},
+            "pricing": {"status": "READY", "reasons": []},
+            "transactions": {"status": "READY", "reasons": []},
+            "reporting": {"status": "READY", "reasons": []},
+            "blocking_reasons": [],
+        }
+
     async def _cashflow(*args, **kwargs):
         return 200, {
             "as_of_date": "2026-03-27",
@@ -59,6 +68,7 @@ def test_portfolio_workspace_router(monkeypatch):
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio", _get_portfolio)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.query_assets_under_management", _query_aum)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_support_overview", _support)
+    monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_readiness", _readiness)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_cashflow_projection", _cashflow)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.query_cash_balances", _cash_balances)
 

--- a/tests/unit/test_performance_workspace_service.py
+++ b/tests/unit/test_performance_workspace_service.py
@@ -832,6 +832,30 @@ async def test_performance_workspace_service_projects_detail_contract():
 
 
 @pytest.mark.asyncio
+async def test_performance_workspace_service_projects_portfolio_performance_snapshot():
+    service = PerformanceWorkspaceService(
+        workbench_service=_StubWorkbenchService(),
+        analytics_client=_StubAnalyticsClient(),
+        lotus_core_query_client=_StubLotusCoreQueryClient(),
+    )
+
+    response = await service.get_portfolio_performance_snapshot(
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-performance",
+        period="YTD",
+        chart_frequency="monthly",
+        detail_basis="NET",
+        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+    )
+
+    assert response.portfolio_return_pct == 15.1
+    assert response.benchmark_return_pct == 14.72
+    assert response.excess_return_pct == 0.38
+    assert response.sparkline[0].as_of_date == "2026-01-31"
+    assert response.sparkline[0].portfolio_return_pct == 2.0
+
+
+@pytest.mark.asyncio
 async def test_performance_workspace_service_aligns_mismatched_dimensions_to_shared_segment():
     analytics_client = _StubAnalyticsClient()
     service = PerformanceWorkspaceService(

--- a/tests/unit/test_performance_workspace_service.py
+++ b/tests/unit/test_performance_workspace_service.py
@@ -684,8 +684,7 @@ async def test_performance_workspace_service_resolves_linked_benchmark_when_code
 
     assert response.benchmark_code == "BMK_GLOBAL_BALANCED_60_40"
     assert (
-        analytics_client.workspace_summary_calls[0]["benchmark_id"]
-        == "BMK_GLOBAL_BALANCED_60_40"
+        analytics_client.workspace_summary_calls[0]["benchmark_id"] == "BMK_GLOBAL_BALANCED_60_40"
     )
     assert query_client.benchmark_assignment_calls[0]["portfolio_id"] == "DEMO_ADV_USD_001"
 

--- a/tests/unit/test_portfolio_service.py
+++ b/tests/unit/test_portfolio_service.py
@@ -43,6 +43,15 @@ class _StubLotusCoreQueryClient:
             "controls_blocking": False,
         }
 
+    async def get_portfolio_readiness(self, portfolio_id: str, correlation_id: str, **kwargs):
+        return 200, {
+            "holdings": {"status": "READY", "reasons": []},
+            "pricing": {"status": "READY", "reasons": []},
+            "transactions": {"status": "READY", "reasons": []},
+            "reporting": {"status": "READY", "reasons": []},
+            "blocking_reasons": [],
+        }
+
     async def get_cashflow_projection(self, portfolio_id: str, correlation_id: str, **kwargs):
         return 200, {
             "as_of_date": "2026-03-27",
@@ -239,6 +248,10 @@ class _CountingLotusCoreQueryClient(_StubLotusCoreQueryClient):
     async def get_support_overview(self, portfolio_id: str, correlation_id: str):
         self._record("get_support_overview")
         return await super().get_support_overview(portfolio_id, correlation_id)
+
+    async def get_portfolio_readiness(self, portfolio_id: str, correlation_id: str, **kwargs):
+        self._record("get_portfolio_readiness")
+        return await super().get_portfolio_readiness(portfolio_id, correlation_id, **kwargs)
 
     async def get_cashflow_projection(self, portfolio_id: str, correlation_id: str, **kwargs):
         self._record("get_cashflow_projection")

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -359,8 +359,7 @@ async def test_lotus_core_query_client_fetches_benchmark_assignment():
     assert payload["benchmark_id"] == "BMK_PB_GLOBAL_BALANCED_60_40"
     request = _FakeAsyncClient.calls[0]
     assert request["url"] == (
-        "http://core-control/integration/portfolios/"
-        "PB_SG_GLOBAL_BAL_001/benchmark-assignment"
+        "http://core-control/integration/portfolios/PB_SG_GLOBAL_BAL_001/benchmark-assignment"
     )
     assert request["json"] == {
         "as_of_date": "2026-03-28",


### PR DESCRIPTION
## Summary
- pass source-owned portfolio contract fields through gateway portfolio APIs, including readiness buckets, reporting currency, settlement date, look-through allocation posture, and transaction security filtering
- add a portfolio performance snapshot endpoint backed by existing performance workspace service logic
- refresh monetary-float governance allowlist for the updated contract surface

## Validation
- `python -m pytest tests\unit\test_portfolio_service.py tests\integration\test_portfolio_router.py tests\unit\test_performance_workspace_service.py tests\unit\test_upstream_clients.py -q`
- `python -m ruff check src\app\clients\lotus_core_query_client.py src\app\contracts\portfolio.py src\app\routers\portfolio.py src\app\services\performance_workspace_service.py src\app\services\platform_capabilities_service.py src\app\services\portfolio_service.py tests\integration\test_portfolio_router.py tests\unit\test_performance_workspace_service.py tests\unit\test_portfolio_service.py tests\unit\test_upstream_clients.py`
- `git diff --check main...fix/benchmark-resolution-dedupe`