### PR TITLE
Add RFC-0100 gateway report job boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It depends on:
 - `lotus-manage`
   management workflow capability when split routing is enabled
 - `lotus-report`
-  reporting snapshot, summary, and review payloads
+  reporting snapshot, summary, review payloads, and durable report job lifecycle
 - `lotus-ai`
   evidence-grounded advisor-brief support through the explicit workflow-pack execution seam and shared run-ledger surfaces
 - `lotus-platform`
@@ -89,6 +89,8 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/workbench/*`
 - `reporting`
   `/api/v1/reports/*`
+- `report-jobs`
+  `/api/v1/report-jobs/*`
 - platform surfaces
   `/health`, `/health/live`, `/health/ready`, `/metrics`, `/docs`
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -32,8 +32,9 @@ Current repository posture:
 1. `lotus-gateway` is the primary backend contract for `lotus-workbench`,
 2. the repository is moving from thin pass-through behavior to a cleaner experience-API posture,
 3. performance, proposal, foundation, reporting, and capability aggregation routes are active,
-4. report job initiation/status/cancellation routes are active for gateway-first portfolio review
-   report job workflows under `/api/v1/reports/portfolio-reviews` and `/api/v1/report-jobs/*`,
+4. report job initiation/status/event-history/cancellation routes are active for gateway-first
+   portfolio review report job workflows under `/api/v1/reports/portfolio-reviews` and
+   `/api/v1/report-jobs/*`,
 5. domain-product catalog, dependency-graph, and live trust certification discovery routes are
    active under `/api/v1/domain-products`,
 6. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -32,11 +32,13 @@ Current repository posture:
 1. `lotus-gateway` is the primary backend contract for `lotus-workbench`,
 2. the repository is moving from thin pass-through behavior to a cleaner experience-API posture,
 3. performance, proposal, foundation, reporting, and capability aggregation routes are active,
-4. domain-product catalog, dependency-graph, and live trust certification discovery routes are
+4. report job initiation/status/cancellation routes are active for gateway-first portfolio review
+   report job workflows under `/api/v1/reports/portfolio-reviews` and `/api/v1/report-jobs/*`,
+5. domain-product catalog, dependency-graph, and live trust certification discovery routes are
    active under `/api/v1/domain-products`,
-5. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
-6. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
-7. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
+6. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
+7. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
+8. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
 
 ## Architecture And Module Map
 

--- a/src/app/clients/reporting_client.py
+++ b/src/app/clients/reporting_client.py
@@ -117,16 +117,19 @@ class ReportingClient:
         self,
         *,
         job_id: str,
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/jobs/{job_id}"
+        headers = propagation_headers(correlation_id)
+        headers.update(caller_headers)
         return await request_with_retry(
             method="GET",
             url=url,
             timeout_seconds=self._timeout,
             max_retries=self._max_retries,
             backoff_seconds=self._retry_backoff_seconds,
-            headers=propagation_headers(correlation_id),
+            headers=headers,
         )
 
     async def cancel_report_job(

--- a/src/app/clients/reporting_client.py
+++ b/src/app/clients/reporting_client.py
@@ -132,6 +132,25 @@ class ReportingClient:
             headers=headers,
         )
 
+    async def get_report_job_events(
+        self,
+        *,
+        job_id: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/jobs/{job_id}/events"
+        headers = propagation_headers(correlation_id)
+        headers.update(caller_headers)
+        return await request_with_retry(
+            method="GET",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=headers,
+        )
+
     async def cancel_report_job(
         self,
         *,

--- a/src/app/clients/reporting_client.py
+++ b/src/app/clients/reporting_client.py
@@ -90,3 +90,60 @@ class ReportingClient:
             json_body=payload,
             headers=headers,
         )
+
+    async def submit_portfolio_review_job(
+        self,
+        *,
+        payload: dict[str, Any],
+        idempotency_key: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/portfolio-reviews"
+        headers = propagation_headers(correlation_id)
+        headers["Idempotency-Key"] = idempotency_key
+        headers.update(caller_headers)
+        return await request_with_retry(
+            method="POST",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            json_body=payload,
+            headers=headers,
+        )
+
+    async def get_report_job(
+        self,
+        *,
+        job_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/jobs/{job_id}"
+        return await request_with_retry(
+            method="GET",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=propagation_headers(correlation_id),
+        )
+
+    async def cancel_report_job(
+        self,
+        *,
+        job_id: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/jobs/{job_id}/cancel"
+        headers = propagation_headers(correlation_id)
+        headers.update(caller_headers)
+        return await request_with_retry(
+            method="POST",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=headers,
+        )

--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -190,3 +190,64 @@ class ReportingReviewResponse(BaseModel):
     )
 
     model_config = {"populate_by_name": True}
+
+
+class PortfolioReviewJobRequest(BaseModel):
+    portfolio_scope: dict[str, Any] = Field(
+        ...,
+        description="Portfolio scope for the report job. First wave supports portfolio_ids.",
+        examples=[{"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]}],
+    )
+    as_of_date: str = Field(
+        ...,
+        description="Business as-of date in YYYY-MM-DD format for the report job.",
+        examples=["2026-04-22"],
+    )
+    requested_output_formats: list[str] = Field(
+        default_factory=lambda: ["json"],
+        description="Requested output formats. The first job-ledger wave accepts JSON intent only.",
+        examples=[["json"]],
+    )
+    reporting_currency: str | None = Field(
+        default=None,
+        description="Optional reporting currency included in the report request hash.",
+        examples=["USD"],
+    )
+    options: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Output-affecting report options included in idempotency hashing.",
+        examples=[
+            {
+                "sections": ["OVERVIEW", "PERFORMANCE", "RISK_ANALYTICS"],
+                "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+            }
+        ],
+    )
+
+
+class ReportJobHandleResponse(BaseModel):
+    report_request_id: str = Field(examples=["rrq_4f7c85b39f7d4e7b8d0bb420d34a1d2c"])
+    report_job_id: str = Field(examples=["rjob_83ca965c50334c40a17d2b8cc94873a5"])
+    status: str = Field(examples=["accepted"])
+    status_url: str = Field(examples=["/api/v1/report-jobs/rjob_83ca965c50334c40a17d2b8cc94873a5"])
+    idempotency_key: str = Field(examples=["portfolio-review-PB_SG_GLOBAL_BAL_001-2026-04-22"])
+
+
+class ReportJobStatusResponse(BaseModel):
+    report_job_id: str = Field(examples=["rjob_83ca965c50334c40a17d2b8cc94873a5"])
+    report_request_id: str = Field(examples=["rrq_4f7c85b39f7d4e7b8d0bb420d34a1d2c"])
+    report_type: str = Field(examples=["portfolio_review"])
+    portfolio_scope: dict[str, Any] = Field(examples=[{"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]}])
+    status: str = Field(examples=["accepted"])
+    failure_category: str | None = Field(default=None, examples=[None])
+    failure_message: str | None = Field(default=None, examples=[None])
+    current_step: str = Field(examples=["accepted"])
+    retry_eligible: bool = Field(examples=[False])
+    cancel_requested: bool = Field(examples=[False])
+    created_at: datetime = Field(examples=["2026-04-22T09:00:00Z"])
+    updated_at: datetime = Field(examples=["2026-04-22T09:00:00Z"])
+    started_at: datetime | None = Field(default=None)
+    completed_at: datetime | None = Field(default=None)
+    cancelled_at: datetime | None = Field(default=None)
+    correlation_id: str = Field(examples=["corr-portfolio-review-1"])
+    trace_id: str = Field(examples=["4bf92f3577b34da6a3ce929d0e0e4736"])

--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -226,28 +226,177 @@ class PortfolioReviewJobRequest(BaseModel):
 
 
 class ReportJobHandleResponse(BaseModel):
-    report_request_id: str = Field(examples=["rrq_4f7c85b39f7d4e7b8d0bb420d34a1d2c"])
-    report_job_id: str = Field(examples=["rjob_83ca965c50334c40a17d2b8cc94873a5"])
-    status: str = Field(examples=["accepted"])
-    status_url: str = Field(examples=["/api/v1/report-jobs/rjob_83ca965c50334c40a17d2b8cc94873a5"])
-    idempotency_key: str = Field(examples=["portfolio-review-PB_SG_GLOBAL_BAL_001-2026-04-22"])
+    report_request_id: str = Field(
+        ...,
+        description="Opaque durable report request identifier stored by lotus-report.",
+        examples=["rrq_4f7c85b39f7d4e7b8d0bb420d34a1d2c"],
+    )
+    report_job_id: str = Field(
+        ...,
+        description="Opaque durable report job identifier used for gateway status operations.",
+        examples=["rjob_83ca965c50334c40a17d2b8cc94873a5"],
+    )
+    status: str = Field(
+        ...,
+        description="Current product-safe report job status.",
+        examples=["accepted"],
+    )
+    status_url: str = Field(
+        ...,
+        description="Gateway-relative URL for product-safe report job status retrieval.",
+        examples=["/api/v1/report-jobs/rjob_83ca965c50334c40a17d2b8cc94873a5"],
+    )
+    idempotency_key: str = Field(
+        ...,
+        description="Caller-supplied idempotency key associated with this job.",
+        examples=["portfolio-review-PB_SG_GLOBAL_BAL_001-2026-04-22"],
+    )
 
 
 class ReportJobStatusResponse(BaseModel):
-    report_job_id: str = Field(examples=["rjob_83ca965c50334c40a17d2b8cc94873a5"])
-    report_request_id: str = Field(examples=["rrq_4f7c85b39f7d4e7b8d0bb420d34a1d2c"])
-    report_type: str = Field(examples=["portfolio_review"])
-    portfolio_scope: dict[str, Any] = Field(examples=[{"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]}])
-    status: str = Field(examples=["accepted"])
-    failure_category: str | None = Field(default=None, examples=[None])
-    failure_message: str | None = Field(default=None, examples=[None])
-    current_step: str = Field(examples=["accepted"])
-    retry_eligible: bool = Field(examples=[False])
-    cancel_requested: bool = Field(examples=[False])
-    created_at: datetime = Field(examples=["2026-04-22T09:00:00Z"])
-    updated_at: datetime = Field(examples=["2026-04-22T09:00:00Z"])
-    started_at: datetime | None = Field(default=None)
-    completed_at: datetime | None = Field(default=None)
-    cancelled_at: datetime | None = Field(default=None)
-    correlation_id: str = Field(examples=["corr-portfolio-review-1"])
-    trace_id: str = Field(examples=["4bf92f3577b34da6a3ce929d0e0e4736"])
+    report_job_id: str = Field(
+        ...,
+        description="Opaque durable report job identifier.",
+        examples=["rjob_83ca965c50334c40a17d2b8cc94873a5"],
+    )
+    report_request_id: str = Field(
+        ...,
+        description="Opaque durable report request identifier linked to this job.",
+        examples=["rrq_4f7c85b39f7d4e7b8d0bb420d34a1d2c"],
+    )
+    report_type: str = Field(
+        ...,
+        description="Report type handled by the job.",
+        examples=["portfolio_review"],
+    )
+    portfolio_scope: dict[str, Any] = Field(
+        ...,
+        description="Portfolio scope submitted for the report job.",
+        examples=[{"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]}],
+    )
+    status: str = Field(..., description="Current product-safe job status.", examples=["accepted"])
+    failure_category: str | None = Field(
+        default=None,
+        description="Machine-readable failure category when failed or cancelled.",
+        examples=[None],
+    )
+    failure_message: str | None = Field(
+        default=None,
+        description="Support-safe failure message when failed or cancelled.",
+        examples=[None],
+    )
+    current_step: str = Field(
+        ...,
+        description="Current lifecycle step for support diagnostics.",
+        examples=["accepted"],
+    )
+    retry_eligible: bool = Field(
+        ...,
+        description="Whether retry or replay is currently permitted.",
+        examples=[False],
+    )
+    cancel_requested: bool = Field(
+        ...,
+        description="Whether cancellation has been requested and recorded.",
+        examples=[False],
+    )
+    created_at: datetime = Field(
+        ...,
+        description="UTC timestamp when the job was created.",
+        examples=["2026-04-22T09:00:00Z"],
+    )
+    updated_at: datetime = Field(
+        ...,
+        description="UTC timestamp for the latest job update.",
+        examples=["2026-04-22T09:00:00Z"],
+    )
+    started_at: datetime | None = Field(
+        default=None,
+        description="UTC timestamp when processing started, if processing has begun.",
+        examples=[None],
+    )
+    completed_at: datetime | None = Field(
+        default=None,
+        description="UTC timestamp when the job completed, if complete.",
+        examples=[None],
+    )
+    cancelled_at: datetime | None = Field(
+        default=None,
+        description="UTC timestamp when the job was cancelled, if cancelled.",
+        examples=[None],
+    )
+    correlation_id: str = Field(
+        ...,
+        description="Correlation identifier captured by lotus-report.",
+        examples=["corr-portfolio-review-1"],
+    )
+    trace_id: str = Field(
+        ...,
+        description="Distributed trace identifier captured by lotus-report.",
+        examples=["4bf92f3577b34da6a3ce929d0e0e4736"],
+    )
+
+
+class ReportStatusEvent(BaseModel):
+    status_event_id: str = Field(
+        ...,
+        description="Opaque append-only status event identifier.",
+        examples=["rse_d7e9c3b87d864b098997d4fe5bd2de2a"],
+    )
+    report_job_id: str = Field(
+        ...,
+        description="Report job identifier associated with this event.",
+        examples=["rjob_83ca965c50334c40a17d2b8cc94873a5"],
+    )
+    from_status: str | None = Field(
+        default=None,
+        description="Previous status when this event is a transition.",
+        examples=[None],
+    )
+    to_status: str = Field(
+        ...,
+        description="New status recorded by this event.",
+        examples=["accepted"],
+    )
+    event_type: str = Field(
+        ...,
+        description="Machine-readable lifecycle event type.",
+        examples=["job_accepted"],
+    )
+    message: str | None = Field(
+        default=None,
+        description="Support-safe lifecycle event message.",
+        examples=["Portfolio review report job accepted."],
+    )
+    actor: str = Field(
+        ...,
+        description="Actor or system principal associated with this event.",
+        examples=["advisor-123"],
+    )
+    created_at: datetime = Field(
+        ...,
+        description="UTC timestamp when this event was appended.",
+        examples=["2026-04-22T09:00:00Z"],
+    )
+    correlation_id: str = Field(
+        ...,
+        description="Correlation identifier associated with this event.",
+        examples=["corr-portfolio-review-1"],
+    )
+    trace_id: str = Field(
+        ...,
+        description="Distributed trace identifier associated with this event.",
+        examples=["4bf92f3577b34da6a3ce929d0e0e4736"],
+    )
+
+
+class ReportJobStatusEventsResponse(BaseModel):
+    report_job_id: str = Field(
+        ...,
+        description="Report job identifier whose event history is returned.",
+        examples=["rjob_83ca965c50334c40a17d2b8cc94873a5"],
+    )
+    events: list[ReportStatusEvent] = Field(
+        ...,
+        description="Append-only lifecycle events ordered by creation time.",
+    )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -16,6 +16,7 @@ from app.routers.intake import router as intake_router
 from app.routers.platform import router as platform_router
 from app.routers.portfolio import router as portfolio_router
 from app.routers.proposals import router as proposals_router
+from app.routers.reporting import jobs_router as reporting_jobs_router
 from app.routers.reporting import router as reporting_router
 from app.routers.workbench import router as workbench_router
 
@@ -41,6 +42,7 @@ app.include_router(foundation_router)
 app.include_router(portfolio_router)
 app.include_router(workbench_router)
 app.include_router(reporting_router)
+app.include_router(reporting_jobs_router)
 
 
 @app.get("/health")

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -1,19 +1,23 @@
 from datetime import UTC, datetime
-from typing import Annotated
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Body, HTTPException, Path, Query, status
+from fastapi import APIRouter, Body, Header, HTTPException, Path, Query, status
 
 from app.clients.reporting_client import ReportingClient
 from app.config import settings
 from app.contracts.reporting import (
+    PortfolioReviewJobRequest,
     ReportingPortfolioRequest,
     ReportingReviewResponse,
     ReportingSnapshotResponse,
     ReportingSummaryResponse,
+    ReportJobHandleResponse,
+    ReportJobStatusResponse,
 )
 from app.middleware.correlation import correlation_id_var
 
 router = APIRouter(prefix="/api/v1/reports", tags=["Reporting"])
+jobs_router = APIRouter(prefix="/api/v1/report-jobs", tags=["Reporting"])
 
 SUMMARY_REQUEST_EXAMPLES = {
     "wealthSummary": {
@@ -51,6 +55,86 @@ REVIEW_REQUEST_EXAMPLES = {
     }
 }
 
+PORTFOLIO_REVIEW_JOB_REQUEST_EXAMPLES = {
+    "portfolioReviewJob": {
+        "summary": "Portfolio review job request",
+        "description": "Create a durable job handle for asynchronous portfolio review generation.",
+        "value": {
+            "portfolio_scope": {"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]},
+            "as_of_date": "2026-04-22",
+            "requested_output_formats": ["json"],
+            "reporting_currency": "USD",
+            "options": {
+                "sections": ["OVERVIEW", "PERFORMANCE", "RISK_ANALYTICS"],
+                "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+            },
+        },
+    }
+}
+
+
+def _reporting_client() -> ReportingClient:
+    return ReportingClient(
+        base_url=settings.reporting_aggregation_base_url,
+        timeout_seconds=settings.upstream_timeout_seconds,
+        max_retries=settings.upstream_max_retries,
+        retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+    )
+
+
+def _caller_headers(
+    *,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> dict[str, str]:
+    values = {
+        "X-Actor-Id": actor_id,
+        "X-Caller-Application": caller_application or "lotus-gateway",
+        "X-Tenant-Id": tenant_id,
+        "X-Region": region,
+        "X-Booking-Center-Code": booking_center_code,
+        "X-Role": role,
+    }
+    return {key: value for key, value in values.items() if value}
+
+
+def _raise_report_job_error(status_code: int, payload: dict[str, Any]) -> None:
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    error_code = detail.get("code") if isinstance(detail, dict) else None
+    message = detail.get("message") if isinstance(detail, dict) else "Report job unavailable."
+
+    if status_code == status.HTTP_400_BAD_REQUEST and error_code == "missing_idempotency_key":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "missing_idempotency_key", "message": message},
+        )
+    if status_code == status.HTTP_404_NOT_FOUND and error_code == "report_job_not_found":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "report_job_not_found", "message": message},
+        )
+    if status_code == status.HTTP_409_CONFLICT:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": error_code or "report_job_conflict", "message": message},
+        )
+    if status_code >= status.HTTP_400_BAD_REQUEST:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={
+                "code": "report_job_upstream_unavailable",
+                "message": "Report job service is unavailable.",
+            },
+        )
+
+
+def _gateway_status_url(job_id: str) -> str:
+    return f"/api/v1/report-jobs/{job_id}"
+
 
 @router.get(
     "/{portfolio_id}/snapshot",
@@ -79,12 +163,7 @@ async def get_reporting_snapshot(
         ),
     ],
 ) -> ReportingSnapshotResponse:
-    client = ReportingClient(
-        base_url=settings.reporting_aggregation_base_url,
-        timeout_seconds=settings.upstream_timeout_seconds,
-        max_retries=settings.upstream_max_retries,
-        retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
-    )
+    client = _reporting_client()
     correlation_id = correlation_id_var.get()
     status_code, payload = await client.get_portfolio_snapshot(
         portfolio_id=portfolio_id,
@@ -146,12 +225,7 @@ async def get_reporting_summary(
         ),
     ],
 ) -> ReportingSummaryResponse:
-    client = ReportingClient(
-        base_url=settings.reporting_aggregation_base_url,
-        timeout_seconds=settings.upstream_timeout_seconds,
-        max_retries=settings.upstream_max_retries,
-        retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
-    )
+    client = _reporting_client()
     correlation_id = correlation_id_var.get()
     request_payload = request.to_upstream_payload()
     status_code, payload = await client.post_portfolio_summary(
@@ -207,12 +281,7 @@ async def get_reporting_review(
         ),
     ],
 ) -> ReportingReviewResponse:
-    client = ReportingClient(
-        base_url=settings.reporting_aggregation_base_url,
-        timeout_seconds=settings.upstream_timeout_seconds,
-        max_retries=settings.upstream_max_retries,
-        retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
-    )
+    client = _reporting_client()
     correlation_id = correlation_id_var.get()
     request_payload = request.to_upstream_payload()
     status_code, payload = await client.post_portfolio_review(
@@ -234,3 +303,111 @@ async def get_reporting_review(
         asOfDate=as_of_date,
         data=payload,
     )
+
+
+@router.post(
+    "/portfolio-reviews",
+    response_model=ReportJobHandleResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Submit portfolio review report job",
+    description=(
+        "Create a durable portfolio review report job through the governed gateway boundary. "
+        "The response is a job handle, not a rendered document."
+    ),
+)
+async def submit_portfolio_review_report_job(
+    request: Annotated[
+        PortfolioReviewJobRequest,
+        Body(
+            description="Portfolio review report job request.",
+            openapi_examples=PORTFOLIO_REVIEW_JOB_REQUEST_EXAMPLES,
+        ),
+    ],
+    idempotency_key: Annotated[
+        str | None,
+        Header(
+            alias="Idempotency-Key",
+            description="Required caller idempotency key for job creation.",
+        ),
+    ] = None,
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> ReportJobHandleResponse:
+    correlation_id = correlation_id_var.get()
+    if not idempotency_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "missing_idempotency_key",
+                "message": "Idempotency-Key is required.",
+            },
+        )
+
+    status_code, payload = await _reporting_client().submit_portfolio_review_job(
+        payload=request.model_dump(exclude_none=True, mode="json"),
+        idempotency_key=idempotency_key,
+        caller_headers=_caller_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id,
+    )
+    _raise_report_job_error(status_code, payload)
+    response = ReportJobHandleResponse.model_validate(payload)
+    return response.model_copy(update={"status_url": _gateway_status_url(response.report_job_id)})
+
+
+@jobs_router.get(
+    "/{job_id}",
+    response_model=ReportJobStatusResponse,
+    summary="Get report job status",
+    description="Return product-safe report job status and diagnostics from lotus-report.",
+)
+async def get_report_job_status(
+    job_id: Annotated[str, Path(description="Opaque report job identifier.")],
+) -> ReportJobStatusResponse:
+    status_code, payload = await _reporting_client().get_report_job(
+        job_id=job_id,
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_job_error(status_code, payload)
+    return ReportJobStatusResponse.model_validate(payload)
+
+
+@jobs_router.post(
+    "/{job_id}/cancel",
+    response_model=ReportJobStatusResponse,
+    summary="Cancel report job before render or archive",
+    description="Cancel a report job while it is still before render, archive, or completion.",
+)
+async def cancel_report_job(
+    job_id: Annotated[str, Path(description="Opaque report job identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> ReportJobStatusResponse:
+    status_code, payload = await _reporting_client().cancel_report_job(
+        job_id=job_id,
+        caller_headers=_caller_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_job_error(status_code, payload)
+    return ReportJobStatusResponse.model_validate(payload)

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -12,6 +12,7 @@ from app.contracts.reporting import (
     ReportingSnapshotResponse,
     ReportingSummaryResponse,
     ReportJobHandleResponse,
+    ReportJobStatusEventsResponse,
     ReportJobStatusResponse,
 )
 from app.middleware.correlation import correlation_id_var
@@ -412,6 +413,40 @@ async def get_report_job_status(
     )
     _raise_report_job_error(status_code, payload)
     return ReportJobStatusResponse.model_validate(payload)
+
+
+@jobs_router.get(
+    "/{job_id}/events",
+    response_model=ReportJobStatusEventsResponse,
+    summary="Get report job event history",
+    description=(
+        "Return append-only report job lifecycle events through the governed gateway boundary. "
+        "Use this endpoint for operational support when current status alone is insufficient."
+    ),
+)
+async def get_report_job_events(
+    job_id: Annotated[str, Path(description="Opaque report job identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> ReportJobStatusEventsResponse:
+    status_code, payload = await _reporting_client().get_report_job_events(
+        job_id=job_id,
+        caller_headers=_caller_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_job_error(status_code, payload)
+    return ReportJobStatusEventsResponse.model_validate(payload)
 
 
 @jobs_router.post(

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -373,9 +373,23 @@ async def submit_portfolio_review_report_job(
 )
 async def get_report_job_status(
     job_id: Annotated[str, Path(description="Opaque report job identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> ReportJobStatusResponse:
     status_code, payload = await _reporting_client().get_report_job(
         job_id=job_id,
+        caller_headers=_caller_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
         correlation_id=correlation_id_var.get(),
     )
     _raise_report_job_error(status_code, payload)

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -91,11 +91,29 @@ def _caller_headers(
     booking_center_code: str | None,
     role: str | None,
 ) -> dict[str, str]:
+    missing = [
+        name
+        for name, value in {
+            "X-Actor-Id": actor_id,
+            "X-Tenant-Id": tenant_id,
+            "X-Region": region,
+        }.items()
+        if not value or not value.strip()
+    ]
+    if missing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "missing_caller_context",
+                "message": "Required caller context headers are missing.",
+                "missing_headers": missing,
+            },
+        )
     values = {
-        "X-Actor-Id": actor_id,
+        "X-Actor-Id": actor_id.strip() if actor_id else actor_id,
         "X-Caller-Application": caller_application or "lotus-gateway",
-        "X-Tenant-Id": tenant_id,
-        "X-Region": region,
+        "X-Tenant-Id": tenant_id.strip() if tenant_id else tenant_id,
+        "X-Region": region.strip() if region else region,
         "X-Booking-Center-Code": booking_center_code,
         "X-Role": role,
     }

--- a/tests/contract/test_reporting_contract.py
+++ b/tests/contract/test_reporting_contract.py
@@ -68,10 +68,16 @@ def test_reporting_openapi_contract_registered() -> None:
     assert "/api/v1/reports/{portfolio_id}/snapshot" in spec["paths"]
     assert "/api/v1/reports/{portfolio_id}/summary" in spec["paths"]
     assert "/api/v1/reports/{portfolio_id}/review" in spec["paths"]
+    assert "/api/v1/reports/portfolio-reviews" in spec["paths"]
+    assert "/api/v1/report-jobs/{job_id}" in spec["paths"]
+    assert "/api/v1/report-jobs/{job_id}/cancel" in spec["paths"]
 
     snapshot_path = spec["paths"]["/api/v1/reports/{portfolio_id}/snapshot"]["get"]
     summary_path = spec["paths"]["/api/v1/reports/{portfolio_id}/summary"]["post"]
     review_path = spec["paths"]["/api/v1/reports/{portfolio_id}/review"]["post"]
+    job_submit_path = spec["paths"]["/api/v1/reports/portfolio-reviews"]["post"]
+    job_status_path = spec["paths"]["/api/v1/report-jobs/{job_id}"]["get"]
+    job_cancel_path = spec["paths"]["/api/v1/report-jobs/{job_id}/cancel"]["post"]
     request_schema = spec["components"]["schemas"]["ReportingPortfolioRequest"]
     snapshot_schema = spec["components"]["schemas"]["ReportingSnapshotResponse"]
     summary_schema = spec["components"]["schemas"]["ReportingSummaryResponse"]
@@ -80,6 +86,12 @@ def test_reporting_openapi_contract_registered() -> None:
     assert snapshot_path["description"]
     assert summary_path["description"]
     assert review_path["description"]
+    assert job_submit_path["summary"] == "Submit portfolio review report job"
+    assert job_status_path["summary"] == "Get report job status"
+    assert job_cancel_path["summary"] == "Cancel report job before render or archive"
+    assert "RFC-" not in str(job_submit_path)
+    assert "RFC-" not in str(job_status_path)
+    assert "RFC-" not in str(job_cancel_path)
     snapshot_parameters = {
         parameter["name"]: parameter for parameter in snapshot_path["parameters"]
     }

--- a/tests/contract/test_reporting_contract.py
+++ b/tests/contract/test_reporting_contract.py
@@ -70,6 +70,7 @@ def test_reporting_openapi_contract_registered() -> None:
     assert "/api/v1/reports/{portfolio_id}/review" in spec["paths"]
     assert "/api/v1/reports/portfolio-reviews" in spec["paths"]
     assert "/api/v1/report-jobs/{job_id}" in spec["paths"]
+    assert "/api/v1/report-jobs/{job_id}/events" in spec["paths"]
     assert "/api/v1/report-jobs/{job_id}/cancel" in spec["paths"]
 
     snapshot_path = spec["paths"]["/api/v1/reports/{portfolio_id}/snapshot"]["get"]
@@ -77,6 +78,7 @@ def test_reporting_openapi_contract_registered() -> None:
     review_path = spec["paths"]["/api/v1/reports/{portfolio_id}/review"]["post"]
     job_submit_path = spec["paths"]["/api/v1/reports/portfolio-reviews"]["post"]
     job_status_path = spec["paths"]["/api/v1/report-jobs/{job_id}"]["get"]
+    job_events_path = spec["paths"]["/api/v1/report-jobs/{job_id}/events"]["get"]
     job_cancel_path = spec["paths"]["/api/v1/report-jobs/{job_id}/cancel"]["post"]
     request_schema = spec["components"]["schemas"]["ReportingPortfolioRequest"]
     snapshot_schema = spec["components"]["schemas"]["ReportingSnapshotResponse"]
@@ -88,10 +90,21 @@ def test_reporting_openapi_contract_registered() -> None:
     assert review_path["description"]
     assert job_submit_path["summary"] == "Submit portfolio review report job"
     assert job_status_path["summary"] == "Get report job status"
+    assert job_events_path["summary"] == "Get report job event history"
     assert job_cancel_path["summary"] == "Cancel report job before render or archive"
     assert "RFC-" not in str(job_submit_path)
     assert "RFC-" not in str(job_status_path)
+    assert "RFC-" not in str(job_events_path)
     assert "RFC-" not in str(job_cancel_path)
+    for schema_name in [
+        "ReportJobHandleResponse",
+        "ReportJobStatusResponse",
+        "ReportJobStatusEventsResponse",
+        "ReportStatusEvent",
+    ]:
+        properties = spec["components"]["schemas"][schema_name]["properties"]
+        for property_contract in properties.values():
+            assert property_contract.get("description")
     snapshot_parameters = {
         parameter["name"]: parameter for parameter in snapshot_path["parameters"]
     }

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -377,8 +377,8 @@ def test_portfolio_review_job_gateway_requires_idempotency_key():
 def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
     calls: list[tuple[str, str, dict[str, str] | None]] = []
 
-    async def _mock_get_job(self, *, job_id, correlation_id):
-        calls.append(("get", job_id, None))
+    async def _mock_get_job(self, *, job_id, caller_headers, correlation_id):
+        calls.append(("get", job_id, caller_headers))
         return 200, {
             "report_job_id": job_id,
             "report_request_id": "rrq_1",
@@ -430,7 +430,10 @@ def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
     )
 
     client = TestClient(app)
-    status_response = client.get("/api/v1/report-jobs/rjob_1")
+    status_response = client.get(
+        "/api/v1/report-jobs/rjob_1",
+        headers={"X-Actor-Id": "advisor-123", "X-Tenant-Id": "tenant-sg"},
+    )
     cancel_response = client.post(
         "/api/v1/report-jobs/rjob_1/cancel",
         headers={"X-Actor-Id": "advisor-123", "X-Tenant-Id": "tenant-sg"},
@@ -440,14 +443,17 @@ def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
     assert status_response.json()["status"] == "accepted"
     assert cancel_response.status_code == 200
     assert cancel_response.json()["status"] == "cancelled"
-    assert calls[0] == ("get", "rjob_1", None)
+    assert calls[0][0:2] == ("get", "rjob_1")
+    assert calls[0][2]["X-Actor-Id"] == "advisor-123"
+    assert calls[0][2]["X-Caller-Application"] == "lotus-gateway"
+    assert calls[0][2]["X-Tenant-Id"] == "tenant-sg"
     assert calls[1][0:2] == ("cancel", "rjob_1")
     assert calls[1][2]["X-Actor-Id"] == "advisor-123"
     assert calls[1][2]["X-Caller-Application"] == "lotus-gateway"
 
 
 def test_report_job_gateway_errors_are_product_safe(monkeypatch):
-    async def _mock_get_job(self, *, job_id, correlation_id):  # noqa: ARG001
+    async def _mock_get_job(self, *, job_id, caller_headers, correlation_id):  # noqa: ARG001
         return 500, {"detail": "sqlite traceback internal-host report.dev.lotus"}
 
     monkeypatch.setattr(

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -290,3 +290,175 @@ def test_reporting_review_upstream_error(monkeypatch):
         json={"as_of_date": "2026-02-24"},
     )
     assert response.status_code == 502
+
+
+def _job_payload():
+    return {
+        "portfolio_scope": {"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]},
+        "as_of_date": "2026-04-22",
+        "requested_output_formats": ["json"],
+        "reporting_currency": "USD",
+        "options": {
+            "sections": ["OVERVIEW", "PERFORMANCE"],
+            "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+        },
+    }
+
+
+def test_portfolio_review_job_gateway_route_forwards_context(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _mock_submit_job(
+        self,
+        *,
+        payload,
+        idempotency_key,
+        caller_headers,
+        correlation_id,
+    ):
+        captured["payload"] = payload
+        captured["idempotency_key"] = idempotency_key
+        captured["caller_headers"] = caller_headers
+        captured["correlation_id"] = correlation_id
+        return 202, {
+            "report_request_id": "rrq_1",
+            "report_job_id": "rjob_1",
+            "status": "accepted",
+            "status_url": "/reports/jobs/rjob_1",
+            "idempotency_key": idempotency_key,
+        }
+
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.submit_portfolio_review_job",
+        _mock_submit_job,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/reports/portfolio-reviews",
+        json=_job_payload(),
+        headers={
+            "Idempotency-Key": "idem-gateway-1",
+            "X-Actor-Id": "advisor-123",
+            "X-Caller-Application": "lotus-workbench",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+            "X-Booking-Center-Code": "SG",
+            "X-Role": "advisor",
+            "X-Correlation-Id": "corr-gateway-job",
+        },
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["report_job_id"] == "rjob_1"
+    assert body["status_url"] == "/api/v1/report-jobs/rjob_1"
+    assert captured["payload"] == _job_payload()
+    assert captured["idempotency_key"] == "idem-gateway-1"
+    assert captured["caller_headers"] == {
+        "X-Actor-Id": "advisor-123",
+        "X-Caller-Application": "lotus-workbench",
+        "X-Tenant-Id": "tenant-sg",
+        "X-Region": "APAC",
+        "X-Booking-Center-Code": "SG",
+        "X-Role": "advisor",
+    }
+    assert captured["correlation_id"] == "corr-gateway-job"
+
+
+def test_portfolio_review_job_gateway_requires_idempotency_key():
+    client = TestClient(app)
+    response = client.post("/api/v1/reports/portfolio-reviews", json=_job_payload())
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "missing_idempotency_key"
+
+
+def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
+    calls: list[tuple[str, str, dict[str, str] | None]] = []
+
+    async def _mock_get_job(self, *, job_id, correlation_id):
+        calls.append(("get", job_id, None))
+        return 200, {
+            "report_job_id": job_id,
+            "report_request_id": "rrq_1",
+            "report_type": "portfolio_review",
+            "portfolio_scope": {"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]},
+            "status": "accepted",
+            "failure_category": None,
+            "failure_message": None,
+            "current_step": "accepted",
+            "retry_eligible": False,
+            "cancel_requested": False,
+            "created_at": "2026-04-22T09:00:00Z",
+            "updated_at": "2026-04-22T09:00:00Z",
+            "started_at": None,
+            "completed_at": None,
+            "cancelled_at": None,
+            "correlation_id": correlation_id,
+            "trace_id": "trace-job",
+        }
+
+    async def _mock_cancel_job(self, *, job_id, caller_headers, correlation_id):
+        calls.append(("cancel", job_id, caller_headers))
+        return 200, {
+            "report_job_id": job_id,
+            "report_request_id": "rrq_1",
+            "report_type": "portfolio_review",
+            "portfolio_scope": {"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]},
+            "status": "cancelled",
+            "failure_category": "cancelled",
+            "failure_message": "Report job cancelled before render or archive processing.",
+            "current_step": "cancelled",
+            "retry_eligible": False,
+            "cancel_requested": True,
+            "created_at": "2026-04-22T09:00:00Z",
+            "updated_at": "2026-04-22T09:01:00Z",
+            "started_at": None,
+            "completed_at": None,
+            "cancelled_at": "2026-04-22T09:01:00Z",
+            "correlation_id": correlation_id,
+            "trace_id": "trace-job",
+        }
+
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_report_job", _mock_get_job
+    )
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.cancel_report_job",
+        _mock_cancel_job,
+    )
+
+    client = TestClient(app)
+    status_response = client.get("/api/v1/report-jobs/rjob_1")
+    cancel_response = client.post(
+        "/api/v1/report-jobs/rjob_1/cancel",
+        headers={"X-Actor-Id": "advisor-123", "X-Tenant-Id": "tenant-sg"},
+    )
+
+    assert status_response.status_code == 200
+    assert status_response.json()["status"] == "accepted"
+    assert cancel_response.status_code == 200
+    assert cancel_response.json()["status"] == "cancelled"
+    assert calls[0] == ("get", "rjob_1", None)
+    assert calls[1][0:2] == ("cancel", "rjob_1")
+    assert calls[1][2]["X-Actor-Id"] == "advisor-123"
+    assert calls[1][2]["X-Caller-Application"] == "lotus-gateway"
+
+
+def test_report_job_gateway_errors_are_product_safe(monkeypatch):
+    async def _mock_get_job(self, *, job_id, correlation_id):  # noqa: ARG001
+        return 500, {"detail": "sqlite traceback internal-host report.dev.lotus"}
+
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_report_job", _mock_get_job
+    )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/report-jobs/rjob_500")
+
+    assert response.status_code == 502
+    body = response.json()
+    assert body["detail"]["code"] == "report_job_upstream_unavailable"
+    assert "sqlite" not in str(body).lower()
+    assert "report.dev.lotus" not in str(body)

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -435,8 +435,32 @@ def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
             "trace_id": "trace-job",
         }
 
+    async def _mock_get_job_events(self, *, job_id, caller_headers, correlation_id):
+        calls.append(("events", job_id, caller_headers))
+        return 200, {
+            "report_job_id": job_id,
+            "events": [
+                {
+                    "status_event_id": "rse_1",
+                    "report_job_id": job_id,
+                    "from_status": None,
+                    "to_status": "accepted",
+                    "event_type": "job_accepted",
+                    "message": "Portfolio review report job accepted.",
+                    "actor": "advisor-123",
+                    "created_at": "2026-04-22T09:00:00Z",
+                    "correlation_id": correlation_id,
+                    "trace_id": "trace-job",
+                }
+            ],
+        }
+
     monkeypatch.setattr(
         "app.clients.reporting_client.ReportingClient.get_report_job", _mock_get_job
+    )
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_report_job_events",
+        _mock_get_job_events,
     )
     monkeypatch.setattr(
         "app.clients.reporting_client.ReportingClient.cancel_report_job",
@@ -446,6 +470,14 @@ def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
     client = TestClient(app)
     status_response = client.get(
         "/api/v1/report-jobs/rjob_1",
+        headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+        },
+    )
+    events_response = client.get(
+        "/api/v1/report-jobs/rjob_1/events",
         headers={
             "X-Actor-Id": "advisor-123",
             "X-Tenant-Id": "tenant-sg",
@@ -463,6 +495,8 @@ def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
 
     assert status_response.status_code == 200
     assert status_response.json()["status"] == "accepted"
+    assert events_response.status_code == 200
+    assert events_response.json()["events"][0]["event_type"] == "job_accepted"
     assert cancel_response.status_code == 200
     assert cancel_response.json()["status"] == "cancelled"
     assert calls[0][0:2] == ("get", "rjob_1")
@@ -470,10 +504,14 @@ def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
     assert calls[0][2]["X-Caller-Application"] == "lotus-gateway"
     assert calls[0][2]["X-Tenant-Id"] == "tenant-sg"
     assert calls[0][2]["X-Region"] == "APAC"
-    assert calls[1][0:2] == ("cancel", "rjob_1")
+    assert calls[1][0:2] == ("events", "rjob_1")
     assert calls[1][2]["X-Actor-Id"] == "advisor-123"
     assert calls[1][2]["X-Caller-Application"] == "lotus-gateway"
     assert calls[1][2]["X-Region"] == "APAC"
+    assert calls[2][0:2] == ("cancel", "rjob_1")
+    assert calls[2][2]["X-Actor-Id"] == "advisor-123"
+    assert calls[2][2]["X-Caller-Application"] == "lotus-gateway"
+    assert calls[2][2]["X-Region"] == "APAC"
 
 
 def test_report_job_gateway_errors_are_product_safe(monkeypatch):

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -374,6 +374,20 @@ def test_portfolio_review_job_gateway_requires_idempotency_key():
     assert response.json()["detail"]["code"] == "missing_idempotency_key"
 
 
+def test_portfolio_review_job_gateway_requires_caller_context():
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/reports/portfolio-reviews",
+        json=_job_payload(),
+        headers={"Idempotency-Key": "idem-missing-context"},
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["code"] == "missing_caller_context"
+    assert detail["missing_headers"] == ["X-Actor-Id", "X-Tenant-Id", "X-Region"]
+
+
 def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
     calls: list[tuple[str, str, dict[str, str] | None]] = []
 
@@ -432,11 +446,19 @@ def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
     client = TestClient(app)
     status_response = client.get(
         "/api/v1/report-jobs/rjob_1",
-        headers={"X-Actor-Id": "advisor-123", "X-Tenant-Id": "tenant-sg"},
+        headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+        },
     )
     cancel_response = client.post(
         "/api/v1/report-jobs/rjob_1/cancel",
-        headers={"X-Actor-Id": "advisor-123", "X-Tenant-Id": "tenant-sg"},
+        headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+        },
     )
 
     assert status_response.status_code == 200
@@ -447,9 +469,11 @@ def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
     assert calls[0][2]["X-Actor-Id"] == "advisor-123"
     assert calls[0][2]["X-Caller-Application"] == "lotus-gateway"
     assert calls[0][2]["X-Tenant-Id"] == "tenant-sg"
+    assert calls[0][2]["X-Region"] == "APAC"
     assert calls[1][0:2] == ("cancel", "rjob_1")
     assert calls[1][2]["X-Actor-Id"] == "advisor-123"
     assert calls[1][2]["X-Caller-Application"] == "lotus-gateway"
+    assert calls[1][2]["X-Region"] == "APAC"
 
 
 def test_report_job_gateway_errors_are_product_safe(monkeypatch):
@@ -461,7 +485,14 @@ def test_report_job_gateway_errors_are_product_safe(monkeypatch):
     )
 
     client = TestClient(app)
-    response = client.get("/api/v1/report-jobs/rjob_500")
+    response = client.get(
+        "/api/v1/report-jobs/rjob_500",
+        headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+        },
+    )
 
     assert response.status_code == 502
     body = response.json()

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1500,6 +1500,12 @@ async def test_reporting_client_report_job_routes_forward_governed_headers():
     )
     status_code, status_payload = await client.get_report_job(
         job_id="rjob_1",
+        caller_headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+            "X-Role": "advisor",
+        },
         correlation_id="corr-job-1",
     )
     cancel_status, cancel_payload = await client.cancel_report_job(
@@ -1521,6 +1527,9 @@ async def test_reporting_client_report_job_routes_forward_governed_headers():
     assert _FakeAsyncClient.calls[0]["headers"]["X-Tenant-Id"] == "tenant-sg"
     assert _FakeAsyncClient.calls[0]["headers"]["X-Correlation-Id"] == "corr-job-1"
     assert _FakeAsyncClient.calls[1]["url"] == "http://ras/reports/jobs/rjob_1"
+    assert _FakeAsyncClient.calls[1]["headers"]["X-Actor-Id"] == "advisor-123"
+    assert _FakeAsyncClient.calls[1]["headers"]["X-Tenant-Id"] == "tenant-sg"
+    assert _FakeAsyncClient.calls[1]["headers"]["X-Correlation-Id"] == "corr-job-1"
     assert _FakeAsyncClient.calls[2]["url"] == "http://ras/reports/jobs/rjob_1/cancel"
     assert _FakeAsyncClient.calls[2]["headers"]["X-Actor-Id"] == "advisor-123"
 

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1481,6 +1481,7 @@ async def test_reporting_client_report_job_routes_forward_governed_headers():
     client = ReportingClient(base_url="http://ras", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(202, {"report_job_id": "rjob_1"})
     _FakeAsyncClient.queue_json(200, {"status": "accepted"})
+    _FakeAsyncClient.queue_json(200, {"events": []})
     _FakeAsyncClient.queue_json(200, {"status": "cancelled"})
 
     submit_status, submit_payload = await client.submit_portfolio_review_job(
@@ -1508,6 +1509,16 @@ async def test_reporting_client_report_job_routes_forward_governed_headers():
         },
         correlation_id="corr-job-1",
     )
+    events_status, events_payload = await client.get_report_job_events(
+        job_id="rjob_1",
+        caller_headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+            "X-Role": "advisor",
+        },
+        correlation_id="corr-job-1",
+    )
     cancel_status, cancel_payload = await client.cancel_report_job(
         job_id="rjob_1",
         caller_headers={"X-Actor-Id": "advisor-123"},
@@ -1518,6 +1529,8 @@ async def test_reporting_client_report_job_routes_forward_governed_headers():
     assert submit_payload["report_job_id"] == "rjob_1"
     assert status_code == 200
     assert status_payload["status"] == "accepted"
+    assert events_status == 200
+    assert events_payload["events"] == []
     assert cancel_status == 200
     assert cancel_payload["status"] == "cancelled"
     assert _FakeAsyncClient.calls[0]["url"] == "http://ras/reports/portfolio-reviews"
@@ -1530,8 +1543,12 @@ async def test_reporting_client_report_job_routes_forward_governed_headers():
     assert _FakeAsyncClient.calls[1]["headers"]["X-Actor-Id"] == "advisor-123"
     assert _FakeAsyncClient.calls[1]["headers"]["X-Tenant-Id"] == "tenant-sg"
     assert _FakeAsyncClient.calls[1]["headers"]["X-Correlation-Id"] == "corr-job-1"
-    assert _FakeAsyncClient.calls[2]["url"] == "http://ras/reports/jobs/rjob_1/cancel"
+    assert _FakeAsyncClient.calls[2]["url"] == "http://ras/reports/jobs/rjob_1/events"
     assert _FakeAsyncClient.calls[2]["headers"]["X-Actor-Id"] == "advisor-123"
+    assert _FakeAsyncClient.calls[2]["headers"]["X-Tenant-Id"] == "tenant-sg"
+    assert _FakeAsyncClient.calls[2]["headers"]["X-Correlation-Id"] == "corr-job-1"
+    assert _FakeAsyncClient.calls[3]["url"] == "http://ras/reports/jobs/rjob_1/cancel"
+    assert _FakeAsyncClient.calls[3]["headers"]["X-Actor-Id"] == "advisor-123"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1477,6 +1477,55 @@ async def test_reporting_client_summary_and_review_routes():
 
 
 @pytest.mark.asyncio
+async def test_reporting_client_report_job_routes_forward_governed_headers():
+    client = ReportingClient(base_url="http://ras", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(202, {"report_job_id": "rjob_1"})
+    _FakeAsyncClient.queue_json(200, {"status": "accepted"})
+    _FakeAsyncClient.queue_json(200, {"status": "cancelled"})
+
+    submit_status, submit_payload = await client.submit_portfolio_review_job(
+        payload={
+            "portfolio_scope": {"portfolio_ids": ["P1"]},
+            "as_of_date": "2026-04-22",
+            "requested_output_formats": ["json"],
+        },
+        idempotency_key="idem-job-1",
+        caller_headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+            "X-Role": "advisor",
+        },
+        correlation_id="corr-job-1",
+    )
+    status_code, status_payload = await client.get_report_job(
+        job_id="rjob_1",
+        correlation_id="corr-job-1",
+    )
+    cancel_status, cancel_payload = await client.cancel_report_job(
+        job_id="rjob_1",
+        caller_headers={"X-Actor-Id": "advisor-123"},
+        correlation_id="corr-job-1",
+    )
+
+    assert submit_status == 202
+    assert submit_payload["report_job_id"] == "rjob_1"
+    assert status_code == 200
+    assert status_payload["status"] == "accepted"
+    assert cancel_status == 200
+    assert cancel_payload["status"] == "cancelled"
+    assert _FakeAsyncClient.calls[0]["url"] == "http://ras/reports/portfolio-reviews"
+    assert _FakeAsyncClient.calls[0]["json"]["portfolio_scope"] == {"portfolio_ids": ["P1"]}
+    assert _FakeAsyncClient.calls[0]["headers"]["Idempotency-Key"] == "idem-job-1"
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Actor-Id"] == "advisor-123"
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Tenant-Id"] == "tenant-sg"
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Correlation-Id"] == "corr-job-1"
+    assert _FakeAsyncClient.calls[1]["url"] == "http://ras/reports/jobs/rjob_1"
+    assert _FakeAsyncClient.calls[2]["url"] == "http://ras/reports/jobs/rjob_1/cancel"
+    assert _FakeAsyncClient.calls[2]["headers"]["X-Actor-Id"] == "advisor-123"
+
+
+@pytest.mark.asyncio
 async def test_reporting_client_snapshot_request_uses_live_aggregation_query_contract():
     client = ReportingClient(base_url="http://ras", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"rows": []})

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -30,7 +30,8 @@
 - reporting snapshot and reporting request payloads use `asOfDate`
 - portfolio review report job initiation uses canonical snake_case body fields and requires
   `Idempotency-Key`
-- report job status and cancellation are gateway-first under `/api/v1/report-jobs/*`
+- report job status, append-only event history, and cancellation are gateway-first under
+  `/api/v1/report-jobs/*`
 - intake upload routes accept camelCase multipart aliases such as `entityType`, `sampleSize`, and
   `allowPartial`
 - selected lookup filters remain snake_case, such as `cif_id`, `booking_center`, `product_type`,
@@ -108,6 +109,12 @@ Report job status:
 
 ```bash
 curl "http://127.0.0.1:8111/api/v1/report-jobs/rjob_example"
+```
+
+Report job event history:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/report-jobs/rjob_example/events"
 ```
 
 Proposal creation:

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -15,6 +15,7 @@
 - `GET /api/v1/portfolio/*`
 - `GET` and `POST /api/v1/workbench/*`
 - `GET` and `POST /api/v1/reports/*`
+- `GET` and `POST /api/v1/report-jobs/*`
 - `/health`, `/health/live`, `/health/ready`, `/metrics`, `/docs`
 
 ## Current contract notes
@@ -27,6 +28,9 @@
 - domain-product trust certification returns certified platform trust posture when the RFC-0087
   artifact exists and an explicit unavailable posture when it has not been generated
 - reporting snapshot and reporting request payloads use `asOfDate`
+- portfolio review report job initiation uses canonical snake_case body fields and requires
+  `Idempotency-Key`
+- report job status and cancellation are gateway-first under `/api/v1/report-jobs/*`
 - intake upload routes accept camelCase multipart aliases such as `entityType`, `sampleSize`, and
   `allowPartial`
 - selected lookup filters remain snake_case, such as `cif_id`, `booking_center`, `product_type`,
@@ -83,6 +87,27 @@ Reporting summary:
 curl -X POST "http://127.0.0.1:8111/api/v1/reports/DEMO_DPM_EUR_001/summary" \
   -H "Content-Type: application/json" \
   -d "{\"asOfDate\":\"2026-02-24\",\"sections\":[\"WEALTH\",\"ALLOCATION\"],\"allocationDimensions\":[\"asset_class\"]}"
+```
+
+Portfolio review report job:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/reports/portfolio-reviews" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: portfolio-review-PB_SG_GLOBAL_BAL_001-2026-04-22" \
+  -H "X-Actor-Id: advisor-123" \
+  -H "X-Caller-Application: lotus-workbench" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -H "X-Booking-Center-Code: SG" \
+  -H "X-Role: advisor" \
+  -d "{\"portfolio_scope\":{\"portfolio_ids\":[\"PB_SG_GLOBAL_BAL_001\"]},\"as_of_date\":\"2026-04-22\",\"requested_output_formats\":[\"json\"],\"reporting_currency\":\"USD\",\"options\":{\"sections\":[\"OVERVIEW\",\"PERFORMANCE\",\"RISK_ANALYTICS\"],\"benchmark_code\":\"BMK_GLOBAL_BALANCED_60_40\"}}"
+```
+
+Report job status:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/report-jobs/rjob_example"
 ```
 
 Proposal creation:


### PR DESCRIPTION
## Summary

- Adds the RFC-0100 gateway-first portfolio review report job boundary.
- Adds product-facing gateway APIs:
  - POST /api/v1/reports/portfolio-reviews
  - GET /api/v1/report-jobs/{job_id}
  - POST /api/v1/report-jobs/{job_id}/cancel
- Propagates idempotency, actor, caller application, tenant, region, booking center, role, correlation, and trace context to lotus-report.
- Normalizes report job errors into product-safe gateway responses.
- Updates OpenAPI contract tests, upstream client tests, README, repo context, and repo-authored wiki source.

## Validation

- python -m ruff check src/app/contracts/reporting.py src/app/clients/reporting_client.py src/app/routers/reporting.py src/app/main.py tests/integration/test_reporting_router.py tests/unit/test_upstream_clients.py tests/contract/test_reporting_contract.py
- python -m pytest tests/integration/test_reporting_router.py tests/unit/test_upstream_clients.py::test_reporting_client_report_job_routes_forward_governed_headers tests/contract/test_reporting_contract.py
- wiki check: Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway reports expected drift for API-Surface.md changed in this PR; publish after merge.

## RFC-0100 posture

Gateway remains a product-facing boundary and does not own report job persistence, rendering, archive, or reporting methodology.