### PR TITLE
Harden gateway traceparent propagation

### DIFF
--- a/src/app/middleware/correlation.py
+++ b/src/app/middleware/correlation.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 import time
 from contextvars import ContextVar
 from datetime import UTC, datetime
@@ -17,6 +18,8 @@ from app.middleware.server_timing import (
 correlation_id_var: ContextVar[str] = ContextVar("correlation_id", default="")
 request_id_var: ContextVar[str] = ContextVar("request_id", default="")
 trace_id_var: ContextVar[str] = ContextVar("trace_id", default="")
+
+_W3C_TRACE_ID_PATTERN = re.compile(r"^[0-9a-f]{32}$")
 
 
 class JsonFormatter(logging.Formatter):
@@ -62,10 +65,20 @@ def resolve_trace_id(request: Request) -> str:
     traceparent = request.headers.get("traceparent")
     if traceparent:
         parts = traceparent.split("-")
-        if len(parts) >= 4 and len(parts[1]) == 32:
+        if len(parts) >= 4 and _is_w3c_trace_id(parts[1]):
             return parts[1]
     incoming = request.headers.get("X-Trace-Id")
     return incoming if incoming else uuid4().hex
+
+
+def _is_w3c_trace_id(trace_id: str) -> bool:
+    return bool(_W3C_TRACE_ID_PATTERN.fullmatch(trace_id))
+
+
+def _traceparent_header(trace_id: str) -> str | None:
+    if not _is_w3c_trace_id(trace_id):
+        return None
+    return f"00-{trace_id}-0000000000000001-01"
 
 
 def propagation_headers(correlation_id: str | None = None) -> dict[str, str]:
@@ -73,12 +86,15 @@ def propagation_headers(correlation_id: str | None = None) -> dict[str, str]:
         correlation_id or correlation_id_var.get() or f"corr_{uuid4().hex[:12]}"
     )
     resolved_trace_id = trace_id_var.get() or uuid4().hex
-    return {
+    headers = {
         "X-Correlation-Id": resolved_correlation_id,
         "X-Request-Id": request_id_var.get() or f"req_{uuid4().hex[:12]}",
         "X-Trace-Id": resolved_trace_id,
-        "traceparent": f"00-{resolved_trace_id}-0000000000000001-01",
     }
+    traceparent = _traceparent_header(resolved_trace_id)
+    if traceparent:
+        headers["traceparent"] = traceparent
+    return headers
 
 
 async def correlation_middleware(request: Request, call_next):
@@ -114,7 +130,9 @@ async def correlation_middleware(request: Request, call_next):
     response.headers["X-Correlation-Id"] = correlation_id
     response.headers["X-Request-Id"] = request_id
     response.headers["X-Trace-Id"] = trace_id
-    response.headers["traceparent"] = f"00-{trace_id}-0000000000000001-01"
+    traceparent = _traceparent_header(trace_id)
+    if traceparent:
+        response.headers["traceparent"] = traceparent
     response.headers["Server-Timing"] = format_server_timing_header(duration_ms)
     restore_server_timing_metrics(server_timing_token)
     return response

--- a/tests/unit/test_correlation_middleware.py
+++ b/tests/unit/test_correlation_middleware.py
@@ -65,6 +65,7 @@ def test_trace_id_falls_back_to_x_trace_id_when_traceparent_invalid():
     )
     assert response.status_code == 200
     assert response.headers.get("X-Trace-Id") == "trace-from-header"
+    assert "traceparent" not in response.headers
 
 
 def test_trace_id_generated_when_missing():
@@ -104,3 +105,12 @@ def test_resolve_trace_id_prefers_valid_traceparent():
 
     resolved = resolve_trace_id(_FakeRequest())
     assert resolved == "0123456789abcdef0123456789abcdef"
+
+
+def test_valid_x_trace_id_emits_traceparent():
+    trace_id = "0123456789abcdef0123456789abcdef"
+    client = TestClient(app)
+    response = client.get("/health", headers={"X-Trace-Id": trace_id})
+
+    assert response.status_code == 200
+    assert response.headers.get("traceparent") == f"00-{trace_id}-0000000000000001-01"


### PR DESCRIPTION
RFC-0105 Slice 2 trace hardening.\n\nChanges:\n- Preserve non-W3C trace IDs in X-Trace-Id without emitting invalid traceparent.\n- Emit traceparent only for valid 32-hex W3C trace IDs.\n- Add middleware tests for invalid and valid trace IDs.\n\nLocal evidence:\n- python -m pytest tests/unit/test_correlation_middleware.py -q\n- python -m ruff check src/app/middleware/correlation.py tests/unit/test_correlation_middleware.py\n- make check\n- git diff --check