### PR TITLE
Publish RFC-0097 advisor-brief task-flow posture

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -35,7 +35,7 @@ Current repository posture:
 4. domain-product catalog, dependency-graph, and live trust certification discovery routes are
    active under `/api/v1/domain-products`,
 5. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
-6. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids,
+6. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
 7. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
 
 ## Architecture And Module Map

--- a/docs/rfcs/RFC-0097-slice-gateway-task-flow-posture-review.md
+++ b/docs/rfcs/RFC-0097-slice-gateway-task-flow-posture-review.md
@@ -42,6 +42,13 @@ posture without deriving review states or replacement lineage from narrative tex
    - passed with existing CRLF normalization warnings only.
 6. `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway`
    - reported expected branch-local drift for `Integrations.md`; publish after merge to `main`.
+7. Post-review contract correction: parser now accepts real upstream `workflow_pack_version`.
+   `python -m pytest tests\unit\test_advisor_brief_service.py tests\unit\test_upstream_clients.py tests\integration\test_workbench_router.py tests\contract\test_workbench_contract.py -q`
+   - 95 passed.
+8. Post-review `python -m ruff check src\app\services\advisor_brief_service.py tests\unit\test_advisor_brief_service.py`
+   - passed.
+9. Post-review `make typecheck`
+   - passed.
 
 ## Remaining RFC-0097 Gaps
 

--- a/docs/rfcs/RFC-0097-slice-gateway-task-flow-posture-review.md
+++ b/docs/rfcs/RFC-0097-slice-gateway-task-flow-posture-review.md
@@ -49,6 +49,9 @@ posture without deriving review states or replacement lineage from narrative tex
    - passed.
 9. Post-review `make typecheck`
    - passed.
+10. Handoff-readiness follow-up: gateway now preserves `handoff_refs` from upstream task-flow posture.
+    `python -m pytest tests\unit\test_advisor_brief_service.py tests\unit\test_upstream_clients.py tests\integration\test_workbench_router.py tests\contract\test_workbench_contract.py -q`
+    - 95 passed.
 
 ## Remaining RFC-0097 Gaps
 

--- a/docs/rfcs/RFC-0097-slice-gateway-task-flow-posture-review.md
+++ b/docs/rfcs/RFC-0097-slice-gateway-task-flow-posture-review.md
@@ -1,0 +1,52 @@
+# RFC-0097 Gateway Task-Flow Posture Slice Review
+
+## Scope
+
+This slice publishes bounded `lotus-ai` RFC-0097 task-flow posture through the existing
+advisor-brief Gateway contract. Gateway remains a composition boundary: it forwards filters to
+`lotus-ai`, selects the task flow linked to the advisor-brief run id, and preserves returned
+posture without deriving review states or replacement lineage from narrative text.
+
+## Implemented
+
+1. `LotusAiClient` can read filtered workflow-pack task-flow catalog posture from `lotus-ai`.
+2. `AdvisorBriefResponse` now carries optional `workflow_pack_task_flow` posture.
+3. Advisor-brief execution and review-action responses refresh both run posture and task-flow
+   posture.
+4. Replacement lineage is preserved as structured task-flow lineage for `REVISE` and `SUPERSEDE`.
+5. RFC-0082 upstream-family documentation and Gateway wiki integration notes now describe the
+   bounded task-flow posture dependency.
+
+## Review Findings
+
+1. The slice uses the existing advisor-brief product contract instead of adding a thin generic
+   pass-through route.
+2. Gateway does not infer task-flow state from review-action requests or summaries; it only preserves
+   the `lotus-ai` read model.
+3. The task-flow parser fails closed to `None` on malformed or unavailable upstream posture, which
+   keeps the advisor brief usable while avoiding invented lineage.
+4. The focused tests prove both client forwarding and product-contract preservation; broader
+   Workbench rendering remains a downstream slice.
+
+## Proof
+
+1. `python -m pytest tests\unit\test_advisor_brief_service.py tests\unit\test_upstream_clients.py tests\integration\test_workbench_router.py -q`
+   - 92 passed.
+2. `python -m ruff check ...touched gateway files...`
+   - passed.
+3. `python -m pytest tests\unit\test_advisor_brief_service.py tests\unit\test_upstream_clients.py tests\integration\test_workbench_router.py tests\contract\test_workbench_contract.py -q`
+   - 95 passed.
+4. `make typecheck`
+   - passed.
+5. `git diff --check`
+   - passed with existing CRLF normalization warnings only.
+6. `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway`
+   - reported expected branch-local drift for `Integrations.md`; publish after merge to `main`.
+
+## Remaining RFC-0097 Gaps
+
+1. Workbench must consume and render the Gateway task-flow posture without relying on fallback data.
+2. Heartbeat attention needs an adapter for stale, blocked, degraded, and review-waiting task flows.
+3. Domain handoff execution remains a future cross-service slice.
+4. Final governance review, API certification check, docs/context/wiki publication, and branch
+   hygiene remain required before RFC closure.

--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -43,7 +43,7 @@ outputs.
 | `lotus-advise` | proposal lifecycle and advisory workflow surfaces | proposal workflow composition | advisory decision workflow remains in `lotus-advise` |
 | `lotus-manage` | management workflow surfaces where split routing still applies | management workflow composition | discretionary management operations remain in `lotus-manage` |
 | `lotus-report` | report snapshot rows | report-ready experience payloads | report generation and report row semantics remain in `lotus-report` |
