### PR TITLE
RFC-0100: certify gateway report job operations surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It depends on:
 - `lotus-manage`
   management workflow capability when split routing is enabled
 - `lotus-report`
-  reporting snapshot, summary, review payloads, and durable report job lifecycle
+  reporting snapshot, summary, review payloads, and durable report job lifecycle/search
 - `lotus-ai`
   evidence-grounded advisor-brief support through the explicit workflow-pack execution seam and shared run-ledger surfaces
 - `lotus-platform`
@@ -90,7 +90,7 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
 - `reporting`
   `/api/v1/reports/*`
 - `report-jobs`
-  `/api/v1/report-jobs/*`
+  `/api/v1/report-jobs`, `/api/v1/report-jobs/*`
 - platform surfaces
   `/health`, `/health/live`, `/health/ready`, `/metrics`, `/docs`
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -32,9 +32,9 @@ Current repository posture:
 1. `lotus-gateway` is the primary backend contract for `lotus-workbench`,
 2. the repository is moving from thin pass-through behavior to a cleaner experience-API posture,
 3. performance, proposal, foundation, reporting, and capability aggregation routes are active,
-4. report job initiation/status/event-history/cancellation routes are active for gateway-first
-   portfolio review report job workflows under `/api/v1/reports/portfolio-reviews` and
-   `/api/v1/report-jobs/*`,
+4. report job initiation/search/status/event-history/cancellation routes are active for
+   gateway-first portfolio review report job workflows under `/api/v1/reports/portfolio-reviews`,
+   `/api/v1/report-jobs`, and `/api/v1/report-jobs/*`,
 5. domain-product catalog, dependency-graph, and live trust certification discovery routes are
    active under `/api/v1/domain-products`,
 6. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,

--- a/src/app/clients/reporting_client.py
+++ b/src/app/clients/reporting_client.py
@@ -132,6 +132,26 @@ class ReportingClient:
             headers=headers,
         )
 
