### PR TITLE
Standardize canonical benchmark code across gateway surfaces

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -20,19 +20,19 @@ Run deterministic lotus-gateway demos for:
 Use the seeded flagship mandate:
 
 - portfolio: `DEMO_ADV_USD_001`
-- assigned benchmark: `BMK_GLOBAL_BALANCED_60_40`
+- assigned benchmark: `BMK_PB_GLOBAL_BALANCED_60_40`
 - alternate benchmark: `BMK_GLOBAL_GROWTH_80_20`
 
 Probe the split contracts:
 
 ```bash
-curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
 
-curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/details?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/details?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
 
-curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/horizon-comparison?detail_basis=NET&chart_frequency=monthly&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/horizon-comparison?detail_basis=NET&chart_frequency=monthly&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
 
-curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/attribution-trend?period=YTD&chart_frequency=monthly&detail_basis=NET&attribution_dimension=asset_class&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/attribution-trend?period=YTD&chart_frequency=monthly&detail_basis=NET&attribution_dimension=asset_class&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
 ```
 
 Verify:

--- a/src/app/contracts/advisor_brief.py
+++ b/src/app/contracts/advisor_brief.py
@@ -330,7 +330,7 @@ class AdvisorBriefResponse(BaseModel):
                 "chart_frequency": "monthly",
                 "contribution_dimension": "asset_class",
                 "attribution_dimension": "asset_class",
-                "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+                "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
                 "status": "partial",
                 "summary": (
                     "YTD portfolio return for PF 1001 is 1.25% versus Private Banking "
@@ -349,7 +349,7 @@ class AdvisorBriefResponse(BaseModel):
                                 "target_mode": "summary",
                                 "route": (
                                     "/performance?portfolioId=PF_1001&period=YTD"
-                                    "&detailBasis=NET&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                                    "&detailBasis=NET&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
                                 ),
                             }
                         ],
@@ -361,7 +361,7 @@ class AdvisorBriefResponse(BaseModel):
                         "target_mode": "summary",
                         "route": (
                             "/performance?portfolioId=PF_1001&period=YTD"
-                            "&detailBasis=NET&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                            "&detailBasis=NET&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
                         ),
                     }
                 ],
@@ -378,7 +378,7 @@ class AdvisorBriefResponse(BaseModel):
                                 "target_mode": "analysis",
                                 "route": (
                                     "/performance?portfolioId=PF_1001&period=YTD"
-                                    "&detailBasis=NET&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                                    "&detailBasis=NET&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
                                 ),
                             }
                         ],
@@ -392,7 +392,7 @@ class AdvisorBriefResponse(BaseModel):
                         "target_mode": "summary",
                         "route": (
                             "/performance?portfolioId=PF_1001&period=YTD"
-                            "&detailBasis=NET&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                            "&detailBasis=NET&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
                         ),
                         "state": "ready",
                     },
@@ -403,7 +403,7 @@ class AdvisorBriefResponse(BaseModel):
                         "target_mode": "summary",
                         "route": (
                             "/performance?portfolioId=PF_1001&period=YTD"
-                            "&detailBasis=NET&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                            "&detailBasis=NET&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
                         ),
                         "state": "partial",
                     },