-| `lotus-ai` | advisor-brief and AI-supported surfaces | evidence-grounded narrative support | gateway must not invent unsupported evidence or model outputs |
+| `lotus-ai` | advisor-brief, workflow-pack run-ledger, and RFC-0097 task-flow posture surfaces | evidence-grounded narrative support plus bounded run/task-flow posture for Workbench | gateway must not invent unsupported evidence, model outputs, review states, replacement lineage, or task-flow authority |
 
 ## Conformance Rules
 

--- a/src/app/clients/lotus_ai_client.py
+++ b/src/app/clients/lotus_ai_client.py
@@ -118,6 +118,33 @@ class LotusAiClient:
             retry_timeout_exceptions=False,
         )
 
+    async def list_workflow_pack_task_flows(
+        self,
+        *,
+        correlation_id: str,
+        workflow_pack_id: str | None = None,
+        caller: str | None = None,
+        workflow_surface: str | None = None,
+        limit: int = 25,
+    ) -> tuple[int, dict[str, Any]]:
+        params: dict[str, Any] = {"limit": limit}
+        if workflow_pack_id is not None:
+            params["workflow_pack_id"] = workflow_pack_id
+        if caller is not None:
+            params["caller"] = caller
+        if workflow_surface is not None:
+            params["workflow_surface"] = workflow_surface
+        return await request_with_retry(
+            method="GET",
+            url=f"{self._base_url}/platform/workflow-packs/task-flows",
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            params=params,
+            headers=propagation_headers(correlation_id),
+            retry_timeout_exceptions=False,
+        )
+
     async def apply_workflow_pack_run_review_action(
         self,
         *,

--- a/src/app/contracts/advisor_brief.py
+++ b/src/app/contracts/advisor_brief.py
@@ -225,6 +225,67 @@ class AdvisorBriefWorkflowPackRun(BaseModel):
     )
 
 
+class AdvisorBriefWorkflowPackTaskFlowLineage(BaseModel):
+    superseded_run_id: str = Field(
+        description="Workflow-pack run id superseded by this lineage edge.",
+        examples=["packrun_advisor_brief_req-1"],
+    )
+    replacement_run_id: str = Field(
+        description="Replacement workflow-pack run id preserving lineage.",
+        examples=["packrun_advisor_brief_req-2"],
+    )
+    review_action_ref: str = Field(
+        description="Review action that created the replacement lineage edge.",
+        examples=["REVISE"],
+    )
+    reason: str = Field(
+        description="Operator reason preserved with the replacement lineage edge.",
+        examples=["Advisor requested a revised brief."],
+    )
+
+
+class AdvisorBriefWorkflowPackTaskFlow(BaseModel):
+    task_flow_id: str = Field(
+        description="Stable lotus-ai task-flow identifier linked to this advisor-brief run.",
+        examples=["taskflow_advisor_brief_packrun_advisor_brief_req-1"],
+    )
+    workflow_pack_id: str = Field(
+        description="Workflow-pack id that owns this task-flow record.",
+        examples=["advisor_brief.pack"],
+    )
+    version: str = Field(description="Workflow-pack version for this task flow.", examples=["v1"])
+    flow_status: str = Field(
+        description="Current lotus-ai task-flow lifecycle state.",
+        examples=["WAITING_FOR_REVIEW"],
+    )
+    current_step_id: str | None = Field(
+        default=None,
+        description="Current task-flow step id when the task flow is active or waiting.",
+        examples=["generate_advisor_brief"],
+    )
+    run_refs: list[str] = Field(
+        default_factory=list,
+        description="Workflow-pack run ids linked to this task flow.",
+        examples=[["packrun_advisor_brief_req-1"]],
+    )
+    review_states: dict[str, str] = Field(
+        default_factory=dict,
+        description="Review-state snapshot by run or review id as emitted by lotus-ai.",
+    )
+    supportability_status: str = Field(
+        description="Current lotus-ai supportability posture for this task flow.",
+        examples=["ACTION_REQUIRED"],
+    )
+    replacement_lineage: list[AdvisorBriefWorkflowPackTaskFlowLineage] = Field(
+        default_factory=list,
+        description="Replacement lineage preserved from lotus-ai task-flow posture.",
+    )
+    updated_at: str = Field(
+        description="UTC timestamp when lotus-ai last updated the task flow.",
+        examples=["2026-04-21T03:22:00Z"],
+    )
+
+
 class AdvisorBriefResponse(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
@@ -395,6 +456,18 @@ class AdvisorBriefResponse(BaseModel):
                         }
                     ],
                 },
