### PR TITLE
Expose RFC 0104 scheduler admin routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/report-jobs`, `/api/v1/report-jobs/*`
 - `report-batches`
   `/api/v1/report-batches`, `/api/v1/report-batches/*`
+- `report-batch-schedules`
+  `/api/v1/report-batch-schedules`, `/api/v1/report-batch-schedules:run-due`
 - `archived documents`
   `/api/v1/documents/{document_id}`, `/api/v1/documents/{document_id}/download`
 - platform surfaces

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -36,8 +36,9 @@ Current repository posture:
    gateway-first portfolio review report job workflows under `/api/v1/reports/portfolio-reviews`,
    `/api/v1/report-jobs`, and `/api/v1/report-jobs/*`,
 5. RFC-0104 report batch materialization/status/control/retry/recovery/bounded operator-run routes
-   are active under `/api/v1/report-batches` and `/api/v1/report-batches/*`; lifecycle and
-   execution truth remain in `lotus-report`,
+   are active under `/api/v1/report-batches` and `/api/v1/report-batches/*`; config-backed
+   scheduler list/run-due routes are active under `/api/v1/report-batch-schedules`; lifecycle,
+   scheduler configuration, and execution truth remain in `lotus-report`,
 6. archived generated-document metadata and controlled download routes are active under
    `/api/v1/documents/{document_id}` and `/api/v1/documents/{document_id}/download` as the
    product-facing boundary over `lotus-archive`,

--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -90,6 +90,9 @@ This RFC-0082 documentation slice reflects current runtime behavior:
 4. RFC-0104 report batch materialization, status, control, recovery, retry, and bounded run-once
    operator actions are exposed through gateway-owned `/api/v1/report-batches` routes while
    preserving `lotus-report` as the lifecycle and execution authority.
+5. RFC-0104 config-backed scheduler list and run-due actions are exposed through gateway-owned
+   `/api/v1/report-batch-schedules` routes while preserving `lotus-report` as the scheduler
+   configuration and materialization authority.
 
 ## Gap Register
 

--- a/src/app/clients/reporting_client.py
+++ b/src/app/clients/reporting_client.py
@@ -252,3 +252,41 @@ class ReportingClient:
             json_body=payload,
             headers=headers,
         )
+
+    async def list_report_batch_schedules(
+        self,
+        *,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/batch-schedules"
+        headers = propagation_headers(correlation_id)
+        headers.update(caller_headers)
+        return await request_with_retry(
+            method="GET",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=headers,
+        )
+
+    async def run_due_report_batch_schedules(
+        self,
+        *,
+        payload: dict[str, Any],
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/batch-schedules:run-due"
+        headers = propagation_headers(correlation_id)
+        headers.update(caller_headers)
+        return await request_with_retry(
+            method="POST",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            json_body=payload,
+            headers=headers,
+        )

--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -910,6 +910,57 @@ BATCH_WORKER_RUN_RESPONSE_EXAMPLE: dict[str, Any] = {
     "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
 }
 
+BATCH_SCHEDULE_LIST_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "scheduler_id": "lotus-report-batch-scheduler-1",
+    "interval_seconds": 60.0,
+    "tenant_id": "tenant-sg",
+    "region": "APAC",
+    "booking_center_code": "SG",
+    "schedule_count": 1,
+    "enabled_schedule_count": 1,
+    "schedules": [
+        {
+            "schedule_id": "monthly-sg-global-bal",
+            "enabled": True,
+            "selector_mode": "explicit_portfolio_list",
+            "frequency": "monthly",
+            "as_of_date": "2026-04-22",
+            "portfolio_count": 1,
+            "manifest_entry_count": 0,
+            "requested_output_formats": ["pdf"],
+            "reporting_currency": "USD",
+            "max_batch_size": 250,
+            "template_id": "portfolio-review",
+            "template_version": "v1",
+            "render_package_version": "portfolio-review.v1",
+            "manifest_source": None,
+            "manifest_version": None,
+            "manifest_hash": None,
+            "option_keys": ["sections"],
+        }
+    ],
+}
+
+BATCH_SCHEDULER_RUN_REQUEST_EXAMPLE: dict[str, Any] = {"pass_sequence": 1}
+
+BATCH_SCHEDULER_RUN_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "scheduler_id": "lotus-report-batch-scheduler-1",
+    "attempted_count": 1,
+    "materialized_count": 1,
+    "skipped_schedule_ids": [],
+    "materialized": [
+        {
+            "schedule_id": "monthly-sg-global-bal",
+            "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+            "idempotency_key": "scheduled-batch-2f6d1a8f2ef24f019e7d7f37507f352c",
+            "item_count": 1,
+            "status": "materialized",
+        }
+    ],
+    "correlation_id": "corr-batch-scheduler-1-abc123def456",
+    "trace_id": "trace1234567890abcdef1234567890ab",
+}
+
 REPORT_BATCH_ERROR_EXAMPLES: dict[str, dict[str, Any]] = {
     "missing_idempotency_key": REPORT_JOB_ERROR_EXAMPLES["missing_idempotency_key"],
     "missing_caller_context": REPORT_JOB_ERROR_EXAMPLES["missing_caller_context"],
@@ -935,6 +986,12 @@ REPORT_BATCH_ERROR_EXAMPLES: dict[str, dict[str, Any]] = {
         "detail": {
             "code": "batch_worker_run_failed",
             "message": "Report batch run could not be completed.",
+        }
+    },
+    "batch_scheduler_run_failed": {
+        "detail": {
+            "code": "batch_scheduler_run_failed",
+            "message": "Report batch scheduler pass could not be completed.",
         }
     },
     "report_batch_upstream_unavailable": {
@@ -1182,3 +1239,80 @@ class BatchWorkerRunResponse(BaseModel):
         description="Per-item execution outcomes.",
     )
     status_url: str = Field(..., description="Gateway-relative URL for batch status retrieval.")
+
+
+class BatchScheduleSummaryResponse(BaseModel):
+    schedule_id: str = Field(..., description="Governed schedule identifier.")
+    enabled: bool = Field(..., description="Whether the configured schedule is enabled.")
+    selector_mode: str = Field(..., description="Configured selector mode.")
+    frequency: str = Field(..., description="Configured production cycle frequency.")
+    as_of_date: date = Field(..., description="Business as-of date used by this schedule.")
+    portfolio_count: int = Field(..., ge=0, description="Configured explicit portfolio count.")
+    manifest_entry_count: int = Field(
+        ..., ge=0, description="Configured inline manifest entry count."
+    )
+    requested_output_formats: list[str] = Field(
+        ..., description="Requested output formats for materialized batch items."
+    )
+    reporting_currency: str | None = Field(default=None, description="Reporting currency.")
+    max_batch_size: int = Field(..., ge=1, description="Maximum materialized item count.")
+    template_id: str = Field(..., description="Report template identifier.")
+    template_version: str = Field(..., description="Report template version.")
+    render_package_version: str = Field(..., description="Render package contract version.")
+    manifest_source: str | None = Field(default=None, description="Inline manifest source.")
+    manifest_version: str | None = Field(default=None, description="Inline manifest version.")
+    manifest_hash: str | None = Field(default=None, description="Stable inline manifest hash.")
+    option_keys: list[str] = Field(
+        default_factory=list,
+        description="Sorted configured option keys without exposing option values.",
+    )
+
+
+class BatchScheduleListResponse(BaseModel):
+    scheduler_id: str = Field(..., description="Stable scheduler identity.")
+    interval_seconds: float = Field(..., ge=0, description="Configured scheduler interval.")
+    tenant_id: str = Field(..., description="Tenant context used by configured schedules.")
+    region: str = Field(..., description="Region context used by configured schedules.")
+    booking_center_code: str | None = Field(
+        default=None, description="Optional booking-center context."
+    )
+    schedule_count: int = Field(..., ge=0, description="Total configured schedule count.")
+    enabled_schedule_count: int = Field(..., ge=0, description="Enabled configured schedule count.")
+    schedules: list[BatchScheduleSummaryResponse] = Field(
+        ..., description="Configured report batch schedules."
+    )
+
+
+class BatchSchedulerRunRequest(BaseModel):
+    pass_sequence: int = Field(
+        1,
+        ge=1,
+        description="Deterministic scheduler pass sequence for correlation and idempotency proof.",
+        examples=[1],
+    )
+
+
+class BatchSchedulerMaterializationResponse(BaseModel):
+    schedule_id: str = Field(..., description="Schedule that produced or reused this batch.")
+    batch_id: str = Field(..., description="Durable report batch identifier.")
+    idempotency_key: str = Field(..., description="Deterministic scheduled idempotency key.")
+    item_count: int = Field(..., ge=0, description="Materialized batch item count.")
+    status: str = Field(..., description="Batch status after materialization or reuse.")
+
+
+class BatchSchedulerRunResponse(BaseModel):
+    scheduler_id: str = Field(..., description="Stable scheduler identity.")
+    attempted_count: int = Field(..., ge=0, description="Enabled schedule count attempted.")
+    materialized_count: int = Field(
+        ..., ge=0, description="Batches materialized or idempotently reused."
+    )
+    skipped_schedule_ids: list[str] = Field(
+        default_factory=list,
+        description="Enabled schedule ids skipped because no eligible candidates were resolved.",
+    )
+    materialized: list[BatchSchedulerMaterializationResponse] = Field(
+        default_factory=list,
+        description="Durable batch materialization results.",
+    )
+    correlation_id: str = Field(..., description="Scheduler correlation id used for this pass.")
+    trace_id: str = Field(..., description="Scheduler trace id used for this pass.")

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -20,6 +20,7 @@ from app.routers.proposals import router as proposals_router
 from app.routers.reporting import batches_router as reporting_batches_router
 from app.routers.reporting import jobs_router as reporting_jobs_router
 from app.routers.reporting import router as reporting_router
+from app.routers.reporting import schedules_router as reporting_schedules_router
 from app.routers.workbench import router as workbench_router
 
 
@@ -50,6 +51,10 @@ app = FastAPI(
             ),
         },
         {
+            "name": "Report Batch Schedules",
+            "description": "Gateway-facing report batch scheduler inspection and run APIs.",
+        },
+        {
             "name": "Archived Documents",
             "description": (
                 "Gateway-facing archived document metadata and controlled download APIs."
@@ -72,6 +77,7 @@ app.include_router(workbench_router)
 app.include_router(reporting_router)
 app.include_router(reporting_jobs_router)
 app.include_router(reporting_batches_router)
+app.include_router(reporting_schedules_router)
 app.include_router(archive_documents_router)
 
 

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -10,6 +10,9 @@ from app.contracts.reporting import (
     BATCH_CREATE_REQUEST_EXAMPLE,
     BATCH_HANDLE_RESPONSE_EXAMPLE,
     BATCH_RECOVERY_RESPONSE_EXAMPLE,
+    BATCH_SCHEDULE_LIST_RESPONSE_EXAMPLE,
+    BATCH_SCHEDULER_RUN_REQUEST_EXAMPLE,
+    BATCH_SCHEDULER_RUN_RESPONSE_EXAMPLE,
     BATCH_STATUS_RESPONSE_EXAMPLE,
     BATCH_WORKER_RUN_REQUEST_EXAMPLE,
     BATCH_WORKER_RUN_RESPONSE_EXAMPLE,
@@ -20,6 +23,9 @@ from app.contracts.reporting import (
     BatchCreateRequest,
     BatchHandleResponse,
     BatchRecoveryResponse,
+    BatchScheduleListResponse,
+    BatchSchedulerRunRequest,
+    BatchSchedulerRunResponse,
     BatchStatusResponse,
     BatchWorkerRunRequest,
     BatchWorkerRunResponse,
@@ -40,6 +46,10 @@ from app.services.caller_context import caller_context_headers
 router = APIRouter(prefix="/api/v1/reports", tags=["Reports"])
 jobs_router = APIRouter(prefix="/api/v1/report-jobs", tags=["Report Jobs"])
 batches_router = APIRouter(prefix="/api/v1/report-batches", tags=["Report Batches"])
+schedules_router = APIRouter(
+    prefix="/api/v1/report-batch-schedules",
+    tags=["Report Batch Schedules"],
+)
 
 SUMMARY_REQUEST_EXAMPLES = {
     "wealthSummary": {
@@ -1172,3 +1182,113 @@ async def run_report_batch_once(
     )
     _raise_report_batch_error(status_code, payload)
     return BatchWorkerRunResponse.model_validate(_rewrite_batch_status_url(payload))
+
+
+@schedules_router.get(
+    "",
+    response_model=BatchScheduleListResponse,
+    summary="List governed report batch schedules",
+    description=(
+        "List the report batch schedules currently configured in lotus-report. Schedules remain "
+        "owned by governed report service configuration; this gateway endpoint does not create, "
+        "edit, or delete schedules."
+    ),
+    openapi_extra={
+        "responses": {
+            "200": {
+                "content": {"application/json": {"example": BATCH_SCHEDULE_LIST_RESPONSE_EXAMPLE}}
+            }
+        }
+    },
+    responses={
+        **_batch_error_response(
+            502,
+            example_key="report_batch_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        )
+    },
+)
+async def list_report_batch_schedules(
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> BatchScheduleListResponse:
+    status_code, payload = await _reporting_client().list_report_batch_schedules(
+        caller_headers=_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_batch_error(status_code, payload)
+    return BatchScheduleListResponse.model_validate(payload)
+
+
+@schedules_router.post(
+    ":run-due",
+    response_model=BatchSchedulerRunResponse,
+    summary="Run one bounded report batch scheduler pass",
+    description=(
+        "Run one bounded scheduler materialization pass through lotus-report. The pass resolves "
+        "enabled schedules and creates or reuses durable idempotent batches. It does not execute "
+        "batch items; batch workers remain responsible for dispatch, render, archive, and "
+        "reconciliation."
+    ),
+    openapi_extra={
+        "requestBody": {
+            "content": {"application/json": {"example": BATCH_SCHEDULER_RUN_REQUEST_EXAMPLE}}
+        },
+        "responses": {
+            "200": {
+                "content": {"application/json": {"example": BATCH_SCHEDULER_RUN_RESPONSE_EXAMPLE}}
+            }
+        },
+    },
+    responses={
+        **_batch_error_response(
+            409,
+            example_key="batch_scheduler_run_failed",
+            description=(
+                "Returned when lotus-report cannot safely materialize configured schedules."
+            ),
+        ),
+        **_batch_error_response(
+            502,
+            example_key="report_batch_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
+)
+async def run_due_report_batch_schedules(
+    request: Annotated[
+        BatchSchedulerRunRequest,
+        Body(description="Bounded report batch scheduler-run request."),
+    ],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> BatchSchedulerRunResponse:
+    status_code, payload = await _reporting_client().run_due_report_batch_schedules(
+        payload=request.model_dump(exclude_none=True, mode="json"),
+        caller_headers=_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_batch_error(status_code, payload)
+    return BatchSchedulerRunResponse.model_validate(payload)

--- a/tests/contract/test_reporting_contract.py
+++ b/tests/contract/test_reporting_contract.py
@@ -145,6 +145,8 @@ def test_reporting_openapi_contract_registered() -> None:
     assert "/api/v1/report-batches/{batch_id}:retry-failed" in spec["paths"]
     assert "/api/v1/report-batches/{batch_id}:recover-expired-leases" in spec["paths"]
     assert "/api/v1/report-batches/{batch_id}:run-once" in spec["paths"]
+    assert "/api/v1/report-batch-schedules" in spec["paths"]
+    assert "/api/v1/report-batch-schedules:run-due" in spec["paths"]
 
     snapshot_path = spec["paths"]["/api/v1/reports/{portfolio_id}/snapshot"]["get"]
     summary_path = spec["paths"]["/api/v1/reports/{portfolio_id}/summary"]["post"]
@@ -157,6 +159,8 @@ def test_reporting_openapi_contract_registered() -> None:
     batch_create_path = spec["paths"]["/api/v1/report-batches"]["post"]
     batch_status_path = spec["paths"]["/api/v1/report-batches/{batch_id}"]["get"]
     batch_run_path = spec["paths"]["/api/v1/report-batches/{batch_id}:run-once"]["post"]
+    schedule_list_path = spec["paths"]["/api/v1/report-batch-schedules"]["get"]
+    schedule_run_path = spec["paths"]["/api/v1/report-batch-schedules:run-due"]["post"]
     request_schema = spec["components"]["schemas"]["ReportingPortfolioRequest"]
     snapshot_schema = spec["components"]["schemas"]["ReportingSnapshotResponse"]
     summary_schema = spec["components"]["schemas"]["ReportingSummaryResponse"]
@@ -173,6 +177,8 @@ def test_reporting_openapi_contract_registered() -> None:
     assert batch_create_path["summary"] == "Create report batch"
     assert batch_status_path["summary"] == "Get report batch status"
     assert batch_run_path["summary"] == "Run one bounded report batch worker pass"
+    assert schedule_list_path["summary"] == "List governed report batch schedules"
+    assert schedule_run_path["summary"] == "Run one bounded report batch scheduler pass"
     assert "RFC-" not in str(job_submit_path)
     assert "RFC-" not in str(job_list_path)
     assert "RFC-" not in str(job_status_path)
@@ -198,6 +204,11 @@ def test_reporting_openapi_contract_registered() -> None:
         "BatchWorkerRunRequest",
         "BatchWorkerRunResponse",
         "BatchWorkerItemExecutionResponse",
+        "BatchScheduleListResponse",
+        "BatchScheduleSummaryResponse",
+        "BatchSchedulerRunRequest",
+        "BatchSchedulerRunResponse",
+        "BatchSchedulerMaterializationResponse",
     ]:
         properties = spec["components"]["schemas"][schema_name]["properties"]
         for property_contract in properties.values():

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -856,6 +856,91 @@ def test_report_batch_gateway_routes_forward_context_and_rewrite_status_urls(mon
     ]
 
 
+def test_report_batch_schedule_gateway_routes_forward_context(monkeypatch):
+    calls: list[tuple[str, dict[str, str], str | None]] = []
+
+    async def _mock_list_schedules(self, *, caller_headers, correlation_id):
+        calls.append(("list", caller_headers, correlation_id))
+        return 200, {
+            "scheduler_id": "scheduler-gateway-unit",
+            "interval_seconds": 60.0,
+            "tenant_id": "tenant-sg",
+            "region": "APAC",
+            "booking_center_code": "SG",
+            "schedule_count": 1,
+            "enabled_schedule_count": 1,
+            "schedules": [
+                {
+                    "schedule_id": "monthly-sg-global-bal",
+                    "enabled": True,
+                    "selector_mode": "explicit_portfolio_list",
+                    "frequency": "monthly",
+                    "as_of_date": "2026-04-22",
+                    "portfolio_count": 1,
+                    "manifest_entry_count": 0,
+                    "requested_output_formats": ["pdf"],
+                    "reporting_currency": "USD",
+                    "max_batch_size": 250,
+                    "template_id": "portfolio-review",
+                    "template_version": "v1",
+                    "render_package_version": "portfolio-review.v1",
+                    "manifest_source": None,
+                    "manifest_version": None,
+                    "manifest_hash": None,
+                    "option_keys": ["sections"],
+                }
+            ],
+        }
+
+    async def _mock_run_due_schedules(self, *, payload, caller_headers, correlation_id):
+        calls.append(("run-due", caller_headers, correlation_id))
+        assert payload == {"pass_sequence": 4}
+        return 200, {
+            "scheduler_id": "scheduler-gateway-unit",
+            "attempted_count": 1,
+            "materialized_count": 1,
+            "skipped_schedule_ids": [],
+            "materialized": [
+                {
+                    "schedule_id": "monthly-sg-global-bal",
+                    "batch_id": "rbch_sched_1",
+                    "idempotency_key": "scheduled-batch-1",
+                    "item_count": 1,
+                    "status": "materialized",
+                }
+            ],
+            "correlation_id": "corr-batch-scheduler-4-unit",
+            "trace_id": "trace-scheduler-unit",
+        }
+
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.list_report_batch_schedules",
+        _mock_list_schedules,
+    )
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.run_due_report_batch_schedules",
+        _mock_run_due_schedules,
+    )
+
+    client = TestClient(app)
+    list_response = client.get("/api/v1/report-batch-schedules", headers=_batch_headers())
+    run_response = client.post(
+        "/api/v1/report-batch-schedules:run-due",
+        json={"pass_sequence": 4},
+        headers=_batch_headers(),
+    )
+
+    assert list_response.status_code == 200
+    assert list_response.json()["schedule_count"] == 1
+    assert list_response.json()["schedules"][0]["schedule_id"] == "monthly-sg-global-bal"
+    assert run_response.status_code == 200
+    assert run_response.json()["materialized"][0]["batch_id"] == "rbch_sched_1"
+    assert [call[0] for call in calls] == ["list", "run-due"]
+    assert calls[0][1]["X-Caller-Application"] == "lotus-gateway"
+    assert calls[1][1]["X-Actor-Id"] == "operator-123"
+    assert calls[0][2] == "corr-gateway-batch"
+
+
 def test_report_batch_gateway_requires_idempotency_and_caller_context():
     client = TestClient(app)
     missing_idempotency = client.post(

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1576,6 +1576,8 @@ async def test_reporting_client_report_batch_routes_forward_governed_headers():
     _FakeAsyncClient.queue_json(200, {"batch_id": "rbch_1", "status": "materialized"})
     _FakeAsyncClient.queue_json(200, {"batch_id": "rbch_1", "status": "paused"})
     _FakeAsyncClient.queue_json(200, {"batch_id": "rbch_1", "status": "completed"})
+    _FakeAsyncClient.queue_json(200, {"scheduler_id": "scheduler-1", "schedule_count": 1})
+    _FakeAsyncClient.queue_json(200, {"scheduler_id": "scheduler-1", "materialized_count": 1})
 
     create_status, create_payload = await client.create_report_batch(
         payload={"selector_mode": "explicit_portfolio_list"},
@@ -1601,6 +1603,15 @@ async def test_reporting_client_report_batch_routes_forward_governed_headers():
         correlation_id="corr-batch-1",
         payload={"worker_id": "worker-1"},
     )
+    schedules_status, schedules_payload = await client.list_report_batch_schedules(
+        caller_headers=caller_headers,
+        correlation_id="corr-batch-1",
+    )
+    run_due_status, run_due_payload = await client.run_due_report_batch_schedules(
+        payload={"pass_sequence": 2},
+        caller_headers=caller_headers,
+        correlation_id="corr-batch-1",
+    )
 
     assert create_status == 202
     assert create_payload["batch_id"] == "rbch_1"
@@ -1610,6 +1621,10 @@ async def test_reporting_client_report_batch_routes_forward_governed_headers():
     assert pause_payload["status"] == "paused"
     assert run_status == 200
     assert run_payload["status"] == "completed"
+    assert schedules_status == 200
+    assert schedules_payload["schedule_count"] == 1
+    assert run_due_status == 200
+    assert run_due_payload["materialized_count"] == 1
     assert _FakeAsyncClient.calls[0]["url"] == "http://ras/reports/batches"
     assert _FakeAsyncClient.calls[0]["json"] == {"selector_mode": "explicit_portfolio_list"}
     assert _FakeAsyncClient.calls[0]["headers"]["Idempotency-Key"] == "idem-batch-1"
@@ -1620,6 +1635,10 @@ async def test_reporting_client_report_batch_routes_forward_governed_headers():
     assert _FakeAsyncClient.calls[2]["url"] == "http://ras/reports/batches/rbch_1:pause"
     assert _FakeAsyncClient.calls[3]["url"] == "http://ras/reports/batches/rbch_1:run-once"
     assert _FakeAsyncClient.calls[3]["json"] == {"worker_id": "worker-1"}
+    assert _FakeAsyncClient.calls[4]["url"] == "http://ras/reports/batch-schedules"
+    assert _FakeAsyncClient.calls[4]["headers"]["X-Actor-Id"] == "operator-123"
+    assert _FakeAsyncClient.calls[5]["url"] == "http://ras/reports/batch-schedules:run-due"
+    assert _FakeAsyncClient.calls[5]["json"] == {"pass_sequence": 2}
 
 
 @pytest.mark.asyncio

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -18,6 +18,7 @@
 - `GET /api/v1/report-jobs` and `GET`/`POST /api/v1/report-jobs/*`
 - `POST /api/v1/report-batches`, `GET /api/v1/report-batches/{batch_id}`, and
   `POST /api/v1/report-batches/{batch_id}:*`
+- `GET /api/v1/report-batch-schedules` and `POST /api/v1/report-batch-schedules:run-due`
 - `GET /api/v1/documents/{document_id}`
 - `GET /api/v1/documents/{document_id}/download`
 - `/health`, `/health/live`, `/health/ready`, `/metrics`, `/docs`
@@ -43,6 +44,9 @@
 - report batch materialization, status, pause, resume, cancel, retry-failed,
   recover-expired-leases, and bounded run-once operator actions are gateway-first under
   `/api/v1/report-batches`; `lotus-report` remains the batch lifecycle and execution authority
+- report batch schedule list and run-due actions are gateway-first under
+  `/api/v1/report-batch-schedules`; schedules remain config-backed in `lotus-report`, and gateway
+  does not expose schedule CRUD or scheduler registry management
 - report batch materialization requires `Idempotency-Key`; all report batch routes require
   `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`, with optional `X-Caller-Application`,
   `X-Booking-Center-Code`, and `X-Role` forwarded as caller context

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -28,6 +28,8 @@
   report generation job initiation, search, status, event history, and cancellation
 - `report-batches`
   batch materialization, status, control, and bounded operator-run boundary over `lotus-report`
+- `report-batch-schedules`
+  config-backed scheduler inspection and bounded run-due boundary over `lotus-report`
 - `archived documents`
   generated-document metadata and controlled download boundary over `lotus-archive`
 
@@ -39,5 +41,5 @@
 4. RFC-0082 classification governs how new upstream dependencies are justified
 5. generated-document retrieval is product-facing through gateway; archive storage, retention,
    purge, legal-hold mutation, and access-event ownership stay in `lotus-archive`
-6. report batch lifecycle and execution truth stay in `lotus-report`; gateway exposes the
-   governed operator boundary and rewrites only gateway-relative status URLs
+6. report batch lifecycle, scheduler configuration, and execution truth stay in `lotus-report`;
+   gateway exposes the governed operator boundary and rewrites only gateway-relative status URLs


### PR DESCRIPTION
## Summary
- proxy report batch schedule list and run-due APIs through gateway-owned routes
- add gateway contracts, OpenAPI examples, upstream client wiring, and docs/wiki truth
- preserve lotus-report ownership of scheduler configuration and materialization

## Validation
- python -m pytest tests/integration/test_reporting_router.py::test_report_batch_gateway_routes_forward_context_and_rewrite_status_urls tests/integration/test_reporting_router.py::test_report_batch_schedule_gateway_routes_forward_context tests/unit/test_upstream_clients.py::test_reporting_client_report_batch_routes_forward_governed_headers tests/contract/test_reporting_contract.py::test_reporting_openapi_contract_registered -q
- python -m ruff check src/app/contracts/reporting.py src/app/clients/reporting_client.py src/app/routers/reporting.py src/app/main.py tests/integration/test_reporting_router.py tests/unit/test_upstream_clients.py tests/contract/test_reporting_contract.py
- python -m ruff format --check src/app/contracts/reporting.py src/app/clients/reporting_client.py src/app/routers/reporting.py src/app/main.py tests/integration/test_reporting_router.py tests/unit/test_upstream_clients.py tests/contract/test_reporting_contract.py
- git diff --check
- make check