@@ -555,7 +555,7 @@ class AdvisorBriefResponse(BaseModel):
     benchmark_code: str | None = Field(
         default=None,
         description="Resolved benchmark code used when generating the advisor brief.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     )
     status: AdvisorBriefStatus = Field(
         description="Overall availability status of the advisor brief output.",

--- a/src/app/contracts/performance_workspace.py
+++ b/src/app/contracts/performance_workspace.py
@@ -186,7 +186,7 @@ class AttributionSummaryView(BaseModel):
     benchmark_id: str | None = Field(
         default=None,
         description="Resolved benchmark identifier used for the attribution analysis.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     )
     benchmark_return_source: str | None = Field(
         default=None,
@@ -536,7 +536,7 @@ class PerformanceHorizonComparisonResponse(BaseModel):
     benchmark_code: str | None = Field(
         default=None,
         description="Resolved benchmark code used for horizon comparison rows when available.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     )
     benchmark_options: list[PerformanceBenchmarkOptionView] = Field(
         default_factory=list,
@@ -571,10 +571,10 @@ class PerformanceHorizonComparisonResponse(BaseModel):
                 "detail_basis": "NET",
                 "chart_frequency": "monthly",
                 "requested_chart_frequency_supported": True,
-                "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+                "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
                 "benchmark_options": [
                     {
-                        "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+                        "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
                         "benchmark_name": "Global Balanced 60/40",
                         "benchmark_currency": "USD",
                         "benchmark_type": "composite",
@@ -753,7 +753,7 @@ class PerformanceAttributionTrendResponse(BaseModel):
     benchmark_code: str | None = Field(
         default=None,
         description="Resolved benchmark code used for the attribution trend when available.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     )
     rows: list[PerformanceAttributionTrendRow] = Field(
         default_factory=list,
@@ -787,7 +787,7 @@ class PerformanceAttributionTrendResponse(BaseModel):
                 "attribution_dimension": "asset_class",
                 "requested_chart_frequency_supported": True,
                 "requested_attribution_dimension_supported": True,
-                "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+                "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
                 "rows": [
                     {
                         "period_label": "2026-01",
@@ -925,7 +925,7 @@ class PerformanceWorkspaceSummaryResponse(BaseModel):
     benchmark_code: str | None = Field(
         default=None,
         description="Resolved benchmark code used for the performance summary when available.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     )
     benchmark_options: list[PerformanceBenchmarkOptionView] = Field(
         default_factory=list,
@@ -964,10 +964,10 @@ class PerformanceWorkspaceSummaryResponse(BaseModel):
                 "requested_chart_frequency_supported": True,
                 "requested_contribution_dimension_supported": True,
                 "requested_attribution_dimension_supported": True,
-                "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+                "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
                 "benchmark_options": [
                     {
-                        "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+                        "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
                         "benchmark_name": "Global Balanced 60/40",
                         "benchmark_currency": "USD",
                         "benchmark_type": "composite",
@@ -1031,7 +1031,7 @@ class PerformanceWorkspaceSummaryResponse(BaseModel):
                     "benchmark_return_pct": 4.91,
                     "active_return_pct": 0.52,
                     "annualized_return_pct": 5.42,
-                    "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                    "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                     "benchmark_return_source": "calculated",
                     "benchmark_input_mode": "stateful",
                     "begin_market_value": 1200000.0,
@@ -1048,7 +1048,7 @@ class PerformanceWorkspaceSummaryResponse(BaseModel):
                     "benchmark_return_pct": 5.12,
                     "active_return_pct": 0.76,
                     "annualized_return_pct": 5.88,
-                    "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                    "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                     "benchmark_return_source": "calculated",
                     "benchmark_input_mode": "stateful",
                     "begin_market_value": 1200000.0,
@@ -1150,7 +1150,7 @@ class PerformanceWorkspaceDetailsResponse(BaseModel):
     benchmark_code: str | None = Field(
         default=None,
         description="Resolved benchmark code used for the performance details when available.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     )
     capabilities: PerformanceWorkspaceCapabilities = Field(
         description="Gateway-published capability posture for the performance details surface."
@@ -1207,7 +1207,7 @@ class PerformanceWorkspaceDetailsResponse(BaseModel):
                 "requested_contribution_dimension_supported": True,
                 "requested_attribution_dimension_supported": True,
                 "segment": "asset_class",
-                "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+                "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
                 "capabilities": {
                     "summary_kpis": {"state": "supported"},
                     "return_path": {"state": "supported"},
@@ -1308,7 +1308,7 @@ class PerformanceWorkspaceDetailsResponse(BaseModel):
                     "metric_basis": "NET",
                     "model": "BF",
                     "linking": "carino",
-                    "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                    "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                     "benchmark_return_source": "calculated",
                     "active_return_pct": 0.52,
                     "sum_of_effects_pct": 0.5,

--- a/src/app/contracts/portfolio.py
+++ b/src/app/contracts/portfolio.py
@@ -2060,7 +2060,7 @@ class PortfolioPerformanceSnapshotResponse(BaseModel):
     benchmark_code: str | None = Field(
         default=None,
         description="Resolved benchmark code used for the comparison values when available.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     )
     portfolio_return_pct: float | None = Field(
         default=None,

--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -130,7 +130,7 @@ class ReportingPortfolioRequest(BaseModel):
             "Optional benchmark identifier forwarded to lotus-report for performance and risk "
             "review context."
         ),
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     )
 
     model_config = {"populate_by_name": True, "extra": "allow"}
@@ -343,7 +343,7 @@ class PortfolioReviewJobRequest(BaseModel):
         examples=[
             {
                 "sections": ["OVERVIEW", "PERFORMANCE", "RISK_ANALYTICS"],
-                "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+                "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
             }
         ],
     )

--- a/src/app/contracts/risk_workspace.py
+++ b/src/app/contracts/risk_workspace.py
@@ -1580,7 +1580,7 @@ class WorkbenchRiskModuleEnvelope(BaseModel):
     benchmark_code: str | None = Field(
         default=None,
         description="Resolved benchmark code used by the risk module when available.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     )
     source_service: str = Field(
         default="lotus-risk",
@@ -1621,7 +1621,7 @@ class WorkbenchRiskSummaryResponse(WorkbenchRiskModuleEnvelope):
                 "portfolio_id": "PF_1001",
                 "period": "YTD",
                 "as_of_date": "2026-02-24",
-                "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+                "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
                 "source_service": "lotus-risk",
                 "state": "partial",
                 "payload": {

--- a/src/app/routers/portfolio.py
+++ b/src/app/routers/portfolio.py
@@ -795,11 +795,11 @@ async def get_portfolio_performance_snapshot(
             "Optional benchmark override. When omitted, the portfolio-assigned benchmark is used "
             "when available."
         ),
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
         openapi_examples={
             "balanced": {
                 "summary": "Balanced benchmark override",
-                "value": "BMK_GLOBAL_BALANCED_60_40",
+                "value": "BMK_PB_GLOBAL_BALANCED_60_40",
             }
         },
     ),

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -56,7 +56,7 @@ REVIEW_REQUEST_EXAMPLES = {
             ],
             "allocationDimensions": ["asset_class"],
             "lookThroughMode": "full",
-            "benchmarkCode": "BMK_GLOBAL_BALANCED_60_40",
+            "benchmarkCode": "BMK_PB_GLOBAL_BALANCED_60_40",
         },
     }
 }
@@ -72,7 +72,7 @@ PORTFOLIO_REVIEW_JOB_REQUEST_EXAMPLES = {
             "reporting_currency": "USD",
             "options": {
                 "sections": ["OVERVIEW", "PERFORMANCE", "RISK_ANALYTICS"],
-                "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+                "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
             },
         },
     }

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -331,7 +331,7 @@ async def get_workbench_risk_summary(
     benchmark_code: str | None = Query(
         default=None,
         description="Optional benchmark override used for relative risk context.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     ),
     as_of_date: str | None = Query(
         default=None,
@@ -385,7 +385,7 @@ async def get_workbench_risk_concentration(
     benchmark_code: str | None = Query(
         default=None,
         description="Optional benchmark override used for relative concentration context.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     ),
     as_of_date: str | None = Query(
         default=None,
@@ -442,7 +442,7 @@ async def get_workbench_risk_drawdown(
     benchmark_code: str | None = Query(
         default=None,
         description="Optional benchmark override used for relative drawdown context.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     ),
     as_of_date: str | None = Query(
         default=None,
@@ -507,7 +507,7 @@ async def get_workbench_risk_rolling(
     benchmark_code: str | None = Query(
         default=None,
         description="Optional benchmark override used for relative rolling-risk context.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     ),
     as_of_date: str | None = Query(
         default=None,
@@ -576,7 +576,7 @@ async def get_workbench_risk_attribution(
     benchmark_code: str | None = Query(
         default=None,
         description="Optional benchmark override used for relative attribution context.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     ),
     as_of_date: str | None = Query(
         default=None,
@@ -667,7 +667,7 @@ async def get_performance_workspace_summary(
     benchmark_code: str | None = Query(
         default=None,
         description="Optional benchmark override used for summary-relative performance context.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     ),
     report_start_date: str | None = Query(
         default=None,
@@ -744,7 +744,7 @@ async def get_performance_workspace_details(
     benchmark_code: str | None = Query(
         default=None,
         description="Optional benchmark override used for detailed relative performance context.",
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     ),
     report_start_date: str | None = Query(
         default=None,
@@ -855,7 +855,7 @@ async def get_performance_horizon_comparison(
             "Optional benchmark override. When omitted, the portfolio-assigned benchmark is used "
             "when available."
         ),
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     ),
     chart_frequency: str = Query(
         default="monthly",
@@ -949,7 +949,7 @@ async def get_performance_attribution_trend(
             "Optional benchmark override. When omitted, the portfolio-assigned benchmark is used "
             "when available."
         ),
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     ),
     report_start_date: str | None = Query(
         default=None,
@@ -1032,7 +1032,7 @@ async def get_performance_advisor_brief(
             "Optional benchmark override. When omitted, the portfolio-assigned benchmark is used "
             "when available."
         ),
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     ),
     report_start_date: str | None = Query(
         default=None,
@@ -1113,7 +1113,7 @@ async def post_performance_advisor_brief_review_action(
             "Optional benchmark override. When omitted, the portfolio-assigned benchmark is used "
             "when available."
         ),
-        examples=["BMK_GLOBAL_BALANCED_60_40"],
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
     ),
     report_start_date: str | None = Query(
         default=None,

--- a/tests/contract/test_portfolio_contract.py
+++ b/tests/contract/test_portfolio_contract.py
@@ -423,7 +423,7 @@ def test_portfolio_performance_snapshot_contract_shape() -> None:
         report_start_date="2026-01-01",
         report_end_date="2026-03-27",
         period="YTD",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
         portfolio_return_pct=15.1,
         benchmark_return_pct=14.72,
         excess_return_pct=0.38,
@@ -436,7 +436,7 @@ def test_portfolio_performance_snapshot_contract_shape() -> None:
             }
         ],
     )
-    assert payload.benchmark_code == "BMK_GLOBAL_BALANCED_60_40"
+    assert payload.benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert payload.portfolio_return_pct == 15.1
     assert payload.benchmark_return_pct == 14.72
     assert payload.excess_return_pct == 0.38
@@ -1065,7 +1065,7 @@ def test_portfolio_openapi_contract_registered() -> None:
     assert performance_snapshot_parameters["detail_basis"]["examples"]["net"]["value"] == "NET"
     assert performance_snapshot_parameters["benchmark_code"]["description"]
     assert performance_snapshot_parameters["benchmark_code"]["examples"]["balanced"]["value"] == (
-        "BMK_GLOBAL_BALANCED_60_40"
+        "BMK_PB_GLOBAL_BALANCED_60_40"
     )
     assert performance_snapshot_parameters["explicit_start_date"]["description"]
     assert (
@@ -1091,7 +1091,7 @@ def test_portfolio_openapi_contract_registered() -> None:
     assert performance_snapshot_schema["properties"]["portfolio_id"]["description"]
     assert performance_snapshot_schema["properties"]["benchmark_code"]["description"]
     assert performance_snapshot_schema["properties"]["benchmark_code"]["examples"] == [
-        "BMK_GLOBAL_BALANCED_60_40"
+        "BMK_PB_GLOBAL_BALANCED_60_40"
     ]
     assert performance_snapshot_schema["properties"]["portfolio_return_pct"]["description"]
     assert performance_snapshot_schema["properties"]["portfolio_return_pct"]["examples"] == [15.1]

--- a/tests/contract/test_reporting_contract.py
+++ b/tests/contract/test_reporting_contract.py
@@ -48,7 +48,7 @@ def test_reporting_request_normalizes_documented_aliases() -> None:
         sections=["WEALTH", "ALLOCATION"],
         allocationDimensions=["asset_class", "currency"],
         lookThroughMode="direct_only",
-        benchmarkCode="BMK_GLOBAL_BALANCED_60_40",
+        benchmarkCode="BMK_PB_GLOBAL_BALANCED_60_40",
         includeBenchmarks=True,
     )
 
@@ -58,7 +58,7 @@ def test_reporting_request_normalizes_documented_aliases() -> None:
         "sections": ["WEALTH", "ALLOCATION"],
         "allocation_dimensions": ["asset_class", "currency"],
         "look_through_mode": "direct_only",
-        "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+        "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
         "includeBenchmarks": True,
     }
 
@@ -154,7 +154,7 @@ def test_reporting_openapi_contract_registered() -> None:
         review_path["requestBody"]["content"]["application/json"]["examples"]["frontOfficeReview"][
             "value"
         ]["benchmarkCode"]
-        == "BMK_GLOBAL_BALANCED_60_40"
+        == "BMK_PB_GLOBAL_BALANCED_60_40"
     )
     assert request_schema["properties"]["asOfDate"]["description"]
     assert request_schema["properties"]["reportingCurrency"]["description"]

--- a/tests/contract/test_workbench_contract.py
+++ b/tests/contract/test_workbench_contract.py
@@ -217,7 +217,7 @@ def test_workbench_openapi_contract_registered() -> None:
     assert risk_summary_parameters["detail_basis"]["schema"]["examples"] == ["NET"]
     assert risk_summary_parameters["benchmark_code"]["description"]
     assert risk_summary_parameters["benchmark_code"]["schema"]["examples"] == [
-        "BMK_GLOBAL_BALANCED_60_40"
+        "BMK_PB_GLOBAL_BALANCED_60_40"
     ]
     assert risk_summary_parameters["as_of_date"]["description"]
     assert risk_summary_parameters["as_of_date"]["schema"]["examples"] == ["2026-02-24"]
@@ -232,7 +232,7 @@ def test_workbench_openapi_contract_registered() -> None:
     assert risk_concentration_parameters["period"]["schema"]["examples"] == ["YTD"]
     assert risk_concentration_parameters["benchmark_code"]["description"]
     assert risk_concentration_parameters["benchmark_code"]["schema"]["examples"] == [
-        "BMK_GLOBAL_BALANCED_60_40"
+        "BMK_PB_GLOBAL_BALANCED_60_40"
     ]
     assert risk_concentration_parameters["as_of_date"]["description"]
     assert risk_concentration_parameters["as_of_date"]["schema"]["examples"] == ["2026-02-24"]
@@ -248,7 +248,7 @@ def test_workbench_openapi_contract_registered() -> None:
     assert risk_drawdown_parameters["detail_basis"]["schema"]["default"] == "NET"
     assert risk_drawdown_parameters["benchmark_code"]["description"]
     assert risk_drawdown_parameters["benchmark_code"]["schema"]["examples"] == [
-        "BMK_GLOBAL_BALANCED_60_40"
+        "BMK_PB_GLOBAL_BALANCED_60_40"
     ]
     assert risk_drawdown_parameters["as_of_date"]["description"]
     assert risk_drawdown_parameters["as_of_date"]["schema"]["examples"] == ["2026-02-24"]
@@ -268,7 +268,7 @@ def test_workbench_openapi_contract_registered() -> None:
     assert risk_rolling_parameters["detail_basis"]["schema"]["default"] == "NET"
     assert risk_rolling_parameters["benchmark_code"]["description"]
     assert risk_rolling_parameters["benchmark_code"]["schema"]["examples"] == [
-        "BMK_GLOBAL_BALANCED_60_40"
+        "BMK_PB_GLOBAL_BALANCED_60_40"
     ]
     assert risk_rolling_parameters["as_of_date"]["description"]
     assert risk_rolling_parameters["as_of_date"]["schema"]["examples"] == ["2026-02-24"]
@@ -291,7 +291,7 @@ def test_workbench_openapi_contract_registered() -> None:
     assert risk_attribution_parameters["detail_basis"]["schema"]["default"] == "NET"
     assert risk_attribution_parameters["benchmark_code"]["description"]
     assert risk_attribution_parameters["benchmark_code"]["schema"]["examples"] == [
-        "BMK_GLOBAL_BALANCED_60_40"
+        "BMK_PB_GLOBAL_BALANCED_60_40"
     ]
     assert risk_attribution_parameters["as_of_date"]["description"]
     assert risk_attribution_parameters["as_of_date"]["schema"]["examples"] == ["2026-02-24"]
@@ -323,7 +323,7 @@ def test_workbench_openapi_contract_registered() -> None:
     assert performance_summary_parameters["detail_basis"]["schema"]["default"] == "NET"
     assert performance_summary_parameters["benchmark_code"]["description"]
     assert performance_summary_parameters["benchmark_code"]["schema"]["examples"] == [
-        "BMK_GLOBAL_BALANCED_60_40"
+        "BMK_PB_GLOBAL_BALANCED_60_40"
     ]
     assert performance_summary_parameters["report_start_date"]["description"]
     assert performance_summary_parameters["report_start_date"]["schema"]["examples"] == [
@@ -351,7 +351,7 @@ def test_workbench_openapi_contract_registered() -> None:
     assert performance_details_parameters["detail_basis"]["schema"]["default"] == "NET"
     assert performance_details_parameters["benchmark_code"]["description"]
     assert performance_details_parameters["benchmark_code"]["schema"]["examples"] == [
-        "BMK_GLOBAL_BALANCED_60_40"
+        "BMK_PB_GLOBAL_BALANCED_60_40"
     ]
     assert performance_details_parameters["report_start_date"]["description"]
     assert performance_details_parameters["report_start_date"]["schema"]["examples"] == [

--- a/tests/integration/test_portfolio_router.py
+++ b/tests/integration/test_portfolio_router.py
@@ -1695,7 +1695,7 @@ def test_portfolio_performance_snapshot_router(monkeypatch):
             "report_start_date": "2026-01-01",
             "report_end_date": "2026-03-27",
             "period": "EXPLICIT",
-            "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+            "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
             "portfolio_return_pct": 15.1,
             "benchmark_return_pct": 14.72,
             "excess_return_pct": 0.38,
@@ -1736,7 +1736,7 @@ def test_portfolio_performance_snapshot_router(monkeypatch):
             "period": "EXPLICIT",
             "chart_frequency": "quarterly",
             "detail_basis": "GROSS",
-            "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+            "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
             "explicit_start_date": "2026-01-01",
             "explicit_end_date": "2026-03-27",
         },
@@ -1749,7 +1749,7 @@ def test_portfolio_performance_snapshot_router(monkeypatch):
     assert body["portfolio_id"] == "PF_1001"
     assert body["as_of_date"] == "2026-03-27"
     assert body["period"] == "EXPLICIT"
-    assert body["benchmark_code"] == "BMK_GLOBAL_BALANCED_60_40"
+    assert body["benchmark_code"] == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert body["report_start_date"] == "2026-01-01"
     assert body["report_end_date"] == "2026-03-27"
     assert body["portfolio_return_pct"] == 15.1
@@ -1765,7 +1765,7 @@ def test_portfolio_performance_snapshot_router(monkeypatch):
     assert captured["period"] == "EXPLICIT"
     assert captured["chart_frequency"] == "quarterly"
     assert captured["detail_basis"] == "GROSS"
-    assert captured["benchmark_code"] == "BMK_GLOBAL_BALANCED_60_40"
+    assert captured["benchmark_code"] == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert captured["explicit_start_date"] == "2026-01-01"
     assert captured["explicit_end_date"] == "2026-03-27"
 

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -187,7 +187,7 @@ def test_reporting_review_success(monkeypatch):
             "sections": ["OVERVIEW"],
             "allocation_dimensions": ["asset_class"],
             "look_through_mode": "full",
-            "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+            "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
         }
         return 200, {
             "portfolio_id": portfolio_id,
@@ -239,7 +239,7 @@ def test_reporting_review_success(monkeypatch):
             "sections": ["OVERVIEW"],
             "allocationDimensions": ["asset_class"],
             "lookThroughMode": "full",
-            "benchmarkCode": "BMK_GLOBAL_BALANCED_60_40",
+            "benchmarkCode": "BMK_PB_GLOBAL_BALANCED_60_40",
         },
     )
     assert response.status_code == 200
@@ -342,7 +342,7 @@ def _job_payload():
         "reporting_currency": "USD",
         "options": {
             "sections": ["OVERVIEW", "PERFORMANCE"],
-            "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+            "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
         },
     }
 

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -1479,7 +1479,7 @@ def test_workbench_performance_summary_router_preserves_query_context(monkeypatc
         "/api/v1/workbench/PF_1001/performance/summary"
         "?period=EXPLICIT&chart_frequency=weekly&contribution_dimension=sector"
         "&attribution_dimension=country&detail_basis=GROSS"
-        "&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+        "&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
         "&report_start_date=2026-01-01&report_end_date=2026-03-27",
         headers={"X-Correlation-Id": "corr-performance-summary"},
     )
@@ -1494,7 +1494,7 @@ def test_workbench_performance_summary_router_preserves_query_context(monkeypatc
         "contribution_dimension": "sector",
         "attribution_dimension": "country",
         "detail_basis": "GROSS",
-        "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+        "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
         "explicit_start_date": "2026-01-01",
         "explicit_end_date": "2026-03-27",
     }
@@ -1502,7 +1502,7 @@ def test_workbench_performance_summary_router_preserves_query_context(monkeypatc
     assert body["report_start_date"] == "2026-01-01"
     assert body["report_end_date"] == "2026-03-27"
     assert body["detail_basis"] == "GROSS"
-    assert body["benchmark_code"] == "BMK_GLOBAL_BALANCED_60_40"
+    assert body["benchmark_code"] == "BMK_PB_GLOBAL_BALANCED_60_40"
 
 
 def test_workbench_performance_details_router_preserves_query_context(monkeypatch):
@@ -1594,7 +1594,7 @@ def test_workbench_performance_details_router_preserves_query_context(monkeypatc
         "/api/v1/workbench/PF_1001/performance/details"
         "?period=EXPLICIT&chart_frequency=weekly&contribution_dimension=sector"
         "&attribution_dimension=country&detail_basis=GROSS"
-        "&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+        "&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
         "&report_start_date=2026-01-01&report_end_date=2026-03-27",
         headers={"X-Correlation-Id": "corr-performance-details"},
     )
@@ -1609,7 +1609,7 @@ def test_workbench_performance_details_router_preserves_query_context(monkeypatc
         "contribution_dimension": "sector",
         "attribution_dimension": "country",
         "detail_basis": "GROSS",
-        "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+        "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
         "explicit_start_date": "2026-01-01",
         "explicit_end_date": "2026-03-27",
     }
@@ -1617,7 +1617,7 @@ def test_workbench_performance_details_router_preserves_query_context(monkeypatc
     assert body["report_start_date"] == "2026-01-01"
     assert body["report_end_date"] == "2026-03-27"
     assert body["detail_basis"] == "GROSS"
-    assert body["benchmark_code"] == "BMK_GLOBAL_BALANCED_60_40"
+    assert body["benchmark_code"] == "BMK_PB_GLOBAL_BALANCED_60_40"
 
 
 def test_workbench_performance_evidence_artifact_router(monkeypatch):
@@ -1784,7 +1784,7 @@ def test_workbench_performance_horizon_comparison_router_preserves_query_context
     client = TestClient(app)
     response = client.get(
         "/api/v1/workbench/PF_1001/performance/horizon-comparison"
-        "?period=EXPLICIT&detail_basis=GROSS&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+        "?period=EXPLICIT&detail_basis=GROSS&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
         "&chart_frequency=weekly&report_start_date=2026-01-01&report_end_date=2026-03-27",
         headers={"X-Correlation-Id": "corr-horizon"},
     )
@@ -1795,7 +1795,7 @@ def test_workbench_performance_horizon_comparison_router_preserves_query_context
         "correlation_id": "corr-horizon",
         "period": "EXPLICIT",
         "detail_basis": "GROSS",
-        "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+        "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
         "chart_frequency": "weekly",
         "explicit_start_date": "2026-01-01",
         "explicit_end_date": "2026-03-27",
@@ -1924,7 +1924,7 @@ def test_workbench_performance_attribution_trend_router_preserves_query_context(
     response = client.get(
         "/api/v1/workbench/PF_1001/performance/attribution-trend"
         "?period=EXPLICIT&chart_frequency=weekly&attribution_dimension=country"
-        "&detail_basis=GROSS&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+        "&detail_basis=GROSS&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
         "&report_start_date=2026-01-01&report_end_date=2026-03-27",
         headers={"X-Correlation-Id": "corr-attribution-trend"},
     )
@@ -1937,7 +1937,7 @@ def test_workbench_performance_attribution_trend_router_preserves_query_context(
         "chart_frequency": "weekly",
         "attribution_dimension": "country",
         "detail_basis": "GROSS",
-        "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+        "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
         "explicit_start_date": "2026-01-01",
         "explicit_end_date": "2026-03-27",
     }
@@ -1990,7 +1990,7 @@ def test_workbench_performance_horizon_comparison_openapi_contract():
     assert response_schema["example"]["rows"][0]["period"] == "MTD"
     assert (
         response_schema["example"]["benchmark_options"][0]["benchmark_code"]
-        == "BMK_GLOBAL_BALANCED_60_40"
+        == "BMK_PB_GLOBAL_BALANCED_60_40"
     )
 
 
@@ -2031,7 +2031,7 @@ def test_workbench_performance_evidence_openapi_contract():
     assert summary_schema["properties"]["capabilities"]["description"]
     assert (
         summary_schema["example"]["benchmark_options"][0]["benchmark_code"]
-        == "BMK_GLOBAL_BALANCED_60_40"
+        == "BMK_PB_GLOBAL_BALANCED_60_40"
     )
     assert summary_schema["example"]["evidence_view"]["state"] == "partial"
     assert details_schema["properties"]["correlation_id"]["description"]
@@ -2241,7 +2241,7 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
             chart_frequency="monthly",
             contribution_dimension="asset_class",
             attribution_dimension="asset_class",
-            benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+            benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
             status=AdvisorBriefStatus.READY,
             summary="Advisor summary.",
             talking_points=[
@@ -2257,7 +2257,7 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
                             target_mode="summary",
                             route=(
                                 "/performance?portfolioId=PF_1001&period=YTD"
-                                "&detailBasis=NET&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                                "&detailBasis=NET&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
                             ),
                         )
                     ],
@@ -2269,7 +2269,7 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
                     target_mode="summary",
                     route=(
                         "/performance?portfolioId=PF_1001&period=YTD"
-                        "&detailBasis=NET&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                        "&detailBasis=NET&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
                     ),
                 )
             ],
@@ -2282,7 +2282,7 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
                     target_mode="summary",
                     route=(
                         "/performance?portfolioId=PF_1001&period=YTD"
-                        "&detailBasis=NET&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                        "&detailBasis=NET&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
                     ),
                 )
             ],
@@ -2335,7 +2335,7 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
         "/api/v1/workbench/PF_1001/performance/advisor-brief"
         "?period=YTD&chart_frequency=monthly&detail_basis=NET"
         "&contribution_dimension=asset_class&attribution_dimension=asset_class"
-        "&benchmark_code=BMK_GLOBAL_BALANCED_60_40&report_start_date=2026-01-01"
+        "&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40&report_start_date=2026-01-01"
         "&report_end_date=2026-04-04"
     )
 
@@ -2361,7 +2361,7 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
     assert captured_call["portfolio_id"] == "PF_1001"
     assert captured_call["period"] == "YTD"
     assert captured_call["detail_basis"] == "NET"
-    assert captured_call["benchmark_code"] == "BMK_GLOBAL_BALANCED_60_40"
+    assert captured_call["benchmark_code"] == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert captured_call["explicit_start_date"] == "2026-01-01"
     assert captured_call["explicit_end_date"] == "2026-04-04"
 
@@ -2432,7 +2432,7 @@ def test_workbench_performance_advisor_brief_router_preserves_query_context(monk
         "/api/v1/workbench/PF_1001/performance/advisor-brief"
         "?period=EXPLICIT&chart_frequency=weekly&contribution_dimension=sector"
         "&attribution_dimension=country&detail_basis=GROSS"
-        "&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+        "&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
         "&report_start_date=2026-01-01&report_end_date=2026-03-27",
         headers={"X-Correlation-Id": "corr-advisor-brief"},
     )
@@ -2446,7 +2446,7 @@ def test_workbench_performance_advisor_brief_router_preserves_query_context(monk
         "contribution_dimension": "sector",
         "attribution_dimension": "country",
         "detail_basis": "GROSS",
-        "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+        "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
         "explicit_start_date": "2026-01-01",
         "explicit_end_date": "2026-03-27",
     }
@@ -2562,7 +2562,7 @@ def test_workbench_performance_advisor_brief_review_action_router(monkeypatch):
         "/api/v1/workbench/PF_1001/performance/advisor-brief/review-actions"
         "?period=EXPLICIT&chart_frequency=weekly&contribution_dimension=sector"
         "&attribution_dimension=country&detail_basis=GROSS"
-        "&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+        "&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
         "&report_start_date=2026-01-01&report_end_date=2026-03-27",
         headers={"X-Correlation-Id": "corr-advisor-brief-review"},
         json={
@@ -2601,7 +2601,7 @@ def test_workbench_performance_advisor_brief_review_action_router(monkeypatch):
         "contribution_dimension": "sector",
         "attribution_dimension": "country",
         "detail_basis": "GROSS",
-        "benchmark_code": "BMK_GLOBAL_BALANCED_60_40",
+        "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
         "request": {
             "action_type": "SUPERSEDE",
             "reviewed_by": "advisor_1",

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -315,7 +315,7 @@ async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_acti
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.status == "ready"
@@ -328,7 +328,7 @@ async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_acti
     assert response.source_metrics[0].label == "Portfolio Return"
     assert response.source_metrics[0].route == (
         "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET"
-        "&benchmark=BMK_GLOBAL_BALANCED_60_40"
+        "&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
     )
     assert response.ai_audit["request_id"] == "req-1"
     assert response.ai_audit["provider_mode"] == "openai"
@@ -409,7 +409,7 @@ async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_acti
     assert ai_client.execute_calls[0]["task_request"]["context"]["source_refs"] == [
         "lotus-gateway:workbench:PF_1001:performance-summary:YTD",
         "lotus-gateway:workbench:PF_1001:performance-details:YTD",
-        "lotus-performance:benchmark:PF_1001:BMK_GLOBAL_BALANCED_60_40:YTD",
+        "lotus-performance:benchmark:PF_1001:BMK_PB_GLOBAL_BALANCED_60_40:YTD",
     ]
     assert ai_client.consumer_view_calls == [
         {"run_id": "packrun_advisor_brief_req-1", "correlation_id": "corr-1"}
@@ -439,7 +439,7 @@ async def test_advisor_brief_service_marks_partial_for_partial_sources_or_ai():
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.status == "partial"
@@ -480,7 +480,7 @@ async def test_advisor_brief_service_marks_partial_for_partial_sources_or_ai():
                     "target_mode": "analysis",
                     "route": (
                         "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET"
-                        "&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                        "&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
                     ),
                 }
             ],
@@ -497,7 +497,7 @@ async def test_advisor_brief_service_marks_partial_for_partial_sources_or_ai():
                     "target_mode": "analysis",
                     "route": (
                         "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET"
-                        "&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                        "&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
                     ),
                 }
             ],
@@ -514,7 +514,7 @@ async def test_advisor_brief_service_marks_partial_for_partial_sources_or_ai():
                     "target_mode": "summary",
                     "route": (
                         "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET"
-                        "&benchmark=BMK_GLOBAL_BALANCED_60_40"
+                        "&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
                     ),
                 }
             ],
@@ -584,7 +584,7 @@ async def test_advisor_brief_service_preserves_rejected_workflow_pack_run_postur
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.status == "partial"
@@ -632,7 +632,7 @@ async def test_advisor_brief_service_reuses_cached_response_for_identical_reques
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
     second = await service.get_performance_advisor_brief(
         portfolio_id="PF_1001",
@@ -642,7 +642,7 @@ async def test_advisor_brief_service_reuses_cached_response_for_identical_reques
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert first.summary == second.summary
@@ -671,7 +671,7 @@ async def test_advisor_brief_service_cache_key_changes_when_request_shape_change
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
     await service.get_performance_advisor_brief(
         portfolio_id="PF_1001",
@@ -681,7 +681,7 @@ async def test_advisor_brief_service_cache_key_changes_when_request_shape_change
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="GROSS",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert len(workspace_service.calls) == 2
@@ -713,7 +713,7 @@ async def test_advisor_brief_service_treats_supported_capabilities_as_ready():
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.status == "ready"
@@ -772,7 +772,7 @@ async def test_advisor_brief_service_normalizes_raw_position_ids_in_fallback_cop
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert "PF_1001:" not in response.talking_points[1].headline
@@ -801,7 +801,7 @@ async def test_advisor_brief_service_omits_workflow_pack_run_when_surfaces_unava
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.workflow_pack_run is None
@@ -828,7 +828,7 @@ async def test_advisor_brief_service_applies_review_action_and_returns_updated_r
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
         request=AdvisorBriefWorkflowPackRunReviewActionRequest(
             action_type="ACCEPT",
             reviewed_by="advisor_1",
@@ -904,7 +904,7 @@ async def test_advisor_brief_service_preserves_replacement_lineage_for_review_tr
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
         request=AdvisorBriefWorkflowPackRunReviewActionRequest(
             action_type=action_type,
             reviewed_by="advisor_1",
@@ -971,7 +971,7 @@ async def test_advisor_brief_service_surfaces_lineage_conflicts_without_rewritin
             contribution_dimension="asset_class",
             attribution_dimension="asset_class",
             detail_basis="NET",
-            benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+            benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
             request=AdvisorBriefWorkflowPackRunReviewActionRequest(
                 action_type="SUPERSEDE",
                 reviewed_by="advisor_1",
@@ -1008,7 +1008,7 @@ async def test_advisor_brief_service_records_source_and_ai_server_timing_spans()
             contribution_dimension="asset_class",
             attribution_dimension="asset_class",
             detail_basis="NET",
-            benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+            benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
         )
 
         server_timing = format_server_timing_header(1.0)
@@ -1041,10 +1041,10 @@ def _build_workspace(
         requested_contribution_dimension_supported=True,
         requested_attribution_dimension_supported=True,
         segment="asset_class",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
         benchmark_options=[
             PerformanceBenchmarkOptionView(
-                benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+                benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
                 benchmark_name="Private Banking Global Balanced 60/40",
                 benchmark_currency="USD",
             )
@@ -1081,7 +1081,7 @@ def _build_workspace(
             portfolio_return_pct=1.25,
             benchmark_return_pct=7.93,
             active_return_pct=-6.68,
-            benchmark_id="BMK_GLOBAL_BALANCED_60_40",
+            benchmark_id="BMK_PB_GLOBAL_BALANCED_60_40",
             end_market_value=1_087_461.0,
             net_cash_flow=14_725.0,
         ),
@@ -1090,7 +1090,7 @@ def _build_workspace(
             portfolio_return_pct=1.45,
             benchmark_return_pct=7.93,
             active_return_pct=-6.48,
-            benchmark_id="BMK_GLOBAL_BALANCED_60_40",
+            benchmark_id="BMK_PB_GLOBAL_BALANCED_60_40",
             end_market_value=1_087_461.0,
             net_cash_flow=14_725.0,
         ),
@@ -1126,7 +1126,7 @@ def _build_workspace(
             metric_basis="NET",
             model="BF",
             linking="Carino",
-            benchmark_id="BMK_GLOBAL_BALANCED_60_40",
+            benchmark_id="BMK_PB_GLOBAL_BALANCED_60_40",
             active_return_pct=-6.68,
             sum_of_effects_pct=-6.67,
             residual_pct=-0.01,

--- a/tests/unit/test_performance_workspace_service.py
+++ b/tests/unit/test_performance_workspace_service.py
@@ -136,7 +136,7 @@ class _StubAnalyticsClient:
                 )
             return 200, {
                 "benchmark_context": {
-                    "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                    "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                     "return_source": "calculated",
                 },
                 "calculation_id": "calc-twr",
@@ -231,7 +231,7 @@ class _StubLotusCoreQueryClient:
             {
                 "records": [
                     {
-                        "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                        "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                         "benchmark_name": "Global Balanced 60/40",
                         "benchmark_currency": "USD",
                         "benchmark_type": "composite",
@@ -255,7 +255,7 @@ class _StubLotusCoreQueryClient:
         return (
             200,
             {
-                "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                 "assignment_status": "active",
             },
         )
@@ -266,7 +266,7 @@ def _workspace_summary_payload(*, include_detail_blocks: bool = True) -> dict:
         "results_by_period": {
             "MTD": {
                 "benchmark": {
-                    "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                    "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                     "return_source": "calculated",
                     "summary": {
                         "period_return": {"base": 1.0},
@@ -294,7 +294,7 @@ def _workspace_summary_payload(*, include_detail_blocks: bool = True) -> dict:
             },
             "QTD": {
                 "benchmark": {
-                    "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                    "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                     "return_source": "calculated",
                     "input_mode": "stateful",
                     "summary": {
@@ -413,7 +413,7 @@ def _workspace_summary_payload(*, include_detail_blocks: bool = True) -> dict:
                     "model": "BF",
                     "linking": "carino",
                     "benchmark_context": {
-                        "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                        "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                         "return_source": "calculated",
                     },
                     "result": {
@@ -451,7 +451,7 @@ def _workspace_summary_payload(*, include_detail_blocks: bool = True) -> dict:
             },
             "YTD": {
                 "benchmark": {
-                    "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                    "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                     "return_source": "calculated",
                     "input_mode": "stateful",
                     "summary": {
@@ -652,7 +652,7 @@ def _workspace_summary_payload(*, include_detail_blocks: bool = True) -> dict:
                     "model": "BF",
                     "linking": "carino",
                     "benchmark_context": {
-                        "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                        "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                         "return_source": "calculated",
                     },
                     "result": {
@@ -712,7 +712,7 @@ def _workspace_summary_payload(*, include_detail_blocks: bool = True) -> dict:
             },
             "1Y": {
                 "benchmark": {
-                    "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                    "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                     "return_source": "calculated",
                     "summary": {
                         "period_return": {"base": 12.6},
@@ -754,7 +754,7 @@ def _twr_payload_for_period(result_key: str, source_label: str) -> dict:
     source = _workspace_summary_payload()["results_by_period"][source_label]
     return {
         "benchmark_context": {
-            "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+            "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
             "return_source": "calculated",
         },
         "results_by_period": {
@@ -823,7 +823,7 @@ def _attribution_payload(*, dimension: str, report_start_date: str, report_end_d
     totals = totals_by_month[month]
     return {
         "benchmark_context": {
-            "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+            "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
             "return_source": "calculated",
         },
         "results_by_period": {
@@ -865,7 +865,7 @@ def _attribution_payload(*, dimension: str, report_start_date: str, report_end_d
 def _attribution_detail_payload(*, dimension: str) -> dict:
     return {
         "benchmark_context": {
-            "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+            "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
             "return_source": "calculated",
         },
         "results_by_period": {
@@ -983,7 +983,7 @@ async def test_performance_workspace_service_deduplicates_benchmark_catalog_opti
             {
                 "records": [
                     {
-                        "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                        "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                         "benchmark_name": "Global Balanced 60/40",
                         "benchmark_currency": "USD",
                         "benchmark_type": "composite",
@@ -991,7 +991,7 @@ async def test_performance_workspace_service_deduplicates_benchmark_catalog_opti
                         "benchmark_provider": "Lotus",
                     },
                     {
-                        "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                        "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                         "benchmark_name": "Global Balanced 60/40",
                         "benchmark_currency": "USD",
                         "benchmark_type": "composite",
@@ -1009,13 +1009,13 @@ async def test_performance_workspace_service_deduplicates_benchmark_catalog_opti
                 ]
             },
         ),
-        assigned_benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        assigned_benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
         warnings=warnings,
         partial_failures=partial_failures,
     )
 
     assert [option.benchmark_code for option in options] == [
-        "BMK_GLOBAL_BALANCED_60_40",
+        "BMK_PB_GLOBAL_BALANCED_60_40",
         "BMK_GLOBAL_GROWTH_80_20",
     ]
     assert options[0].is_assigned is True
@@ -1041,7 +1041,7 @@ async def test_performance_workspace_service_returns_workspace_summary_contract(
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.portfolio.portfolio_id == "DEMO_ADV_USD_001"
@@ -1078,11 +1078,11 @@ async def test_performance_workspace_service_returns_workspace_summary_contract(
     assert response.contribution.levels[0].total_weight_avg_pct is None
     assert response.contribution.position_rows[0].position_id == "AAPL_US"
     assert response.attribution is not None
-    assert response.attribution.benchmark_id == "BMK_GLOBAL_BALANCED_60_40"
+    assert response.attribution.benchmark_id == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert response.attribution.levels[0].rows[0].portfolio_weight_avg_pct == 61.0
     assert response.attribution.levels[0].rows[0].benchmark_return_pct == 6.8
     assert response.benchmark_options[0].is_assigned is True
-    assert response.benchmark_options[0].benchmark_code == "BMK_GLOBAL_BALANCED_60_40"
+    assert response.benchmark_options[0].benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert response.capabilities.return_path.state == "supported"
     assert response.capabilities.return_path.earliest_available_date == "2026-01-01"
     assert response.capabilities.return_path.latest_available_date == "2026-03-27"
@@ -1160,7 +1160,7 @@ async def test_performance_workspace_service_projects_summary_contract():
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.portfolio_id == "DEMO_ADV_USD_001"
@@ -1205,7 +1205,7 @@ async def test_performance_workspace_service_reuses_cached_workspace_summary_res
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
     second_response = await service.get_performance_workspace_summary(
         portfolio_id="DEMO_ADV_USD_001",
@@ -1215,7 +1215,7 @@ async def test_performance_workspace_service_reuses_cached_workspace_summary_res
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert first_response.net_performance.portfolio_return_pct == 15.1
@@ -1245,7 +1245,7 @@ async def test_performance_workspace_service_clear_upstream_cache_forces_summary
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
     service.clear_upstream_cache()
     await service.get_performance_workspace_summary(
@@ -1256,7 +1256,7 @@ async def test_performance_workspace_service_clear_upstream_cache_forces_summary
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert len(analytics_client.workspace_summary_calls) == 2
@@ -1286,9 +1286,9 @@ async def test_performance_workspace_service_resolves_linked_benchmark_when_code
         benchmark_code=None,
     )
 
-    assert response.benchmark_code == "BMK_GLOBAL_BALANCED_60_40"
-    assert (
-        analytics_client.workspace_summary_calls[0]["benchmark_id"] == "BMK_GLOBAL_BALANCED_60_40"
+    assert response.benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert analytics_client.workspace_summary_calls[0]["benchmark_id"] == (
+        "BMK_PB_GLOBAL_BALANCED_60_40"
     )
     assert query_client.benchmark_assignment_calls[0]["portfolio_id"] == "DEMO_ADV_USD_001"
     assert query_client.benchmark_assignment_calls[0]["as_of_date"] == "2026-03-27"
@@ -1310,12 +1310,12 @@ async def test_performance_workspace_service_builds_horizon_comparison_contract(
         correlation_id="corr-performance",
         period="YTD",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
         chart_frequency="monthly",
     )
 
     assert response.portfolio_id == "DEMO_ADV_USD_001"
-    assert response.benchmark_code == "BMK_GLOBAL_BALANCED_60_40"
+    assert response.benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert response.reporting_currency == "USD"
     assert response.period == "YTD"
     assert response.report_start_date == "2026-01-01"
@@ -1369,7 +1369,7 @@ async def test_workspace_service_maps_position_contributions_from_upstream_contr
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.contribution is not None
@@ -1417,7 +1417,7 @@ async def test_workspace_service_preserves_full_contribution_row_coverage():
         contribution_dimension="sector",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.contribution is not None
@@ -1455,7 +1455,7 @@ async def test_workspace_service_preserves_full_attribution_row_coverage():
         contribution_dimension="asset_class",
         attribution_dimension="country",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.attribution is not None
@@ -1484,9 +1484,9 @@ async def test_performance_workspace_service_resolves_linked_benchmark_for_horiz
         chart_frequency="monthly",
     )
 
-    assert response.benchmark_code == "BMK_GLOBAL_BALANCED_60_40"
-    assert (
-        analytics_client.workspace_summary_calls[0]["benchmark_id"] == "BMK_GLOBAL_BALANCED_60_40"
+    assert response.benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert analytics_client.workspace_summary_calls[0]["benchmark_id"] == (
+        "BMK_PB_GLOBAL_BALANCED_60_40"
     )
     assert query_client.benchmark_assignment_calls[0]["portfolio_id"] == "DEMO_ADV_USD_001"
     assert query_client.benchmark_assignment_calls[0]["as_of_date"] == "2026-03-27"
@@ -1507,7 +1507,7 @@ async def test_performance_workspace_service_normalizes_unsupported_horizon_freq
         correlation_id="corr-performance",
         period="YTD",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
         chart_frequency="weekly",
     )
 
@@ -1531,7 +1531,7 @@ async def test_performance_workspace_service_builds_explicit_horizon_comparison_
         correlation_id="corr-performance",
         period="YTD",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
         chart_frequency="monthly",
         explicit_start_date="2026-01-01",
         explicit_end_date="2026-03-27",
@@ -1563,7 +1563,7 @@ async def test_performance_workspace_service_builds_attribution_trend_contract()
         chart_frequency="monthly",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.portfolio_id == "DEMO_ADV_USD_001"
@@ -1593,7 +1593,7 @@ async def test_performance_workspace_service_normalizes_unsupported_attribution_
         chart_frequency="weekly",
         attribution_dimension="issuer",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.chart_frequency == "monthly"
@@ -1625,8 +1625,8 @@ async def test_performance_workspace_service_resolves_linked_benchmark_for_attri
         benchmark_code=None,
     )
 
-    assert response.benchmark_code == "BMK_GLOBAL_BALANCED_60_40"
-    assert analytics_client.attribution_calls[0]["benchmark_id"] == "BMK_GLOBAL_BALANCED_60_40"
+    assert response.benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert analytics_client.attribution_calls[0]["benchmark_id"] == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert query_client.benchmark_assignment_calls[0]["portfolio_id"] == "DEMO_ADV_USD_001"
     assert query_client.benchmark_assignment_calls[0]["as_of_date"] == "2026-03-27"
     assert query_client.benchmark_assignment_calls[0]["reporting_currency"] == "USD"
@@ -1650,7 +1650,7 @@ async def test_performance_workspace_service_projects_detail_contract():
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.portfolio_id == "DEMO_ADV_USD_001"
@@ -1658,7 +1658,7 @@ async def test_performance_workspace_service_projects_detail_contract():
     assert response.contribution is not None
     assert response.contribution.position_rows[0].position_id == "AAPL_US"
     assert response.attribution is not None
-    assert response.attribution.benchmark_id == "BMK_GLOBAL_BALANCED_60_40"
+    assert response.attribution.benchmark_id == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert response.capabilities.contribution_ranking.state == "supported"
     assert response.capabilities.attribution_detail.state == "supported"
     assert analytics_client.workspace_summary_calls[0]["include_detail_blocks"] is False
@@ -1685,7 +1685,7 @@ async def test_performance_workspace_service_normalizes_qtd_workspace_summary_to
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.period == "QTD"
@@ -1711,7 +1711,7 @@ async def test_performance_workspace_service_projects_portfolio_performance_snap
         period="YTD",
         chart_frequency="monthly",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.portfolio_return_pct == 15.1
@@ -1770,7 +1770,7 @@ async def test_performance_workspace_service_marks_portfolio_performance_snapsho
         period="YTD",
         chart_frequency="monthly",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.portfolio_return_pct is None
@@ -1807,7 +1807,7 @@ async def test_performance_workspace_service_aligns_mismatched_dimensions_to_sha
         contribution_dimension="sector",
         attribution_dimension="country",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.segment == "sector"
@@ -1835,7 +1835,7 @@ async def test_performance_workspace_service_normalizes_unsupported_controls():
         contribution_dimension="currency",
         attribution_dimension="issuer",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.chart_frequency == "monthly"
@@ -1881,7 +1881,7 @@ async def test_workspace_details_use_independent_dimensions_and_keep_segment_con
         contribution_dimension="sector",
         attribution_dimension="currency",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.contribution_dimension == "sector"
@@ -1935,7 +1935,7 @@ async def test_workspace_details_do_not_fallback_when_detail_is_segment_only():
         contribution_dimension="sector",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.contribution is not None
@@ -1963,7 +1963,7 @@ async def test_performance_workspace_service_skips_reference_lookup_for_explicit
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
         explicit_start_date="2026-01-15",
         explicit_end_date="2026-03-20",
     )
@@ -1996,7 +1996,7 @@ async def test_performance_workspace_service_handles_workspace_summary_failure()
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.net_performance.portfolio_return_pct is None
@@ -2040,7 +2040,7 @@ async def test_performance_workspace_service_marks_pending_lineage_as_partial_ev
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.capabilities.evidence.state == "partial"
@@ -2082,7 +2082,7 @@ async def test_performance_workspace_service_marks_missing_execution_and_lineage
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.capabilities.evidence.state == "unavailable"
@@ -2111,7 +2111,7 @@ async def test_performance_workspace_service_handles_benchmark_catalog_failure()
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.benchmark_options == []
@@ -2136,7 +2136,7 @@ async def test_performance_workspace_service_marks_aggregate_contribution_as_par
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     response.contribution.position_rows = []
@@ -2177,7 +2177,7 @@ async def test_performance_workspace_service_marks_summary_only_attribution_as_p
         contribution_dimension="asset_class",
         attribution_dimension="asset_class",
         detail_basis="NET",
-        benchmark_code="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
     )
 
     assert response.attribution is not None
@@ -2241,7 +2241,7 @@ async def test_performance_workspace_service_fetches_assignment_and_catalog_conc
         timeout=0.2,
     )
 
-    assert response.benchmark_code == "BMK_GLOBAL_BALANCED_60_40"
+    assert response.benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert len(query_client.benchmark_assignment_calls) == 1
     assert len(query_client.benchmark_catalog_calls) == 1
 

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -601,7 +601,7 @@ async def test_lotus_analytics_client_workspace_summary_uses_canonical_summary_c
         period="YTD",
         chart_frequency="quarterly",
         detail_basis="NET",
-        benchmark_id="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_id="BMK_PB_GLOBAL_BALANCED_60_40",
         reporting_currency="USD",
         segment="asset_class",
         correlation_id="corr-performance",
@@ -618,7 +618,7 @@ async def test_lotus_analytics_client_workspace_summary_uses_canonical_summary_c
     assert "segmentation" not in request["json"]
     assert "contribution" not in request["json"]
     assert "attribution" not in request["json"]
-    assert request["json"]["benchmark"]["benchmark_id"] == "BMK_GLOBAL_BALANCED_60_40"
+    assert request["json"]["benchmark"]["benchmark_id"] == "BMK_PB_GLOBAL_BALANCED_60_40"
 
 
 @pytest.mark.asyncio
@@ -654,7 +654,7 @@ async def test_lotus_analytics_client_retries_workspace_summary_when_calculation
         period="YTD",
         chart_frequency="quarterly",
         detail_basis="NET",
-        benchmark_id="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_id="BMK_PB_GLOBAL_BALANCED_60_40",
         reporting_currency="USD",
         segment="asset_class",
         correlation_id="corr-performance",
@@ -699,7 +699,7 @@ async def test_lotus_analytics_client_disables_timeout_retries_for_workspace_sum
         period="QTD",
         chart_frequency="monthly",
         detail_basis="NET",
-        benchmark_id="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_id="BMK_PB_GLOBAL_BALANCED_60_40",
         reporting_currency="USD",
         segment="asset_class",
         correlation_id="corr-performance",
@@ -735,7 +735,7 @@ async def test_lotus_analytics_client_workspace_summary_omits_unsupported_curren
         period="YTD",
         chart_frequency="monthly",
         detail_basis="NET",
-        benchmark_id="BMK_GLOBAL_BALANCED_60_40",
+        benchmark_id="BMK_PB_GLOBAL_BALANCED_60_40",
         reporting_currency="USD",
         segment="asset_class",
         correlation_id="corr-performance",
@@ -1606,7 +1606,7 @@ async def test_lotus_core_query_client_posts_benchmark_catalog_request():
         {
             "records": [
                 {
-                    "benchmark_id": "BMK_GLOBAL_BALANCED_60_40",
+                    "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                     "benchmark_name": "Global Balanced 60/40",
                 }
             ]
@@ -1620,7 +1620,7 @@ async def test_lotus_core_query_client_posts_benchmark_catalog_request():
     )
 
     assert status_code == 200
-    assert payload["records"][0]["benchmark_id"] == "BMK_GLOBAL_BALANCED_60_40"
+    assert payload["records"][0]["benchmark_id"] == "BMK_PB_GLOBAL_BALANCED_60_40"
     request = _FakeAsyncClient.calls[0]
     assert request["url"] == "http://core-control/integration/benchmarks/catalog"
     assert request["json"]["as_of_date"] == "2026-03-27"

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -83,7 +83,7 @@ curl "http://127.0.0.1:8111/api/v1/foundation/portfolios/PF_1001/workspace"
 Performance summary:
 
 ```bash
-curl "http://127.0.0.1:8111/api/v1/workbench/DEMO_ADV_USD_001/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
+curl "http://127.0.0.1:8111/api/v1/workbench/DEMO_ADV_USD_001/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
 ```
 
 Reporting summary:
@@ -99,7 +99,7 @@ Reporting portfolio review:
 ```bash
 curl -X POST "http://127.0.0.1:8111/api/v1/reports/DEMO_DPM_EUR_001/review" \
   -H "Content-Type: application/json" \
-  -d "{\"asOfDate\":\"2026-02-24\",\"sections\":[\"OVERVIEW\",\"PERFORMANCE\",\"RISK_ANALYTICS\"],\"allocationDimensions\":[\"asset_class\"],\"lookThroughMode\":\"full\",\"benchmarkCode\":\"BMK_GLOBAL_BALANCED_60_40\"}"
+  -d "{\"asOfDate\":\"2026-02-24\",\"sections\":[\"OVERVIEW\",\"PERFORMANCE\",\"RISK_ANALYTICS\"],\"allocationDimensions\":[\"asset_class\"],\"lookThroughMode\":\"full\",\"benchmarkCode\":\"BMK_PB_GLOBAL_BALANCED_60_40\"}"
 ```
 
 Portfolio review report job:
@@ -114,7 +114,7 @@ curl -X POST "http://127.0.0.1:8111/api/v1/reports/portfolio-reviews" \
   -H "X-Region: APAC" \
   -H "X-Booking-Center-Code: SG" \
   -H "X-Role: advisor" \
-  -d "{\"portfolio_scope\":{\"portfolio_ids\":[\"PB_SG_GLOBAL_BAL_001\"]},\"as_of_date\":\"2026-04-22\",\"requested_output_formats\":[\"json\"],\"reporting_currency\":\"USD\",\"options\":{\"sections\":[\"OVERVIEW\",\"PERFORMANCE\",\"RISK_ANALYTICS\"],\"benchmark_code\":\"BMK_GLOBAL_BALANCED_60_40\"}}"
+  -d "{\"portfolio_scope\":{\"portfolio_ids\":[\"PB_SG_GLOBAL_BAL_001\"]},\"as_of_date\":\"2026-04-22\",\"requested_output_formats\":[\"json\"],\"reporting_currency\":\"USD\",\"options\":{\"sections\":[\"OVERVIEW\",\"PERFORMANCE\",\"RISK_ANALYTICS\"],\"benchmark_code\":\"BMK_PB_GLOBAL_BALANCED_60_40\"}}"
 ```
 
 Report job status:


### PR DESCRIPTION
## Summary
- standardize the canonical benchmark code across gateway reporting, workbench, portfolio, and advisor-brief surfaces
- update contract examples, router examples, demo docs, and tests so gateway truth matches the corrected RFC-101 ecosystem behavior
- keep benchmark-facing OpenAPI and downstream client expectations aligned with the canonical `BMK_PB_GLOBAL_BALANCED_60_40` identifier

## Validation
- `python -m pytest tests/contract/test_reporting_contract.py tests/contract/test_workbench_contract.py tests/contract/test_portfolio_contract.py tests/integration/test_reporting_router.py tests/integration/test_workbench_router.py tests/integration/test_portfolio_router.py tests/unit/test_advisor_brief_service.py tests/unit/test_performance_workspace_service.py tests/unit/test_upstream_clients.py -q`
- `make openapi-gate`
- `make check`

## Notes
- no remaining `BMK_GLOBAL_BALANCED_60_40` references remain in `lotus-gateway`
- repo-authored wiki source updated in this branch
- publish required after merge: `lotus-gateway`