+                "workflow_pack_task_flow": {
+                    "task_flow_id": "taskflow_advisor_brief_packrun_advisor_brief_air_123",
+                    "workflow_pack_id": "advisor_brief.pack",
+                    "version": "v1",
+                    "flow_status": "WAITING_FOR_REVIEW",
+                    "current_step_id": "generate_advisor_brief",
+                    "run_refs": ["packrun_advisor_brief_air_123"],
+                    "review_states": {"packrun_advisor_brief_air_123": "AWAITING_REVIEW"},
+                    "supportability_status": "ACTION_REQUIRED",
+                    "replacement_lineage": [],
+                    "updated_at": "2026-04-04T07:45:21Z",
+                },
                 "warnings": ["AI_DEGRADED"],
                 "partial_failures": [
                     {
@@ -523,6 +596,13 @@ class AdvisorBriefResponse(BaseModel):
         description=(
             "Bounded lotus-ai workflow-pack run posture preserved for the advisor brief when the "
             "shared run-ledger contract is available."
+        ),
+    )
+    workflow_pack_task_flow: AdvisorBriefWorkflowPackTaskFlow | None = Field(
+        default=None,
+        description=(
+            "Bounded lotus-ai task-flow posture linked to the advisor-brief run when the "
+            "RFC-0097 task-flow contract is available."
         ),
     )
     warnings: list[str] = Field(

--- a/src/app/contracts/advisor_brief.py
+++ b/src/app/contracts/advisor_brief.py
@@ -244,6 +244,25 @@ class AdvisorBriefWorkflowPackTaskFlowLineage(BaseModel):
     )
 
 
+class AdvisorBriefWorkflowPackTaskFlowHandoff(BaseModel):
+    handoff_id: str = Field(
+        description="Stable task-flow handoff identifier emitted by lotus-ai.",
+        examples=["taskflow_advisor_brief_req-1_handoff_packrun_advisor_brief_req-1"],
+    )
+    owner_service: str = Field(
+        description="Service boundary that owns the consequence-bearing handoff.",
+        examples=["lotus-gateway"],
+    )
+    status: str = Field(
+        description="Current lotus-ai handoff readiness posture.",
+        examples=["READY_FOR_HANDOFF"],
+    )
+    domain_ref: str | None = Field(
+        default=None,
+        description="Domain-owned workflow reference when the owner service has created one.",
+    )
+
+
 class AdvisorBriefWorkflowPackTaskFlow(BaseModel):
     task_flow_id: str = Field(
         description="Stable lotus-ai task-flow identifier linked to this advisor-brief run.",
@@ -279,6 +298,10 @@ class AdvisorBriefWorkflowPackTaskFlow(BaseModel):
     replacement_lineage: list[AdvisorBriefWorkflowPackTaskFlowLineage] = Field(
         default_factory=list,
         description="Replacement lineage preserved from lotus-ai task-flow posture.",
+    )
+    handoff_refs: list[AdvisorBriefWorkflowPackTaskFlowHandoff] = Field(
+        default_factory=list,
+        description="Domain-owner handoff posture preserved from lotus-ai task-flow posture.",
     )
     updated_at: str = Field(
         description="UTC timestamp when lotus-ai last updated the task flow.",
@@ -466,6 +489,7 @@ class AdvisorBriefResponse(BaseModel):
                     "review_states": {"packrun_advisor_brief_air_123": "AWAITING_REVIEW"},
                     "supportability_status": "ACTION_REQUIRED",
                     "replacement_lineage": [],
+                    "handoff_refs": [],
                     "updated_at": "2026-04-04T07:45:21Z",
                 },
                 "warnings": ["AI_DEGRADED"],

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -17,6 +17,8 @@ from app.contracts.advisor_brief import (
     AdvisorBriefWorkflowPackRun,
     AdvisorBriefWorkflowPackRunFinding,
     AdvisorBriefWorkflowPackRunReviewActionRequest,
+    AdvisorBriefWorkflowPackTaskFlow,
+    AdvisorBriefWorkflowPackTaskFlowLineage,
 )
 from app.contracts.performance_workspace import (
     AttributionSummaryView,
@@ -285,6 +287,11 @@ class AdvisorBriefService:
             ai_audit=ai_audit,
             correlation_id=correlation_id,
         )
+        workflow_pack_task_flow = await _load_advisor_brief_workflow_pack_task_flow(
+            lotus_ai_client=self._lotus_ai_client,
+            ai_audit=ai_audit,
+            correlation_id=correlation_id,
+        )
 
         return AdvisorBriefResponse(
             correlation_id=correlation_id,
@@ -313,6 +320,7 @@ class AdvisorBriefService:
             ai_audit=ai_audit,
             ai_evidence=ai_evidence,
             workflow_pack_run=workflow_pack_run,
+            workflow_pack_task_flow=workflow_pack_task_flow,
             warnings=workspace.warnings,
             partial_failures=workspace.partial_failures,
         )
@@ -379,8 +387,18 @@ class AdvisorBriefService:
             ai_audit=brief.ai_audit,
             correlation_id=correlation_id,
         )
+        workflow_pack_task_flow = await _load_advisor_brief_workflow_pack_task_flow(
+            lotus_ai_client=self._lotus_ai_client,
+            ai_audit=brief.ai_audit,
+            correlation_id=correlation_id,
+        )
         self.clear_cache()
-        return brief.model_copy(update={"workflow_pack_run": workflow_pack_run})
+        return brief.model_copy(
+            update={
+                "workflow_pack_run": workflow_pack_run,
+                "workflow_pack_task_flow": workflow_pack_task_flow,
+            }
+        )
 
 
 async def _load_advisor_brief_workflow_pack_run(
@@ -449,6 +467,112 @@ def _resolve_advisor_brief_workflow_pack_run_id(*, ai_audit: dict[str, Any]) -> 
     if request_id is None:
         return None
     return f"packrun_advisor_brief_{request_id}"
+
+
+async def _load_advisor_brief_workflow_pack_task_flow(
+    *,
+    lotus_ai_client: LotusAiClient,
+    ai_audit: dict[str, Any],
+    correlation_id: str,
+) -> AdvisorBriefWorkflowPackTaskFlow | None:
+    run_id = _resolve_advisor_brief_workflow_pack_run_id(ai_audit=ai_audit)
+    if run_id is None:
+        return None
+
+    task_flow_status, task_flow_payload = await lotus_ai_client.list_workflow_pack_task_flows(
+        correlation_id=correlation_id,
+        workflow_pack_id="advisor_brief.pack",
+        caller="lotus-gateway",
+        workflow_surface="advisor-brief-workspace",
+        limit=25,
+    )
+    if task_flow_status != 200:
+        return None
+
+    for value in _safe_list(task_flow_payload.get("task_flows")):
+        task_flow = _parse_advisor_brief_workflow_pack_task_flow(value=value, run_id=run_id)
+        if task_flow is not None:
+            return task_flow
+    return None
+
+
+def _parse_advisor_brief_workflow_pack_task_flow(
+    *,
+    value: Any,
+    run_id: str,
+) -> AdvisorBriefWorkflowPackTaskFlow | None:
+    item = _safe_dict(value)
+    run_refs = [
+        ref for ref in (_safe_str(value) for value in _safe_list(item.get("run_refs"))) if ref
+    ]
+    if run_id not in run_refs:
+        return None
+
+    task_flow_id = _safe_str(item.get("task_flow_id"))
+    workflow_pack_id = _safe_str(item.get("workflow_pack_id"))
+    version = _safe_str(item.get("version"))
+    flow_status = _safe_str(item.get("flow_status"))
+    supportability_status = _safe_str(item.get("supportability_status"))
+    updated_at = _safe_str(item.get("updated_at"))
+    if task_flow_id is None:
+        return None
+    if workflow_pack_id is None:
+        return None
+    if version is None:
+        return None
+    if flow_status is None:
+        return None
+    if supportability_status is None:
+        return None
+    if updated_at is None:
+        return None
+
+    lineage = [
+        lineage_item
+        for lineage_item in (
+            _parse_task_flow_lineage(value=value)
+            for value in _safe_list(item.get("replacement_lineage"))
+        )
+        if lineage_item is not None
+    ]
+    review_states = {
+        str(key): str(value)
+        for key, value in _safe_dict(item.get("review_states")).items()
+        if key and value
+    }
+    return AdvisorBriefWorkflowPackTaskFlow(
+        task_flow_id=task_flow_id,
+        workflow_pack_id=workflow_pack_id,
+        version=version,
+        flow_status=flow_status,
+        current_step_id=_safe_str(item.get("current_step_id")),
+        run_refs=run_refs,
+        review_states=review_states,
+        supportability_status=supportability_status,
+        replacement_lineage=lineage,
+        updated_at=updated_at,
+    )
+
+
+def _parse_task_flow_lineage(*, value: Any) -> AdvisorBriefWorkflowPackTaskFlowLineage | None:
+    item = _safe_dict(value)
+    superseded_run_id = _safe_str(item.get("superseded_run_id"))
+    replacement_run_id = _safe_str(item.get("replacement_run_id"))
+    review_action_ref = _safe_str(item.get("review_action_ref"))
+    reason = _safe_str(item.get("reason"))
+    if (
+        superseded_run_id is None
+        or replacement_run_id is None
+        or review_action_ref is None
+        or reason is None
+    ):
+        return None
+    return AdvisorBriefWorkflowPackTaskFlowLineage(
+        superseded_run_id=superseded_run_id,
+        replacement_run_id=replacement_run_id,
+        review_action_ref=review_action_ref,
+        reason=reason,
+    )
 
 
 def _parse_workflow_pack_run_finding(*, value: Any) -> AdvisorBriefWorkflowPackRunFinding | None:

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -18,6 +18,7 @@ from app.contracts.advisor_brief import (
     AdvisorBriefWorkflowPackRunFinding,
     AdvisorBriefWorkflowPackRunReviewActionRequest,
     AdvisorBriefWorkflowPackTaskFlow,
+    AdvisorBriefWorkflowPackTaskFlowHandoff,
     AdvisorBriefWorkflowPackTaskFlowLineage,
 )
 from app.contracts.performance_workspace import (
@@ -535,6 +536,13 @@ def _parse_advisor_brief_workflow_pack_task_flow(
         )
         if lineage_item is not None
     ]
+    handoff_refs = [
+        handoff
+        for handoff in (
+            _parse_task_flow_handoff(value=value) for value in _safe_list(item.get("handoff_refs"))
+        )
+        if handoff is not None
+    ]
     review_states = {
         str(key): str(value)
         for key, value in _safe_dict(item.get("review_states")).items()
@@ -550,6 +558,7 @@ def _parse_advisor_brief_workflow_pack_task_flow(
         review_states=review_states,
         supportability_status=supportability_status,
         replacement_lineage=lineage,
+        handoff_refs=handoff_refs,
         updated_at=updated_at,
     )
 
@@ -572,6 +581,21 @@ def _parse_task_flow_lineage(*, value: Any) -> AdvisorBriefWorkflowPackTaskFlowL
         replacement_run_id=replacement_run_id,
         review_action_ref=review_action_ref,
         reason=reason,
+    )
+
+
+def _parse_task_flow_handoff(*, value: Any) -> AdvisorBriefWorkflowPackTaskFlowHandoff | None:
+    item = _safe_dict(value)
+    handoff_id = _safe_str(item.get("handoff_id"))
+    owner_service = _safe_str(item.get("owner_service"))
+    status = _safe_str(item.get("status"))
+    if handoff_id is None or owner_service is None or status is None:
+        return None
+    return AdvisorBriefWorkflowPackTaskFlowHandoff(
+        handoff_id=handoff_id,
+        owner_service=owner_service,
+        status=status,
+        domain_ref=_safe_str(item.get("domain_ref")),
     )
 
 

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -510,7 +510,7 @@ def _parse_advisor_brief_workflow_pack_task_flow(
 
     task_flow_id = _safe_str(item.get("task_flow_id"))
     workflow_pack_id = _safe_str(item.get("workflow_pack_id"))
-    version = _safe_str(item.get("version"))
+    version = _safe_str(item.get("workflow_pack_version")) or _safe_str(item.get("version"))
     flow_status = _safe_str(item.get("flow_status"))
     supportability_status = _safe_str(item.get("supportability_status"))
     updated_at = _safe_str(item.get("updated_at"))

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -12,6 +12,8 @@ from app.contracts.advisor_brief import (
     AdvisorBriefWorkflowPackRun,
     AdvisorBriefWorkflowPackRunFinding,
     AdvisorBriefWorkflowPackRunReviewActionRequest,
+    AdvisorBriefWorkflowPackTaskFlow,
+    AdvisorBriefWorkflowPackTaskFlowLineage,
 )
 from app.contracts.workbench import WorkbenchPortfolioSummary
 from app.main import app
@@ -2064,6 +2066,10 @@ def test_workbench_performance_advisor_brief_openapi_contract():
     response_schema = schema["components"]["schemas"]["AdvisorBriefResponse"]
     narrative_schema = schema["components"]["schemas"]["AdvisorBriefNarrativeItem"]
     evidence_ref_schema = schema["components"]["schemas"]["AdvisorBriefEvidenceRef"]
+    task_flow_schema = schema["components"]["schemas"]["AdvisorBriefWorkflowPackTaskFlow"]
+    task_flow_lineage_schema = schema["components"]["schemas"][
+        "AdvisorBriefWorkflowPackTaskFlowLineage"
+    ]
 
     assert "lotus-ai" in route["description"]
     assert portfolio_parameter["description"]
@@ -2089,6 +2095,10 @@ def test_workbench_performance_advisor_brief_openapi_contract():
     )
     assert response_schema["properties"]["supportability"]["description"]
     assert response_schema["properties"]["workflow_pack_run"]["description"]
+    assert response_schema["properties"]["workflow_pack_task_flow"]["description"]
+    assert task_flow_schema["properties"]["flow_status"]["description"]
+    assert task_flow_schema["properties"]["replacement_lineage"]["description"]
+    assert task_flow_lineage_schema["properties"]["replacement_run_id"]["description"]
     assert response_schema["properties"]["warnings"]["examples"] == [["AI_DEGRADED"]]
     assert (
         response_schema["properties"]["partial_failures"]["examples"][0][0]["source"]
@@ -2412,6 +2422,25 @@ def test_workbench_performance_advisor_brief_review_action_router(monkeypatch):
                 replacement_run_id="packrun_advisor_brief_req-2",
                 findings=[],
             ),
+            workflow_pack_task_flow=AdvisorBriefWorkflowPackTaskFlow(
+                task_flow_id="taskflow_advisor_brief_req-1",
+                workflow_pack_id="advisor_brief.pack",
+                version="v1",
+                flow_status="SUPERSEDED",
+                current_step_id=None,
+                run_refs=["packrun_advisor_brief_req-1"],
+                review_states={"packrun_advisor_brief_req-1": "SUPERSEDED"},
+                supportability_status="HISTORICAL",
+                replacement_lineage=[
+                    AdvisorBriefWorkflowPackTaskFlowLineage(
+                        superseded_run_id="packrun_advisor_brief_req-1",
+                        replacement_run_id="packrun_advisor_brief_req-2",
+                        review_action_ref="SUPERSEDE",
+                        reason="Advisor brief superseded in favor of the replacement run.",
+                    )
+                ],
+                updated_at="2026-04-21T03:00:00Z",
+            ),
         )
 
     monkeypatch.setattr(
@@ -2441,6 +2470,14 @@ def test_workbench_performance_advisor_brief_review_action_router(monkeypatch):
     assert body["workflow_pack_run"]["supportability_status"] == "HISTORICAL"
     assert body["workflow_pack_run"]["superseded"] is True
     assert body["workflow_pack_run"]["replacement_run_id"] == "packrun_advisor_brief_req-2"
+    assert body["workflow_pack_task_flow"]["flow_status"] == "SUPERSEDED"
+    assert body["workflow_pack_task_flow"]["supportability_status"] == "HISTORICAL"
+    assert body["workflow_pack_task_flow"]["replacement_lineage"][0] == {
+        "superseded_run_id": "packrun_advisor_brief_req-1",
+        "replacement_run_id": "packrun_advisor_brief_req-2",
+        "review_action_ref": "SUPERSEDE",
+        "reason": "Advisor brief superseded in favor of the replacement run.",
+    }
     assert captured == {
         "portfolio_id": "PF_1001",
         "correlation_id": "corr-advisor-brief-review",

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -13,6 +13,7 @@ from app.contracts.advisor_brief import (
     AdvisorBriefWorkflowPackRunFinding,
     AdvisorBriefWorkflowPackRunReviewActionRequest,
     AdvisorBriefWorkflowPackTaskFlow,
+    AdvisorBriefWorkflowPackTaskFlowHandoff,
     AdvisorBriefWorkflowPackTaskFlowLineage,
 )
 from app.contracts.workbench import WorkbenchPortfolioSummary
@@ -2070,6 +2071,9 @@ def test_workbench_performance_advisor_brief_openapi_contract():
     task_flow_lineage_schema = schema["components"]["schemas"][
         "AdvisorBriefWorkflowPackTaskFlowLineage"
     ]
+    task_flow_handoff_schema = schema["components"]["schemas"][
+        "AdvisorBriefWorkflowPackTaskFlowHandoff"
+    ]
 
     assert "lotus-ai" in route["description"]
     assert portfolio_parameter["description"]
@@ -2098,7 +2102,9 @@ def test_workbench_performance_advisor_brief_openapi_contract():
     assert response_schema["properties"]["workflow_pack_task_flow"]["description"]
     assert task_flow_schema["properties"]["flow_status"]["description"]
     assert task_flow_schema["properties"]["replacement_lineage"]["description"]
+    assert task_flow_schema["properties"]["handoff_refs"]["description"]
     assert task_flow_lineage_schema["properties"]["replacement_run_id"]["description"]
+    assert task_flow_handoff_schema["properties"]["owner_service"]["description"]
     assert response_schema["properties"]["warnings"]["examples"] == [["AI_DEGRADED"]]
     assert (
         response_schema["properties"]["partial_failures"]["examples"][0][0]["source"]
@@ -2439,6 +2445,16 @@ def test_workbench_performance_advisor_brief_review_action_router(monkeypatch):
                         reason="Advisor brief superseded in favor of the replacement run.",
                     )
                 ],
+                handoff_refs=[
+                    AdvisorBriefWorkflowPackTaskFlowHandoff(
+                        handoff_id=(
+                            "taskflow_advisor_brief_req-1_handoff_packrun_advisor_brief_req-1"
+                        ),
+                        owner_service="lotus-gateway",
+                        status="READY_FOR_HANDOFF",
+                        domain_ref=None,
+                    )
+                ],
                 updated_at="2026-04-21T03:00:00Z",
             ),
         )
