### PR TITLE
Add RFC-0108 Slice 2 Gateway telemetry constants

### DIFF
--- a/src/app/observability/analytics_ui.py
+++ b/src/app/observability/analytics_ui.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 
 ANALYTICS_UI_ALLOWED_LABELS = frozenset(
     {
@@ -57,9 +57,68 @@ ANALYTICS_UI_STATE_VOCABULARY = frozenset(
     }
 )
 
+ANALYTICS_UI_SEVERITY_LEVELS = frozenset({"info", "warning", "action_required", "critical"})
+
+ANALYTICS_UI_ATTENTION_EVENT_TYPES = frozenset(
+    {
+        "panel_stale",
+        "panel_degraded",
+        "panel_repeated_failure",
+        "source_partial",
+        "permission_blocked",
+    }
+)
+
+ANALYTICS_UI_AUDIT_EVENT_TYPES = frozenset(
+    {
+        "analytics_read_allowed",
+        "analytics_read_denied",
+        "protected_diagnostics_lookup",
+    }
+)
+
 GATEWAY_ANALYTICS_UI_METRIC_FAMILIES = (
     "lotus_gateway_analytics_fanout_duration_seconds",
     "lotus_gateway_analytics_degraded_total",
+)
+
+GATEWAY_ANALYTICS_UI_LOG_EVENTS = (
+    "gateway.analytics.fanout.completed",
+    "gateway.analytics.fanout.degraded",
+)
+
+ANALYTICS_UI_TRACE_ATTRIBUTES = (
+    "route",
+    "panel",
+    "service",
+    "operation",
+    "state",
+    "freshness_bucket",
+    "supportability_state",
+    "status_class",
+    "error_category",
+)
+
+ANALYTICS_UI_ATTENTION_EVENT_ATTRIBUTES = (
+    "route",
+    "panel",
+    "attention_type",
+    "severity",
+    "state",
+    "reason",
+    "freshness_bucket",
+    "supportability_state",
+)
+
+ANALYTICS_UI_AUDIT_EVENT_ATTRIBUTES = (
+    "route",
+    "panel",
+    "operation",
+    "state",
+    "reason",
+    "status_class",
+    "region",
+    "environment",
 )
 
 
@@ -68,17 +127,25 @@ def is_analytics_ui_state(value: str) -> bool:
 
 
 def validate_analytics_ui_labels(labels: Mapping[str, object]) -> dict[str, str]:
-    label_names = set(labels)
-    forbidden = sorted(label_names & ANALYTICS_UI_FORBIDDEN_FIELDS)
-    if forbidden:
-        raise ValueError(f"Analytics UI labels include forbidden field(s): {', '.join(forbidden)}")
-
-    unsupported = sorted(label_names - ANALYTICS_UI_ALLOWED_LABELS)
-    if unsupported:
-        raise ValueError(
-            f"Analytics UI labels include unsupported field(s): {', '.join(unsupported)}"
-        )
+    validate_analytics_ui_attributes(labels)
 
     return {
         key: str(value) for key, value in labels.items() if value is not None and str(value) != ""
     }
+
+
+def validate_analytics_ui_attributes(attribute_names: Iterable[str]) -> tuple[str, ...]:
+    attribute_set = set(attribute_names)
+    forbidden = sorted(attribute_set & ANALYTICS_UI_FORBIDDEN_FIELDS)
+    if forbidden:
+        raise ValueError(
+            f"Analytics UI attributes include forbidden field(s): {', '.join(forbidden)}"
+        )
+
+    unsupported = sorted(attribute_set - ANALYTICS_UI_ALLOWED_LABELS)
+    if unsupported:
+        raise ValueError(
+            f"Analytics UI attributes include unsupported field(s): {', '.join(unsupported)}"
+        )
+
+    return tuple(attribute_names)

--- a/tests/unit/test_analytics_ui_observability_contract.py
+++ b/tests/unit/test_analytics_ui_observability_contract.py
@@ -2,10 +2,18 @@ import pytest
 
 from app.observability.analytics_ui import (
     ANALYTICS_UI_ALLOWED_LABELS,
+    ANALYTICS_UI_ATTENTION_EVENT_ATTRIBUTES,
+    ANALYTICS_UI_ATTENTION_EVENT_TYPES,
+    ANALYTICS_UI_AUDIT_EVENT_ATTRIBUTES,
+    ANALYTICS_UI_AUDIT_EVENT_TYPES,
     ANALYTICS_UI_FORBIDDEN_FIELDS,
+    ANALYTICS_UI_SEVERITY_LEVELS,
     ANALYTICS_UI_STATE_VOCABULARY,
+    ANALYTICS_UI_TRACE_ATTRIBUTES,
+    GATEWAY_ANALYTICS_UI_LOG_EVENTS,
     GATEWAY_ANALYTICS_UI_METRIC_FAMILIES,
     is_analytics_ui_state,
+    validate_analytics_ui_attributes,
     validate_analytics_ui_labels,
 )
 
@@ -21,6 +29,33 @@ def test_state_vocabulary_matches_governed_analytics_ui_states() -> None:
     assert "permission_blocked" in ANALYTICS_UI_STATE_VOCABULARY
     assert is_analytics_ui_state("degraded")
     assert not is_analytics_ui_state("blocked")
+
+
+def test_gateway_log_events_and_severity_vocabularies_are_explicit() -> None:
+    assert GATEWAY_ANALYTICS_UI_LOG_EVENTS == (
+        "gateway.analytics.fanout.completed",
+        "gateway.analytics.fanout.degraded",
+    )
+    assert ANALYTICS_UI_SEVERITY_LEVELS == {
+        "info",
+        "warning",
+        "action_required",
+        "critical",
+    }
+    assert "source_partial" in ANALYTICS_UI_ATTENTION_EVENT_TYPES
+    assert "analytics_read_denied" in ANALYTICS_UI_AUDIT_EVENT_TYPES
+
+
+def test_trace_attention_and_audit_attributes_are_bounded_and_product_safe() -> None:
+    for attributes in (
+        ANALYTICS_UI_TRACE_ATTRIBUTES,
+        ANALYTICS_UI_ATTENTION_EVENT_ATTRIBUTES,
+        ANALYTICS_UI_AUDIT_EVENT_ATTRIBUTES,
+    ):
+        assert validate_analytics_ui_attributes(attributes) == attributes
+        assert "portfolio_id" not in attributes
+        assert "client_name" not in attributes
+        assert "screen_content" not in attributes
 
 
 def test_validate_analytics_ui_labels_accepts_bounded_non_sensitive_fields() -> None:
@@ -47,12 +82,16 @@ def test_validate_analytics_ui_labels_rejects_forbidden_sensitive_fields() -> No
     for field in ANALYTICS_UI_FORBIDDEN_FIELDS:
         with pytest.raises(ValueError, match="forbidden field"):
             validate_analytics_ui_labels({field: "sensitive"})
+        with pytest.raises(ValueError, match="forbidden field"):
+            validate_analytics_ui_attributes((field,))
 
 
 def test_validate_analytics_ui_labels_rejects_ad_hoc_label_drift() -> None:
     assert "portfolio_id" not in ANALYTICS_UI_ALLOWED_LABELS
     with pytest.raises(ValueError, match="unsupported field"):
         validate_analytics_ui_labels({"custom_dimension": "drift"})
+    with pytest.raises(ValueError, match="unsupported field"):
+        validate_analytics_ui_attributes(("custom_dimension",))
 
 
 def test_validate_analytics_ui_labels_drops_empty_optional_values() -> None:


### PR DESCRIPTION
## Summary
- adds Slice 2 code-owned analytics UI telemetry contract constants for Gateway
- defines planned gateway log event names, severity levels, attention/audit event vocabularies, and trace/attention/audit attributes
- adds attribute-list validation so future fan-out telemetry cannot drift into sensitive or ad hoc fields

## Validation
- `python -m pytest tests\unit\test_analytics_ui_observability_contract.py -q`
- `python -m ruff check src\app\observability\analytics_ui.py tests\unit\test_analytics_ui_observability_contract.py`
- `python -m ruff format --check src\app\observability\analytics_ui.py tests\unit\test_analytics_ui_observability_contract.py`

## Scope notes
- No runtime gateway fan-out telemetry is emitted in this PR.
- Correlation propagation, metrics, dashboards, attention events, audit events, and browser proof remain later RFC-0108 slices.
- No wiki source changed in this repo for Slice 2.
