### PR TITLE
Add RFC 104 report batch gateway routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ It depends on:
 - `lotus-manage`
   management workflow capability when split routing is enabled
 - `lotus-report`
-  reporting snapshot, summary, review payloads, and durable report job lifecycle/search
+  reporting snapshot, summary, review payloads, durable report job lifecycle/search, and
+  RFC-0104 batch materialization/status/control/operator-run APIs
 - `lotus-archive`
   archived generated-document metadata and controlled binary retrieval
 - `lotus-ai`
@@ -93,6 +94,8 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/reports/*`
 - `report-jobs`
   `/api/v1/report-jobs`, `/api/v1/report-jobs/*`
+- `report-batches`
+  `/api/v1/report-batches`, `/api/v1/report-batches/*`
 - `archived documents`
   `/api/v1/documents/{document_id}`, `/api/v1/documents/{document_id}/download`
 - platform surfaces
@@ -220,7 +223,10 @@ Important current parameter conventions:
 7. some lookup filters intentionally remain snake_case, such as `cif_id`, `booking_center`,
    `product_type`, and `instrument_page_limit`
 8. proposal write routes require `Idempotency-Key`
-9. archived document metadata and download routes require caller context headers:
+9. report batch materialization uses canonical snake_case body fields and requires
+   `Idempotency-Key`; report batch status/control/operator-run routes require caller context
+   headers and forward the operation to `lotus-report` as the lifecycle authority
+10. archived document metadata and download routes require caller context headers:
    `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; the gateway calls `lotus-archive` as
    `lotus-gateway` and does not expose archive storage locations
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -35,14 +35,17 @@ Current repository posture:
 4. report job initiation/search/status/event-history/cancellation routes are active for
    gateway-first portfolio review report job workflows under `/api/v1/reports/portfolio-reviews`,
    `/api/v1/report-jobs`, and `/api/v1/report-jobs/*`,
-5. archived generated-document metadata and controlled download routes are active under
+5. RFC-0104 report batch materialization/status/control/retry/recovery/bounded operator-run routes
+   are active under `/api/v1/report-batches` and `/api/v1/report-batches/*`; lifecycle and
+   execution truth remain in `lotus-report`,
+6. archived generated-document metadata and controlled download routes are active under
    `/api/v1/documents/{document_id}` and `/api/v1/documents/{document_id}/download` as the
    product-facing boundary over `lotus-archive`,
-6. domain-product catalog, dependency-graph, and live trust certification discovery routes are
+7. domain-product catalog, dependency-graph, and live trust certification discovery routes are
    active under `/api/v1/domain-products`,
-7. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
-8. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
-9. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
+8. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
+9. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
+10. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
 
 ## Architecture And Module Map
 
@@ -149,6 +152,9 @@ Most relevant current governance:
    `lotus-platform/output/trust-certification/domain-product-live-trust-certification.json`;
    deployment-specific paths should use `DOMAIN_PRODUCT_CATALOG_PATH`,
    `DOMAIN_PRODUCT_DEPENDENCY_GRAPH_PATH`, and `DOMAIN_PRODUCT_LIVE_TRUST_CERTIFICATION_PATH`.
+9. report batch gateway routes are an RFC-0104 API/operator boundary only; Workbench batch UI,
+   RFC-0105 replay/dashboard operations, and RFC-0106 entitlement certification remain separate
+   implementation scopes until explicitly delivered and proven.
 
 ## Context Maintenance Rule
 

--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -42,7 +42,7 @@ outputs.
 | `lotus-risk` | calculate risk, concentration, drawdown, rolling metrics, historical attribution | risk workspace modules and risk panels | risk methodology, concentration, drawdown, and attribution semantics remain in `lotus-risk` |
 | `lotus-advise` | proposal lifecycle and advisory workflow surfaces | proposal workflow composition | advisory decision workflow remains in `lotus-advise` |
 | `lotus-manage` | management workflow surfaces where split routing still applies | management workflow composition | discretionary management operations remain in `lotus-manage` |
-| `lotus-report` | report snapshot rows, summary/review payloads, report job status/search/event/cancellation APIs | report-ready experience payloads and durable report-job support posture | report generation, request semantics, and job lifecycle truth remain in `lotus-report` |
+| `lotus-report` | report snapshot rows, summary/review payloads, report job status/search/event/cancellation APIs, report batch materialization/status/control/operator-run APIs | report-ready experience payloads, durable report-job support posture, and RFC-0104 batch operator boundary | report generation, request semantics, job lifecycle truth, batch lifecycle truth, and batch execution truth remain in `lotus-report` |
 | `lotus-archive` | archived document metadata, current-document resolution, and binary download APIs | gateway-controlled generated-document retrieval for product clients | archive metadata, retention, legal-hold, purge, lifecycle, checksum, storage, and access-audit truth remain in `lotus-archive`; gateway exposes metadata and controlled download only |
 | `lotus-ai` | advisor-brief, workflow-pack run-ledger, and RFC-0097 task-flow posture surfaces | evidence-grounded narrative support plus bounded run/task-flow posture for Workbench | gateway must not invent unsupported evidence, model outputs, review states, replacement lineage, or task-flow authority |
 
@@ -87,6 +87,9 @@ This RFC-0082 documentation slice reflects current runtime behavior:
    route rather than exposing direct lotus-performance URLs.
 3. archived generated-document metadata and binary links are exposed through gateway-owned document
    routes rather than exposing direct lotus-archive URLs.
+4. RFC-0104 report batch materialization, status, control, recovery, retry, and bounded run-once
+   operator actions are exposed through gateway-owned `/api/v1/report-batches` routes while
+   preserving `lotus-report` as the lifecycle and execution authority.
 
 ## Gap Register
 
@@ -102,6 +105,9 @@ This RFC-0082 documentation slice reflects current runtime behavior:
 5. Gateway archive retrieval currently has no product-owned entitlement engine beyond caller-context
    propagation and upstream archive authorization; if client-level document entitlements are required,
    the policy source must be defined before expanding UI access.
+6. Gateway report batch routes are an operator/API boundary only. Workbench batch UI, RFC-0105
+   replay/dashboard operations, and RFC-0106 entitlement certification must not be inferred from
+   these routes until those slices are implemented and proven.
 
 ## Validation Lane
 

--- a/src/app/clients/reporting_client.py
+++ b/src/app/clients/reporting_client.py
@@ -189,3 +189,66 @@ class ReportingClient:
             backoff_seconds=self._retry_backoff_seconds,
             headers=headers,
         )
+
+    async def create_report_batch(
+        self,
+        *,
+        payload: dict[str, Any],
+        idempotency_key: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/batches"
+        headers = propagation_headers(correlation_id)
+        headers["Idempotency-Key"] = idempotency_key
+        headers.update(caller_headers)
+        return await request_with_retry(
+            method="POST",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            json_body=payload,
+            headers=headers,
+        )
+
+    async def get_report_batch(
+        self,
+        *,
+        batch_id: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/batches/{batch_id}"
+        headers = propagation_headers(correlation_id)
+        headers.update(caller_headers)
+        return await request_with_retry(
+            method="GET",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=headers,
+        )
+
+    async def control_report_batch(
+        self,
+        *,
+        batch_id: str,
+        action: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+        payload: dict[str, Any] | None = None,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/batches/{batch_id}:{action}"
+        headers = propagation_headers(correlation_id)
+        headers.update(caller_headers)
+        return await request_with_retry(
+            method="POST",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            json_body=payload,
+            headers=headers,
+        )

--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -1,5 +1,5 @@
-from datetime import datetime
-from typing import Any
+from datetime import date, datetime
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -761,3 +761,424 @@ class ReportJobListResponse(BaseModel):
     )
 
     model_config = {"populate_by_name": True}
+
+
+BatchStatus = Literal[
+    "materialized",
+    "running",
+    "paused",
+    "cancelled",
+    "completed",
+    "completed_with_failures",
+    "failed",
+]
+BatchItemStatus = Literal[
+    "materialized",
+    "leased",
+    "waiting_on_report_job",
+    "succeeded",
+    "failed_retryable",
+    "failed_terminal",
+    "cancelled",
+    "recovery_pending",
+]
+
+BATCH_CREATE_REQUEST_EXAMPLE: dict[str, Any] = {
+    "selector_mode": "explicit_portfolio_list",
+    "portfolio_ids": ["PB_SG_GLOBAL_BAL_001"],
+    "source_candidates": [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "tenant_id": "tenant-sg",
+            "region": "APAC",
+            "active": True,
+            "selected": True,
+            "source_system": "lotus-core",
+            "source_object": "PortfolioScope",
+        }
+    ],
+    "as_of_date": "2026-04-22",
+    "requested_output_formats": ["pdf"],
+    "reporting_currency": "USD",
+    "options": {"sections": ["OVERVIEW", "PERFORMANCE"]},
+    "max_batch_size": 250,
+}
+
+BATCH_HANDLE_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+    "status": "materialized",
+    "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+    "idempotency_key": "batch-portfolio-review-2026-04-22",
+    "item_count": 1,
+}
+
+BATCH_STATUS_RESPONSE_EXAMPLE: dict[str, Any] = {
+    **BATCH_HANDLE_RESPONSE_EXAMPLE,
+    "selector_mode": "explicit_portfolio_list",
+    "tenant_id": "tenant-sg",
+    "region": "APAC",
+    "materialized_portfolio_ids": ["PB_SG_GLOBAL_BAL_001"],
+    "as_of_date": "2026-04-22",
+    "requested_output_formats": ["pdf"],
+    "reporting_currency": "USD",
+    "status_counts": {"materialized": 1},
+    "items": [
+        {
+            "batch_item_id": "rbci_1a3b5c7d9e0f4a12a45f7a8d00bd129c",
+            "item_position": 1,
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "status": "materialized",
+            "report_job_id": None,
+            "attempt_count": 0,
+            "retry_eligible": False,
+            "next_retry_at": None,
+            "last_error_category": None,
+            "last_error_summary": None,
+            "created_at": "2026-04-22T09:00:00Z",
+            "started_at": None,
+            "completed_at": None,
+            "cancelled_at": None,
+        }
+    ],
+    "created_at": "2026-04-22T09:00:00Z",
+    "updated_at": "2026-04-22T09:00:00Z",
+    "started_at": None,
+    "completed_at": None,
+    "cancelled_at": None,
+    "failed_at": None,
+    "correlation_id": "corr-batch-1",
+    "trace_id": "trace-batch-1",
+}
+
+BATCH_CONTROL_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+    "status": "paused",
+    "affected_count": 1,
+    "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+}
+
+BATCH_RECOVERY_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+    "status": "running",
+    "recovered_count": 1,
+    "recovery_pending_item_ids": ["rbci_1a3b5c7d9e0f4a12a45f7a8d00bd129c"],
+    "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+}
+
+BATCH_WORKER_RUN_REQUEST_EXAMPLE: dict[str, Any] = {
+    "worker_id": "lotus-report-batch-worker-1",
+    "recover_expired_leases": True,
+    "dispatch_policy": {
+        "max_active_batches": 1,
+        "max_active_items": 5,
+        "max_active_upstream_jobs": 3,
+        "max_active_render_jobs": 2,
+        "max_active_archive_jobs": 2,
+        "lease_seconds": 300,
+    },
+    "runtime_load": {
+        "active_batches": 0,
+        "active_items": 0,
+        "active_upstream_jobs": 0,
+        "active_render_jobs": 0,
+        "active_archive_jobs": 0,
+    },
+}
+
+BATCH_WORKER_RUN_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+    "status": "completed",
+    "batch_status_before": "materialized",
+    "batch_status_after": "completed",
+    "recovered_count": 0,
+    "leased_count": 1,
+    "dispatched_count": 1,
+    "executed_count": 1,
+    "report_job_ids": ["rjob_83ca965c50334c40a17d2b8cc94873a5"],
+    "back_pressure_reasons": [],
+    "skipped_reason": None,
+    "execution_results": [
+        {
+            "batch_item_id": "rbci_1a3b5c7d9e0f4a12a45f7a8d00bd129c",
+            "report_job_id": "rjob_83ca965c50334c40a17d2b8cc94873a5",
+            "item_status": "succeeded",
+            "report_job_status": "archived",
+            "failure_category": None,
+            "retry_eligible": False,
+        }
+    ],
+    "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+}
+
+REPORT_BATCH_ERROR_EXAMPLES: dict[str, dict[str, Any]] = {
+    "missing_idempotency_key": REPORT_JOB_ERROR_EXAMPLES["missing_idempotency_key"],
+    "missing_caller_context": REPORT_JOB_ERROR_EXAMPLES["missing_caller_context"],
+    "idempotency_conflict": {
+        "detail": {
+            "code": "idempotency_conflict",
+            "message": "Idempotency-Key was reused with a different batch request.",
+        }
+    },
+    "invalid_batch_selector": {
+        "detail": {
+            "code": "invalid_batch_selector",
+            "message": "Batch selector could not be materialized from eligible portfolios.",
+        }
+    },
+    "report_batch_not_found": {
+        "detail": {
+            "code": "report_batch_not_found",
+            "message": "Report batch was not found.",
+        }
+    },
+    "batch_worker_run_failed": {
+        "detail": {
+            "code": "batch_worker_run_failed",
+            "message": "Report batch run could not be completed.",
+        }
+    },
+    "report_batch_upstream_unavailable": {
+        "detail": {
+            "code": "report_batch_upstream_unavailable",
+            "message": "Report batch service is unavailable.",
+        }
+    },
+}
+
+
+class PortfolioBatchCandidate(BaseModel):
+    portfolio_id: str = Field(
+        ...,
+        description="Portfolio identifier from lotus-core portfolio scope.",
+        examples=["PB_SG_GLOBAL_BAL_001"],
+    )
+    tenant_id: str = Field(
+        ..., description="Tenant that owns the portfolio.", examples=["tenant-sg"]
+    )
+    region: str = Field(..., description="Region that owns the portfolio.", examples=["APAC"])
+    active: bool = Field(..., description="Whether the portfolio is active.", examples=[True])
+    selected: bool = Field(
+        False,
+        description="Whether selected-subset materialization includes this portfolio.",
+        examples=[True],
+    )
+    source_system: str = Field(
+        "lotus-core",
+        description="Authoritative source system for the portfolio candidate.",
+        examples=["lotus-core"],
+    )
+    source_object: str = Field(
+        "PortfolioScope",
+        description="Authoritative source object or API contract for the candidate.",
+        examples=["PortfolioScope"],
+    )
+
+
+class BatchCreateRequest(BaseModel):
+    selector_mode: str = Field(
+        ...,
+        description="Portfolio selector mode used to materialize batch items.",
+        examples=["explicit_portfolio_list"],
+    )
+    portfolio_ids: list[str] = Field(
+        default_factory=list,
+        description="Requested portfolio identifiers for explicit-list selection.",
+        examples=[["PB_SG_GLOBAL_BAL_001"]],
+    )
+    source_candidates: list[PortfolioBatchCandidate] = Field(
+        default_factory=list,
+        description="Portfolio candidates resolved from lotus-core before materialization.",
+    )
+    as_of_date: date = Field(
+        ...,
+        description="Business as-of date for all materialized batch items.",
+        examples=["2026-04-22"],
+    )
+    requested_output_formats: list[str] = Field(
+        default_factory=lambda: ["pdf"],
+        description="Requested output formats for each report job.",
+        examples=[["pdf"]],
+    )
+    reporting_currency: str | None = Field(
+        default=None,
+        description="Reporting currency passed into each report job.",
+        examples=["USD"],
+    )
+    options: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Report options that affect every materialized batch item.",
+        examples=[{"sections": ["OVERVIEW", "PERFORMANCE"]}],
+    )
+    max_batch_size: int = Field(
+        250,
+        ge=1,
+        le=1000,
+        description="Maximum number of materialized items allowed for this request.",
+        examples=[250],
+    )
+
+
+class BatchHandleResponse(BaseModel):
+    batch_id: str = Field(..., description="Opaque durable batch identifier.")
+    status: BatchStatus = Field(..., description="Current product-safe batch status.")
+    status_url: str = Field(
+        ...,
+        description="Gateway-relative URL for product-safe batch status retrieval.",
+    )
+    idempotency_key: str = Field(
+        ...,
+        description="Caller-supplied idempotency key associated with this batch request.",
+    )
+    item_count: int = Field(..., ge=0, description="Number of materialized portfolio items.")
+
+
+class BatchItemStatusResponse(BaseModel):
+    batch_item_id: str = Field(..., description="Opaque durable batch item identifier.")
+    item_position: int = Field(..., ge=1, description="Deterministic item ordering.")
+    portfolio_id: str = Field(..., description="Portfolio represented by this batch item.")
+    status: BatchItemStatus = Field(..., description="Current product-safe item status.")
+    report_job_id: str | None = Field(
+        default=None,
+        description="Linked report job identifier after dispatch.",
+    )
+    attempt_count: int = Field(0, ge=0, description="Number of recorded attempts.")
+    retry_eligible: bool = Field(False, description="Whether bounded retry is currently allowed.")
+    next_retry_at: datetime | None = Field(default=None, description="Earliest retry timestamp.")
+    last_error_category: str | None = Field(
+        default=None,
+        description="Support-safe failure category for the latest item failure.",
+    )
+    last_error_summary: str | None = Field(
+        default=None,
+        description="Support-safe summary for the latest item failure.",
+    )
+    created_at: datetime = Field(..., description="UTC timestamp when the item was materialized.")
+    started_at: datetime | None = Field(default=None, description="UTC item start timestamp.")
+    completed_at: datetime | None = Field(
+        default=None, description="UTC item completion timestamp."
+    )
+    cancelled_at: datetime | None = Field(
+        default=None, description="UTC item cancellation timestamp."
+    )
+
+
+class BatchStatusResponse(BaseModel):
+    batch_id: str = Field(..., description="Opaque durable batch identifier.")
+    selector_mode: str = Field(..., description="Portfolio selector mode used.")
+    tenant_id: str = Field(..., description="Tenant ownership boundary for the batch.")
+    region: str = Field(..., description="Regional ownership boundary for the batch.")
+    materialized_portfolio_ids: list[str] = Field(
+        ...,
+        description="Portfolio identifiers materialized into durable batch items.",
+    )
+    as_of_date: date = Field(..., description="Business as-of date applied to all items.")
+    requested_output_formats: list[str] = Field(..., description="Requested output formats.")
+    reporting_currency: str | None = Field(
+        default=None, description="Requested reporting currency."
+    )
+    status: BatchStatus = Field(..., description="Current product-safe batch status.")
+    item_count: int = Field(..., ge=0, description="Number of materialized items.")
+    status_counts: dict[str, int] = Field(..., description="Counts by current item status.")
+    items: list[BatchItemStatusResponse] = Field(..., description="Ordered item status details.")
+    created_at: datetime = Field(..., description="UTC timestamp when the batch was materialized.")
+    updated_at: datetime | None = Field(default=None, description="UTC latest update timestamp.")
+    started_at: datetime | None = Field(default=None, description="UTC batch start timestamp.")
+    completed_at: datetime | None = Field(
+        default=None, description="UTC batch completion timestamp."
+    )
+    cancelled_at: datetime | None = Field(
+        default=None, description="UTC batch cancellation timestamp."
+    )
+    failed_at: datetime | None = Field(default=None, description="UTC batch failure timestamp.")
+    correlation_id: str = Field(..., description="Correlation identifier captured at creation.")
+    trace_id: str = Field(..., description="Distributed trace identifier captured at creation.")
+
+
+class BatchControlResponse(BaseModel):
+    batch_id: str = Field(..., description="Opaque durable batch identifier.")
+    status: BatchStatus = Field(..., description="Batch status after the control operation.")
+    affected_count: int = Field(..., ge=0, description="Number of affected records.")
+    status_url: str = Field(..., description="Gateway-relative URL for batch status retrieval.")
+
+
+class BatchRecoveryResponse(BaseModel):
+    batch_id: str = Field(..., description="Opaque durable batch identifier.")
+    status: BatchStatus = Field(..., description="Batch status after expired-lease recovery.")
+    recovered_count: int = Field(..., ge=0, description="Number of recovered expired leases.")
+    recovery_pending_item_ids: list[str] = Field(
+        default_factory=list,
+        description="Batch items moved to recovery-pending posture.",
+    )
+    status_url: str = Field(..., description="Gateway-relative URL for batch status retrieval.")
+
+
+class BatchRuntimeLoad(BaseModel):
+    active_batches: int = Field(0, ge=0, description="Currently active durable batches.")
+    active_items: int = Field(0, ge=0, description="Currently active batch items.")
+    active_upstream_jobs: int = Field(0, ge=0, description="Active upstream data jobs.")
+    active_render_jobs: int = Field(0, ge=0, description="Active render jobs.")
+    active_archive_jobs: int = Field(0, ge=0, description="Active archive jobs.")
+
+
+class BatchDispatchPolicy(BaseModel):
+    max_active_batches: int = Field(1, ge=1, description="Maximum active batches allowed.")
+    max_active_items: int = Field(5, ge=1, description="Maximum items leased by one run.")
+    max_active_upstream_jobs: int = Field(3, ge=1, description="Upstream work limit.")
+    max_active_render_jobs: int = Field(2, ge=1, description="Render work limit.")
+    max_active_archive_jobs: int = Field(2, ge=1, description="Archive work limit.")
+    lease_seconds: int = Field(300, ge=1, description="Lease duration for item dispatch.")
+
+
+class BatchWorkerRunRequest(BaseModel):
+    worker_id: str = Field(
+        ...,
+        min_length=1,
+        description="Stable operator or service worker identifier recorded on leased items.",
+        examples=["lotus-report-batch-worker-1"],
+    )
+    recover_expired_leases: bool = Field(
+        True,
+        description="Whether expired unjobbed item leases are recovered before dispatch.",
+    )
+    runtime_load: BatchRuntimeLoad | None = Field(
+        default=None,
+        description="Optional caller-supplied work snapshot for back-pressure decisions.",
+    )
+    dispatch_policy: BatchDispatchPolicy | None = Field(
+        default=None,
+        description="Optional explicit dispatch policy for this bounded operator run.",
+    )
+
+
+class BatchWorkerItemExecutionResponse(BaseModel):
+    batch_item_id: str = Field(..., description="Batch item advanced by this run.")
+    report_job_id: str = Field(..., description="Report job linked to the batch item.")
+    item_status: BatchItemStatus = Field(..., description="Batch item status after execution.")
+    report_job_status: str = Field(..., description="Report job status observed after execution.")
+    failure_category: str | None = Field(default=None, description="Product-safe failure category.")
+    retry_eligible: bool = Field(False, description="Whether bounded retry remains available.")
+
+
+class BatchWorkerRunResponse(BaseModel):
+    batch_id: str = Field(..., description="Opaque durable batch identifier processed.")
+    status: BatchStatus = Field(..., description="Batch status after the bounded run.")
+    batch_status_before: BatchStatus = Field(..., description="Batch status before the run.")
+    batch_status_after: BatchStatus = Field(..., description="Batch status after the run.")
+    recovered_count: int = Field(..., ge=0, description="Expired leases recovered before dispatch.")
+    leased_count: int = Field(..., ge=0, description="Eligible items leased during dispatch.")
+    dispatched_count: int = Field(..., ge=0, description="Report jobs created or reused.")
+    executed_count: int = Field(..., ge=0, description="Waiting items advanced through execution.")
+    report_job_ids: list[str] = Field(
+        default_factory=list,
+        description="Report job identifiers linked during this bounded run.",
+    )
+    back_pressure_reasons: list[str] = Field(
+        default_factory=list,
+        description="Product-safe reasons dispatch was skipped or limited.",
+    )
+    skipped_reason: str | None = Field(default=None, description="Reason the batch was not run.")
+    execution_results: list[BatchWorkerItemExecutionResponse] = Field(
+        default_factory=list,
+        description="Per-item execution outcomes.",
+    )
+    status_url: str = Field(..., description="Gateway-relative URL for batch status retrieval.")

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -17,6 +17,7 @@ from app.routers.intake import router as intake_router
 from app.routers.platform import router as platform_router
 from app.routers.portfolio import router as portfolio_router
 from app.routers.proposals import router as proposals_router
+from app.routers.reporting import batches_router as reporting_batches_router
 from app.routers.reporting import jobs_router as reporting_jobs_router
 from app.routers.reporting import router as reporting_router
 from app.routers.workbench import router as workbench_router
@@ -42,6 +43,13 @@ app = FastAPI(
             ),
         },
         {
+            "name": "Report Batches",
+            "description": (
+                "Gateway-facing report batch materialization, status, control, and bounded "
+                "operator-run APIs."
+            ),
+        },
+        {
             "name": "Archived Documents",
             "description": (
                 "Gateway-facing archived document metadata and controlled download APIs."
@@ -63,6 +71,7 @@ app.include_router(portfolio_router)
 app.include_router(workbench_router)
 app.include_router(reporting_router)
 app.include_router(reporting_jobs_router)
+app.include_router(reporting_batches_router)
 app.include_router(archive_documents_router)
 
 

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -6,8 +6,23 @@ from fastapi import APIRouter, Body, Header, HTTPException, Path, Query, status
 from app.clients.reporting_client import ReportingClient
 from app.config import settings
 from app.contracts.reporting import (
+    BATCH_CONTROL_RESPONSE_EXAMPLE,
+    BATCH_CREATE_REQUEST_EXAMPLE,
+    BATCH_HANDLE_RESPONSE_EXAMPLE,
+    BATCH_RECOVERY_RESPONSE_EXAMPLE,
+    BATCH_STATUS_RESPONSE_EXAMPLE,
+    BATCH_WORKER_RUN_REQUEST_EXAMPLE,
+    BATCH_WORKER_RUN_RESPONSE_EXAMPLE,
+    REPORT_BATCH_ERROR_EXAMPLES,
     REPORT_JOB_ERROR_EXAMPLES,
     REPORT_JOB_LIST_RESPONSE_EXAMPLE,
+    BatchControlResponse,
+    BatchCreateRequest,
+    BatchHandleResponse,
+    BatchRecoveryResponse,
+    BatchStatusResponse,
+    BatchWorkerRunRequest,
+    BatchWorkerRunResponse,
     PortfolioReviewJobRequest,
     ReportingPortfolioRequest,
     ReportingReviewResponse,
@@ -24,6 +39,7 @@ from app.services.caller_context import caller_context_headers
 
 router = APIRouter(prefix="/api/v1/reports", tags=["Reports"])
 jobs_router = APIRouter(prefix="/api/v1/report-jobs", tags=["Report Jobs"])
+batches_router = APIRouter(prefix="/api/v1/report-batches", tags=["Report Batches"])
 
 SUMMARY_REQUEST_EXAMPLES = {
     "wealthSummary": {
@@ -148,6 +164,92 @@ def _job_error_response(
 
 def _gateway_status_url(job_id: str) -> str:
     return f"/api/v1/report-jobs/{job_id}"
+
+
+def _gateway_batch_status_url(batch_id: str) -> str:
+    return f"/api/v1/report-batches/{batch_id}"
+
+
+def _rewrite_batch_status_url(payload: dict[str, Any]) -> dict[str, Any]:
+    batch_id = payload.get("batch_id")
+    if isinstance(batch_id, str) and batch_id:
+        return {**payload, "status_url": _gateway_batch_status_url(batch_id)}
+    return payload
+
+
+def _raise_report_batch_error(status_code: int, payload: dict[str, Any]) -> None:
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    error_code = detail.get("code") if isinstance(detail, dict) else None
+    message = detail.get("message") if isinstance(detail, dict) else "Report batch unavailable."
+
+    if status_code == status.HTTP_400_BAD_REQUEST and error_code in {
+        "missing_idempotency_key",
+        "missing_caller_context",
+        "empty_batch_selector",
+        "batch_size_exceeded",
+        "unsupported_batch_selector",
+        "invalid_batch_selector",
+    }:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+    if status_code == status.HTTP_404_NOT_FOUND and error_code == "report_batch_not_found":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "report_batch_not_found", "message": message},
+        )
+    if status_code == status.HTTP_409_CONFLICT and error_code in {
+        "idempotency_conflict",
+        "batch_worker_run_failed",
+    }:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": error_code, "message": message},
+        )
+    if status_code >= status.HTTP_400_BAD_REQUEST:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={
+                "code": "report_batch_upstream_unavailable",
+                "message": "Report batch service is unavailable.",
+            },
+        )
+
+
+def _batch_error_response(
+    status_code: int,
+    *,
+    example_key: str,
+    description: str,
+) -> dict[int | str, dict[str, Any]]:
+    return {
+        status_code: {
+            "model": ReportJobErrorResponse,
+            "description": description,
+            "content": {
+                "application/json": {
+                    "example": REPORT_BATCH_ERROR_EXAMPLES[example_key],
+                }
+            },
+        }
+    }
+
+
+def _context_headers(
+    *,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> dict[str, str]:
+    return caller_context_headers(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
 
 
 @router.get(
@@ -667,3 +769,406 @@ async def cancel_report_job(
     )
     _raise_report_job_error(status_code, payload)
     return ReportJobStatusResponse.model_validate(payload)
+
+
+@batches_router.post(
+    "",
+    response_model=BatchHandleResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Create report batch",
+    description=(
+        "Create a durable report batch through the governed gateway boundary. Use this endpoint "
+        "when operations need idempotent materialization of a portfolio-report batch before the "
+        "batch worker advances items. The lifecycle ledger and item execution remain owned by "
+        "lotus-report."
+    ),
+    openapi_extra={
+        "requestBody": {
+            "content": {
+                "application/json": {
+                    "example": BATCH_CREATE_REQUEST_EXAMPLE,
+                    "examples": {
+                        "explicitPortfolioList": {
+                            "summary": "Explicit portfolio list",
+                            "value": BATCH_CREATE_REQUEST_EXAMPLE,
+                        }
+                    },
+                }
+            }
+        },
+        "responses": {
+            "202": {
+                "content": {
+                    "application/json": {
+                        "example": BATCH_HANDLE_RESPONSE_EXAMPLE,
+                    }
+                }
+            }
+        },
+    },
+    responses={
+        **_batch_error_response(
+            400,
+            example_key="missing_idempotency_key",
+            description="Returned when idempotency, caller context, or selector input is invalid.",
+        ),
+        **_batch_error_response(
+            409,
+            example_key="idempotency_conflict",
+            description="Returned when the idempotency key conflicts with another batch request.",
+        ),
+        **_batch_error_response(
+            502,
+            example_key="report_batch_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
+)
+async def create_report_batch(
+    request: Annotated[
+        BatchCreateRequest,
+        Body(description="Report batch materialization request."),
+    ],
+    idempotency_key: Annotated[
+        str | None,
+        Header(
+            alias="Idempotency-Key",
+            description="Required caller idempotency key for batch creation.",
+        ),
+    ] = None,
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> BatchHandleResponse:
+    if not idempotency_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=REPORT_BATCH_ERROR_EXAMPLES["missing_idempotency_key"]["detail"],
+        )
+    status_code, payload = await _reporting_client().create_report_batch(
+        payload=request.model_dump(exclude_none=True, mode="json"),
+        idempotency_key=idempotency_key,
+        caller_headers=_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_batch_error(status_code, payload)
+    return BatchHandleResponse.model_validate(_rewrite_batch_status_url(payload))
+
+
+@batches_router.get(
+    "/{batch_id}",
+    response_model=BatchStatusResponse,
+    summary="Get report batch status",
+    description=(
+        "Return product-safe batch status and item progress from lotus-report. Use this endpoint "
+        "when a caller needs aggregate status, item status counts, retry eligibility, or linked "
+        "report-job identifiers for a known batch."
+    ),
+    openapi_extra={
+        "responses": {
+            "200": {"content": {"application/json": {"example": BATCH_STATUS_RESPONSE_EXAMPLE}}}
+        }
+    },
+    responses={
+        **_batch_error_response(
+            404,
+            example_key="report_batch_not_found",
+            description="Returned when the requested report batch does not exist.",
+        ),
+        **_batch_error_response(
+            502,
+            example_key="report_batch_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
+)
+async def get_report_batch_status(
+    batch_id: Annotated[str, Path(description="Opaque durable report batch identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> BatchStatusResponse:
+    status_code, payload = await _reporting_client().get_report_batch(
+        batch_id=batch_id,
+        caller_headers=_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_batch_error(status_code, payload)
+    return BatchStatusResponse.model_validate(payload)
+
+
+async def _control_batch(
+    *,
+    batch_id: str,
+    action: str,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> BatchControlResponse:
+    status_code, payload = await _reporting_client().control_report_batch(
+        batch_id=batch_id,
+        action=action,
+        caller_headers=_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_batch_error(status_code, payload)
+    return BatchControlResponse.model_validate(_rewrite_batch_status_url(payload))
+
+
+@batches_router.post(
+    "/{batch_id}:pause",
+    response_model=BatchControlResponse,
+    summary="Pause report batch dispatch",
+    description=(
+        "Pause new item dispatch for a materialized or running report batch while preserving "
+        "already-created report jobs under their own lotus-report lifecycle."
+    ),
+    openapi_extra={
+        "responses": {
+            "200": {"content": {"application/json": {"example": BATCH_CONTROL_RESPONSE_EXAMPLE}}}
+        }
+    },
+)
+async def pause_report_batch(
+    batch_id: Annotated[str, Path(description="Opaque durable report batch identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> BatchControlResponse:
+    return await _control_batch(
+        batch_id=batch_id,
+        action="pause",
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+
+
+@batches_router.post(
+    "/{batch_id}:resume",
+    response_model=BatchControlResponse,
+    summary="Resume report batch dispatch",
+    description="Resume a paused report batch so eligible items may be advanced by the worker.",
+)
+async def resume_report_batch(
+    batch_id: Annotated[str, Path(description="Opaque durable report batch identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> BatchControlResponse:
+    return await _control_batch(
+        batch_id=batch_id,
+        action="resume",
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+
+
+@batches_router.post(
+    "/{batch_id}:cancel",
+    response_model=BatchControlResponse,
+    summary="Cancel unstarted report batch work",
+    description=(
+        "Cancel remaining batch work that has not created report jobs. Existing report jobs are "
+        "preserved for audit and downstream lifecycle reconciliation."
+    ),
+)
+async def cancel_report_batch(
+    batch_id: Annotated[str, Path(description="Opaque durable report batch identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> BatchControlResponse:
+    return await _control_batch(
+        batch_id=batch_id,
+        action="cancel",
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+
+
+@batches_router.post(
+    "/{batch_id}:retry-failed",
+    response_model=BatchControlResponse,
+    summary="Retry eligible failed report batch items",
+    description=(
+        "Ask lotus-report to reset only retryable failed batch items whose retry policy permits "
+        "another attempt. Items with linked report jobs are not requeued."
+    ),
+)
+async def retry_failed_report_batch_items(
+    batch_id: Annotated[str, Path(description="Opaque durable report batch identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> BatchControlResponse:
+    return await _control_batch(
+        batch_id=batch_id,
+        action="retry-failed",
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+
+
+@batches_router.post(
+    "/{batch_id}:recover-expired-leases",
+    response_model=BatchRecoveryResponse,
+    summary="Recover expired report batch item leases",
+    description=(
+        "Recover expired unjobbed item leases through lotus-report so the worker can safely "
+        "redispatch them without duplicating existing report jobs."
+    ),
+    openapi_extra={
+        "responses": {
+            "200": {"content": {"application/json": {"example": BATCH_RECOVERY_RESPONSE_EXAMPLE}}}
+        }
+    },
+)
+async def recover_expired_report_batch_leases(
+    batch_id: Annotated[str, Path(description="Opaque durable report batch identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> BatchRecoveryResponse:
+    status_code, payload = await _reporting_client().control_report_batch(
+        batch_id=batch_id,
+        action="recover-expired-leases",
+        caller_headers=_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_batch_error(status_code, payload)
+    return BatchRecoveryResponse.model_validate(_rewrite_batch_status_url(payload))
+
+
+@batches_router.post(
+    "/{batch_id}:run-once",
+    response_model=BatchWorkerRunResponse,
+    summary="Run one bounded report batch worker pass",
+    description=(
+        "Run one bounded operator-controlled pass for a durable report batch through "
+        "lotus-report. This action may recover expired unjobbed leases, dispatch eligible items "
+        "under back-pressure policy, and advance waiting items through report job, snapshot, "
+        "render, archive, and batch reconciliation. It is not a scheduler loop."
+    ),
+    openapi_extra={
+        "requestBody": {
+            "content": {"application/json": {"example": BATCH_WORKER_RUN_REQUEST_EXAMPLE}}
+        },
+        "responses": {
+            "200": {"content": {"application/json": {"example": BATCH_WORKER_RUN_RESPONSE_EXAMPLE}}}
+        },
+    },
+    responses={
+        **_batch_error_response(
+            404,
+            example_key="report_batch_not_found",
+            description="Returned when the requested report batch does not exist.",
+        ),
+        **_batch_error_response(
+            409,
+            example_key="batch_worker_run_failed",
+            description="Returned when durable batch or linked report-job state is inconsistent.",
+        ),
+        **_batch_error_response(
+            502,
+            example_key="report_batch_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
+)
+async def run_report_batch_once(
+    request: Annotated[
+        BatchWorkerRunRequest,
+        Body(description="Bounded report batch worker-run request."),
+    ],
+    batch_id: Annotated[str, Path(description="Opaque durable report batch identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> BatchWorkerRunResponse:
+    status_code, payload = await _reporting_client().control_report_batch(
+        batch_id=batch_id,
+        action="run-once",
+        caller_headers=_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+        payload=request.model_dump(exclude_none=True, mode="json"),
+    )
+    _raise_report_batch_error(status_code, payload)
+    return BatchWorkerRunResponse.model_validate(_rewrite_batch_status_url(payload))

--- a/tests/contract/test_reporting_contract.py
+++ b/tests/contract/test_reporting_contract.py
@@ -1,6 +1,9 @@
 from fastapi.testclient import TestClient
 
 from app.contracts.reporting import (
+    BatchHandleResponse,
+    BatchStatusResponse,
+    BatchWorkerRunResponse,
     ReportingPortfolioRequest,
     ReportingReviewResponse,
     ReportingSnapshotResponse,
@@ -40,6 +43,65 @@ def test_reporting_contract_shapes() -> None:
     assert summary.data["wealth"]["total_market_value"] == 123.0
     assert review.data["overview"]["total_market_value"] == 1000.0
 
+    batch = BatchHandleResponse(
+        batch_id="rbch_1",
+        status="materialized",
+        status_url="/api/v1/report-batches/rbch_1",
+        idempotency_key="idem-batch-1",
+        item_count=1,
+    )
+    batch_status = BatchStatusResponse(
+        batch_id="rbch_1",
+        selector_mode="explicit_portfolio_list",
+        tenant_id="tenant-sg",
+        region="APAC",
+        materialized_portfolio_ids=["PB_SG_GLOBAL_BAL_001"],
+        as_of_date="2026-04-22",
+        requested_output_formats=["pdf"],
+        reporting_currency="USD",
+        status="materialized",
+        item_count=1,
+        status_counts={"materialized": 1},
+        items=[
+            {
+                "batch_item_id": "rbci_1",
+                "item_position": 1,
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "status": "materialized",
+                "report_job_id": None,
+                "created_at": "2026-04-22T09:00:00Z",
+            }
+        ],
+        created_at="2026-04-22T09:00:00Z",
+        updated_at="2026-04-22T09:00:00Z",
+        correlation_id="corr-batch-1",
+        trace_id="trace-batch-1",
+    )
+    batch_run = BatchWorkerRunResponse(
+        batch_id="rbch_1",
+        status="completed",
+        batch_status_before="materialized",
+        batch_status_after="completed",
+        recovered_count=0,
+        leased_count=1,
+        dispatched_count=1,
+        executed_count=1,
+        report_job_ids=["rjob_1"],
+        execution_results=[
+            {
+                "batch_item_id": "rbci_1",
+                "report_job_id": "rjob_1",
+                "item_status": "succeeded",
+                "report_job_status": "archived",
+            }
+        ],
+        status_url="/api/v1/report-batches/rbch_1",
+    )
+
+    assert batch.status_url == "/api/v1/report-batches/rbch_1"
+    assert batch_status.items[0].portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert batch_run.report_job_ids == ["rjob_1"]
+
 
 def test_reporting_request_normalizes_documented_aliases() -> None:
     request = ReportingPortfolioRequest(
@@ -75,6 +137,14 @@ def test_reporting_openapi_contract_registered() -> None:
     assert "/api/v1/report-jobs/{job_id}" in spec["paths"]
     assert "/api/v1/report-jobs/{job_id}/events" in spec["paths"]
     assert "/api/v1/report-jobs/{job_id}/cancel" in spec["paths"]
+    assert "/api/v1/report-batches" in spec["paths"]
+    assert "/api/v1/report-batches/{batch_id}" in spec["paths"]
+    assert "/api/v1/report-batches/{batch_id}:pause" in spec["paths"]
+    assert "/api/v1/report-batches/{batch_id}:resume" in spec["paths"]
+    assert "/api/v1/report-batches/{batch_id}:cancel" in spec["paths"]
+    assert "/api/v1/report-batches/{batch_id}:retry-failed" in spec["paths"]
+    assert "/api/v1/report-batches/{batch_id}:recover-expired-leases" in spec["paths"]
+    assert "/api/v1/report-batches/{batch_id}:run-once" in spec["paths"]
 
     snapshot_path = spec["paths"]["/api/v1/reports/{portfolio_id}/snapshot"]["get"]
     summary_path = spec["paths"]["/api/v1/reports/{portfolio_id}/summary"]["post"]
@@ -84,6 +154,9 @@ def test_reporting_openapi_contract_registered() -> None:
     job_status_path = spec["paths"]["/api/v1/report-jobs/{job_id}"]["get"]
     job_events_path = spec["paths"]["/api/v1/report-jobs/{job_id}/events"]["get"]
     job_cancel_path = spec["paths"]["/api/v1/report-jobs/{job_id}/cancel"]["post"]
+    batch_create_path = spec["paths"]["/api/v1/report-batches"]["post"]
+    batch_status_path = spec["paths"]["/api/v1/report-batches/{batch_id}"]["get"]
+    batch_run_path = spec["paths"]["/api/v1/report-batches/{batch_id}:run-once"]["post"]
     request_schema = spec["components"]["schemas"]["ReportingPortfolioRequest"]
     snapshot_schema = spec["components"]["schemas"]["ReportingSnapshotResponse"]
     summary_schema = spec["components"]["schemas"]["ReportingSummaryResponse"]
@@ -97,6 +170,9 @@ def test_reporting_openapi_contract_registered() -> None:
     assert job_status_path["summary"] == "Get report job status"
     assert job_events_path["summary"] == "Get report job event history"
     assert job_cancel_path["summary"] == "Cancel report job before render or archive"
+    assert batch_create_path["summary"] == "Create report batch"
+    assert batch_status_path["summary"] == "Get report batch status"
+    assert batch_run_path["summary"] == "Run one bounded report batch worker pass"
     assert "RFC-" not in str(job_submit_path)
     assert "RFC-" not in str(job_list_path)
     assert "RFC-" not in str(job_status_path)
@@ -112,6 +188,16 @@ def test_reporting_openapi_contract_registered() -> None:
         "ReportJobStatusResponse",
         "ReportJobStatusEventsResponse",
         "ReportStatusEvent",
+        "BatchCreateRequest",
+        "PortfolioBatchCandidate",
+        "BatchHandleResponse",
+        "BatchStatusResponse",
+        "BatchItemStatusResponse",
+        "BatchControlResponse",
+        "BatchRecoveryResponse",
+        "BatchWorkerRunRequest",
+        "BatchWorkerRunResponse",
+        "BatchWorkerItemExecutionResponse",
     ]:
         properties = spec["components"]["schemas"][schema_name]["properties"]
         for property_contract in properties.values():

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -632,3 +632,265 @@ def test_report_job_gateway_errors_are_product_safe(monkeypatch):
     assert body["detail"]["code"] == "report_job_upstream_unavailable"
     assert "sqlite" not in str(body).lower()
     assert "report.dev.lotus" not in str(body)
+
+
+def _batch_headers() -> dict[str, str]:
+    return {
+        "X-Actor-Id": "operator-123",
+        "X-Tenant-Id": "tenant-sg",
+        "X-Region": "APAC",
+        "X-Correlation-Id": "corr-gateway-batch",
+    }
+
+
+def _batch_payload() -> dict[str, object]:
+    return {
+        "selector_mode": "explicit_portfolio_list",
+        "portfolio_ids": ["PB_SG_GLOBAL_BAL_001"],
+        "source_candidates": [
+            {
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "tenant_id": "tenant-sg",
+                "region": "APAC",
+                "active": True,
+                "selected": True,
+                "source_system": "lotus-core",
+                "source_object": "PortfolioScope",
+            }
+        ],
+        "as_of_date": "2026-04-22",
+        "requested_output_formats": ["pdf"],
+        "reporting_currency": "USD",
+        "options": {"sections": ["OVERVIEW"]},
+        "max_batch_size": 250,
+    }
+
+
+def _batch_status_payload(status: str = "materialized") -> dict[str, object]:
+    return {
+        "batch_id": "rbch_1",
+        "selector_mode": "explicit_portfolio_list",
+        "tenant_id": "tenant-sg",
+        "region": "APAC",
+        "materialized_portfolio_ids": ["PB_SG_GLOBAL_BAL_001"],
+        "as_of_date": "2026-04-22",
+        "requested_output_formats": ["pdf"],
+        "reporting_currency": "USD",
+        "status": status,
+        "item_count": 1,
+        "status_counts": {status: 1},
+        "items": [
+            {
+                "batch_item_id": "rbci_1",
+                "item_position": 1,
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "status": status,
+                "report_job_id": None,
+                "attempt_count": 0,
+                "retry_eligible": False,
+                "next_retry_at": None,
+                "last_error_category": None,
+                "last_error_summary": None,
+                "created_at": "2026-04-22T09:00:00Z",
+                "started_at": None,
+                "completed_at": None,
+                "cancelled_at": None,
+            }
+        ],
+        "created_at": "2026-04-22T09:00:00Z",
+        "updated_at": "2026-04-22T09:00:00Z",
+        "started_at": None,
+        "completed_at": None,
+        "cancelled_at": None,
+        "failed_at": None,
+        "correlation_id": "corr-gateway-batch",
+        "trace_id": "trace-batch",
+    }
+
+
+def test_report_batch_gateway_routes_forward_context_and_rewrite_status_urls(monkeypatch):
+    calls: list[tuple[str, str | None, dict[str, str]]] = []
+
+    async def _mock_create_batch(
+        self,
+        *,
+        payload,
+        idempotency_key,
+        caller_headers,
+        correlation_id,
+    ):
+        calls.append(("create", idempotency_key, caller_headers))
+        assert payload == _batch_payload()
+        assert correlation_id == "corr-gateway-batch"
+        return 202, {
+            "batch_id": "rbch_1",
+            "status": "materialized",
+            "status_url": "/reports/batches/rbch_1",
+            "idempotency_key": idempotency_key,
+            "item_count": 1,
+        }
+
+    async def _mock_get_batch(self, *, batch_id, caller_headers, correlation_id):
+        calls.append(("get", batch_id, caller_headers))
+        assert correlation_id == "corr-gateway-batch"
+        return 200, _batch_status_payload()
+
+    async def _mock_control_batch(
+        self,
+        *,
+        batch_id,
+        action,
+        caller_headers,
+        correlation_id,
+        payload=None,
+    ):
+        calls.append((action, batch_id, caller_headers))
+        assert correlation_id == "corr-gateway-batch"
+        if action == "recover-expired-leases":
+            return 200, {
+                "batch_id": batch_id,
+                "status": "running",
+                "recovered_count": 1,
+                "recovery_pending_item_ids": ["rbci_1"],
+                "status_url": "/reports/batches/rbch_1",
+            }
+        if action == "run-once":
+            assert payload == {"worker_id": "worker-1", "recover_expired_leases": True}
+            return 200, {
+                "batch_id": batch_id,
+                "status": "completed",
+                "batch_status_before": "materialized",
+                "batch_status_after": "completed",
+                "recovered_count": 0,
+                "leased_count": 1,
+                "dispatched_count": 1,
+                "executed_count": 1,
+                "report_job_ids": ["rjob_1"],
+                "back_pressure_reasons": [],
+                "skipped_reason": None,
+                "execution_results": [
+                    {
+                        "batch_item_id": "rbci_1",
+                        "report_job_id": "rjob_1",
+                        "item_status": "succeeded",
+                        "report_job_status": "archived",
+                        "failure_category": None,
+                        "retry_eligible": False,
+                    }
+                ],
+                "status_url": "/reports/batches/rbch_1",
+            }
+        status_by_action = {
+            "pause": "paused",
+            "resume": "running",
+            "cancel": "cancelled",
+            "retry-failed": "running",
+        }
+        return 200, {
+            "batch_id": batch_id,
+            "status": status_by_action[action],
+            "affected_count": 1,
+            "status_url": "/reports/batches/rbch_1",
+        }
+
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.create_report_batch",
+        _mock_create_batch,
+    )
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_report_batch",
+        _mock_get_batch,
+    )
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.control_report_batch",
+        _mock_control_batch,
+    )
+
+    client = TestClient(app)
+    create_response = client.post(
+        "/api/v1/report-batches",
+        json=_batch_payload(),
+        headers={**_batch_headers(), "Idempotency-Key": "idem-batch-1"},
+    )
+    status_response = client.get("/api/v1/report-batches/rbch_1", headers=_batch_headers())
+    pause_response = client.post("/api/v1/report-batches/rbch_1:pause", headers=_batch_headers())
+    resume_response = client.post("/api/v1/report-batches/rbch_1:resume", headers=_batch_headers())
+    cancel_response = client.post("/api/v1/report-batches/rbch_1:cancel", headers=_batch_headers())
+    retry_response = client.post(
+        "/api/v1/report-batches/rbch_1:retry-failed",
+        headers=_batch_headers(),
+    )
+    recovery_response = client.post(
+        "/api/v1/report-batches/rbch_1:recover-expired-leases",
+        headers=_batch_headers(),
+    )
+    run_response = client.post(
+        "/api/v1/report-batches/rbch_1:run-once",
+        json={"worker_id": "worker-1", "recover_expired_leases": True},
+        headers=_batch_headers(),
+    )
+
+    assert create_response.status_code == 202
+    assert create_response.json()["status_url"] == "/api/v1/report-batches/rbch_1"
+    assert status_response.status_code == 200
+    assert status_response.json()["items"][0]["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
+    assert pause_response.json()["status"] == "paused"
+    assert resume_response.json()["status"] == "running"
+    assert cancel_response.json()["status"] == "cancelled"
+    assert retry_response.json()["status"] == "running"
+    assert recovery_response.json()["status_url"] == "/api/v1/report-batches/rbch_1"
+    assert recovery_response.json()["recovered_count"] == 1
+    assert run_response.json()["status_url"] == "/api/v1/report-batches/rbch_1"
+    assert run_response.json()["report_job_ids"] == ["rjob_1"]
+    assert calls[0][0:2] == ("create", "idem-batch-1")
+    assert calls[0][2]["X-Caller-Application"] == "lotus-gateway"
+    assert calls[0][2]["X-Actor-Id"] == "operator-123"
+    assert calls[1][0:2] == ("get", "rbch_1")
+    assert [call[0] for call in calls[2:]] == [
+        "pause",
+        "resume",
+        "cancel",
+        "retry-failed",
+        "recover-expired-leases",
+        "run-once",
+    ]
+
+
+def test_report_batch_gateway_requires_idempotency_and_caller_context():
+    client = TestClient(app)
+    missing_idempotency = client.post(
+        "/api/v1/report-batches",
+        json=_batch_payload(),
+        headers=_batch_headers(),
+    )
+    missing_context = client.post(
+        "/api/v1/report-batches",
+        json=_batch_payload(),
+        headers={"Idempotency-Key": "idem-batch-1"},
+    )
+
+    assert missing_idempotency.status_code == 400
+    assert missing_idempotency.json()["detail"]["code"] == "missing_idempotency_key"
+    assert missing_context.status_code == 400
+    detail = missing_context.json()["detail"]
+    assert detail["code"] == "missing_caller_context"
+    assert detail["missing_headers"] == ["X-Actor-Id", "X-Tenant-Id", "X-Region"]
+
+
+def test_report_batch_gateway_errors_are_product_safe(monkeypatch):
+    async def _mock_get_batch(self, *, batch_id, caller_headers, correlation_id):  # noqa: ARG001
+        return 500, {"detail": "postgres traceback internal-host report.dev.lotus"}
+
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_report_batch",
+        _mock_get_batch,
+    )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/report-batches/rbch_500", headers=_batch_headers())
+
+    assert response.status_code == 502
+    body = response.json()
+    assert body["detail"]["code"] == "report_batch_upstream_unavailable"
+    assert "postgres" not in str(body).lower()
+    assert "report.dev.lotus" not in str(body)

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1564,6 +1564,65 @@ async def test_reporting_client_report_job_routes_forward_governed_headers():
 
 
 @pytest.mark.asyncio
+async def test_reporting_client_report_batch_routes_forward_governed_headers():
+    client = ReportingClient(base_url="http://ras", timeout_seconds=2.0)
+    caller_headers = {
+        "X-Actor-Id": "operator-123",
+        "X-Caller-Application": "lotus-gateway",
+        "X-Tenant-Id": "tenant-sg",
+        "X-Region": "APAC",
+    }
+    _FakeAsyncClient.queue_json(202, {"batch_id": "rbch_1"})
+    _FakeAsyncClient.queue_json(200, {"batch_id": "rbch_1", "status": "materialized"})
+    _FakeAsyncClient.queue_json(200, {"batch_id": "rbch_1", "status": "paused"})
+    _FakeAsyncClient.queue_json(200, {"batch_id": "rbch_1", "status": "completed"})
+
+    create_status, create_payload = await client.create_report_batch(
+        payload={"selector_mode": "explicit_portfolio_list"},
+        idempotency_key="idem-batch-1",
+        caller_headers=caller_headers,
+        correlation_id="corr-batch-1",
+    )
+    status_code, status_payload = await client.get_report_batch(
+        batch_id="rbch_1",
+        caller_headers=caller_headers,
+        correlation_id="corr-batch-1",
+    )
+    pause_status, pause_payload = await client.control_report_batch(
+        batch_id="rbch_1",
+        action="pause",
+        caller_headers=caller_headers,
+        correlation_id="corr-batch-1",
+    )
+    run_status, run_payload = await client.control_report_batch(
+        batch_id="rbch_1",
+        action="run-once",
+        caller_headers=caller_headers,
+        correlation_id="corr-batch-1",
+        payload={"worker_id": "worker-1"},
+    )
+
+    assert create_status == 202
+    assert create_payload["batch_id"] == "rbch_1"
+    assert status_code == 200
+    assert status_payload["status"] == "materialized"
+    assert pause_status == 200
+    assert pause_payload["status"] == "paused"
+    assert run_status == 200
+    assert run_payload["status"] == "completed"
+    assert _FakeAsyncClient.calls[0]["url"] == "http://ras/reports/batches"
+    assert _FakeAsyncClient.calls[0]["json"] == {"selector_mode": "explicit_portfolio_list"}
+    assert _FakeAsyncClient.calls[0]["headers"]["Idempotency-Key"] == "idem-batch-1"
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Actor-Id"] == "operator-123"
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Caller-Application"] == "lotus-gateway"
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Correlation-Id"] == "corr-batch-1"
+    assert _FakeAsyncClient.calls[1]["url"] == "http://ras/reports/batches/rbch_1"
+    assert _FakeAsyncClient.calls[2]["url"] == "http://ras/reports/batches/rbch_1:pause"
+    assert _FakeAsyncClient.calls[3]["url"] == "http://ras/reports/batches/rbch_1:run-once"
+    assert _FakeAsyncClient.calls[3]["json"] == {"worker_id": "worker-1"}
+
+
+@pytest.mark.asyncio
 async def test_reporting_client_snapshot_request_uses_live_aggregation_query_contract():
     client = ReportingClient(base_url="http://ras", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"rows": []})

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -16,6 +16,8 @@
 - `GET` and `POST /api/v1/workbench/*`
 - `GET` and `POST /api/v1/reports/*`
 - `GET /api/v1/report-jobs` and `GET`/`POST /api/v1/report-jobs/*`
+- `POST /api/v1/report-batches`, `GET /api/v1/report-batches/{batch_id}`, and
+  `POST /api/v1/report-batches/{batch_id}:*`
 - `GET /api/v1/documents/{document_id}`
 - `GET /api/v1/documents/{document_id}/download`
 - `/health`, `/health/live`, `/health/ready`, `/metrics`, `/docs`
@@ -38,6 +40,12 @@
   `Idempotency-Key`
 - report job search, status, append-only event history, and cancellation are gateway-first under
   `/api/v1/report-jobs` and `/api/v1/report-jobs/*`
+- report batch materialization, status, pause, resume, cancel, retry-failed,
+  recover-expired-leases, and bounded run-once operator actions are gateway-first under
+  `/api/v1/report-batches`; `lotus-report` remains the batch lifecycle and execution authority
+- report batch materialization requires `Idempotency-Key`; all report batch routes require
+  `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`, with optional `X-Caller-Application`,
+  `X-Booking-Center-Code`, and `X-Role` forwarded as caller context
 - archived generated-document metadata and download are gateway-first under `/api/v1/documents/*`;
   `lotus-workbench` must not call `lotus-archive` directly
 - archived document routes require `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional
@@ -144,6 +152,39 @@ Report job event history:
 
 ```bash
 curl "http://127.0.0.1:8111/api/v1/report-jobs/rjob_example/events"
+```
+
+Report batch materialization:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/report-batches" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: batch-PB_SG_GLOBAL_BAL_001-2026-04-22" \
+  -H "X-Actor-Id: support-operator-1" \
+  -H "X-Caller-Application: lotus-workbench" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -d "{\"selector_mode\":\"explicit_portfolio_list\",\"portfolio_ids\":[\"PB_SG_GLOBAL_BAL_001\"],\"source_candidates\":[{\"portfolio_id\":\"PB_SG_GLOBAL_BAL_001\",\"tenant_id\":\"tenant-sg\",\"region\":\"APAC\",\"active\":true,\"selected\":true,\"source_system\":\"lotus-core\",\"source_object\":\"PortfolioScope\"}],\"as_of_date\":\"2026-04-22\",\"requested_output_formats\":[\"pdf\"],\"reporting_currency\":\"USD\",\"options\":{\"sections\":[\"OVERVIEW\",\"PERFORMANCE\"]},\"max_batch_size\":250}"
+```
+
+Report batch status:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/report-batches/rbch_example" \
+  -H "X-Actor-Id: support-operator-1" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC"
+```
+
+Report batch bounded operator run:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/report-batches/rbch_example:run-once" \
+  -H "Content-Type: application/json" \
+  -H "X-Actor-Id: support-operator-1" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -d "{\"worker_id\":\"lotus-report-batch-worker-1\",\"recover_expired_leases\":true,\"dispatch_policy\":{\"max_active_batches\":1,\"max_active_items\":5,\"max_active_upstream_jobs\":3,\"max_active_render_jobs\":2,\"max_active_archive_jobs\":2,\"lease_seconds\":300},\"runtime_load\":{\"active_batches\":0,\"active_items\":0,\"active_upstream_jobs\":0,\"active_render_jobs\":0,\"active_archive_jobs\":0}}"
 ```
 
 Archived document metadata:

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -26,6 +26,8 @@
   report snapshot, summary, and review payloads
 - `report-jobs`
   report generation job initiation, search, status, event history, and cancellation
+- `report-batches`
+  batch materialization, status, control, and bounded operator-run boundary over `lotus-report`
 - `archived documents`
   generated-document metadata and controlled download boundary over `lotus-archive`
 
@@ -37,3 +39,5 @@
 4. RFC-0082 classification governs how new upstream dependencies are justified
 5. generated-document retrieval is product-facing through gateway; archive storage, retention,
    purge, legal-hold mutation, and access-event ownership stay in `lotus-archive`
+6. report batch lifecycle and execution truth stay in `lotus-report`; gateway exposes the
+   governed operator boundary and rewrites only gateway-relative status URLs


### PR DESCRIPTION
## Summary
- Exposes RFC-0104 report batch materialization, status, pause/resume/cancel, retry-failed, recover-expired-leases, and bounded run-once operator routes under `/api/v1/report-batches`.
- Extends the `lotus-report` gateway client and OpenAPI contracts with product-safe batch models, examples, error mappings, caller-context propagation, and gateway-relative status URLs.
- Updates README, repository context, RFC-0082 integration map, and repo-local wiki route/operator documentation.

## Local validation
- `python -m pytest tests/integration/test_reporting_router.py tests/contract/test_reporting_contract.py tests/unit/test_upstream_clients.py -q` -> 74 passed
- `make check` -> 346 passed
- `make ci` -> integration 133 passed, coverage 479 passed / 88.74%, `pip-audit` no known vulnerabilities
- `docker compose config --quiet`
- `docker compose build lotus-gateway`
- `git diff --check`

## Live canonical-stack proof
- Gateway runtime refreshed on `127.0.0.1:8111` with `ARCHIVE_SERVICE_BASE_URL=http://host.docker.internal:8150`; upstream report/render/archive services healthy.
- Created batch via gateway: `POST /api/v1/report-batches`, `batch_id=rbch_71903e99009b4eac87786b872a3a3307`, `idempotency_key=gateway-batch-PB_SG_GLOBAL_BAL_001-2026-04-22-017bfa22`, `correlation_id=corr-gateway-batch-017bfa22`.
- Ran bounded gateway operator action: `POST /api/v1/report-batches/rbch_71903e99009b4eac87786b872a3a3307:run-once`; final gateway status `completed`, `status_counts={"succeeded":1}`.
- DB reconciliation in `lotus-report-postgres`: item `rbit_89b4c087c07b410a96eadd64284441a1` succeeded, report job `rjob_1aaca40b76b24a25aca25b6315be7e2d` archived, snapshot `rsnap_8245f77e6b254fb687e6dc2201a27206` complete/complete, render `rdr_rjob_1aaca40b76b24a25aca25b6315be7e2d_pdf`, archive document `doc_415f47cfa5ee4d809c02b9802d5b2eab`.
- Gateway archive retrieval proved metadata and PDF download: `application/pdf`, 190486 bytes, `%PDF-1.7`, sha256 `731568bcceef2a0542883b7a4ba2ce1b2b00512de2506621b63e7322bfdbddd5`, matching `x-document-checksum`.
- Gateway and report logs captured correlation IDs for create/status/run/archive requests.

## Wiki
- Repo-local `wiki/API-Surface.md` and `wiki/Architecture.md` updated in this PR. Publish after merge with `lotus-platform/automation/Sync-RepoWikis.ps1 -Publish -Repository lotus-gateway`.