### PR TITLE
Harden reporting review gateway contract for RFC-0002

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ Important current parameter conventions:
 4. `GET /api/v1/domain-products/trust-certification` publishes RFC-0087 platform live trust
    certification when present and returns an explicit unavailable posture when the generated
    artifact is absent
-5. reporting snapshot and reporting portfolio requests use `asOfDate`
+5. reporting snapshot and reporting portfolio requests use `asOfDate`; portfolio review requests
+   also document `benchmarkCode` for RFC-0002 performance and risk context
 6. intake upload routes accept camelCase multipart aliases such as `entityType`, `sampleSize`, and
    `allowPartial`
 7. some lookup filters intentionally remain snake_case, such as `cif_id`, `booking_center`,

--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -38,6 +38,15 @@ class ReportingPortfolioRequest(BaseModel):
         description="Optional look-through mode for allocation expansion in reporting payloads.",
         examples=["direct_only"],
     )
+    benchmark_code: str | None = Field(
+        default=None,
+        alias="benchmarkCode",
+        description=(
+            "Optional benchmark identifier forwarded to lotus-report for performance and risk "
+            "review context."
+        ),
+        examples=["BMK_GLOBAL_BALANCED_60_40"],
+    )
 
     model_config = {"populate_by_name": True, "extra": "allow"}
 
@@ -178,13 +187,43 @@ class ReportingReviewResponse(BaseModel):
     )
     data: dict = Field(
         default_factory=dict,
-        description="Opaque lotus-report review payload returned unchanged by gateway.",
+        description=(
+            "Opaque lotus-report review payload returned unchanged by gateway. The gateway "
+            "preserves RFC-0002 client_sections, advisor_sections, readiness, evidence, and "
+            "partial/unavailable section states for Workbench consumers."
+        ),
         examples=[
             {
                 "portfolio_id": "DEMO_DPM_EUR_001",
-                "overview": {"total_market_value": 1000.0},
-                "performance": {"portfolio_return_ytd_pct": 4.2},
-                "risk_analytics": {"volatility_30d_pct": 9.4},
+                "readiness": {"status": "partial", "reason": "Risk Review unavailable."},
+                "client_sections": [
+                    {
+                        "section_id": "risk_review",
+                        "title": "Risk Review",
+                        "status": "unavailable",
+                        "reason_code": "missing_return_history",
+                    }
+                ],
+                "advisor_sections": [
+                    {
+                        "section_id": "advisor_discussion",
+                        "title": "Advisor Discussion And Follow-Up",
+                        "status": "ready",
+                        "items": [
+                            {
+                                "prompt_id": "review_readiness",
+                                "advisor_only": True,
+                                "route_targets": [
+                                    {
+                                        "surface": "lotus-workbench",
+                                        "route_key": "portfolio_review",
+                                        "mutation_allowed": False,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
             }
         ],
     )

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -47,6 +47,7 @@ REVIEW_REQUEST_EXAMPLES = {
             ],
             "allocationDimensions": ["asset_class"],
             "lookThroughMode": "full",
+            "benchmarkCode": "BMK_GLOBAL_BALANCED_60_40",
         },
     }
 }

--- a/tests/contract/test_reporting_contract.py
+++ b/tests/contract/test_reporting_contract.py
@@ -48,6 +48,7 @@ def test_reporting_request_normalizes_documented_aliases() -> None:
         sections=["WEALTH", "ALLOCATION"],
         allocationDimensions=["asset_class", "currency"],
         lookThroughMode="direct_only",
+        benchmarkCode="BMK_GLOBAL_BALANCED_60_40",
         includeBenchmarks=True,
     )
 
@@ -57,6 +58,7 @@ def test_reporting_request_normalizes_documented_aliases() -> None:
         "sections": ["WEALTH", "ALLOCATION"],
         "allocation_dimensions": ["asset_class", "currency"],
         "look_through_mode": "direct_only",
+        "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
         "includeBenchmarks": True,
     }
 
@@ -114,11 +116,18 @@ def test_reporting_openapi_contract_registered() -> None:
         ]["lookThroughMode"]
         == "full"
     )
+    assert (
+        review_path["requestBody"]["content"]["application/json"]["examples"]["frontOfficeReview"][
+            "value"
+        ]["benchmarkCode"]
+        == "BMK_GLOBAL_BALANCED_60_40"
+    )
     assert request_schema["properties"]["asOfDate"]["description"]
     assert request_schema["properties"]["reportingCurrency"]["description"]
     assert request_schema["properties"]["sections"]["description"]
     assert request_schema["properties"]["allocationDimensions"]["description"]
     assert request_schema["properties"]["lookThroughMode"]["description"]
+    assert request_schema["properties"]["benchmarkCode"]["description"]
     assert snapshot_schema["properties"]["correlationId"]["description"]
     assert snapshot_schema["properties"]["contractVersion"]["description"]
     assert snapshot_schema["properties"]["sourceService"]["description"]
@@ -142,7 +151,11 @@ def test_reporting_openapi_contract_registered() -> None:
     assert review_schema["properties"]["portfolioId"]["description"]
     assert review_schema["properties"]["asOfDate"]["description"]
     assert review_schema["properties"]["data"]["description"]
+    review_example = review_schema["properties"]["data"]["examples"][0]
+    assert review_example["readiness"]["status"] == "partial"
+    assert review_example["client_sections"][0]["status"] == "unavailable"
+    assert review_example["advisor_sections"][0]["items"][0]["advisor_only"] is True
     assert (
-        review_schema["properties"]["data"]["examples"][0]["risk_analytics"]["volatility_30d_pct"]
-        == 9.4
+        review_example["advisor_sections"][0]["items"][0]["route_targets"][0]["mutation_allowed"]
+        is False
     )

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -187,8 +187,43 @@ def test_reporting_review_success(monkeypatch):
             "sections": ["OVERVIEW"],
             "allocation_dimensions": ["asset_class"],
             "look_through_mode": "full",