@@ -2477,6 +2493,12 @@ def test_workbench_performance_advisor_brief_review_action_router(monkeypatch):
         "replacement_run_id": "packrun_advisor_brief_req-2",
         "review_action_ref": "SUPERSEDE",
         "reason": "Advisor brief superseded in favor of the replacement run.",
+    }
+    assert body["workflow_pack_task_flow"]["handoff_refs"][0] == {
+        "handoff_id": "taskflow_advisor_brief_req-1_handoff_packrun_advisor_brief_req-1",
+        "owner_service": "lotus-gateway",
+        "status": "READY_FOR_HANDOFF",
+        "domain_ref": None,
     }
     assert captured == {
         "portfolio_id": "PF_1001",

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -144,9 +144,29 @@ class _StubLotusAiClient:
                 }
             ],
         }
+        self.task_flow_status_code = 200
+        self.task_flow_payload = {
+            "task_flows": [
+                {
+                    "task_flow_id": "taskflow_advisor_brief_req-1",
+                    "workflow_pack_id": "advisor_brief.pack",
+                    "version": "v1",
+                    "flow_status": "WAITING_FOR_REVIEW",
+                    "current_step_id": "generate_advisor_brief",
+                    "run_refs": ["packrun_advisor_brief_req-1"],
+                    "review_states": {
+                        "packrun_advisor_brief_req-1": "AWAITING_REVIEW",
+                    },
+                    "supportability_status": "ACTION_REQUIRED",
+                    "replacement_lineage": [],
+                    "updated_at": "2026-04-21T03:00:00Z",
+                }
+            ]
+        }
         self.execute_calls: list[dict[str, object]] = []
         self.consumer_view_calls: list[dict[str, object]] = []
         self.operator_profile_calls: list[dict[str, object]] = []
