### PR TITLE
RFC-0108 Slice 4 gateway structured fanout logs

### DIFF
--- a/src/app/clients/lotus_analytics_client.py
+++ b/src/app/clients/lotus_analytics_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import Any
 from uuid import uuid4
 
@@ -6,6 +7,12 @@ import httpx
 
 from app.clients.http_resilience import request_with_retry
 from app.middleware.correlation import propagation_headers
+from app.observability.analytics_ui import (
+    emit_gateway_analytics_fanout_log,
+    gateway_analytics_fanout_timer,
+)
+
+logger = logging.getLogger("analytics_ui.gateway")
 
 
 class LotusAnalyticsClient:
@@ -26,6 +33,8 @@ class LotusAnalyticsClient:
         *,
         result_path: str,
         correlation_id: str,
+        service: str,
+        operation: str,
         max_attempts: int = 10,
         poll_interval_seconds: float = 0.35,
     ) -> tuple[int, dict[str, Any]]:
@@ -38,6 +47,7 @@ class LotusAnalyticsClient:
         last_status = 202
         last_payload: dict[str, Any] = {"detail": "async analytics result still pending"}
         for _ in range(max_attempts):
+            started_at = gateway_analytics_fanout_timer()
             status_code, payload = await request_with_retry(
                 method="GET",
                 url=url,
@@ -45,6 +55,14 @@ class LotusAnalyticsClient:
                 max_retries=self._max_retries,
                 backoff_seconds=self._retry_backoff_seconds,
                 headers=headers,
+            )
+            emit_gateway_analytics_fanout_log(
+                logger=logger,
+                started_at=started_at,
+                service=service,
+                operation=f"{operation}.poll",
+                status_code=status_code,
+                payload=payload,
             )
             last_status = status_code
             last_payload = payload
@@ -59,9 +77,13 @@ class LotusAnalyticsClient:
         path: str,
         payload: dict[str, Any],
         correlation_id: str,
+        service: str = "lotus-performance",
+        operation: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}{path}"
         headers = propagation_headers(correlation_id)
+        resolved_operation = operation or path.strip("/").replace("/", ".")
+        started_at = gateway_analytics_fanout_timer()
         status_code, response_payload = await request_with_retry(
             method="POST",
             url=url,
@@ -72,11 +94,20 @@ class LotusAnalyticsClient:
             headers=headers,
             retry_timeout_exceptions=False,
         )
+        emit_gateway_analytics_fanout_log(
+            logger=logger,
+            started_at=started_at,
+            service=service,
+            operation=resolved_operation,
+            status_code=status_code,
+            payload=response_payload,
+        )
         if self._should_retry_duplicate_calculation(
             status_code=status_code, payload=response_payload, request=payload
         ):
             replay_payload = dict(payload)
             replay_payload["calculation_id"] = str(uuid4())
+            replay_started_at = gateway_analytics_fanout_timer()
             status_code, response_payload = await request_with_retry(
                 method="POST",
                 url=url,
@@ -87,12 +118,22 @@ class LotusAnalyticsClient:
                 headers=headers,
                 retry_timeout_exceptions=False,
             )
+            emit_gateway_analytics_fanout_log(
+                logger=logger,
+                started_at=replay_started_at,
+                service=service,
+                operation=f"{resolved_operation}.duplicate-retry",
+                status_code=status_code,
+                payload=response_payload,
+            )
         if status_code == 202 and isinstance(response_payload, dict):
             result_path = response_payload.get("result_path") or response_payload.get("resultPath")
             if isinstance(result_path, str) and result_path:
                 return await self._poll_async_result(
                     result_path=result_path,
                     correlation_id=correlation_id,
+                    service=service,
+                    operation=resolved_operation,
                 )
         return status_code, response_payload
 
@@ -220,6 +261,8 @@ class LotusAnalyticsClient:
                 return await self._poll_async_result(
                     result_path=result_path,
                     correlation_id=correlation_id,
+                    service="lotus-performance",
+                    operation="performance.twr",
                 )
         return status_code, response_payload
 