+            "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
         }
-        return 200, {"portfolio_id": portfolio_id, "overview": {"total_market_value": 1000.0}}
+        return 200, {
+            "portfolio_id": portfolio_id,
+            "readiness": {"status": "partial", "reason": "Risk Review unavailable."},
+            "client_sections": [
+                {
+                    "section_id": "risk_review",
+                    "title": "Risk Review",
+                    "status": "unavailable",
+                    "reason_code": "missing_return_history",
+                    "items": [],
+                }
+            ],
+            "advisor_sections": [
+                {
+                    "section_id": "advisor_discussion",
+                    "title": "Advisor Discussion And Follow-Up",
+                    "status": "ready",
+                    "items": [
+                        {
+                            "prompt_id": "review_readiness",
+                            "advisor_only": True,
+                            "prompt": "Confirm report readiness is partial.",
+                            "route_targets": [
+                                {
+                                    "surface": "lotus-workbench",
+                                    "route_key": "portfolio_review",
+                                    "mutation_allowed": False,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "overview": {"total_market_value": 1000.0},
+        }
 
     monkeypatch.setattr(
         "app.clients.reporting_client.ReportingClient.post_portfolio_review",
@@ -204,6 +239,7 @@ def test_reporting_review_success(monkeypatch):
             "sections": ["OVERVIEW"],
             "allocationDimensions": ["asset_class"],
             "lookThroughMode": "full",
+            "benchmarkCode": "BMK_GLOBAL_BALANCED_60_40",
         },
     )
     assert response.status_code == 200
@@ -215,6 +251,12 @@ def test_reporting_review_success(monkeypatch):
     assert body["asOfDate"] == "2026-02-24"
     assert body["data"]["portfolio_id"] == "DEMO_DPM_EUR_001"
     assert body["data"]["overview"]["total_market_value"] == 1000.0
+    assert body["data"]["readiness"]["status"] == "partial"
+    assert body["data"]["client_sections"][0]["status"] == "unavailable"
+    assert "advisor_only" not in body["data"]["client_sections"][0]
+    advisor_item = body["data"]["advisor_sections"][0]["items"][0]
+    assert advisor_item["advisor_only"] is True
+    assert advisor_item["route_targets"][0]["mutation_allowed"] is False
 
 
 def test_reporting_review_preserves_request_context(monkeypatch):

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -26,7 +26,11 @@
   `producer_repository`, `product_name`, and `product_version`
 - domain-product trust certification returns certified platform trust posture when the RFC-0087
   artifact exists and an explicit unavailable posture when it has not been generated
-- reporting snapshot and reporting request payloads use `asOfDate`
+- reporting snapshot and reporting request payloads use `asOfDate`; portfolio review requests also
+  support `benchmarkCode` for RFC-0002 performance and risk context
+- reporting review preserves `client_sections`, `advisor_sections`, readiness, evidence, and
+  partial/unavailable section states from `lotus-report`; advisor-only material must stay under
+  `advisor_sections`
 - intake upload routes accept camelCase multipart aliases such as `entityType`, `sampleSize`, and
   `allowPartial`
 - selected lookup filters remain snake_case, such as `cif_id`, `booking_center`, `product_type`,
@@ -83,6 +87,14 @@ Reporting summary:
 curl -X POST "http://127.0.0.1:8111/api/v1/reports/DEMO_DPM_EUR_001/summary" \
   -H "Content-Type: application/json" \
   -d "{\"asOfDate\":\"2026-02-24\",\"sections\":[\"WEALTH\",\"ALLOCATION\"],\"allocationDimensions\":[\"asset_class\"]}"
+```
+
+Reporting portfolio review:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/reports/DEMO_DPM_EUR_001/review" \
+  -H "Content-Type: application/json" \
+  -d "{\"asOfDate\":\"2026-02-24\",\"sections\":[\"OVERVIEW\",\"PERFORMANCE\",\"RISK_ANALYTICS\"],\"allocationDimensions\":[\"asset_class\"],\"lookThroughMode\":\"full\",\"benchmarkCode\":\"BMK_GLOBAL_BALANCED_60_40\"}"
 ```
 
 Proposal creation:


### PR DESCRIPTION
## Summary

- Documents and forwards the RFC-0002 enchmarkCode review request field through the gateway reporting contract.
- Updates the reporting review response example to preserve client_sections, ^Gdvisor_sections, readiness, evidence posture, and partial/unavailable states from lotus-report.
- Adds contract/integration assertions that advisor-only material remains under ^Gdvisor_sections and route targets are non-mutating.
- Records gateway wiki/API-surface guidance for Workbench consumers without adding a speculative Workbench preview.

## Validation

- python -m pytest tests/contract/test_reporting_contract.py tests/integration/test_reporting_router.py -q passed: 13 tests.
- make check passed: ruff, format, monetary float guard, mypy, workbench contract smoke, and 340 unit/contract tests.

## Cross-Repo Context

Companion to lotus-report RFC-0002 implementation PR sgajbi/lotus-report#51. Workbench UI preview remains intentionally deferred until the report contract is promoted beyond gateway-readiness proof.

## Remote CI

- GitHub Remote Feature Lane run 24773581491 passed: workflow lint and lint/typecheck/unit.
- GitHub Pull Request Merge Gate run 24773597656 passed: workflow lint, lint/typecheck/unit, integration, coverage, Docker build, and CI-local Docker parity.