+        self.task_flow_calls: list[dict[str, object]] = []
         self.review_action_calls: list[dict[str, object]] = []
         self.review_action_status_code = 200
         self.review_action_payload = {
@@ -194,6 +214,14 @@ class _StubLotusAiClient:
                     "current_summary_note": "Run accepted for bounded downstream workflow use.",
                     "findings": [],
                 }
+                self.task_flow_payload["task_flows"][0] = {
+                    **self.task_flow_payload["task_flows"][0],
+                    "flow_status": "COMPLETED",
+                    "review_states": {
+                        "packrun_advisor_brief_req-1": "ACCEPTED",
+                    },
+                    "supportability_status": "READY",
+                }
             elif action_type == "REVISE":
                 self.operator_profile_payload = {
                     **self.operator_profile_payload,
@@ -206,6 +234,22 @@ class _StubLotusAiClient:
                         "Run was revised in favor of a replacement advisor-brief run."
                     ),
                     "findings": [],
+                }
+                self.task_flow_payload["task_flows"][0] = {
+                    **self.task_flow_payload["task_flows"][0],
+                    "flow_status": "SUPERSEDED",
+                    "review_states": {
+                        "packrun_advisor_brief_req-1": "REVISED",
+                    },
+                    "supportability_status": "HISTORICAL",
+                    "replacement_lineage": [
+                        {
+                            "superseded_run_id": "packrun_advisor_brief_req-1",
+                            "replacement_run_id": replacement_run_id,
+                            "review_action_ref": "REVISE",
+                            "reason": request_payload["reason"],
+                        }
+                    ],
                 }
             elif action_type == "SUPERSEDE":
                 self.operator_profile_payload = {
@@ -220,7 +264,27 @@ class _StubLotusAiClient:
                     ),
                     "findings": [],
                 }
