### PR TITLE
RFC-0108 Slice 1 Gateway observability vocabulary

### DIFF
--- a/src/app/observability/__init__.py
+++ b/src/app/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Gateway observability contracts."""

--- a/src/app/observability/analytics_ui.py
+++ b/src/app/observability/analytics_ui.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+ANALYTICS_UI_ALLOWED_LABELS = frozenset(
+    {
+        "route",
+        "panel",
+        "service",
+        "operation",
+        "state",
+        "reason",
+        "freshness_bucket",
+        "supportability_state",
+        "attention_type",
+        "severity",
+        "status_class",
+        "error_category",
+        "region",
+        "environment",
+    }
+)
+
+ANALYTICS_UI_FORBIDDEN_FIELDS = frozenset(
+    {
+        "portfolio_id",
+        "client_id",
+        "client_name",
+        "household_id",
+        "account_id",
+        "instrument_id",
+        "holding_id",
+        "transaction_id",
+        "trace_id",
+        "correlation_id",
+        "document_id",
+        "advisor_id",
+        "advisor_behavior",
+        "screen_content",
+        "request_body",
+        "response_body",
+        "raw_entitlement_failure",
+    }
+)
+
+ANALYTICS_UI_STATE_VOCABULARY = frozenset(
+    {
+        "loading",
+        "ready",
+        "empty",
+        "partial",
+        "stale",
+        "degraded",
+        "error",
+        "permission_blocked",
+        "unsupported",
+    }
+)
+
+GATEWAY_ANALYTICS_UI_METRIC_FAMILIES = (
+    "lotus_gateway_analytics_fanout_duration_seconds",
+    "lotus_gateway_analytics_degraded_total",
+)
+
+
+def is_analytics_ui_state(value: str) -> bool:
+    return value in ANALYTICS_UI_STATE_VOCABULARY
+
+
+def validate_analytics_ui_labels(labels: Mapping[str, object]) -> dict[str, str]:
+    label_names = set(labels)
+    forbidden = sorted(label_names & ANALYTICS_UI_FORBIDDEN_FIELDS)
+    if forbidden:
+        raise ValueError(f"Analytics UI labels include forbidden field(s): {', '.join(forbidden)}")
+
+    unsupported = sorted(label_names - ANALYTICS_UI_ALLOWED_LABELS)
+    if unsupported:
+        raise ValueError(
+            f"Analytics UI labels include unsupported field(s): {', '.join(unsupported)}"
+        )
+
+    return {
+        key: str(value)
+        for key, value in labels.items()
+        if value is not None and str(value) != ""
+    }

--- a/src/app/observability/analytics_ui.py
+++ b/src/app/observability/analytics_ui.py
@@ -80,7 +80,5 @@ def validate_analytics_ui_labels(labels: Mapping[str, object]) -> dict[str, str]
         )
 
     return {
-        key: str(value)
-        for key, value in labels.items()
-        if value is not None and str(value) != ""
+        key: str(value) for key, value in labels.items() if value is not None and str(value) != ""
     }

--- a/tests/unit/test_analytics_ui_observability_contract.py
+++ b/tests/unit/test_analytics_ui_observability_contract.py
@@ -1,0 +1,61 @@
+import pytest
+
+from app.observability.analytics_ui import (
+    ANALYTICS_UI_ALLOWED_LABELS,
+    ANALYTICS_UI_FORBIDDEN_FIELDS,
+    ANALYTICS_UI_STATE_VOCABULARY,
+    GATEWAY_ANALYTICS_UI_METRIC_FAMILIES,
+    is_analytics_ui_state,
+    validate_analytics_ui_labels,
+)
+
+
+def test_gateway_metric_families_are_explicitly_scoped_to_gateway() -> None:
+    assert GATEWAY_ANALYTICS_UI_METRIC_FAMILIES == (
+        "lotus_gateway_analytics_fanout_duration_seconds",
+        "lotus_gateway_analytics_degraded_total",
+    )
+
+
+def test_state_vocabulary_matches_governed_analytics_ui_states() -> None:
+    assert "permission_blocked" in ANALYTICS_UI_STATE_VOCABULARY
+    assert is_analytics_ui_state("degraded")
+    assert not is_analytics_ui_state("blocked")
+
+
+def test_validate_analytics_ui_labels_accepts_bounded_non_sensitive_fields() -> None:
+    labels = validate_analytics_ui_labels(
+        {
+            "route": "performance",
+            "operation": "performance-summary",
+            "service": "lotus-performance",
+            "status_class": "2xx",
+            "state": "ready",
+        }
+    )
+
+    assert labels == {
+        "route": "performance",
+        "operation": "performance-summary",
+        "service": "lotus-performance",
+        "status_class": "2xx",
+        "state": "ready",
+    }
+
+
+def test_validate_analytics_ui_labels_rejects_forbidden_sensitive_fields() -> None:
+    for field in ANALYTICS_UI_FORBIDDEN_FIELDS:
+        with pytest.raises(ValueError, match="forbidden field"):
+            validate_analytics_ui_labels({field: "sensitive"})
+
+
+def test_validate_analytics_ui_labels_rejects_ad_hoc_label_drift() -> None:
+    assert "portfolio_id" not in ANALYTICS_UI_ALLOWED_LABELS
+    with pytest.raises(ValueError, match="unsupported field"):
+        validate_analytics_ui_labels({"custom_dimension": "drift"})
+
+
+def test_validate_analytics_ui_labels_drops_empty_optional_values() -> None:
+    assert validate_analytics_ui_labels(
+        {"route": "portfolio", "operation": "", "state": None, "status_class": "5xx"}
+    ) == {"route": "portfolio", "status_class": "5xx"}

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -18,6 +18,19 @@
 - `/metrics`
   observability surface for runtime monitoring
 
+## Analytics UI observability posture
+
+- RFC-0108 analytics UI observability vocabulary is code-owned in
+  `src/app/observability/analytics_ui.py`.
+- The module defines allowed labels, forbidden fields, state vocabulary, and planned gateway
+  metric-family names before analytics fan-out metrics are emitted.
+- Do not add gateway analytics metric labels outside that contract.
+- `portfolio_id`, `client_id`, `client_name`, `holding_id`, `transaction_id`, `trace_id`,
+  `correlation_id`, request bodies, response bodies, and raw entitlement failures must not become
+  metric labels or structured telemetry dimensions.
+- Gateway fan-out metrics, degraded-source counters, dashboard claims, attention events, and audit
+  events remain planned until later RFC-0108 slices promote them with evidence.
+
 ## Practical probes
 
 ```powershell


### PR DESCRIPTION
## Summary
- add Gateway-owned analytics UI observability vocabulary module
- validate allowed labels, forbidden sensitive fields, state vocabulary, and planned gateway metric families
- update repo-local Operations Runbook to point operators and future work to the code-owned source of truth
- do not emit fan-out metrics or dashboard claims in this slice

## Validation
- python -m pytest tests\\unit\\test_analytics_ui_observability_contract.py -q
- python -m ruff check src\\app\\observability tests\\unit\\test_analytics_ui_observability_contract.py
- git diff --check