+    async def list_report_jobs(
+        self,
+        *,
+        filters: dict[str, Any],
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/jobs"
+        headers = propagation_headers(correlation_id)
+        headers.update(caller_headers)
+        return await request_with_retry(
+            method="GET",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            params=filters,
+            headers=headers,
+        )
+
     async def get_report_job_events(
         self,
         *,

--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -3,6 +3,91 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+REPORT_JOB_LIST_FILTERS_EXAMPLE: dict[str, Any] = {
+    "tenantId": "tenant-sg",
+    "region": "APAC",
+    "status": "accepted",
+    "reportType": "portfolio_review",
+    "portfolioId": "PB_SG_GLOBAL_BAL_001",
+    "asOfDate": "2026-04-22",
+    "idempotencyKey": "portfolio-review-PB_SG_GLOBAL_BAL_001-2026-04-22",
+    "correlationId": "corr-portfolio-review-1",
+    "createdFrom": "2026-04-22T00:00:00Z",
+    "createdTo": "2026-04-23T00:00:00Z",
+    "limit": 25,
+}
+
+REPORT_JOB_LIST_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "count": 1,
+    "appliedFilters": REPORT_JOB_LIST_FILTERS_EXAMPLE,
+    "items": [
+        {
+            "reportJobId": "rjob_83ca965c50334c40a17d2b8cc94873a5",
+            "reportRequestId": "rrq_4f7c85b39f7d4e7b8d0bb420d34a1d2c",
+            "reportType": "portfolio_review",
+            "tenantId": "tenant-sg",
+            "region": "APAC",
+            "portfolioScope": {"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]},
+            "asOfDate": "2026-04-22",
+            "status": "accepted",
+            "failureCategory": None,
+            "currentStep": "accepted",
+            "retryEligible": False,
+            "cancelRequested": False,
+            "idempotencyKey": "portfolio-review-PB_SG_GLOBAL_BAL_001-2026-04-22",
+            "correlationId": "corr-portfolio-review-1",
+            "createdAt": "2026-04-22T09:00:00Z",
+            "updatedAt": "2026-04-22T09:00:00Z",
+        }
+    ],
+}
+
+REPORT_JOB_ERROR_EXAMPLES: dict[str, dict[str, Any]] = {
+    "missing_idempotency_key": {
+        "detail": {
+            "code": "missing_idempotency_key",
+            "message": "Idempotency-Key is required.",
+        }
+    },
+    "missing_caller_context": {
+        "detail": {
+            "code": "missing_caller_context",
+            "message": "Required caller context headers are missing.",
+            "missing_headers": ["X-Actor-Id", "X-Tenant-Id", "X-Region"],
+        }
+    },
+    "report_job_not_found": {
+        "detail": {
+            "code": "report_job_not_found",
+            "message": "Report job was not found.",
+        }
+    },
+    "idempotency_conflict": {
+        "detail": {
+            "code": "idempotency_conflict",
+            "message": "Idempotency-Key was reused with a different report request.",
+        }
+    },
+    "report_job_cannot_be_cancelled": {
+        "detail": {
+            "code": "report_job_cannot_be_cancelled",
+            "message": "Report job can no longer be cancelled.",
+        }
+    },
+    "report_job_upstream_unavailable": {
+        "detail": {
+            "code": "report_job_upstream_unavailable",
+            "message": "Report job service is unavailable.",
+        }
+    },
+    "invalid_report_job_filters": {
+        "detail": {
+            "code": "invalid_report_job_filters",
+            "message": "At least one supported job-search filter is required.",
+        }
+    },
+}
+
 
 class ReportingPortfolioRequest(BaseModel):
     as_of_date: str = Field(
@@ -264,6 +349,32 @@ class PortfolioReviewJobRequest(BaseModel):
     )
 
 
+class ReportJobErrorDetail(BaseModel):
+    code: str = Field(
+        ...,
+        description="Machine-readable error code for deterministic client handling.",
+        examples=["report_job_not_found"],
+    )
+    message: str = Field(
+        ...,
+        description="Support-safe error message explaining the failure.",
+        examples=["Report job was not found."],
+    )
+    missing_headers: list[str] | None = Field(
+        default=None,
+        description="Header names that must be supplied when caller context is incomplete.",
+        examples=[["X-Actor-Id", "X-Tenant-Id", "X-Region"]],
+    )
+
+
+class ReportJobErrorResponse(BaseModel):
+    detail: ReportJobErrorDetail = Field(
+        ...,
+        description="Structured API error payload for product and operational consumers.",
+        examples=[REPORT_JOB_ERROR_EXAMPLES["report_job_not_found"]["detail"]],
+    )
+
+
 class ReportJobHandleResponse(BaseModel):
     report_request_id: str = Field(
         ...,
@@ -438,4 +549,215 @@ class ReportJobStatusEventsResponse(BaseModel):
     events: list[ReportStatusEvent] = Field(
         ...,
         description="Append-only lifecycle events ordered by creation time.",
+        examples=[
+            [
+                {
+                    "statusEventId": "rse_d7e9c3b87d864b098997d4fe5bd2de2a",
+                    "reportJobId": "rjob_83ca965c50334c40a17d2b8cc94873a5",
+                    "fromStatus": None,
+                    "toStatus": "accepted",
+                    "eventType": "job_accepted",
+                    "message": "Portfolio review report job accepted.",
+                    "actor": "advisor-123",
+                    "createdAt": "2026-04-22T09:00:00Z",
+                    "correlationId": "corr-portfolio-review-1",
+                    "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
+                }
+            ]
+        ],
     )
+
+
+class ReportJobListFilters(BaseModel):
+    tenant_id: str | None = Field(
+        default=None,
+        alias="tenantId",
+        description="Tenant filter used to isolate jobs for one tenant scope.",
+        examples=["tenant-sg"],
+    )
+    region: str | None = Field(
+        default=None,
+        alias="region",
+        description="Region filter used to isolate jobs for one operating region.",
+        examples=["APAC"],
+    )
+    status: str | None = Field(
+        default=None,
+        alias="status",
+        description="Current job-status filter.",
+        examples=["accepted"],
+    )
+    report_type: str | None = Field(
+        default=None,
+        alias="reportType",
+        description="Report-type filter for the job search.",
+        examples=["portfolio_review"],
+    )
+    portfolio_id: str | None = Field(
+        default=None,
+        alias="portfolioId",
+        description="Portfolio identifier contained in the submitted portfolio scope.",
+        examples=["PB_SG_GLOBAL_BAL_001"],
+    )
+    as_of_date: str | None = Field(
+        default=None,
+        alias="asOfDate",
+        description="Business as-of date filter for the report request.",
+        examples=["2026-04-22"],
+    )
+    idempotency_key: str | None = Field(
+        default=None,
+        alias="idempotencyKey",
+        description="Idempotency key filter for duplicate-request diagnostics.",
+        examples=["portfolio-review-PB_SG_GLOBAL_BAL_001-2026-04-22"],
+    )
+    correlation_id: str | None = Field(
+        default=None,
+        alias="correlationId",
+        description="Correlation identifier filter for end-to-end operational tracing.",
+        examples=["corr-portfolio-review-1"],
+    )
+    created_from: datetime | None = Field(
+        default=None,
+        alias="createdFrom",
+        description="Inclusive lower UTC bound for job creation time.",
+        examples=["2026-04-22T00:00:00Z"],
+    )
+    created_to: datetime | None = Field(
+        default=None,
+        alias="createdTo",
+        description="Inclusive upper UTC bound for job creation time.",
+        examples=["2026-04-23T00:00:00Z"],
+    )
+    limit: int = Field(
+        default=25,
+        alias="limit",
+        description="Maximum number of jobs returned by this bounded search.",
+        examples=[25],
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+class ReportJobListItem(BaseModel):
+    report_job_id: str = Field(
+        ...,
+        alias="reportJobId",
+        description="Opaque durable report job identifier.",
+        examples=["rjob_83ca965c50334c40a17d2b8cc94873a5"],
+    )
+    report_request_id: str = Field(
+        ...,
+        alias="reportRequestId",
+        description="Opaque durable report request identifier linked to the job.",
+        examples=["rrq_4f7c85b39f7d4e7b8d0bb420d34a1d2c"],
+    )
+    report_type: str = Field(
+        ...,
+        alias="reportType",
+        description="Report type handled by the job.",
+        examples=["portfolio_review"],
+    )
+    tenant_id: str = Field(
+        ...,
+        alias="tenantId",
+        description="Tenant identifier captured when the request was created.",
+        examples=["tenant-sg"],
+    )
+    region: str = Field(
+        ...,
+        alias="region",
+        description="Operating region captured when the request was created.",
+        examples=["APAC"],
+    )
+    portfolio_scope: dict[str, Any] = Field(
+        ...,
+        alias="portfolioScope",
+        description="Submitted portfolio scope for the report job.",
+        examples=[{"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]}],
+    )
+    as_of_date: str = Field(
+        ...,
+        alias="asOfDate",
+        description="Business as-of date submitted for the report job.",
+        examples=["2026-04-22"],
+    )
+    status: str = Field(
+        ...,
+        alias="status",
+        description="Current product-safe report job status.",
+        examples=["accepted"],
+    )
+    failure_category: str | None = Field(
+        default=None,
+        alias="failureCategory",
+        description="Machine-readable failure category when the job failed or was cancelled.",
+        examples=[None],
+    )
+    current_step: str = Field(
+        ...,
+        alias="currentStep",
+        description="Current lifecycle step for support diagnostics.",
+        examples=["accepted"],
+    )
+    retry_eligible: bool = Field(
+        ...,
+        alias="retryEligible",
+        description="Whether retry or replay is currently permitted.",
+        examples=[False],
+    )
+    cancel_requested: bool = Field(
+        ...,
+        alias="cancelRequested",
+        description="Whether cancellation has been requested and recorded.",
+        examples=[False],
+    )
+    idempotency_key: str = Field(
+        ...,
+        alias="idempotencyKey",
+        description="Caller-supplied idempotency key associated with the job.",
+        examples=["portfolio-review-PB_SG_GLOBAL_BAL_001-2026-04-22"],
+    )
+    correlation_id: str = Field(
+        ...,
+        alias="correlationId",
+        description="Correlation identifier captured when the request was created.",
+        examples=["corr-portfolio-review-1"],
+    )
+    created_at: datetime = Field(
+        ...,
+        alias="createdAt",
+        description="UTC timestamp when the job was created.",
+        examples=["2026-04-22T09:00:00Z"],
+    )
+    updated_at: datetime = Field(
+        ...,
+        alias="updatedAt",
+        description="UTC timestamp when the job was last updated.",
+        examples=["2026-04-22T09:00:00Z"],
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+class ReportJobListResponse(BaseModel):
+    count: int = Field(
+        ...,
+        alias="count",
+        description="Number of jobs returned in this bounded response.",
+        examples=[1],
+    )
+    applied_filters: ReportJobListFilters = Field(
+        ...,
+        alias="appliedFilters",
+        description="Normalized filters applied to the job search.",
+        examples=[REPORT_JOB_LIST_FILTERS_EXAMPLE],
+    )
+    items: list[ReportJobListItem] = Field(
+        ...,
+        alias="items",
+        description="Bounded list of support-safe report job summaries.",
+        examples=[REPORT_JOB_LIST_RESPONSE_EXAMPLE["items"]],
+    )
+
+    model_config = {"populate_by_name": True}

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -28,7 +28,20 @@ async def _app_lifespan(application: FastAPI):
     application.state.is_draining = True
 
 
-app = FastAPI(title="Advisor Experience API", version="0.1.0", lifespan=_app_lifespan)
+app = FastAPI(
+    title="Advisor Experience API",
+    version="0.1.0",
+    lifespan=_app_lifespan,
+    openapi_tags=[
+        {"name": "Reports", "description": "Gateway-facing reporting data and command APIs."},
+        {
+            "name": "Report Jobs",
+            "description": (
+                "Gateway-facing report job operations for status and support diagnostics."
+            ),
+        },
+    ],
+)
 setup_logging()
 validate_enterprise_runtime_config()
 app.middleware("http")(correlation_middleware)

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -6,19 +6,23 @@ from fastapi import APIRouter, Body, Header, HTTPException, Path, Query, status
 from app.clients.reporting_client import ReportingClient
 from app.config import settings
 from app.contracts.reporting import (
+    REPORT_JOB_ERROR_EXAMPLES,
+    REPORT_JOB_LIST_RESPONSE_EXAMPLE,
     PortfolioReviewJobRequest,
     ReportingPortfolioRequest,
     ReportingReviewResponse,
     ReportingSnapshotResponse,
     ReportingSummaryResponse,
+    ReportJobErrorResponse,
     ReportJobHandleResponse,
+    ReportJobListResponse,
     ReportJobStatusEventsResponse,
     ReportJobStatusResponse,
 )
 from app.middleware.correlation import correlation_id_var
 
-router = APIRouter(prefix="/api/v1/reports", tags=["Reporting"])
-jobs_router = APIRouter(prefix="/api/v1/report-jobs", tags=["Reporting"])
+router = APIRouter(prefix="/api/v1/reports", tags=["Reports"])
+jobs_router = APIRouter(prefix="/api/v1/report-jobs", tags=["Report Jobs"])
 
 SUMMARY_REQUEST_EXAMPLES = {
     "wealthSummary": {
@@ -132,6 +136,14 @@ def _raise_report_job_error(status_code: int, payload: dict[str, Any]) -> None:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={"code": "missing_idempotency_key", "message": message},
         )
+    if status_code == status.HTTP_400_BAD_REQUEST and error_code in {
+        "missing_caller_context",
+        "invalid_report_job_filters",
+    }:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=detail,
+        )
     if status_code == status.HTTP_404_NOT_FOUND and error_code == "report_job_not_found":
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -150,6 +162,25 @@ def _raise_report_job_error(status_code: int, payload: dict[str, Any]) -> None:
                 "message": "Report job service is unavailable.",
             },
         )
+
+
+def _job_error_response(
+    status_code: int,
+    *,
+    example_key: str,
+    description: str,
+) -> dict[int | str, dict[str, Any]]:
+    return {
+        status_code: {
+            "model": ReportJobErrorResponse,
+            "description": description,
+            "content": {
+                "application/json": {
+                    "example": REPORT_JOB_ERROR_EXAMPLES[example_key],
+                }
+            },
+        }
+    }
 
 
 def _gateway_status_url(job_id: str) -> str:
@@ -332,8 +363,27 @@ async def get_reporting_review(
     summary="Submit portfolio review report job",
     description=(
         "Create a durable portfolio review report job through the governed gateway boundary. "
-        "The response is a job handle, not a rendered document."
+        "Use this endpoint when Workbench or another product client needs asynchronous report "
+        "generation with idempotency and supportable status tracking. The response is a job "
+        "handle, not a rendered document."
     ),
+    responses={
+        **_job_error_response(
+            400,
+            example_key="missing_idempotency_key",
+            description="Returned when idempotency or required caller context is missing.",
+        ),
+        **_job_error_response(
+            409,
+            example_key="idempotency_conflict",
+            description="Returned when the idempotency key conflicts with a different request.",
+        ),
+        **_job_error_response(
+            502,
+            example_key="report_job_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
 )
 async def submit_portfolio_review_report_job(
     request: Annotated[
@@ -386,10 +436,152 @@ async def submit_portfolio_review_report_job(
 
 
 @jobs_router.get(
+    "",
+    response_model=ReportJobListResponse,
+    summary="Search report jobs for operations and support",
+    description=(
+        "Return a bounded list of report jobs through the governed gateway boundary. Use this "
+        "endpoint when operators or support tooling need to find jobs by tenant, region, status, "
+        "portfolio, as-of date, idempotency key, or correlation identifier before drilling into "
+        "status or event history."
+    ),
+    openapi_extra={
+        "responses": {
+            "200": {
+                "content": {
+                    "application/json": {
+                        "example": REPORT_JOB_LIST_RESPONSE_EXAMPLE,
+                    }
+                }
+            }
+        }
+    },
+    responses={
+        **_job_error_response(
+            400,
+            example_key="invalid_report_job_filters",
+            description="Returned when no supported job-search filter is supplied.",
+        ),
+        **_job_error_response(
+            502,
+            example_key="report_job_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
+)
+async def list_report_jobs(
+    tenant_id_filter: Annotated[
+        str | None,
+        Query(alias="tenantId", description="Return only jobs for this tenant identifier."),
+    ] = None,
+    region_filter: Annotated[
+        str | None,
+        Query(alias="region", description="Return only jobs for this operating region."),
+    ] = None,
+    status_filter: Annotated[
+        str | None,
+        Query(alias="status", description="Return only jobs in this current lifecycle status."),
+    ] = None,
+    report_type_filter: Annotated[
+        str | None,
+        Query(alias="reportType", description="Return only jobs for this report type."),
+    ] = None,
+    portfolio_id_filter: Annotated[
+        str | None,
+        Query(
+            alias="portfolioId",
+            description="Return only jobs whose scope includes this portfolio.",
+        ),
+    ] = None,
+    as_of_date_filter: Annotated[
+        str | None,
+        Query(alias="asOfDate", description="Return only jobs for this business as-of date."),
+    ] = None,
+    idempotency_key_filter: Annotated[
+        str | None,
+        Query(alias="idempotencyKey", description="Return only jobs for this idempotency key."),
+    ] = None,
+    correlation_id_filter: Annotated[
+        str | None,
+        Query(
+            alias="correlationId",
+            description="Return only jobs for this correlation identifier.",
+        ),
+    ] = None,
+    created_from: Annotated[
+        str | None,
+        Query(alias="createdFrom", description="Inclusive UTC lower bound for job creation time."),
+    ] = None,
+    created_to: Annotated[
+        str | None,
+        Query(alias="createdTo", description="Inclusive UTC upper bound for job creation time."),
+    ] = None,
+    limit: Annotated[
+        int,
+        Query(
+            alias="limit",
+            ge=1,
+            le=100,
+            description="Maximum number of report jobs returned by this bounded search.",
+        ),
+    ] = 25,
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> ReportJobListResponse:
+    filters = {
+        "tenantId": tenant_id_filter,
+        "region": region_filter,
+        "status": status_filter,
+        "reportType": report_type_filter,
+        "portfolioId": portfolio_id_filter,
+        "asOfDate": as_of_date_filter,
+        "idempotencyKey": idempotency_key_filter,
+        "correlationId": correlation_id_filter,
+        "createdFrom": created_from,
+        "createdTo": created_to,
+        "limit": limit,
+    }
+    filters = {key: value for key, value in filters.items() if value is not None}
+    status_code, payload = await _reporting_client().list_report_jobs(
+        filters=filters,
+        caller_headers=_caller_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_job_error(status_code, payload)
+    return ReportJobListResponse.model_validate(payload)
+
+
+@jobs_router.get(
     "/{job_id}",
     response_model=ReportJobStatusResponse,
     summary="Get report job status",
-    description="Return product-safe report job status and diagnostics from lotus-report.",
+    description=(
+        "Return product-safe report job status and diagnostics from lotus-report. Use this "
+        "endpoint after submit or search when a caller needs current lifecycle state for one job."
+    ),
+    responses={
+        **_job_error_response(
+            404,
+            example_key="report_job_not_found",
+            description="Returned when the requested report job does not exist.",
+        ),
+        **_job_error_response(
+            502,
+            example_key="report_job_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
 )
 async def get_report_job_status(
     job_id: Annotated[str, Path(description="Opaque report job identifier.")],
@@ -424,6 +616,18 @@ async def get_report_job_status(
         "Return append-only report job lifecycle events through the governed gateway boundary. "
         "Use this endpoint for operational support when current status alone is insufficient."
     ),
+    responses={
+        **_job_error_response(
+            404,
+            example_key="report_job_not_found",
+            description="Returned when the requested report job does not exist.",
+        ),
+        **_job_error_response(
+            502,
+            example_key="report_job_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
 )
 async def get_report_job_events(
     job_id: Annotated[str, Path(description="Opaque report job identifier.")],
@@ -454,7 +658,28 @@ async def get_report_job_events(
     "/{job_id}/cancel",
     response_model=ReportJobStatusResponse,
     summary="Cancel report job before render or archive",
-    description="Cancel a report job while it is still before render, archive, or completion.",
+    description=(
+        "Cancel a report job while it is still before render, archive, or completion. Use this "
+        "endpoint only for bounded pre-render cancellation; rerender, reissue, archive, and legal "
+        "hold semantics are owned by later reporting RFCs."
+    ),
+    responses={
+        **_job_error_response(
+            404,
+            example_key="report_job_not_found",
+            description="Returned when the requested report job does not exist.",
+        ),
+        **_job_error_response(
+            409,
+            example_key="report_job_cannot_be_cancelled",
+            description="Returned when the job has completed or was already cancelled.",
+        ),
+        **_job_error_response(
+            502,
+            example_key="report_job_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
 )
 async def cancel_report_job(
     job_id: Annotated[str, Path(description="Opaque report job identifier.")],

--- a/tests/contract/test_reporting_contract.py
+++ b/tests/contract/test_reporting_contract.py
@@ -71,6 +71,7 @@ def test_reporting_openapi_contract_registered() -> None:
     assert "/api/v1/reports/{portfolio_id}/summary" in spec["paths"]
     assert "/api/v1/reports/{portfolio_id}/review" in spec["paths"]
     assert "/api/v1/reports/portfolio-reviews" in spec["paths"]
+    assert "/api/v1/report-jobs" in spec["paths"]
     assert "/api/v1/report-jobs/{job_id}" in spec["paths"]
     assert "/api/v1/report-jobs/{job_id}/events" in spec["paths"]
     assert "/api/v1/report-jobs/{job_id}/cancel" in spec["paths"]
@@ -79,6 +80,7 @@ def test_reporting_openapi_contract_registered() -> None:
     summary_path = spec["paths"]["/api/v1/reports/{portfolio_id}/summary"]["post"]
     review_path = spec["paths"]["/api/v1/reports/{portfolio_id}/review"]["post"]
     job_submit_path = spec["paths"]["/api/v1/reports/portfolio-reviews"]["post"]
+    job_list_path = spec["paths"]["/api/v1/report-jobs"]["get"]
     job_status_path = spec["paths"]["/api/v1/report-jobs/{job_id}"]["get"]
     job_events_path = spec["paths"]["/api/v1/report-jobs/{job_id}/events"]["get"]
     job_cancel_path = spec["paths"]["/api/v1/report-jobs/{job_id}/cancel"]["post"]
@@ -91,15 +93,22 @@ def test_reporting_openapi_contract_registered() -> None:
     assert summary_path["description"]
     assert review_path["description"]
     assert job_submit_path["summary"] == "Submit portfolio review report job"
+    assert job_list_path["summary"] == "Search report jobs for operations and support"
     assert job_status_path["summary"] == "Get report job status"
     assert job_events_path["summary"] == "Get report job event history"
     assert job_cancel_path["summary"] == "Cancel report job before render or archive"
     assert "RFC-" not in str(job_submit_path)
+    assert "RFC-" not in str(job_list_path)
     assert "RFC-" not in str(job_status_path)
     assert "RFC-" not in str(job_events_path)
     assert "RFC-" not in str(job_cancel_path)
     for schema_name in [
         "ReportJobHandleResponse",
+        "ReportJobListResponse",
+        "ReportJobListItem",
+        "ReportJobListFilters",
+        "ReportJobErrorResponse",
+        "ReportJobErrorDetail",
         "ReportJobStatusResponse",
         "ReportJobStatusEventsResponse",
         "ReportStatusEvent",

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -433,6 +433,45 @@ def test_portfolio_review_job_gateway_requires_caller_context():
 def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
     calls: list[tuple[str, str, dict[str, str] | None]] = []
 
+    async def _mock_list_jobs(self, *, filters, caller_headers, correlation_id):
+        calls.append(("list", filters["portfolioId"], caller_headers))
+        return 200, {
+            "count": 1,
+            "appliedFilters": {
+                "tenantId": "tenant-sg",
+                "region": "APAC",
+                "status": "accepted",
+                "reportType": None,
+                "portfolioId": filters["portfolioId"],
+                "asOfDate": None,
+                "idempotencyKey": None,
+                "correlationId": correlation_id,
+                "createdFrom": None,
+                "createdTo": None,
+                "limit": 25,
+            },
+            "items": [
+                {
+                    "reportJobId": "rjob_1",
+                    "reportRequestId": "rrq_1",
+                    "reportType": "portfolio_review",
+                    "tenantId": "tenant-sg",
+                    "region": "APAC",
+                    "portfolioScope": {"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]},
+                    "asOfDate": "2026-04-22",
+                    "status": "accepted",
+                    "failureCategory": None,
+                    "currentStep": "accepted",
+                    "retryEligible": False,
+                    "cancelRequested": False,
+                    "idempotencyKey": "idem-gateway-1",
+                    "correlationId": correlation_id,
+                    "createdAt": "2026-04-22T09:00:00Z",
+                    "updatedAt": "2026-04-22T09:00:00Z",
+                }
+            ],
+        }
+
     async def _mock_get_job(self, *, job_id, caller_headers, correlation_id):
         calls.append(("get", job_id, caller_headers))
         return 200, {
@@ -498,6 +537,9 @@ def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
         }
 
     monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.list_report_jobs", _mock_list_jobs
+    )
+    monkeypatch.setattr(
         "app.clients.reporting_client.ReportingClient.get_report_job", _mock_get_job
     )
     monkeypatch.setattr(
@@ -510,6 +552,14 @@ def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
     )
 
     client = TestClient(app)
+    list_response = client.get(
+        "/api/v1/report-jobs?portfolioId=PB_SG_GLOBAL_BAL_001",
+        headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+        },
+    )
     status_response = client.get(
         "/api/v1/report-jobs/rjob_1",
         headers={
@@ -535,25 +585,28 @@ def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
         },
     )
 
+    assert list_response.status_code == 200
+    assert list_response.json()["items"][0]["reportJobId"] == "rjob_1"
     assert status_response.status_code == 200
     assert status_response.json()["status"] == "accepted"
     assert events_response.status_code == 200
     assert events_response.json()["events"][0]["event_type"] == "job_accepted"
     assert cancel_response.status_code == 200
     assert cancel_response.json()["status"] == "cancelled"
-    assert calls[0][0:2] == ("get", "rjob_1")
+    assert calls[0][0:2] == ("list", "PB_SG_GLOBAL_BAL_001")
     assert calls[0][2]["X-Actor-Id"] == "advisor-123"
     assert calls[0][2]["X-Caller-Application"] == "lotus-gateway"
     assert calls[0][2]["X-Tenant-Id"] == "tenant-sg"
     assert calls[0][2]["X-Region"] == "APAC"
-    assert calls[1][0:2] == ("events", "rjob_1")
+    assert calls[1][0:2] == ("get", "rjob_1")
     assert calls[1][2]["X-Actor-Id"] == "advisor-123"
     assert calls[1][2]["X-Caller-Application"] == "lotus-gateway"
     assert calls[1][2]["X-Region"] == "APAC"
-    assert calls[2][0:2] == ("cancel", "rjob_1")
+    assert calls[2][0:2] == ("events", "rjob_1")
     assert calls[2][2]["X-Actor-Id"] == "advisor-123"
     assert calls[2][2]["X-Caller-Application"] == "lotus-gateway"
     assert calls[2][2]["X-Region"] == "APAC"
+    assert calls[3][0:2] == ("cancel", "rjob_1")
 
 
 def test_report_job_gateway_errors_are_product_safe(monkeypatch):

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -15,7 +15,7 @@
 - `GET /api/v1/portfolio/*`
 - `GET` and `POST /api/v1/workbench/*`
 - `GET` and `POST /api/v1/reports/*`
-- `GET` and `POST /api/v1/report-jobs/*`
+- `GET /api/v1/report-jobs` and `GET`/`POST /api/v1/report-jobs/*`
 - `/health`, `/health/live`, `/health/ready`, `/metrics`, `/docs`
 
 ## Current contract notes
@@ -34,8 +34,8 @@
   `advisor_sections`
 - portfolio review report job initiation uses canonical snake_case body fields and requires
   `Idempotency-Key`
-- report job status, append-only event history, and cancellation are gateway-first under
-  `/api/v1/report-jobs/*`
+- report job search, status, append-only event history, and cancellation are gateway-first under
+  `/api/v1/report-jobs` and `/api/v1/report-jobs/*`
 - intake upload routes accept camelCase multipart aliases such as `entityType`, `sampleSize`, and
   `allowPartial`
 - selected lookup filters remain snake_case, such as `cif_id`, `booking_center`, `product_type`,
@@ -121,6 +121,15 @@ Report job status:
 
 ```bash
 curl "http://127.0.0.1:8111/api/v1/report-jobs/rjob_example"
+```
+
+Report job operational search:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/report-jobs?tenantId=tenant-sg&region=APAC&portfolioId=PB_SG_GLOBAL_BAL_001&status=accepted&limit=25" \
+  -H "X-Actor-Id: support-operator-1" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC"
 ```
 
 Report job event history:


### PR DESCRIPTION
## Summary
- add gateway-certified report job operator APIs for list, status, events, and cancel
- keep report operations grouped and product-safe through the gateway boundary
- tighten OpenAPI, wiki, and operator documentation for RFC-0100

## Validation
- make check
- make test-integration
- gateway reporting contract and integration coverage

## Notes
- this PR covers the lotus-gateway side of RFC-0100
- lotus-report ledger and service changes are raised separately in lotus-report