+                self.task_flow_payload["task_flows"][0] = {
+                    **self.task_flow_payload["task_flows"][0],
+                    "flow_status": "SUPERSEDED",
+                    "review_states": {
+                        "packrun_advisor_brief_req-1": "SUPERSEDED",
+                    },
+                    "supportability_status": "HISTORICAL",
+                    "replacement_lineage": [
+                        {
+                            "superseded_run_id": "packrun_advisor_brief_req-1",
+                            "replacement_run_id": replacement_run_id,
+                            "review_action_ref": "SUPERSEDE",
+                            "reason": request_payload["reason"],
+                        }
+                    ],
+                }
         return self.review_action_status_code, self.review_action_payload
+
+    async def list_workflow_pack_task_flows(self, **kwargs):
+        self.task_flow_calls.append(kwargs)
+        return self.task_flow_status_code, self.task_flow_payload
 
 
 @pytest.mark.asyncio
@@ -258,6 +322,21 @@ async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_acti
     assert response.ai_audit["request_id"] == "req-1"
     assert response.ai_audit["provider_mode"] == "openai"
     assert response.ai_audit["provider_id"] == "text.openai"
+    assert response.workflow_pack_task_flow is not None
+    assert response.workflow_pack_task_flow.task_flow_id == "taskflow_advisor_brief_req-1"
+    assert response.workflow_pack_task_flow.flow_status == "WAITING_FOR_REVIEW"
+    assert response.workflow_pack_task_flow.review_states == {
+        "packrun_advisor_brief_req-1": "AWAITING_REVIEW",
+    }
+    assert ai_client.task_flow_calls == [
+        {
+            "correlation_id": "corr-1",
+            "workflow_pack_id": "advisor_brief.pack",
+            "caller": "lotus-gateway",
+            "workflow_surface": "advisor-brief-workspace",
+            "limit": 25,
+        }
+    ]
     assert response.ai_audit["adapter_kind"] == "OPENAI_LIVE"
     assert response.ai_audit["model_id"] == "gpt-5.4"
     assert response.ai_audit["stubbed"] is False