@@ -451,6 +494,8 @@ class LotusAnalyticsClient:
             path="/analytics/risk/calculate",
             payload=payload,
             correlation_id=correlation_id,
+            service="lotus-risk",
+            operation="analytics.risk.calculate",
         )
 
     async def post_risk_concentration(
@@ -462,6 +507,8 @@ class LotusAnalyticsClient:
             path="/analytics/risk/concentration",
             payload=payload,
             correlation_id=correlation_id,
+            service="lotus-risk",
+            operation="analytics.risk.concentration",
         )
 
     async def post_risk_drawdown(
@@ -473,6 +520,8 @@ class LotusAnalyticsClient:
             path="/analytics/risk/drawdown",
             payload=payload,
             correlation_id=correlation_id,
+            service="lotus-risk",
+            operation="analytics.risk.drawdown",
         )
 
     async def post_risk_rolling_metrics(
@@ -484,6 +533,8 @@ class LotusAnalyticsClient:
             path="/analytics/risk/rolling-metrics",
             payload=payload,
             correlation_id=correlation_id,
+            service="lotus-risk",
+            operation="analytics.risk.rolling-metrics",
         )
 
     async def post_risk_historical_attribution(
@@ -495,4 +546,6 @@ class LotusAnalyticsClient:
             path="/analytics/risk/historical-attribution",
             payload=payload,
             correlation_id=correlation_id,
+            service="lotus-risk",
+            operation="analytics.risk.historical-attribution",
         )

--- a/src/app/observability/analytics_ui.py
+++ b/src/app/observability/analytics_ui.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import logging
+import time
 from collections.abc import Iterable, Mapping
