### PR TITLE
feat: add gateway report snapshot lineage/read paths for RFC-0105 diagnostics

### DIFF
--- a/src/app/clients/reporting_client.py
+++ b/src/app/clients/reporting_client.py
@@ -171,6 +171,63 @@ class ReportingClient:
             headers=headers,
         )
 
+    async def get_report_job_lineage(
+        self,
+        *,
+        job_id: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/jobs/{job_id}/lineage"
+        headers = propagation_headers(correlation_id)
+        headers.update(caller_headers)
+        return await request_with_retry(
+            method="GET",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=headers,
+        )
+
+    async def get_report_snapshot(
+        self,
+        *,
+        snapshot_id: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/snapshots/{snapshot_id}"
+        headers = propagation_headers(correlation_id)
+        headers.update(caller_headers)
+        return await request_with_retry(
+            method="GET",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=headers,
+        )
+
+    async def get_report_snapshot_lineage(
+        self,
+        *,
+        snapshot_id: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/snapshots/{snapshot_id}/lineage"
+        headers = propagation_headers(correlation_id)
+        headers.update(caller_headers)
+        return await request_with_retry(
+            method="GET",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=headers,
+        )
+
     async def cancel_report_job(
         self,
         *,

--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -54,9 +54,7 @@ REPORT_JOB_SNAPSHOT_RESPONSE_EXAMPLE: dict[str, Any] = {
         "portfolio_id": "PB_SG_GLOBAL_BAL_001",
         "as_of_date": "2026-04-22",
     },
-    "snapshotHash": (
-        "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a84e426238637f4a5b7dd"
-    ),
+    "snapshotHash": ("sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a84e426238637f4a5b7dd"),
     "snapshotStorageRef": None,
     "supportabilityStatus": "complete",
     "completenessStatus": "complete",
@@ -82,12 +80,8 @@ REPORT_JOB_UPSTREAM_CALL_RESPONSE_EXAMPLE: dict[str, Any] = {
     "endpoint": "/reporting/portfolio-summary/query",
     "method": "POST",
     "contractVersion": "v1",
-    "requestHash": (
-        "sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531f80903c123c25f6d8c09780"
-    ),
-    "responseHash": (
-        "sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915963c4b3d74a3a07844f52"
-    ),
+    "requestHash": ("sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531f80903c123c25f6d8c09780"),
+    "responseHash": ("sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915963c4b3d74a3a07844f52"),
     "responseRef": None,
     "statusCode": 200,
     "latencyMs": 184,
@@ -907,9 +901,7 @@ class ReportInputSnapshotRecord(BaseModel):
         ...,
         alias="snapshotHash",
         description="Canonical SHA-256 hash of the inline snapshot payload.",
-        examples=[
-            "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a84e426238637f4a5b7dd"
-        ],
+        examples=["sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a84e426238637f4a5b7dd"],
     )
     snapshot_storage_ref: str | None = Field(
         ...,

--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -42,6 +42,70 @@ REPORT_JOB_LIST_RESPONSE_EXAMPLE: dict[str, Any] = {
     ],
 }
 
+REPORT_JOB_SNAPSHOT_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "snapshotId": "rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf",
+    "reportJobId": "rjob_83ca965c50334c40a17d2b8cc94873a5",
+    "reportType": "portfolio_review",
+    "reportDataContractVersion": "v1",
+    "portfolioScope": {"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]},
+    "asOfDate": "2026-04-22",
+    "snapshotPayload": {
+        "report_id": "portfolio-review:PB_SG_GLOBAL_BAL_001:2026-04-22",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "as_of_date": "2026-04-22",
+    },
+    "snapshotHash": (
+        "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a84e426238637f4a5b7dd"
+    ),
+    "snapshotStorageRef": None,
+    "supportabilityStatus": "complete",
+    "completenessStatus": "complete",
+    "lineageSummary": {
+        "sourceServices": ["lotus-core", "lotus-performance", "lotus-risk"],
+        "callCount": 8,
+        "supportability_status": "complete",
+        "partialCallCount": 0,
+        "unavailableCallCount": 0,
+        "notSupportedCallCount": 0,
+        "redactedCallCount": 0,
+    },
+    "capturedAt": "2026-04-22T09:00:03Z",
+    "createdAt": "2026-04-22T09:00:03Z",
+    "correlationId": "corr-portfolio-review-1",
+    "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
+}
+
+REPORT_JOB_UPSTREAM_CALL_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "upstreamCallId": "ruc_7c5d4f1e4cb6455fa11c06821c57b88f",
+    "snapshotId": "rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf",
+    "serviceName": "lotus-core",
+    "endpoint": "/reporting/portfolio-summary/query",
+    "method": "POST",
+    "contractVersion": "v1",
+    "requestHash": (
+        "sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531f80903c123c25f6d8c09780"
+    ),
+    "responseHash": (
+        "sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915963c4b3d74a3a07844f52"
+    ),
+    "responseRef": None,
+    "statusCode": 200,
+    "latencyMs": 184,
+    "supportabilityStatus": "complete",
+    "completenessStatus": "complete",
+    "failureCategory": "none",
+    "failureMessage": None,
+    "capturedAt": "2026-04-22T09:00:02Z",
+    "createdAt": "2026-04-22T09:00:02Z",
+    "correlationId": "corr-portfolio-review-1",
+    "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
+}
+
+REPORT_JOB_LINEAGE_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "snapshot": REPORT_JOB_SNAPSHOT_RESPONSE_EXAMPLE,
+    "upstreamCalls": [REPORT_JOB_UPSTREAM_CALL_RESPONSE_EXAMPLE],
+}
+
 REPORT_JOB_ERROR_EXAMPLES: dict[str, dict[str, Any]] = {
     "missing_idempotency_key": {
         "detail": {
@@ -60,6 +124,12 @@ REPORT_JOB_ERROR_EXAMPLES: dict[str, dict[str, Any]] = {
         "detail": {
             "code": "report_job_not_found",
             "message": "Report job was not found.",
+        }
+    },
+    "report_snapshot_not_found": {
+        "detail": {
+            "code": "report_snapshot_not_found",
+            "message": "Report snapshot was not found.",
         }
     },
     "idempotency_conflict": {
@@ -758,6 +828,277 @@ class ReportJobListResponse(BaseModel):
         alias="items",
         description="Bounded list of support-safe report job summaries.",
         examples=[REPORT_JOB_LIST_RESPONSE_EXAMPLE["items"]],
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+SnapshotPosture = Literal[
+    "complete",
+    "partial",
+    "unavailable",
+    "not_supported",
+    "redacted",
+    "error",
+]
+
+
+UpstreamFailureCategory = Literal[
+    "none",
+    "partial_data",
+    "unsupported_input",
+    "upstream_unavailable",
+    "upstream_error",
+    "timeout",
+    "redacted",
+]
+
+
+class ReportInputSnapshotRecord(BaseModel):
+    snapshot_id: str = Field(
+        ...,
+        alias="snapshotId",
+        description="Opaque durable snapshot identifier.",
+        examples=["rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf"],
+    )
+    report_job_id: str = Field(
+        ...,
+        alias="reportJobId",
+        description="Opaque report job identifier that owns this snapshot.",
+        examples=["rjob_83ca965c50334c40a17d2b8cc94873a5"],
+    )
+    report_type: str = Field(
+        ...,
+        alias="reportType",
+        description="Report type captured by this snapshot.",
+        examples=["portfolio_review"],
+    )
+    report_data_contract_version: str = Field(
+        ...,
+        alias="reportDataContractVersion",
+        description="Version of the machine-readable report data contract captured in snapshot.",
+        examples=["v1"],
+    )
+    portfolio_scope: dict[str, Any] = Field(
+        ...,
+        alias="portfolioScope",
+        description="Portfolio scope captured for the snapshot.",
+        examples=[{"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]}],
+    )
+    as_of_date: str = Field(
+        ...,
+        alias="asOfDate",
+        description="Business as-of date represented by the snapshot.",
+        examples=["2026-04-22"],
+    )
+    snapshot_payload: dict[str, Any] = Field(
+        ...,
+        alias="snapshotPayload",
+        description="Support-safe inline snapshot payload stored inline for deterministic lookup.",
+        examples=[
+            {
+                "report_id": "portfolio-review:PB_SG_GLOBAL_BAL_001:2026-04-22",
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "as_of_date": "2026-04-22",
+            }
+        ],
+    )
+    snapshot_hash: str = Field(
+        ...,
+        alias="snapshotHash",
+        description="Canonical SHA-256 hash of the inline snapshot payload.",
+        examples=[
+            "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a84e426238637f4a5b7dd"
+        ],
+    )
+    snapshot_storage_ref: str | None = Field(
+        ...,
+        alias="snapshotStorageRef",
+        description="Optional reference for large or sensitive raw payloads.",
+        examples=[None],
+    )
+    supportability_status: SnapshotPosture = Field(
+        ...,
+        alias="supportabilityStatus",
+        description="Supportability posture for the captured snapshot.",
+        examples=["complete"],
+    )
+    completeness_status: SnapshotPosture = Field(
+        ...,
+        alias="completenessStatus",
+        description="Completeness posture for the captured snapshot.",
+        examples=["complete"],
+    )
+    lineage_summary: dict[str, Any] = Field(
+        ...,
+        alias="lineageSummary",
+        description="Compact lineage summary captured with the snapshot.",
+        examples=[
+            {
+                "sourceServices": ["lotus-core", "lotus-performance", "lotus-risk"],
+                "callCount": 8,
+                "supportability_status": "complete",
+                "partialCallCount": 0,
+                "unavailableCallCount": 0,
+                "notSupportedCallCount": 0,
+                "redactedCallCount": 0,
+            }
+        ],
+    )
+    captured_at: str = Field(
+        ...,
+        alias="capturedAt",
+        description="UTC timestamp when snapshot capture completed.",
+        examples=["2026-04-22T09:00:03Z"],
+    )
+    created_at: str = Field(
+        ...,
+        alias="createdAt",
+        description="UTC timestamp when the durable snapshot row was written.",
+        examples=["2026-04-22T09:00:03Z"],
+    )
+    correlation_id: str = Field(
+        ...,
+        alias="correlationId",
+        description="End-to-end correlation identifier linked to the captured snapshot.",
+        examples=["corr-portfolio-review-1"],
+    )
+    trace_id: str = Field(
+        ...,
+        alias="traceId",
+        description="Distributed trace identifier linked to the captured snapshot.",
+        examples=["4bf92f3577b34da6a3ce929d0e0e4736"],
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+class ReportUpstreamCallRecord(BaseModel):
+    upstream_call_id: str = Field(
+        ...,
+        alias="upstreamCallId",
+        description="Opaque identifier for one recorded upstream call.",
+        examples=["ruc_7c5d4f1e4cb6455fa11c06821c57b88f"],
+    )
+    snapshot_id: str = Field(
+        ...,
+        alias="snapshotId",
+        description="Durable snapshot identifier that owns this upstream call evidence.",
+        examples=["rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf"],
+    )
+    service_name: str = Field(
+        ...,
+        alias="serviceName",
+        description="Authoritative Lotus service called during snapshot capture.",
+        examples=["lotus-core"],
+    )
+    endpoint: str = Field(
+        ...,
+        description="Concrete upstream API path used during the call.",
+        examples=["/reporting/portfolio-summary/query"],
+    )
+    method: str = Field(
+        ...,
+        description="HTTP method used for the upstream call.",
+        examples=["POST"],
+    )
+    contract_version: str = Field(
+        ...,
+        alias="contractVersion",
+        description="Observed or governed upstream contract version for this call.",
+        examples=["v1"],
+    )
+    request_hash: str = Field(
+        ...,
+        alias="requestHash",
+        description="Canonical SHA-256 hash of the support-safe request payload.",
+        examples=["sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531f80903c123c25f6d8c09780"],
+    )
+    response_hash: str | None = Field(
+        ...,
+        alias="responseHash",
+        description="Canonical SHA-256 hash of the support-safe response payload when available.",
+        examples=["sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915963c4b3d74a3a07844f52"],
+    )
+    response_ref: str | None = Field(
+        ...,
+        alias="responseRef",
+        description="Optional reference when response payload is redacted or externalized.",
+        examples=[None],
+    )
+    status_code: int = Field(
+        ...,
+        alias="statusCode",
+        description="HTTP status code or equivalent outcome for the upstream call.",
+        examples=[200],
+    )
+    latency_ms: int = Field(
+        ...,
+        alias="latencyMs",
+        description="Measured upstream round-trip latency in milliseconds.",
+        examples=[184],
+    )
+    supportability_status: SnapshotPosture = Field(
+        ...,
+        alias="supportabilityStatus",
+        description="Supportability posture for this upstream input.",
+        examples=["complete"],
+    )
+    completeness_status: SnapshotPosture = Field(
+        ...,
+        alias="completenessStatus",
+        description="Completeness posture for this upstream input.",
+        examples=["complete"],
+    )
+    failure_category: UpstreamFailureCategory = Field(
+        ...,
+        alias="failureCategory",
+        description="Machine-readable failure or exception category for the upstream call.",
+        examples=["none"],
+    )
+    failure_message: str | None = Field(
+        ...,
+        alias="failureMessage",
+        description="Support-safe failure detail for the upstream call.",
+        examples=[None],
+    )
+    captured_at: str = Field(
+        ...,
+        alias="capturedAt",
+        description="UTC timestamp when the upstream call completed or failed.",
+        examples=["2026-04-22T09:00:02Z"],
+    )
+    created_at: str = Field(
+        ...,
+        alias="createdAt",
+        description="UTC timestamp when the durable upstream-call row was written.",
+        examples=["2026-04-22T09:00:02Z"],
+    )
+    correlation_id: str = Field(
+        ...,
+        alias="correlationId",
+        description="Correlation identifier associated with the upstream call.",
+        examples=["corr-portfolio-review-1"],
+    )
+    trace_id: str = Field(
+        ...,
+        alias="traceId",
+        description="Distributed trace identifier associated with the upstream call.",
+        examples=["4bf92f3577b34da6a3ce929d0e0e4736"],
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+class ReportSnapshotLineageResponse(BaseModel):
+    snapshot: ReportInputSnapshotRecord = Field(
+        ...,
+        description="Durable report input snapshot associated with lineage rows.",
+    )
+    upstream_calls: list[ReportUpstreamCallRecord] = Field(
+        ...,
+        alias="upstreamCalls",
+        description="Append-only upstream-call lineage rows for this snapshot.",
     )
 
     model_config = {"populate_by_name": True}

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -34,11 +34,13 @@ from app.contracts.reporting import (
     ReportingReviewResponse,
     ReportingSnapshotResponse,
     ReportingSummaryResponse,
+    ReportInputSnapshotRecord,
     ReportJobErrorResponse,
     ReportJobHandleResponse,
     ReportJobListResponse,
     ReportJobStatusEventsResponse,
     ReportJobStatusResponse,
+    ReportSnapshotLineageResponse,
 )
 from app.middleware.correlation import correlation_id_var
 from app.services.caller_context import caller_context_headers
@@ -137,6 +139,14 @@ def _raise_report_job_error(status_code: int, payload: dict[str, Any]) -> None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"code": "report_job_not_found", "message": message},
+        )
+    if (
+        status_code == status.HTTP_404_NOT_FOUND
+        and error_code == "report_snapshot_not_found"
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "report_snapshot_not_found", "message": message},
         )
     if status_code == status.HTTP_409_CONFLICT:
         raise HTTPException(
@@ -729,6 +739,52 @@ async def get_report_job_events(
     return ReportJobStatusEventsResponse.model_validate(payload)
 
 
+@jobs_router.get(
+    "/{job_id}/lineage",
+    response_model=ReportSnapshotLineageResponse,
+    summary="Get report snapshot lineage",
+    description=(
+        "Return lineage evidence for a report job’s captured input snapshot and upstream "
+        "dependency calls through the governed gateway boundary."
+    ),
+    responses={
+        **_job_error_response(
+            404,
+            example_key="report_snapshot_not_found",
+            description="Returned when snapshot lineage is unavailable for this report job.",
+        ),
+        **_job_error_response(
+            502,
+            example_key="report_job_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
+)
+async def get_report_job_lineage(
+    job_id: Annotated[str, Path(description="Opaque report job identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> ReportSnapshotLineageResponse:
+    status_code, payload = await _reporting_client().get_report_job_lineage(
+        job_id=job_id,
+        caller_headers=caller_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_job_error(status_code, payload)
+    return ReportSnapshotLineageResponse.model_validate(payload)
+
+
 @jobs_router.post(
     "/{job_id}/cancel",
     response_model=ReportJobStatusResponse,
@@ -779,6 +835,97 @@ async def cancel_report_job(
     )
     _raise_report_job_error(status_code, payload)
     return ReportJobStatusResponse.model_validate(payload)
+
+
+@router.get(
+    "/snapshots/{snapshot_id}",
+    response_model=ReportInputSnapshotRecord,
+    summary="Get report input snapshot",
+    description=(
+        "Return a stable report input snapshot for audit and diagnostics using the "
+        "governed gateway boundary."
+    ),
+    responses={
+        **_job_error_response(
+            404,
+            example_key="report_snapshot_not_found",
+            description="Returned when the requested snapshot identifier does not exist.",
+        ),
+        **_job_error_response(
+            502,
+            example_key="report_job_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
+)
+async def get_report_snapshot(
+    snapshot_id: Annotated[str, Path(description="Opaque report snapshot identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> ReportInputSnapshotRecord:
+    status_code, payload = await _reporting_client().get_report_snapshot(
+        snapshot_id=snapshot_id,
+        caller_headers=caller_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_job_error(status_code, payload)
+    return ReportInputSnapshotRecord.model_validate(payload)
+
+
+@router.get(
+    "/snapshots/{snapshot_id}/lineage",
+    response_model=ReportSnapshotLineageResponse,
+    summary="Get snapshot lineage",
+    description=(
+        "Return lineage evidence for an input snapshot and all upstream calls that formed it."
+    ),
+    responses={
+        **_job_error_response(
+            404,
+            example_key="report_snapshot_not_found",
+            description="Returned when snapshot lineage is unavailable for this snapshot.",
+        ),
+        **_job_error_response(
+            502,
+            example_key="report_job_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
+)
+async def get_report_snapshot_lineage(
+    snapshot_id: Annotated[str, Path(description="Opaque report snapshot identifier.")],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> ReportSnapshotLineageResponse:
+    status_code, payload = await _reporting_client().get_report_snapshot_lineage(
+        snapshot_id=snapshot_id,
+        caller_headers=caller_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+    _raise_report_job_error(status_code, payload)
+    return ReportSnapshotLineageResponse.model_validate(payload)
 
 
 @batches_router.post(

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -140,10 +140,7 @@ def _raise_report_job_error(status_code: int, payload: dict[str, Any]) -> None:
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"code": "report_job_not_found", "message": message},
         )
-    if (
-        status_code == status.HTTP_404_NOT_FOUND
-        and error_code == "report_snapshot_not_found"
-    ):
+    if status_code == status.HTTP_404_NOT_FOUND and error_code == "report_snapshot_not_found":
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"code": "report_snapshot_not_found", "message": message},

--- a/tests/contract/test_reporting_contract.py
+++ b/tests/contract/test_reporting_contract.py
@@ -131,25 +131,23 @@ def test_reporting_contract_shapes() -> None:
             correlationId="corr-portfolio-review-1",
             traceId="4bf92f3577b34da6a3ce929d0e0e4736",
         ),
-            upstreamCalls=[
-                {
-                    "upstreamCallId": "ruc_7c5d4f1e4cb6455fa11c06821c57b88f",
-                    "snapshotId": "rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf",
-                    "serviceName": "lotus-core",
-                    "endpoint": "/reporting/portfolio-summary/query",
-                    "method": "POST",
-                    "contractVersion": "v1",
-                    "requestHash": (
-                        "sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531"
-                        "f80903c123c25f6d8c09780"
-                    ),
-                    "responseHash": (
-                        "sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915"
-                        "963c4b3d74a3a07844f52"
-                    ),
-                    "responseRef": None,
-                    "statusCode": 200,
-                    "latencyMs": 184,
+        upstreamCalls=[
+            {
+                "upstreamCallId": "ruc_7c5d4f1e4cb6455fa11c06821c57b88f",
+                "snapshotId": "rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf",
+                "serviceName": "lotus-core",
+                "endpoint": "/reporting/portfolio-summary/query",
+                "method": "POST",
+                "contractVersion": "v1",
+                "requestHash": (
+                    "sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531f80903c123c25f6d8c09780"
+                ),
+                "responseHash": (
+                    "sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915963c4b3d74a3a07844f52"
+                ),
+                "responseRef": None,
+                "statusCode": 200,
+                "latencyMs": 184,
                 "supportabilityStatus": "complete",
                 "completenessStatus": "complete",
                 "failureCategory": "none",
@@ -162,10 +160,7 @@ def test_reporting_contract_shapes() -> None:
         ],
     )
     assert job_lineage.snapshot.snapshot_id == "rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf"
-    assert (
-        job_lineage.upstream_calls[0].upstream_call_id
-        == "ruc_7c5d4f1e4cb6455fa11c06821c57b88f"
-    )
+    assert job_lineage.upstream_calls[0].upstream_call_id == "ruc_7c5d4f1e4cb6455fa11c06821c57b88f"
 
 
 def test_reporting_request_normalizes_documented_aliases() -> None:

--- a/tests/contract/test_reporting_contract.py
+++ b/tests/contract/test_reporting_contract.py
@@ -8,6 +8,8 @@ from app.contracts.reporting import (
     ReportingReviewResponse,
     ReportingSnapshotResponse,
     ReportingSummaryResponse,
+    ReportInputSnapshotRecord,
+    ReportSnapshotLineageResponse,
 )
 from app.main import app
 
@@ -102,6 +104,69 @@ def test_reporting_contract_shapes() -> None:
     assert batch_status.items[0].portfolio_id == "PB_SG_GLOBAL_BAL_001"
     assert batch_run.report_job_ids == ["rjob_1"]
 
+    job_lineage = ReportSnapshotLineageResponse(
+        snapshot=ReportInputSnapshotRecord(
+            snapshotId="rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf",
+            reportJobId="rjob_83ca965c50334c40a17d2b8cc94873a5",
+            reportType="portfolio_review",
+            reportDataContractVersion="v1",
+            portfolioScope={"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]},
+            asOfDate="2026-04-22",
+            snapshotPayload={"report_id": "portfolio-review:PB_SG_GLOBAL_BAL_001:2026-04-22"},
+            snapshotHash="sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a84e426238637f4a5b7dd",
+            snapshotStorageRef=None,
+            supportabilityStatus="complete",
+            completenessStatus="complete",
+            lineageSummary={
+                "sourceServices": ["lotus-core"],
+                "callCount": 1,
+                "supportability_status": "complete",
+                "partialCallCount": 0,
+                "unavailableCallCount": 0,
+                "notSupportedCallCount": 0,
+                "redactedCallCount": 0,
+            },
+            capturedAt="2026-04-22T09:00:03Z",
+            createdAt="2026-04-22T09:00:03Z",
+            correlationId="corr-portfolio-review-1",
+            traceId="4bf92f3577b34da6a3ce929d0e0e4736",
+        ),
+            upstreamCalls=[
+                {
+                    "upstreamCallId": "ruc_7c5d4f1e4cb6455fa11c06821c57b88f",
+                    "snapshotId": "rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf",
+                    "serviceName": "lotus-core",
+                    "endpoint": "/reporting/portfolio-summary/query",
+                    "method": "POST",
+                    "contractVersion": "v1",
+                    "requestHash": (
+                        "sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531"
+                        "f80903c123c25f6d8c09780"
+                    ),
+                    "responseHash": (
+                        "sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915"
+                        "963c4b3d74a3a07844f52"
+                    ),
+                    "responseRef": None,
+                    "statusCode": 200,
+                    "latencyMs": 184,
+                "supportabilityStatus": "complete",
+                "completenessStatus": "complete",
+                "failureCategory": "none",
+                "failureMessage": None,
+                "capturedAt": "2026-04-22T09:00:03Z",
+                "createdAt": "2026-04-22T09:00:03Z",
+                "correlationId": "corr-portfolio-review-1",
+                "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
+            }
+        ],
+    )
+    assert job_lineage.snapshot.snapshot_id == "rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf"
+    assert (
+        job_lineage.upstream_calls[0].upstream_call_id
+        == "ruc_7c5d4f1e4cb6455fa11c06821c57b88f"
+    )
+
 
 def test_reporting_request_normalizes_documented_aliases() -> None:
     request = ReportingPortfolioRequest(
@@ -136,7 +201,10 @@ def test_reporting_openapi_contract_registered() -> None:
     assert "/api/v1/report-jobs" in spec["paths"]
     assert "/api/v1/report-jobs/{job_id}" in spec["paths"]
     assert "/api/v1/report-jobs/{job_id}/events" in spec["paths"]
+    assert "/api/v1/report-jobs/{job_id}/lineage" in spec["paths"]
     assert "/api/v1/report-jobs/{job_id}/cancel" in spec["paths"]
+    assert "/api/v1/reports/snapshots/{snapshot_id}" in spec["paths"]
+    assert "/api/v1/reports/snapshots/{snapshot_id}/lineage" in spec["paths"]
     assert "/api/v1/report-batches" in spec["paths"]
     assert "/api/v1/report-batches/{batch_id}" in spec["paths"]
     assert "/api/v1/report-batches/{batch_id}:pause" in spec["paths"]
@@ -148,13 +216,16 @@ def test_reporting_openapi_contract_registered() -> None:
     assert "/api/v1/report-batch-schedules" in spec["paths"]
     assert "/api/v1/report-batch-schedules:run-due" in spec["paths"]
 
-    snapshot_path = spec["paths"]["/api/v1/reports/{portfolio_id}/snapshot"]["get"]
+    legacy_snapshot_path = spec["paths"]["/api/v1/reports/{portfolio_id}/snapshot"]["get"]
     summary_path = spec["paths"]["/api/v1/reports/{portfolio_id}/summary"]["post"]
     review_path = spec["paths"]["/api/v1/reports/{portfolio_id}/review"]["post"]
     job_submit_path = spec["paths"]["/api/v1/reports/portfolio-reviews"]["post"]
     job_list_path = spec["paths"]["/api/v1/report-jobs"]["get"]
     job_status_path = spec["paths"]["/api/v1/report-jobs/{job_id}"]["get"]
     job_events_path = spec["paths"]["/api/v1/report-jobs/{job_id}/events"]["get"]
+    job_lineage_path = spec["paths"]["/api/v1/report-jobs/{job_id}/lineage"]["get"]
+    snapshot_record_path = spec["paths"]["/api/v1/reports/snapshots/{snapshot_id}"]["get"]
+    snapshot_lineage_path = spec["paths"]["/api/v1/reports/snapshots/{snapshot_id}/lineage"]["get"]
     job_cancel_path = spec["paths"]["/api/v1/report-jobs/{job_id}/cancel"]["post"]
     batch_create_path = spec["paths"]["/api/v1/report-batches"]["post"]
     batch_status_path = spec["paths"]["/api/v1/report-batches/{batch_id}"]["get"]
@@ -166,13 +237,16 @@ def test_reporting_openapi_contract_registered() -> None:
     summary_schema = spec["components"]["schemas"]["ReportingSummaryResponse"]
     review_schema = spec["components"]["schemas"]["ReportingReviewResponse"]
 
-    assert snapshot_path["description"]
+    assert legacy_snapshot_path["description"]
     assert summary_path["description"]
     assert review_path["description"]
     assert job_submit_path["summary"] == "Submit portfolio review report job"
     assert job_list_path["summary"] == "Search report jobs for operations and support"
     assert job_status_path["summary"] == "Get report job status"
     assert job_events_path["summary"] == "Get report job event history"
+    assert job_lineage_path["summary"] == "Get report snapshot lineage"
+    assert snapshot_record_path["summary"] == "Get report input snapshot"
+    assert snapshot_lineage_path["summary"] == "Get snapshot lineage"
     assert job_cancel_path["summary"] == "Cancel report job before render or archive"
     assert batch_create_path["summary"] == "Create report batch"
     assert batch_status_path["summary"] == "Get report batch status"
@@ -194,6 +268,9 @@ def test_reporting_openapi_contract_registered() -> None:
         "ReportJobStatusResponse",
         "ReportJobStatusEventsResponse",
         "ReportStatusEvent",
+        "ReportInputSnapshotRecord",
+        "ReportUpstreamCallRecord",
+        "ReportSnapshotLineageResponse",
         "BatchCreateRequest",
         "PortfolioBatchCandidate",
         "BatchHandleResponse",
@@ -214,7 +291,7 @@ def test_reporting_openapi_contract_registered() -> None:
         for property_contract in properties.values():
             assert property_contract.get("description")
     snapshot_parameters = {
-        parameter["name"]: parameter for parameter in snapshot_path["parameters"]
+        parameter["name"]: parameter for parameter in legacy_snapshot_path["parameters"]
     }
     summary_parameters = {parameter["name"]: parameter for parameter in summary_path["parameters"]}
     review_parameters = {parameter["name"]: parameter for parameter in review_path["parameters"]}

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -634,8 +634,7 @@ def test_report_job_lineage_gateway_routes_forward_context(monkeypatch):
                     "report_id": "portfolio-review:PB_SG_GLOBAL_BAL_001:2026-04-22"
                 },
                 "snapshot_hash": (
-                    "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a"
-                    "84e426238637f4a5b7dd"
+                    "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a84e426238637f4a5b7dd"
                 ),
                 "snapshot_storage_ref": None,
                 "supportability_status": "complete",
@@ -663,12 +662,10 @@ def test_report_job_lineage_gateway_routes_forward_context(monkeypatch):
                     "method": "POST",
                     "contract_version": "v1",
                     "request_hash": (
-                        "sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531f80"
-                        "903c123c25f6d8c09780"
+                        "sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531f80903c123c25f6d8c09780"
                     ),
                     "response_hash": (
-                        "sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915"
-                        "963c4b3d74a3a07844f52"
+                        "sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915963c4b3d74a3a07844f52"
                     ),
                     "response_ref": None,
                     "status_code": 200,
@@ -736,12 +733,9 @@ def test_report_snapshot_endpoints_forward_context(monkeypatch):
             "report_data_contract_version": "v1",
             "portfolio_scope": {"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]},
             "as_of_date": "2026-04-22",
-            "snapshot_payload": {
-                "report_id": "portfolio-review:PB_SG_GLOBAL_BAL_001:2026-04-22"
-            },
+            "snapshot_payload": {"report_id": "portfolio-review:PB_SG_GLOBAL_BAL_001:2026-04-22"},
             "snapshot_hash": (
-                "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a"
-                "84e426238637f4a5b7dd"
+                "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a84e426238637f4a5b7dd"
             ),
             "snapshot_storage_ref": None,
             "supportability_status": "complete",
@@ -778,8 +772,7 @@ def test_report_snapshot_endpoints_forward_context(monkeypatch):
                     "report_id": "portfolio-review:PB_SG_GLOBAL_BAL_001:2026-04-22"
                 },
                 "snapshot_hash": (
-                    "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a"
-                    "84e426238637f4a5b7dd"
+                    "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a84e426238637f4a5b7dd"
                 ),
                 "snapshot_storage_ref": None,
                 "supportability_status": "complete",
@@ -807,12 +800,10 @@ def test_report_snapshot_endpoints_forward_context(monkeypatch):
                     "method": "POST",
                     "contract_version": "v1",
                     "request_hash": (
-                        "sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531f80"
-                        "903c123c25f6d8c09780"
+                        "sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531f80903c123c25f6d8c09780"
                     ),
                     "response_hash": (
-                        "sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915"
-                        "963c4b3d74a3a07844f52"
+                        "sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915963c4b3d74a3a07844f52"
                     ),
                     "response_ref": None,
                     "status_code": 200,
@@ -901,14 +892,10 @@ def test_report_snapshot_gateway_errors_are_product_safe(monkeypatch):
     async def _mock_get_snapshot(self, *, snapshot_id, caller_headers, correlation_id):  # noqa: ARG001
         return 500, {"detail": "snapshot postgres internal-host report.dev.lotus"}
 
-    async def _mock_get_snapshot_lineage(
-        self, *, snapshot_id, caller_headers, correlation_id
-    ):  # noqa: ARG001
+    async def _mock_get_snapshot_lineage(self, *, snapshot_id, caller_headers, correlation_id):  # noqa: ARG001
         return 500, {"detail": "snapshot lineage postgres internal-host report.dev.lotus"}
 
-    async def _mock_get_job_lineage(
-        self, *, job_id, caller_headers, correlation_id
-    ):  # noqa: ARG001
+    async def _mock_get_job_lineage(self, *, job_id, caller_headers, correlation_id):  # noqa: ARG001
         return 404, {"detail": {"code": "report_snapshot_not_found", "message": "missing snapshot"}}
 
     monkeypatch.setattr(
@@ -939,16 +926,10 @@ def test_report_snapshot_gateway_errors_are_product_safe(monkeypatch):
     )
 
     assert snapshot_response.status_code == 502
-    assert (
-        snapshot_response.json()["detail"]["code"]
-        == "report_job_upstream_unavailable"
-    )
+    assert snapshot_response.json()["detail"]["code"] == "report_job_upstream_unavailable"
     assert "internal-host" not in str(snapshot_response.json())
     assert snapshot_lineage_response.status_code == 502
-    assert (
-        snapshot_lineage_response.json()["detail"]["code"]
-        == "report_job_upstream_unavailable"
-    )
+    assert snapshot_lineage_response.json()["detail"]["code"] == "report_job_upstream_unavailable"
     assert "internal-host" not in str(snapshot_lineage_response.json())
     assert job_lineage_response.status_code == 404
     assert job_lineage_response.json()["detail"]["code"] == "report_snapshot_not_found"

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -609,6 +609,269 @@ def test_report_job_status_and_cancel_are_gateway_first(monkeypatch):
     assert calls[3][0:2] == ("cancel", "rjob_1")
 
 
+def test_report_job_lineage_gateway_routes_forward_context(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _mock_get_job_lineage(
+        self,
+        *,
+        job_id,
+        caller_headers,
+        correlation_id,
+    ):
+        captured["job_id"] = job_id
+        captured["caller_headers"] = caller_headers
+        captured["correlation_id"] = correlation_id
+        return 200, {
+            "snapshot": {
+                "snapshot_id": "rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf",
+                "report_job_id": job_id,
+                "report_type": "portfolio_review",
+                "report_data_contract_version": "v1",
+                "portfolio_scope": {"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]},
+                "as_of_date": "2026-04-22",
+                "snapshot_payload": {
+                    "report_id": "portfolio-review:PB_SG_GLOBAL_BAL_001:2026-04-22"
+                },
+                "snapshot_hash": (
+                    "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a"
+                    "84e426238637f4a5b7dd"
+                ),
+                "snapshot_storage_ref": None,
+                "supportability_status": "complete",
+                "completeness_status": "complete",
+                "lineage_summary": {
+                    "sourceServices": ["lotus-core"],
+                    "callCount": 1,
+                    "supportability_status": "complete",
+                    "partialCallCount": 0,
+                    "unavailableCallCount": 0,
+                    "notSupportedCallCount": 0,
+                    "redactedCallCount": 0,
+                },
+                "captured_at": "2026-04-22T09:00:03Z",
+                "created_at": "2026-04-22T09:00:03Z",
+                "correlation_id": correlation_id,
+                "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+            },
+            "upstream_calls": [
+                {
+                    "upstream_call_id": "ruc_1",
+                    "snapshot_id": "rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf",
+                    "service_name": "lotus-core",
+                    "endpoint": "/reporting/portfolio-summary/query",
+                    "method": "POST",
+                    "contract_version": "v1",
+                    "request_hash": (
+                        "sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531f80"
+                        "903c123c25f6d8c09780"
+                    ),
+                    "response_hash": (
+                        "sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915"
+                        "963c4b3d74a3a07844f52"
+                    ),
+                    "response_ref": None,
+                    "status_code": 200,
+                    "latency_ms": 184,
+                    "supportability_status": "complete",
+                    "completeness_status": "complete",
+                    "failure_category": "none",
+                    "failure_message": None,
+                    "captured_at": "2026-04-22T09:00:03Z",
+                    "created_at": "2026-04-22T09:00:03Z",
+                    "correlation_id": correlation_id,
+                    "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_report_job_lineage",
+        _mock_get_job_lineage,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/report-jobs/rjob_1/lineage",
+        headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Caller-Application": "lotus-workbench",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+            "X-Booking-Center-Code": "SG",
+            "X-Role": "advisor",
+            "X-Correlation-Id": "corr-lineage-1",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["snapshot"]["snapshotId"] == "rsnap_8c0c8f6fc2d947b89cb451d9f4f5d9bf"
+    assert body["snapshot"]["reportJobId"] == "rjob_1"
+    assert len(body["upstreamCalls"]) == 1
+    assert body["upstreamCalls"][0]["upstreamCallId"] == "ruc_1"
+    assert captured["job_id"] == "rjob_1"
+    assert captured["caller_headers"] == {
+        "X-Actor-Id": "advisor-123",
+        "X-Caller-Application": "lotus-workbench",
+        "X-Tenant-Id": "tenant-sg",
+        "X-Region": "APAC",
+        "X-Booking-Center-Code": "SG",
+        "X-Role": "advisor",
+    }
+    assert captured["correlation_id"] == "corr-lineage-1"
+
+
+def test_report_snapshot_endpoints_forward_context(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _mock_get_snapshot(self, *, snapshot_id, caller_headers, correlation_id):
+        captured["snapshot_id"] = snapshot_id
+        captured["caller_headers"] = caller_headers
+        captured["correlation_id"] = correlation_id
+        payload = {
+            "snapshot_id": snapshot_id,
+            "report_job_id": "rjob_1",
+            "report_type": "portfolio_review",
+            "report_data_contract_version": "v1",
+            "portfolio_scope": {"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]},
+            "as_of_date": "2026-04-22",
+            "snapshot_payload": {
+                "report_id": "portfolio-review:PB_SG_GLOBAL_BAL_001:2026-04-22"
+            },
+            "snapshot_hash": (
+                "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a"
+                "84e426238637f4a5b7dd"
+            ),
+            "snapshot_storage_ref": None,
+            "supportability_status": "complete",
+            "completeness_status": "complete",
+            "lineage_summary": {
+                "sourceServices": ["lotus-core"],
+                "callCount": 1,
+                "supportability_status": "complete",
+                "partialCallCount": 0,
+                "unavailableCallCount": 0,
+                "notSupportedCallCount": 0,
+                "redactedCallCount": 0,
+            },
+            "captured_at": "2026-04-22T09:00:03Z",
+            "created_at": "2026-04-22T09:00:03Z",
+            "correlation_id": correlation_id,
+            "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+        }
+        return 200, payload
+
+    async def _mock_get_snapshot_lineage(self, *, snapshot_id, caller_headers, correlation_id):
+        captured["lineage_snapshot_id"] = snapshot_id
+        captured["lineage_caller_headers"] = caller_headers
+        captured["lineage_correlation_id"] = correlation_id
+        return 200, {
+            "snapshot": {
+                "snapshot_id": snapshot_id,
+                "report_job_id": "rjob_1",
+                "report_type": "portfolio_review",
+                "report_data_contract_version": "v1",
+                "portfolio_scope": {"portfolio_ids": ["PB_SG_GLOBAL_BAL_001"]},
+                "as_of_date": "2026-04-22",
+                "snapshot_payload": {
+                    "report_id": "portfolio-review:PB_SG_GLOBAL_BAL_001:2026-04-22"
+                },
+                "snapshot_hash": (
+                    "sha256:7a5486f4a7ef1962f27fe67c6ef392fd0da0dfc7c98a"
+                    "84e426238637f4a5b7dd"
+                ),
+                "snapshot_storage_ref": None,
+                "supportability_status": "complete",
+                "completeness_status": "complete",
+                "lineage_summary": {
+                    "sourceServices": ["lotus-core"],
+                    "callCount": 1,
+                    "supportability_status": "complete",
+                    "partialCallCount": 0,
+                    "unavailableCallCount": 0,
+                    "notSupportedCallCount": 0,
+                    "redactedCallCount": 0,
+                },
+                "captured_at": "2026-04-22T09:00:03Z",
+                "created_at": "2026-04-22T09:00:03Z",
+                "correlation_id": correlation_id,
+                "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+            },
+            "upstream_calls": [
+                {
+                    "upstream_call_id": "ruc_1",
+                    "snapshot_id": snapshot_id,
+                    "service_name": "lotus-core",
+                    "endpoint": "/reporting/portfolio-summary/query",
+                    "method": "POST",
+                    "contract_version": "v1",
+                    "request_hash": (
+                        "sha256:0f5de8ef5cf305bf2e38ed33139e1df8f06fdf531f80"
+                        "903c123c25f6d8c09780"
+                    ),
+                    "response_hash": (
+                        "sha256:9de9c193650baf615ff8dca094d10ff18bdaabf0915"
+                        "963c4b3d74a3a07844f52"
+                    ),
+                    "response_ref": None,
+                    "status_code": 200,
+                    "latency_ms": 184,
+                    "supportability_status": "complete",
+                    "completeness_status": "complete",
+                    "failure_category": "none",
+                    "failure_message": None,
+                    "captured_at": "2026-04-22T09:00:03Z",
+                    "created_at": "2026-04-22T09:00:03Z",
+                    "correlation_id": correlation_id,
+                    "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_report_snapshot",
+        _mock_get_snapshot,
+    )
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_report_snapshot_lineage",
+        _mock_get_snapshot_lineage,
+    )
+
+    client = TestClient(app)
+    snapshot_response = client.get(
+        "/api/v1/reports/snapshots/rsnap_1",
+        headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+            "X-Correlation-Id": "corr-snapshot-route",
+        },
+    )
+    lineage_response = client.get(
+        "/api/v1/reports/snapshots/rsnap_1/lineage",
+        headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+            "X-Correlation-Id": "corr-snapshot-route",
+        },
+    )
+
+    assert snapshot_response.status_code == 200
+    assert snapshot_response.json()["snapshotId"] == "rsnap_1"
+    assert snapshot_response.json()["supportabilityStatus"] == "complete"
+    assert snapshot_response.json()["lineageSummary"]["callCount"] == 1
+    assert lineage_response.status_code == 200
+    assert lineage_response.json()["upstreamCalls"][0]["upstreamCallId"] == "ruc_1"
+    assert captured["snapshot_id"] == "rsnap_1"
+    assert captured["correlation_id"] == "corr-snapshot-route"
+    assert captured["caller_headers"]["X-Actor-Id"] == "advisor-123"
+    assert captured["lineage_snapshot_id"] == "rsnap_1"
+    assert captured["lineage_correlation_id"] == "corr-snapshot-route"
+    assert captured["lineage_caller_headers"]["X-Caller-Application"] == "lotus-gateway"
+
+
 def test_report_job_gateway_errors_are_product_safe(monkeypatch):
     async def _mock_get_job(self, *, job_id, caller_headers, correlation_id):  # noqa: ARG001
         return 500, {"detail": "sqlite traceback internal-host report.dev.lotus"}
@@ -632,6 +895,64 @@ def test_report_job_gateway_errors_are_product_safe(monkeypatch):
     assert body["detail"]["code"] == "report_job_upstream_unavailable"
     assert "sqlite" not in str(body).lower()
     assert "report.dev.lotus" not in str(body)
+
+
+def test_report_snapshot_gateway_errors_are_product_safe(monkeypatch):
+    async def _mock_get_snapshot(self, *, snapshot_id, caller_headers, correlation_id):  # noqa: ARG001
+        return 500, {"detail": "snapshot postgres internal-host report.dev.lotus"}
+
+    async def _mock_get_snapshot_lineage(
+        self, *, snapshot_id, caller_headers, correlation_id
+    ):  # noqa: ARG001
+        return 500, {"detail": "snapshot lineage postgres internal-host report.dev.lotus"}
+
+    async def _mock_get_job_lineage(
+        self, *, job_id, caller_headers, correlation_id
+    ):  # noqa: ARG001
+        return 404, {"detail": {"code": "report_snapshot_not_found", "message": "missing snapshot"}}
+
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_report_snapshot",
+        _mock_get_snapshot,
+    )
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_report_snapshot_lineage",
+        _mock_get_snapshot_lineage,
+    )
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_report_job_lineage",
+        _mock_get_job_lineage,
+    )
+
+    client = TestClient(app)
+    snapshot_response = client.get(
+        "/api/v1/reports/snapshots/rsnap_500",
+        headers={"X-Actor-Id": "advisor-123", "X-Tenant-Id": "tenant-sg", "X-Region": "APAC"},
+    )
+    snapshot_lineage_response = client.get(
+        "/api/v1/reports/snapshots/rsnap_500/lineage",
+        headers={"X-Actor-Id": "advisor-123", "X-Tenant-Id": "tenant-sg", "X-Region": "APAC"},
+    )
+    job_lineage_response = client.get(
+        "/api/v1/report-jobs/rjob_500/lineage",
+        headers={"X-Actor-Id": "advisor-123", "X-Tenant-Id": "tenant-sg", "X-Region": "APAC"},
+    )
+
+    assert snapshot_response.status_code == 502
+    assert (
+        snapshot_response.json()["detail"]["code"]
+        == "report_job_upstream_unavailable"
+    )
+    assert "internal-host" not in str(snapshot_response.json())
+    assert snapshot_lineage_response.status_code == 502
+    assert (
+        snapshot_lineage_response.json()["detail"]["code"]
+        == "report_job_upstream_unavailable"
+    )
+    assert "internal-host" not in str(snapshot_lineage_response.json())
+    assert job_lineage_response.status_code == 404
+    assert job_lineage_response.json()["detail"]["code"] == "report_snapshot_not_found"
+    assert job_lineage_response.json()["detail"]["message"] == "missing snapshot"
 
 
 def _batch_headers() -> dict[str, str]:


### PR DESCRIPTION
Add gateway-first passthrough for report snapshot and job lineage in support of RFC-0105 diagnostics. Includes client contract models for snapshot lineage, new /api/v1/reports/snapshots/* and /api/v1/report-jobs/{job_id}/lineage routes, and gateway-first/error-propagation tests.