@@ -560,6 +639,7 @@ async def test_advisor_brief_service_reuses_cached_response_for_identical_reques
     assert len(ai_client.execute_calls) == 1
     assert len(ai_client.consumer_view_calls) == 1
     assert len(ai_client.operator_profile_calls) == 1
+    assert len(ai_client.task_flow_calls) == 1
 
 
 @pytest.mark.asyncio
@@ -597,6 +677,7 @@ async def test_advisor_brief_service_cache_key_changes_when_request_shape_change
     assert len(ai_client.execute_calls) == 2
     assert len(ai_client.consumer_view_calls) == 2
     assert len(ai_client.operator_profile_calls) == 2
+    assert len(ai_client.task_flow_calls) == 2
 
 
 @pytest.mark.asyncio
@@ -753,6 +834,12 @@ async def test_advisor_brief_service_applies_review_action_and_returns_updated_r
         == "Run accepted for bounded downstream workflow use."
     )
     assert response.workflow_pack_run.findings == []
+    assert response.workflow_pack_task_flow is not None
+    assert response.workflow_pack_task_flow.flow_status == "COMPLETED"
+    assert response.workflow_pack_task_flow.review_states == {
+        "packrun_advisor_brief_req-1": "ACCEPTED",
+    }
+    assert response.workflow_pack_task_flow.supportability_status == "READY"
     assert ai_client.review_action_calls == [
         {
             "run_id": "packrun_advisor_brief_req-1",
@@ -823,6 +910,17 @@ async def test_advisor_brief_service_preserves_replacement_lineage_for_review_tr
     assert response.workflow_pack_run.superseded is True
     assert response.workflow_pack_run.replacement_run_id == "packrun_advisor_brief_req-2"
     assert response.workflow_pack_run.current_summary_note == expected_summary_note
+    assert response.workflow_pack_task_flow is not None
+    assert response.workflow_pack_task_flow.flow_status == "SUPERSEDED"
+    assert (
+        response.workflow_pack_task_flow.review_states["packrun_advisor_brief_req-1"]
+        == expected_review_state
+    )
+    assert response.workflow_pack_task_flow.supportability_status == "HISTORICAL"
+    assert response.workflow_pack_task_flow.replacement_lineage[0].replacement_run_id == (
+        "packrun_advisor_brief_req-2"
+    )
+    assert response.workflow_pack_task_flow.replacement_lineage[0].review_action_ref == action_type
     assert ai_client.review_action_calls == [
         {
             "run_id": "packrun_advisor_brief_req-1",

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -150,7 +150,7 @@ class _StubLotusAiClient:
                 {
                     "task_flow_id": "taskflow_advisor_brief_req-1",
                     "workflow_pack_id": "advisor_brief.pack",
-                    "version": "v1",
+                    "workflow_pack_version": "v1",
                     "flow_status": "WAITING_FOR_REVIEW",
                     "current_step_id": "generate_advisor_brief",
                     "run_refs": ["packrun_advisor_brief_req-1"],

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -159,6 +159,7 @@ class _StubLotusAiClient:
                     },
                     "supportability_status": "ACTION_REQUIRED",
                     "replacement_lineage": [],
+                    "handoff_refs": [],
                     "updated_at": "2026-04-21T03:00:00Z",
                 }
             ]
@@ -221,6 +222,16 @@ class _StubLotusAiClient:
                         "packrun_advisor_brief_req-1": "ACCEPTED",
                     },
                     "supportability_status": "READY",
+                    "handoff_refs": [
+                        {
+                            "handoff_id": (
+                                "taskflow_advisor_brief_req-1_handoff_packrun_advisor_brief_req-1"
+                            ),
+                            "owner_service": "lotus-gateway",
+                            "status": "READY_FOR_HANDOFF",
+                            "domain_ref": None,
+                        }
+                    ],
                 }
             elif action_type == "REVISE":
                 self.operator_profile_payload = {
@@ -840,6 +851,8 @@ async def test_advisor_brief_service_applies_review_action_and_returns_updated_r
         "packrun_advisor_brief_req-1": "ACCEPTED",
     }
     assert response.workflow_pack_task_flow.supportability_status == "READY"