+from typing import Any
 
 ANALYTICS_UI_ALLOWED_LABELS = frozenset(
     {
@@ -87,6 +90,22 @@ GATEWAY_ANALYTICS_UI_LOG_EVENTS = (
     "gateway.analytics.fanout.degraded",
 )
 
+GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS = (
+    "event",
+    "route",
+    "service",
+    "operation",
+    "state",
+    "reason",
+    "freshness_bucket",
+    "supportability_state",
+    "status_class",
+    "error_category",
+    "duration_ms",
+    "warning_count",
+    "partial_failure_count",
+)
+
 ANALYTICS_UI_TRACE_ATTRIBUTES = (
     "route",
     "panel",
@@ -149,3 +168,170 @@ def validate_analytics_ui_attributes(attribute_names: Iterable[str]) -> tuple[st
         )
 
     return tuple(attribute_names)
+
+
+def validate_gateway_analytics_ui_log_fields(fields: Mapping[str, object]) -> dict[str, object]:
+    field_names = set(fields)
+    forbidden = sorted(field_names & ANALYTICS_UI_FORBIDDEN_FIELDS)
+    if forbidden:
+        raise ValueError(
+            f"Analytics UI log fields include forbidden field(s): {', '.join(forbidden)}"
+        )
+
+    unsupported = sorted(field_names - set(GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS))
+    if unsupported:
+        raise ValueError(
+            f"Analytics UI log fields include unsupported field(s): {', '.join(unsupported)}"
+        )
+
+    return {key: value for key, value in fields.items() if value is not None and value != ""}
+
+
+def gateway_analytics_fanout_timer() -> float:
+    return time.perf_counter()
+
+
+def emit_gateway_analytics_fanout_log(
+    *,
+    logger: logging.Logger,
+    started_at: float,
+    service: str,
+    operation: str,
+    status_code: int,
+    payload: Mapping[str, Any],
+) -> None:
+    fields = _gateway_analytics_fanout_fields(
+        started_at=started_at,
+        service=service,
+        operation=operation,
+        status_code=status_code,
+        payload=payload,
+    )
+    event = str(fields["event"])
+    logger.info(event, extra={"extra_fields": fields})
+
+
+def _gateway_analytics_fanout_fields(
+    *,
+    started_at: float,
+    service: str,
+    operation: str,
+    status_code: int,
+    payload: Mapping[str, Any],
+) -> dict[str, object]:
+    state = _resolve_gateway_analytics_state(status_code=status_code, payload=payload)
+    supportability_state = _resolve_supportability_state(payload)
+    reason = _resolve_gateway_analytics_reason(status_code=status_code, payload=payload)
+    fields = {
+        "event": (
+            "gateway.analytics.fanout.degraded"
+            if state in {"partial", "degraded", "error", "unavailable"}
+            else "gateway.analytics.fanout.completed"
+        ),
+        "route": "workbench-analytics",
+        "service": service,
+        "operation": operation,
+        "state": "degraded" if state == "unavailable" else state,
+        "reason": reason,
+        "supportability_state": supportability_state,
+        "status_class": _status_class(status_code),
+        "error_category": _error_category(status_code),
+        "duration_ms": round((time.perf_counter() - started_at) * 1000, 2),
+        "warning_count": _list_count(payload.get("warnings")),
+        "partial_failure_count": _list_count(payload.get("partial_failures")),
+    }
+    return validate_gateway_analytics_ui_log_fields(fields)
+
+
+def _resolve_gateway_analytics_state(*, status_code: int, payload: Mapping[str, Any]) -> str:
+    payload_state = payload.get("state")
+    if isinstance(payload_state, str):
+        normalized = _normalize_state(payload_state)
+        if normalized:
+            return normalized
+
+    supportability_state = _resolve_supportability_state(payload)
+    if supportability_state in {"partial", "degraded", "error", "unavailable"}:
+        return supportability_state
+
+    if _list_count(payload.get("partial_failures")):
+        return "partial"
+    if status_code >= 500:
+        return "degraded"
+    if status_code >= 400:
+        return "error"
+    return "ready"
+
+
+def _resolve_supportability_state(payload: Mapping[str, Any]) -> str | None:
+    supportability = payload.get("supportability")
+    if isinstance(supportability, list):
+        states = {
+            normalized
+            for item in supportability
+            if isinstance(item, Mapping)
+            for normalized in [_normalize_state(item.get("state"))]
+            if normalized
+        }
+        if states & {"unavailable", "degraded", "error"}:
+            return "degraded"
+        if "partial" in states:
+            return "partial"
+        if "ready" in states:
+            return "ready"
+    return None
+
+
+def _resolve_gateway_analytics_reason(
+    *, status_code: int, payload: Mapping[str, Any]
+) -> str | None:
+    warnings = payload.get("warnings")
+    if isinstance(warnings, list) and warnings:
+        return str(warnings[0])
+
+    partial_failures = payload.get("partial_failures")
+    if isinstance(partial_failures, list):
+        for failure in partial_failures:
+            if isinstance(failure, Mapping):
+                error_code = failure.get("error_code")
+                if error_code:
+                    return str(error_code)
+
+    if status_code >= 500:
+        return "UPSTREAM_UNAVAILABLE"
+    if status_code >= 400:
+        return "UPSTREAM_ERROR"
+    return None
+
+
+def _normalize_state(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.lower()
+    if normalized == "supported":
+        return "ready"
+    if normalized == "blocked":
+        return "permission_blocked"
+    if normalized == "unavailable":
+        return "unavailable"
+    if normalized in ANALYTICS_UI_STATE_VOCABULARY:
+        return normalized
+    return None
+
+
+def _status_class(status_code: int) -> str:
+    if status_code <= 0:
+        return "unknown"
+    return f"{status_code // 100}xx"
+
+
+def _error_category(status_code: int) -> str | None:
+    if status_code >= 500:
+        return "upstream_unavailable"
+    if status_code >= 400:
+        return "upstream_error"
+    return None
+
+
+def _list_count(value: object) -> int:
+    return len(value) if isinstance(value, list) else 0

--- a/tests/unit/test_analytics_ui_observability_contract.py
+++ b/tests/unit/test_analytics_ui_observability_contract.py
@@ -12,9 +12,11 @@ from app.observability.analytics_ui import (
     ANALYTICS_UI_TRACE_ATTRIBUTES,
     GATEWAY_ANALYTICS_UI_LOG_EVENTS,
     GATEWAY_ANALYTICS_UI_METRIC_FAMILIES,
+    GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS,
     is_analytics_ui_state,
     validate_analytics_ui_attributes,
     validate_analytics_ui_labels,
+    validate_gateway_analytics_ui_log_fields,
 )
 
 
@@ -44,6 +46,21 @@ def test_gateway_log_events_and_severity_vocabularies_are_explicit() -> None:
     }
     assert "source_partial" in ANALYTICS_UI_ATTENTION_EVENT_TYPES
     assert "analytics_read_denied" in ANALYTICS_UI_AUDIT_EVENT_TYPES
+    assert GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS == (
+        "event",
+        "route",
+        "service",
+        "operation",
+        "state",
+        "reason",
+        "freshness_bucket",
+        "supportability_state",
+        "status_class",
+        "error_category",
+        "duration_ms",
+        "warning_count",
+        "partial_failure_count",
+    )
 
 
 def test_trace_attention_and_audit_attributes_are_bounded_and_product_safe() -> None:
@@ -84,6 +101,8 @@ def test_validate_analytics_ui_labels_rejects_forbidden_sensitive_fields() -> No
             validate_analytics_ui_labels({field: "sensitive"})
         with pytest.raises(ValueError, match="forbidden field"):
             validate_analytics_ui_attributes((field,))
+        with pytest.raises(ValueError, match="forbidden field"):
+            validate_gateway_analytics_ui_log_fields({field: "sensitive"})
 
 
 def test_validate_analytics_ui_labels_rejects_ad_hoc_label_drift() -> None:
@@ -98,3 +117,26 @@ def test_validate_analytics_ui_labels_drops_empty_optional_values() -> None:
     assert validate_analytics_ui_labels(
         {"route": "portfolio", "operation": "", "state": None, "status_class": "5xx"}
     ) == {"route": "portfolio", "status_class": "5xx"}
+
+
+def test_validate_gateway_analytics_ui_log_fields_accepts_structured_runtime_fields() -> None:
+    fields = validate_gateway_analytics_ui_log_fields(
+        {
+            "event": "gateway.analytics.fanout.degraded",
+            "route": "workbench-analytics",
+            "service": "lotus-risk",
+            "operation": "analytics.risk.calculate",
+            "state": "partial",
+            "reason": "RISK_SUMMARY_PARTIAL",
+            "supportability_state": "partial",
+            "status_class": "2xx",
+            "error_category": None,
+            "duration_ms": 12.4,
+            "warning_count": 1,
+            "partial_failure_count": 1,
+        }
+    )
+
+    assert fields["duration_ms"] == 12.4
+    assert fields["warning_count"] == 1
+    assert "error_category" not in fields

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 import httpx
 import pytest
@@ -675,6 +676,94 @@ async def test_lotus_analytics_client_workspace_summary_forwards_trace_context()
     assert headers["traceparent"] == f"00-{trace_id}-0000000000000001-01"
     assert "portfolio_id" not in headers
     assert "client_id" not in headers
+
+
+@pytest.mark.asyncio
+async def test_lotus_analytics_client_emits_safe_structured_fanout_log(caplog):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(
+        200,
+        {
+            "state": "partial",
+            "warnings": ["PERFORMANCE_WORKSPACE_SUMMARY_UNAVAILABLE"],
+            "partial_failures": [
+                {
+                    "source_service": "lotus-performance",
+                    "error_code": "PERFORMANCE_WORKSPACE_SUMMARY_UNAVAILABLE",
+                    "detail": "upstream unavailable",
+                }
+            ],
+            "supportability": [{"key": "portfolio_returns", "state": "partial"}],
+            "results_by_period": {},
+        },
+    )
+
+    status_code, _ = await client.get_workspace_summary(
+        portfolio_id="P1",
+        report_end_date="2026-03-27",
+        report_start_date=None,
+        period="YTD",
+        chart_frequency="monthly",
+        detail_basis="NET",
+        benchmark_id=None,
+        reporting_currency="USD",
+        segment="asset_class",
+        correlation_id="corr-workbench-route-1",
+    )
+
+    assert status_code == 200
+    [record] = [
+        record
+        for record in caplog.records
+        if record.name == "analytics_ui.gateway"
+        and record.message == "gateway.analytics.fanout.degraded"
+    ]
+    fields = record.extra_fields
+    assert fields["event"] == "gateway.analytics.fanout.degraded"
+    assert fields["route"] == "workbench-analytics"
+    assert fields["service"] == "lotus-performance"
+    assert fields["operation"] == "performance.workspace-summary"
+    assert fields["state"] == "partial"
+    assert fields["supportability_state"] == "partial"
+    assert fields["reason"] == "PERFORMANCE_WORKSPACE_SUMMARY_UNAVAILABLE"
+    assert fields["status_class"] == "2xx"
+    assert fields["warning_count"] == 1
+    assert fields["partial_failure_count"] == 1
+    assert isinstance(fields["duration_ms"], float)
+    assert "portfolio_id" not in fields
+    assert "client_id" not in fields
+    assert "request_body" not in fields
+    assert "response_body" not in fields
+
+
+@pytest.mark.asyncio
+async def test_lotus_analytics_client_emits_safe_unavailable_fanout_log(caplog):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(503, {"detail": "upstream communication failure"})
+
+    status_code, payload = await client.post_risk_calculate(
+        payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
+        correlation_id="corr-risk",
+    )
+
+    assert status_code == 503
+    assert payload["detail"] == "upstream communication failure"
+    [record] = [
+        record
+        for record in caplog.records
+        if record.name == "analytics_ui.gateway"
+        and record.message == "gateway.analytics.fanout.degraded"
+    ]
+    fields = record.extra_fields
+    assert fields["service"] == "lotus-risk"
+    assert fields["operation"] == "analytics.risk.calculate"
+    assert fields["state"] == "degraded"
+    assert fields["reason"] == "UPSTREAM_UNAVAILABLE"
+    assert fields["status_class"] == "5xx"
+    assert fields["error_category"] == "upstream_unavailable"
+    assert "portfolio_id" not in fields
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add RFC-0108 Slice 4 product-safe structured fan-out logs for Workbench analytics operations
- classify selected performance and risk fan-out responses into bounded state/supportability/status fields
- preserve backend source ownership for warnings, partial failures, and unavailable responses without logging request/response payloads or portfolio/client identifiers

## Evidence
- python -m pytest tests\unit\test_analytics_ui_observability_contract.py tests\unit\test_upstream_clients.py::test_lotus_analytics_client_emits_safe_structured_fanout_log tests\unit\test_upstream_clients.py::test_lotus_analytics_client_emits_safe_unavailable_fanout_log tests\unit\test_upstream_clients.py::test_lotus_analytics_client_workspace_summary_forwards_trace_context -q
- python -m pytest tests\unit\test_upstream_clients.py tests\unit\test_analytics_ui_observability_contract.py -q
- python -m ruff format src\app\observability\analytics_ui.py src\app\clients\lotus_analytics_client.py tests\unit\test_analytics_ui_observability_contract.py tests\unit\test_upstream_clients.py
- python -m ruff check src\app\observability\analytics_ui.py src\app\clients\lotus_analytics_client.py tests\unit\test_analytics_ui_observability_contract.py tests\unit\test_upstream_clients.py
- git diff --check

## Tiering
- Feature Lane proof: focused unit coverage, broader upstream-client unit suite, ruff checks
- PR Merge Gate: GitHub checks
- No API shape or OpenAPI change in this slice
