### PR TITLE
Normalize gateway risk periods to canonical codes

### DIFF
--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-04-17T14:22:44Z",
+  "generated_at": "2026-04-23T03:30:36Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -682,18 +682,6 @@
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/services/advisor_brief_service.py:992:def _format_pct(value: float | None) -> str:",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-04"
-    },
-    {
-      "finding": "src/app/services/advisor_brief_service.py:998:def _format_currency(value: float | None) -> str:",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-04"
-    },
-    {
       "finding": "src/app/services/foundation_service.py:245:market_value_base = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
@@ -958,28 +946,22 @@
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:1653:def _safe_float(value: Any) -> float | None:",
+      "finding": "src/app/services/risk_workspace_service.py:1655:def _safe_float(value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-20"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:1657:return float(value)",
+      "finding": "src/app/services/risk_workspace_service.py:1659:return float(value)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-20"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:2049:str(key): float(value) if isinstance(value, int | float) else None",
+      "finding": "src/app/services/risk_workspace_service.py:796:value=float(value) if isinstance(value, int | float) else None,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/services/risk_workspace_service.py:794:value=float(value) if isinstance(value, int | float) else None,",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-20"
     },
     {
       "finding": "src/app/services/workbench_service.py:318:current_weight_pct=float(",

--- a/scripts/Start-CanonicalGateway.ps1
+++ b/scripts/Start-CanonicalGateway.ps1
@@ -33,8 +33,8 @@ if ($Foreground) {
 try {
   $existing = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction Stop |
     Select-Object -ExpandProperty OwningProcess -Unique
-  foreach ($pid in $existing) {
-    Stop-Process -Id $pid -Force -ErrorAction SilentlyContinue
+  foreach ($processId in $existing) {
+    Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
   }
 } catch {
 }

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -338,9 +338,9 @@ async def get_workbench_risk_summary(
         description="Optional business as-of date in YYYY-MM-DD format.",
         examples=["2026-02-24"],
     ),
-    reporting_currency: str | None = Query(
-        default=None,
-        description="Optional reporting currency override for the risk summary.",
+    reporting_currency: str = Query(
+        default="USD",
+        description="Reporting currency used for stateful risk and risk-free-rate sourcing.",
         examples=["USD"],
     ),
 ) -> WorkbenchRiskSummaryResponse:
@@ -392,9 +392,9 @@ async def get_workbench_risk_concentration(
         description="Optional business as-of date in YYYY-MM-DD format.",
         examples=["2026-02-24"],
     ),
-    reporting_currency: str | None = Query(
-        default=None,
-        description="Optional reporting currency override for concentration analytics.",
+    reporting_currency: str = Query(
+        default="USD",
+        description="Reporting currency used for stateful concentration analytics.",
         examples=["USD"],
     ),
 ) -> WorkbenchRiskConcentrationResponse:
@@ -449,9 +449,9 @@ async def get_workbench_risk_drawdown(
         description="Optional business as-of date in YYYY-MM-DD format.",
         examples=["2026-02-24"],
     ),
-    reporting_currency: str | None = Query(
-        default=None,
-        description="Optional reporting currency override for drawdown analytics.",
+    reporting_currency: str = Query(
+        default="USD",
+        description="Reporting currency used for stateful drawdown analytics.",
         examples=["USD"],
     ),
     include_underwater_series: bool = Query(
@@ -514,9 +514,11 @@ async def get_workbench_risk_rolling(
         description="Optional business as-of date in YYYY-MM-DD format.",
         examples=["2026-02-24"],
     ),
-    reporting_currency: str | None = Query(
-        default=None,
-        description="Optional reporting currency override for rolling-risk analytics.",
+    reporting_currency: str = Query(
+        default="USD",
+        description=(
+            "Reporting currency used for stateful rolling-risk and risk-free-rate sourcing."
+        ),
         examples=["USD"],
     ),
     include_time_series: bool = Query(
@@ -581,9 +583,9 @@ async def get_workbench_risk_attribution(
         description="Optional business as-of date in YYYY-MM-DD format.",
         examples=["2026-02-24"],
     ),
-    reporting_currency: str | None = Query(
-        default=None,
-        description="Optional reporting currency override for risk attribution analytics.",
+    reporting_currency: str = Query(
+        default="USD",
+        description="Reporting currency used for stateful risk attribution analytics.",
         examples=["USD"],
     ),
     attribution_type: str = Query(

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -48,6 +48,12 @@ _ADVISOR_BRIEF_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 _RISK_WORKSPACE_SERVICE: RiskWorkspaceService | None = None
 _RISK_WORKSPACE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 
+RISK_PERIOD_QUERY_DESCRIPTION = (
+    "Canonical risk horizon. Use platform-governed values such as MTD, QTD, YTD, 1Y, 3Y, 5Y, "
+    "SI, YEAR, or EXPLICIT. Legacy aliases ONE_YEAR, THREE_YEAR, FIVE_YEAR, and ITD may be "
+    "accepted for compatibility but are normalized before calling lotus-risk."
+)
+
 
 def _service_signature() -> tuple[object, ...]:
     return (
@@ -314,7 +320,7 @@ async def get_workbench_risk_summary(
     ),
     period: str = Query(
         default="YTD",
-        description="Risk summary horizon requested by the caller.",
+        description=RISK_PERIOD_QUERY_DESCRIPTION,
         examples=["YTD"],
     ),
     detail_basis: str = Query(
@@ -373,7 +379,7 @@ async def get_workbench_risk_concentration(
     ),
     period: str = Query(
         default="YTD",
-        description="Risk concentration horizon requested by the caller.",
+        description=RISK_PERIOD_QUERY_DESCRIPTION,
         examples=["YTD"],
     ),
     benchmark_code: str | None = Query(
@@ -425,7 +431,7 @@ async def get_workbench_risk_drawdown(
     ),
     period: str = Query(
         default="YTD",
-        description="Risk drawdown horizon requested by the caller.",
+        description=RISK_PERIOD_QUERY_DESCRIPTION,
         examples=["YTD"],
     ),
     detail_basis: str = Query(
@@ -490,7 +496,7 @@ async def get_workbench_risk_rolling(
     ),
     period: str = Query(
         default="YTD",
-        description="Rolling-risk horizon requested by the caller.",
+        description=RISK_PERIOD_QUERY_DESCRIPTION,
         examples=["YTD"],
     ),
     detail_basis: str = Query(
@@ -557,7 +563,7 @@ async def get_workbench_risk_attribution(
     ),
     period: str = Query(
         default="YTD",
-        description="Risk attribution horizon requested by the caller.",
+        description=RISK_PERIOD_QUERY_DESCRIPTION,
         examples=["YTD"],
     ),
     detail_basis: str = Query(

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -1961,14 +1961,16 @@ def _resolve_as_of_date(value: str | None) -> str:
 
 def _normalize_period(value: str) -> str:
     normalized = value.upper()
-    if normalized in {"MTD", "QTD", "YTD", "SI"}:
+    if normalized in {"MTD", "QTD", "YTD", "1Y", "3Y", "5Y", "SI", "YEAR", "EXPLICIT"}:
         return normalized
-    if normalized in {"1Y", "ONE_YEAR"}:
-        return "ONE_YEAR"
-    if normalized in {"3Y", "THREE_YEAR"}:
-        return "THREE_YEAR"
-    if normalized in {"5Y", "FIVE_YEAR"}:
-        return "FIVE_YEAR"
+    if normalized == "ONE_YEAR":
+        return "1Y"
+    if normalized == "THREE_YEAR":
+        return "3Y"
+    if normalized == "FIVE_YEAR":
+        return "5Y"
+    if normalized == "ITD":
+        return "SI"
     return "YTD"
 
 
@@ -2046,7 +2048,7 @@ def _map_rolling_metric_series(
         metric_values_payload = entry.get("metric_values")
         metric_values = (
             {
-                str(key): float(value) if isinstance(value, int | float) else None
+                str(key): _safe_float(value)
                 for key, value in metric_values_payload.items()
                 if isinstance(key, str)
             }

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -107,6 +107,7 @@ _RISK_ATTRIBUTION_ACTIVE_RISK_GATE_REASON = (
     "Issuer is supported for total risk only. Active risk by issuer remains "
     "unavailable until benchmark issuer exposure semantics are approved."
 )
+_DEFAULT_REPORTING_CURRENCY = "USD"
 
 
 class RiskWorkspaceService:
@@ -538,6 +539,7 @@ def _build_summary_request(
     stateful_input: dict[str, Any] = {
         "portfolio_id": portfolio_id,
         "as_of_date": as_of_date,
+        "reporting_currency": _resolve_reporting_currency(reporting_currency),
         "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
         "periods": [{"type": _normalize_period(period), "name": period.upper()}],
         "metrics": _SUMMARY_METRICS,
@@ -552,8 +554,6 @@ def _build_summary_request(
             },
         },
     }
-    if reporting_currency:
-        stateful_input["reporting_currency"] = reporting_currency
     return {"input_mode": "stateful", "stateful_input": stateful_input}
 
 
@@ -566,12 +566,11 @@ def _build_concentration_request(
     stateful_input: dict[str, Any] = {
         "portfolio_id": portfolio_id,
         "as_of_date": as_of_date,
+        "reporting_currency": _resolve_reporting_currency(reporting_currency),
         "include_cash_positions": True,
         "include_zero_quantity_positions": False,
         "top_n": 10,
     }
-    if reporting_currency:
-        stateful_input["reporting_currency"] = reporting_currency
     return {
         "input_mode": "stateful",
         "stateful_input": stateful_input,
@@ -593,6 +592,7 @@ def _build_drawdown_request(
     stateful_input: dict[str, Any] = {
         "portfolio_id": portfolio_id,
         "as_of_date": as_of_date,
+        "reporting_currency": _resolve_reporting_currency(reporting_currency),
         "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
         "periods": [{"type": _normalize_period(period), "name": period.upper()}],
         "benchmark_policy": {
@@ -600,8 +600,6 @@ def _build_drawdown_request(
             "missing_benchmark_policy": "IGNORE",
         },
     }
-    if reporting_currency:
-        stateful_input["reporting_currency"] = reporting_currency
     return {
         "input_mode": "stateful",
         "stateful_input": stateful_input,
@@ -635,6 +633,7 @@ def _build_rolling_request(
     stateful_input: dict[str, Any] = {
         "portfolio_id": portfolio_id,
         "as_of_date": as_of_date,
+        "reporting_currency": _resolve_reporting_currency(reporting_currency),
         "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
         "periods": [{"type": _normalize_period(period), "name": period.upper()}],
         "rolling_options": {
@@ -646,8 +645,6 @@ def _build_rolling_request(
             "include_time_series": include_time_series,
         },
     }
-    if reporting_currency:
-        stateful_input["reporting_currency"] = reporting_currency
     return {"input_mode": "stateful", "stateful_input": stateful_input}
 
 
@@ -665,6 +662,7 @@ def _build_attribution_request(
     stateful_input: dict[str, Any] = {
         "portfolio_id": portfolio_id,
         "as_of_date": as_of_date,
+        "reporting_currency": _resolve_reporting_currency(reporting_currency),
         "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
         "periods": [{"type": _normalize_period(period), "name": period.upper()}],
         "attribution_options": {
@@ -674,11 +672,15 @@ def _build_attribution_request(
             "annualization_basis": 252,
         },
     }
-    if reporting_currency:
-        stateful_input["reporting_currency"] = reporting_currency
     if benchmark_code and attribution_type == "ACTIVE_RISK":
         stateful_input["benchmark_id"] = benchmark_code
     return {"input_mode": "stateful", "stateful_input": stateful_input}
+
+
+def _resolve_reporting_currency(value: str | None) -> str:
+    if value and value.strip():
+        return value.strip().upper()
+    return _DEFAULT_REPORTING_CURRENCY
 
 
 def _normalize_risk_attribution_type(value: str) -> str:

--- a/tests/contract/test_workbench_contract.py
+++ b/tests/contract/test_workbench_contract.py
@@ -206,6 +206,10 @@ def test_workbench_openapi_contract_registered() -> None:
     assert risk_summary_parameters["portfolio_id"]["schema"]["examples"] == ["PF_1001"]
     assert "first-paint" in risk_summary_operation["description"]
     assert risk_summary_parameters["period"]["description"]
+    assert "1Y, 3Y, 5Y" in risk_summary_parameters["period"]["description"]
+    assert (
+        "normalized before calling lotus-risk" in risk_summary_parameters["period"]["description"]
+    )
     assert risk_summary_parameters["period"]["schema"]["default"] == "YTD"
     assert risk_summary_parameters["period"]["schema"]["examples"] == ["YTD"]
     assert risk_summary_parameters["detail_basis"]["description"]
@@ -223,6 +227,7 @@ def test_workbench_openapi_contract_registered() -> None:
     assert risk_concentration_parameters["portfolio_id"]["schema"]["examples"] == ["PF_1001"]
     assert "issuer mapping coverage" in risk_concentration_operation["description"]
     assert risk_concentration_parameters["period"]["description"]
+    assert "1Y, 3Y, 5Y" in risk_concentration_parameters["period"]["description"]
     assert risk_concentration_parameters["period"]["schema"]["default"] == "YTD"
     assert risk_concentration_parameters["period"]["schema"]["examples"] == ["YTD"]
     assert risk_concentration_parameters["benchmark_code"]["description"]
@@ -237,6 +242,7 @@ def test_workbench_openapi_contract_registered() -> None:
     assert risk_drawdown_parameters["portfolio_id"]["schema"]["examples"] == ["PF_1001"]
     assert "include_underwater_series=true" in risk_drawdown_operation["description"]
     assert risk_drawdown_parameters["period"]["description"]
+    assert "1Y, 3Y, 5Y" in risk_drawdown_parameters["period"]["description"]
     assert risk_drawdown_parameters["period"]["schema"]["default"] == "YTD"
     assert risk_drawdown_parameters["detail_basis"]["description"]
     assert risk_drawdown_parameters["detail_basis"]["schema"]["default"] == "NET"
@@ -256,6 +262,7 @@ def test_workbench_openapi_contract_registered() -> None:
     assert "include_time_series=true" in risk_rolling_operation["description"]
     assert "omits rolling sharpe" in risk_rolling_operation["description"].lower()
     assert risk_rolling_parameters["period"]["description"]
+    assert "1Y, 3Y, 5Y" in risk_rolling_parameters["period"]["description"]
     assert risk_rolling_parameters["period"]["schema"]["default"] == "YTD"
     assert risk_rolling_parameters["detail_basis"]["description"]
     assert risk_rolling_parameters["detail_basis"]["schema"]["default"] == "NET"
@@ -278,6 +285,7 @@ def test_workbench_openapi_contract_registered() -> None:
         in (risk_attribution_operation["description"])
     )
     assert risk_attribution_parameters["period"]["description"]
+    assert "1Y, 3Y, 5Y" in risk_attribution_parameters["period"]["description"]
     assert risk_attribution_parameters["period"]["schema"]["default"] == "YTD"
     assert risk_attribution_parameters["detail_basis"]["description"]
     assert risk_attribution_parameters["detail_basis"]["schema"]["default"] == "NET"

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -547,6 +547,52 @@ def test_workbench_risk_summary_router_uses_stateful_gateway_contract(monkeypatc
     assert body["warnings"] == []
     assert body["partial_failures"] == []
     assert captured_payload["stateful_input"]["periods"] == [{"type": "YTD", "name": "YTD"}]
+    assert captured_payload["stateful_input"]["reporting_currency"] == "USD"
+
+
+def test_workbench_risk_summary_router_defaults_reporting_currency_for_risk_free_sourcing(
+    monkeypatch,
+):
+    captured_payload: dict[str, Any] = {}
+
+    async def _risk_calculate(self, payload, correlation_id):  # noqa: ARG001
+        captured_payload.update(payload)
+        return 200, {
+            "scope": {
+                "as_of_date": "2026-04-04",
+                "reporting_currency": "USD",
+                "net_or_gross": "NET",
+            },
+            "results": {
+                "YTD": {
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-04-04",
+                    "metrics": {"SHARPE": {"value": 1.2}},
+                }
+            },
+            "metadata": {
+                "risk_free_context": {
+                    "requested": True,
+                    "applied": True,
+                    "reason": "ANNUAL_RATE_APPLIED",
+                }
+            },
+        }
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.post_risk_calculate",
+        _risk_calculate,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/workbench/PF_RISK_SUMMARY_DEFAULT/risk/summary"
+        "?period=YTD&detail_basis=NET&benchmark_code=BMK_1&as_of_date=2026-04-04",
+        headers={"X-Correlation-Id": "corr-risk-summary-default-currency"},
+    )
+
+    assert response.status_code == 200
+    assert captured_payload["stateful_input"]["reporting_currency"] == "USD"
 
 
 def test_workbench_risk_summary_router_sends_canonical_trailing_period_to_risk(monkeypatch):

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi.testclient import TestClient
 
 from app.contracts.advisor_brief import (
@@ -484,7 +486,10 @@ def test_workbench_analytics_router_preserves_query_context(monkeypatch):
 
 
 def test_workbench_risk_summary_router_uses_stateful_gateway_contract(monkeypatch):
+    captured_payload: dict[str, Any] = {}
+
     async def _risk_calculate(self, payload, correlation_id):  # noqa: ARG001
+        captured_payload.update(payload)
         assert payload["input_mode"] == "stateful"
         assert "stateless_input" not in payload
         assert payload["stateful_input"]["portfolio_id"] == "PF_RISK_SUMMARY"
@@ -541,6 +546,48 @@ def test_workbench_risk_summary_router_uses_stateful_gateway_contract(monkeypatc
     assert body["payload"]["periods"][0]["metrics"][1]["key"] == "SHARPE"
     assert body["warnings"] == []
     assert body["partial_failures"] == []
+    assert captured_payload["stateful_input"]["periods"] == [{"type": "YTD", "name": "YTD"}]
+
+
+def test_workbench_risk_summary_router_sends_canonical_trailing_period_to_risk(monkeypatch):
+    captured_payload: dict[str, Any] = {}
+
+    async def _risk_calculate(self, payload, correlation_id):  # noqa: ARG001
+        captured_payload.update(payload)
+        return 200, {
+            "scope": {
+                "as_of_date": "2026-04-04",
+                "reporting_currency": "USD",
+                "net_or_gross": "NET",
+            },
+            "results": {
+                "3Y": {
+                    "start_date": "2023-04-05",
+                    "end_date": "2026-04-04",
+                    "metrics": {"VOLATILITY": {"value": 0.14}},
+                }
+            },
+        }
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.post_risk_calculate",
+        _risk_calculate,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/workbench/PF_RISK_SUMMARY/risk/summary"
+        "?period=3Y&detail_basis=NET&benchmark_code=BMK_1"
+        "&as_of_date=2026-04-04&reporting_currency=USD",
+        headers={"X-Correlation-Id": "corr-risk-summary-3y"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["payload"]["periods"][0]["key"] == "3Y"
+    assert body["payload"]["periods"][0]["label"] == "3Y"
+    assert body["payload"]["periods"][0]["metrics"][0]["value"] == 0.14
+    assert captured_payload["stateful_input"]["periods"] == [{"type": "3Y", "name": "3Y"}]
 
 
 def test_workbench_risk_concentration_router_maps_stateful_concentration(monkeypatch):


### PR DESCRIPTION
## Summary
- keep Workbench risk gateway calls on platform-governed canonical period codes (`1Y`, `3Y`, `5Y`, `SI`)
- normalize legacy aliases only forward at the gateway API boundary before calling lotus-risk
- update Workbench risk OpenAPI query descriptions so Swagger shows the canonical vocabulary and compatibility behavior
- add integration and OpenAPI contract coverage for canonical period propagation

## Validation
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `python -m pytest tests/integration/test_workbench_router.py::test_workbench_risk_summary_router_uses_stateful_gateway_contract tests/integration/test_workbench_router.py::test_workbench_risk_summary_router_sends_canonical_trailing_period_to_risk -q`

## Docs / Wiki
- Swagger/OpenAPI was updated because it is the consumer-facing API documentation surface for this change.
- No repo-local wiki update is needed: the wiki did not contain stale risk period alias guidance, and duplicating the OpenAPI parameter detail there would create a second source of truth.