+    assert response.workflow_pack_task_flow.handoff_refs[0].status == "READY_FOR_HANDOFF"
+    assert response.workflow_pack_task_flow.handoff_refs[0].owner_service == "lotus-gateway"
     assert ai_client.review_action_calls == [
         {
             "run_id": "packrun_advisor_brief_req-1",

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -513,6 +513,44 @@ async def test_lotus_ai_client_calls_explicit_workflow_pack_execution_contract()
 
 
 @pytest.mark.asyncio
+async def test_lotus_ai_client_lists_workflow_pack_task_flows_with_bounded_filters():
+    client = LotusAiClient(base_url="http://ai", timeout_seconds=3.0)
+    _FakeAsyncClient.queue_json(
+        200,
+        {
+            "task_flow_count": 1,
+            "task_flows": [
+                {
+                    "task_flow_id": "taskflow_advisor_brief_req-1",
+                    "workflow_pack_id": "advisor_brief.pack",
+                    "run_refs": ["packrun_advisor_brief_req-1"],
+                }
+            ],
+        },
+    )
+
+    status, payload = await client.list_workflow_pack_task_flows(
+        correlation_id="corr-ai-task-flow-1",
+        workflow_pack_id="advisor_brief.pack",
+        caller="lotus-gateway",
+        workflow_surface="advisor-brief-workspace",
+        limit=25,
+    )
+
+    assert status == 200
+    assert payload["task_flow_count"] == 1
+    assert _FakeAsyncClient.calls[-1]["method"] == "GET"
+    assert _FakeAsyncClient.calls[-1]["url"] == "http://ai/platform/workflow-packs/task-flows"
+    assert _FakeAsyncClient.calls[-1]["params"] == {
+        "limit": 25,
+        "workflow_pack_id": "advisor_brief.pack",
+        "caller": "lotus-gateway",
+        "workflow_surface": "advisor-brief-workspace",
+    }
+    assert _FakeAsyncClient.calls[-1]["headers"]["X-Correlation-Id"] == "corr-ai-task-flow-1"
+
+
+@pytest.mark.asyncio
 async def test_lotus_analytics_client_twr_request_omits_benchmark_when_not_requested():
     client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -20,7 +20,7 @@
 - `lotus-report`
   reporting snapshot, summary, and review payloads
 - `lotus-ai`
-  evidence-grounded advisor brief narration through the explicit workflow-pack execution seam plus shared workflow-pack run-ledger inspection surfaces
+  evidence-grounded advisor brief narration through the explicit workflow-pack execution seam plus shared workflow-pack run-ledger and RFC-0097 task-flow inspection surfaces
 
 ## Canonical local identities
 
@@ -46,3 +46,4 @@
 1. gateway contracts are product-facing and may differ intentionally from upstream parameter shapes
 2. RFC-0082 governs how upstream dependency families are classified
 3. supportability, readiness, and partial-failure metadata should survive composition
+4. advisor-brief responses preserve `lotus-ai` workflow-pack run posture and task-flow lineage but do not make gateway the review-state or task-flow authority


### PR DESCRIPTION
## Summary
- preserve lotus-ai task-flow posture on the gateway advisor-brief contract
- forward replacement lineage and handoff refs without making gateway source truth
- add client, service, router, OpenAPI, and typecheck coverage
- update RFC-0082 docs, repo context, wiki source, and slice review evidence

## Proof
- `python -m pytest tests\unit\test_advisor_brief_service.py tests\unit\test_upstream_clients.py tests\integration\test_workbench_router.py tests\contract\test_workbench_contract.py -q` -> 95 passed
- `make typecheck` passed
- ruff checks on touched gateway files passed
- `git diff --check` passed with CRLF normalization warnings only

## Wiki
- repo-local `wiki/Integrations.md` changed; publish after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-gateway`.