### PR TITLE
Implement RFC-0108 Slice 7 analytics read audit logs

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -47,6 +47,13 @@ Current repository posture:
 8. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
 9. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
 10. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
+11. RFC-0108 analytics UI observability is active for selected Workbench performance and risk
+    analytics paths: Gateway owns product-safe structured fan-out logs and selected analytics read
+    audit logs. Successful upstream reads emit bounded `analytics_read_allowed` audit records, and
+    upstream `401`/`403` responses emit bounded `analytics_read_denied` audit records. Audit
+    fields must stay limited to route, panel, operation, state, reason, status class, region, and
+    environment; portfolio, client, holding, trace, correlation, request/response body, screen
+    content, and raw entitlement-failure fields remain forbidden.
 
 ## Architecture And Module Map
 

--- a/src/app/clients/lotus_analytics_client.py
+++ b/src/app/clients/lotus_analytics_client.py
@@ -9,6 +9,7 @@ from app.clients.http_resilience import request_with_retry
 from app.middleware.correlation import propagation_headers
 from app.observability.analytics_ui import (
     emit_gateway_analytics_fanout_log,
+    emit_gateway_analytics_read_audit_log,
     gateway_analytics_fanout_timer,
 )
 
@@ -67,6 +68,11 @@ class LotusAnalyticsClient:
             last_status = status_code
             last_payload = payload
             if status_code != 202:
+                emit_gateway_analytics_read_audit_log(
+                    logger=logger,
+                    operation=f"{operation}.poll",
+                    status_code=status_code,
+                )
                 return status_code, payload
             await asyncio.sleep(poll_interval_seconds)
         return last_status, last_payload
@@ -135,6 +141,11 @@ class LotusAnalyticsClient:
                     service=service,
                     operation=resolved_operation,
                 )
+        emit_gateway_analytics_read_audit_log(
+            logger=logger,
+            operation=resolved_operation,
+            status_code=status_code,
+        )
         return status_code, response_payload
 
     @staticmethod

--- a/src/app/observability/analytics_ui.py
+++ b/src/app/observability/analytics_ui.py
@@ -215,15 +215,11 @@ def _validate_gateway_analytics_ui_fields(
     field_names = set(fields)
     forbidden = sorted(field_names & ANALYTICS_UI_FORBIDDEN_FIELDS)
     if forbidden:
-        raise ValueError(
-            f"{error_prefix} include forbidden field(s): {', '.join(forbidden)}"
-        )
+        raise ValueError(f"{error_prefix} include forbidden field(s): {', '.join(forbidden)}")
 
     unsupported = sorted(field_names - supported_fields)
     if unsupported:
-        raise ValueError(
-            f"{error_prefix} include unsupported field(s): {', '.join(unsupported)}"
-        )
+        raise ValueError(f"{error_prefix} include unsupported field(s): {', '.join(unsupported)}")
 
     return {key: value for key, value in fields.items() if value is not None and value != ""}
 

--- a/src/app/observability/analytics_ui.py
+++ b/src/app/observability/analytics_ui.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 from collections.abc import Iterable, Mapping
 from typing import Any
@@ -90,6 +91,11 @@ GATEWAY_ANALYTICS_UI_LOG_EVENTS = (
     "gateway.analytics.fanout.degraded",
 )
 
+GATEWAY_ANALYTICS_UI_AUDIT_LOG_EVENTS = (
+    "gateway.analytics.audit.analytics_read_allowed",
+    "gateway.analytics.audit.analytics_read_denied",
+)
+
 GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS = (
     "event",
     "route",
@@ -104,6 +110,18 @@ GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS = (
     "duration_ms",
     "warning_count",
     "partial_failure_count",
+)
+
+GATEWAY_ANALYTICS_UI_AUDIT_LOG_FIELDS = (
+    "event",
+    "route",
+    "panel",
+    "operation",
+    "state",
+    "reason",
+    "status_class",
+    "region",
+    "environment",
 )
 
 ANALYTICS_UI_TRACE_ATTRIBUTES = (
@@ -171,17 +189,40 @@ def validate_analytics_ui_attributes(attribute_names: Iterable[str]) -> tuple[st
 
 
 def validate_gateway_analytics_ui_log_fields(fields: Mapping[str, object]) -> dict[str, object]:
+    return _validate_gateway_analytics_ui_fields(
+        fields=fields,
+        supported_fields=set(GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS),
+        error_prefix="Analytics UI log fields",
+    )
+
+
+def validate_gateway_analytics_ui_audit_log_fields(
+    fields: Mapping[str, object],
+) -> dict[str, object]:
+    return _validate_gateway_analytics_ui_fields(
+        fields=fields,
+        supported_fields=set(GATEWAY_ANALYTICS_UI_AUDIT_LOG_FIELDS),
+        error_prefix="Analytics UI audit log fields",
+    )
+
+
+def _validate_gateway_analytics_ui_fields(
+    *,
+    fields: Mapping[str, object],
+    supported_fields: set[str],
+    error_prefix: str,
+) -> dict[str, object]:
     field_names = set(fields)
     forbidden = sorted(field_names & ANALYTICS_UI_FORBIDDEN_FIELDS)
     if forbidden:
         raise ValueError(
-            f"Analytics UI log fields include forbidden field(s): {', '.join(forbidden)}"
+            f"{error_prefix} include forbidden field(s): {', '.join(forbidden)}"
         )
 
-    unsupported = sorted(field_names - set(GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS))
+    unsupported = sorted(field_names - supported_fields)
     if unsupported:
         raise ValueError(
-            f"Analytics UI log fields include unsupported field(s): {', '.join(unsupported)}"
+            f"{error_prefix} include unsupported field(s): {', '.join(unsupported)}"
         )
 
     return {key: value for key, value in fields.items() if value is not None and value != ""}
@@ -209,6 +250,21 @@ def emit_gateway_analytics_fanout_log(
     )
     event = str(fields["event"])
     logger.info(event, extra={"extra_fields": fields})
+
+
+def emit_gateway_analytics_read_audit_log(
+    *,
+    logger: logging.Logger,
+    operation: str,
+    status_code: int,
+) -> None:
+    fields = _gateway_analytics_read_audit_fields(
+        operation=operation,
+        status_code=status_code,
+    )
+    if not fields:
+        return
+    logger.info(str(fields["event"]), extra={"extra_fields": fields})
 
 
 def _gateway_analytics_fanout_fields(
@@ -241,6 +297,36 @@ def _gateway_analytics_fanout_fields(
         "partial_failure_count": _list_count(payload.get("partial_failures")),
     }
     return validate_gateway_analytics_ui_log_fields(fields)
+
+
+def _gateway_analytics_read_audit_fields(
+    *,
+    operation: str,
+    status_code: int,
+) -> dict[str, object] | None:
+    if status_code in {401, 403}:
+        event = "gateway.analytics.audit.analytics_read_denied"
+        state = "permission_blocked"
+        reason = "upstream_authorization_denied"
+    elif 0 < status_code < 400:
+        event = "gateway.analytics.audit.analytics_read_allowed"
+        state = "ready"
+        reason = "upstream_read_succeeded"
+    else:
+        return None
+
+    fields = {
+        "event": event,
+        "route": "workbench-analytics",
+        "panel": _panel_for_operation(operation),
+        "operation": operation,
+        "state": state,
+        "reason": reason,
+        "status_class": _status_class(status_code),
+        "region": _safe_dimension(os.getenv("LOTUS_REGION"), default="unknown"),
+        "environment": _safe_dimension(os.getenv("LOTUS_ENVIRONMENT"), default="local"),
+    }
+    return validate_gateway_analytics_ui_audit_log_fields(fields)
 
 
 def _resolve_gateway_analytics_state(*, status_code: int, payload: Mapping[str, Any]) -> str:
@@ -335,3 +421,24 @@ def _error_category(status_code: int) -> str | None:
 
 def _list_count(value: object) -> int:
     return len(value) if isinstance(value, list) else 0
+
+
+def _panel_for_operation(operation: str) -> str:
+    if operation.startswith("analytics.risk."):
+        return "risk-summary"
+    if "workspace-summary" in operation:
+        return "performance-summary"
+    if operation.startswith("performance."):
+        return "performance-details"
+    return "unknown"
+
+
+def _safe_dimension(value: str | None, *, default: str) -> str:
+    if not value:
+        return default
+    cleaned = "".join(
+        character
+        for character in value.strip().lower()
+        if character.isalnum() or character in {"-", "_", "."}
+    )
+    return cleaned[:64] or default

--- a/tests/unit/test_analytics_ui_observability_contract.py
+++ b/tests/unit/test_analytics_ui_observability_contract.py
@@ -10,12 +10,15 @@ from app.observability.analytics_ui import (
     ANALYTICS_UI_SEVERITY_LEVELS,
     ANALYTICS_UI_STATE_VOCABULARY,
     ANALYTICS_UI_TRACE_ATTRIBUTES,
+    GATEWAY_ANALYTICS_UI_AUDIT_LOG_EVENTS,
+    GATEWAY_ANALYTICS_UI_AUDIT_LOG_FIELDS,
     GATEWAY_ANALYTICS_UI_LOG_EVENTS,
     GATEWAY_ANALYTICS_UI_METRIC_FAMILIES,
     GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS,
     is_analytics_ui_state,
     validate_analytics_ui_attributes,
     validate_analytics_ui_labels,
+    validate_gateway_analytics_ui_audit_log_fields,
     validate_gateway_analytics_ui_log_fields,
 )
 
@@ -37,6 +40,10 @@ def test_gateway_log_events_and_severity_vocabularies_are_explicit() -> None:
     assert GATEWAY_ANALYTICS_UI_LOG_EVENTS == (
         "gateway.analytics.fanout.completed",
         "gateway.analytics.fanout.degraded",
+    )
+    assert GATEWAY_ANALYTICS_UI_AUDIT_LOG_EVENTS == (
+        "gateway.analytics.audit.analytics_read_allowed",
+        "gateway.analytics.audit.analytics_read_denied",
     )
     assert ANALYTICS_UI_SEVERITY_LEVELS == {
         "info",
@@ -60,6 +67,17 @@ def test_gateway_log_events_and_severity_vocabularies_are_explicit() -> None:
         "duration_ms",
         "warning_count",
         "partial_failure_count",
+    )
+    assert GATEWAY_ANALYTICS_UI_AUDIT_LOG_FIELDS == (
+        "event",
+        "route",
+        "panel",
+        "operation",
+        "state",
+        "reason",
+        "status_class",
+        "region",
+        "environment",
     )
 
 
@@ -103,6 +121,8 @@ def test_validate_analytics_ui_labels_rejects_forbidden_sensitive_fields() -> No
             validate_analytics_ui_attributes((field,))
         with pytest.raises(ValueError, match="forbidden field"):
             validate_gateway_analytics_ui_log_fields({field: "sensitive"})
+        with pytest.raises(ValueError, match="forbidden field"):
+            validate_gateway_analytics_ui_audit_log_fields({field: "sensitive"})
 
 
 def test_validate_analytics_ui_labels_rejects_ad_hoc_label_drift() -> None:
@@ -140,3 +160,24 @@ def test_validate_gateway_analytics_ui_log_fields_accepts_structured_runtime_fie
     assert fields["duration_ms"] == 12.4
     assert fields["warning_count"] == 1
     assert "error_category" not in fields
+
+
+def test_validate_gateway_analytics_ui_audit_log_fields_accepts_bounded_runtime_fields() -> None:
+    fields = validate_gateway_analytics_ui_audit_log_fields(
+        {
+            "event": "gateway.analytics.audit.analytics_read_denied",
+            "route": "workbench-analytics",
+            "panel": "risk-summary",
+            "operation": "analytics.risk.calculate",
+            "state": "permission_blocked",
+            "reason": "upstream_authorization_denied",
+            "status_class": "4xx",
+            "region": "ap-southeast-1",
+            "environment": "local",
+        }
+    )
+
+    assert fields["event"] == "gateway.analytics.audit.analytics_read_denied"
+    assert fields["state"] == "permission_blocked"
+    assert "portfolio_id" not in fields
+    assert "raw_entitlement_failure" not in fields

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -738,6 +738,97 @@ async def test_lotus_analytics_client_emits_safe_structured_fanout_log(caplog):
 
 
 @pytest.mark.asyncio
+async def test_lotus_analytics_client_emits_safe_read_allowed_audit_log(caplog, monkeypatch):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    monkeypatch.setenv("LOTUS_REGION", "AP-SOUTHEAST-1")
+    monkeypatch.setenv("LOTUS_ENVIRONMENT", "Local")
+    client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(
+        200,
+        {
+            "results_by_period": {},
+            "request_body": {"portfolio_id": "P1"},
+            "response_body": {"client_name": "Sensitive Client"},
+        },
+    )
+
+    status_code, _ = await client.get_workspace_summary(
+        portfolio_id="P1",
+        report_end_date="2026-03-27",
+        report_start_date=None,
+        period="YTD",
+        chart_frequency="monthly",
+        detail_basis="NET",
+        benchmark_id=None,
+        reporting_currency="USD",
+        segment="asset_class",
+        correlation_id="corr-audit-allowed",
+    )
+
+    assert status_code == 200
+    [record] = [
+        record
+        for record in caplog.records
+        if record.name == "analytics_ui.gateway"
+        and record.message == "gateway.analytics.audit.analytics_read_allowed"
+    ]
+    fields = record.extra_fields
+    assert fields == {
+        "event": "gateway.analytics.audit.analytics_read_allowed",
+        "route": "workbench-analytics",
+        "panel": "performance-summary",
+        "operation": "performance.workspace-summary",
+        "state": "ready",
+        "reason": "upstream_read_succeeded",
+        "status_class": "2xx",
+        "region": "ap-southeast-1",
+        "environment": "local",
+    }
+    assert "portfolio_id" not in fields
+    assert "client_name" not in fields
+    assert "request_body" not in fields
+    assert "response_body" not in fields
+
+
+@pytest.mark.asyncio
+async def test_lotus_analytics_client_emits_safe_read_denied_audit_log(caplog):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(
+        403,
+        {
+            "detail": "denied for portfolio P1",
+            "raw_entitlement_failure": "client_name=Sensitive Client",
+        },
+    )
+
+    status_code, _ = await client.post_risk_calculate(
+        payload={"input_mode": "stateful", "stateful_input": {"portfolio_id": "P1"}},
+        correlation_id="corr-audit-denied",
+    )
+
+    assert status_code == 403
+    [record] = [
+        record
+        for record in caplog.records
+        if record.name == "analytics_ui.gateway"
+        and record.message == "gateway.analytics.audit.analytics_read_denied"
+    ]
+    fields = record.extra_fields
+    assert fields["event"] == "gateway.analytics.audit.analytics_read_denied"
+    assert fields["route"] == "workbench-analytics"
+    assert fields["panel"] == "risk-summary"
+    assert fields["operation"] == "analytics.risk.calculate"
+    assert fields["state"] == "permission_blocked"
+    assert fields["reason"] == "upstream_authorization_denied"
+    assert fields["status_class"] == "4xx"
+    assert fields["region"] == "unknown"
+    assert fields["environment"] == "local"
+    assert "portfolio_id" not in fields
+    assert "raw_entitlement_failure" not in fields
+
+
+@pytest.mark.asyncio
 async def test_lotus_analytics_client_emits_safe_unavailable_fanout_log(caplog):
     caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
     client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -28,8 +28,14 @@
 - `portfolio_id`, `client_id`, `client_name`, `holding_id`, `transaction_id`, `trace_id`,
   `correlation_id`, request bodies, response bodies, and raw entitlement failures must not become
   metric labels or structured telemetry dimensions.
-- Gateway fan-out metrics, degraded-source counters, dashboard claims, attention events, and audit
-  events remain planned until later RFC-0108 slices promote them with evidence.
+- Gateway emits product-safe structured fan-out logs for selected Workbench performance and risk
+  analytics operations.
+- Gateway emits product-safe selected analytics read audit logs for upstream read outcomes:
+  `gateway.analytics.audit.analytics_read_allowed` for successful upstream reads and
+  `gateway.analytics.audit.analytics_read_denied` for `401` or `403` upstream denials.
+- Gateway analytics fan-out metrics, degraded-source counters, dashboard claims, Workbench
+  attention events outside the Workbench surface, and protected diagnostics lookup audit remain
+  planned until later RFC-0108 slices promote them with evidence.
 
 ## Practical probes
 


### PR DESCRIPTION
## Summary
- add product-safe Gateway analytics read audit events for selected Workbench performance/risk analytics reads
- emit analytics_read_allowed for successful upstream reads and analytics_read_denied for upstream 401/403 denials
- update Gateway wiki/context with bounded audit posture and remaining protected diagnostics scope

## Validation
- python -m pytest tests\\unit\\test_analytics_ui_observability_contract.py tests\\unit\\test_upstream_clients.py::test_lotus_analytics_client_emits_safe_structured_fanout_log tests\\unit\\test_upstream_clients.py::test_lotus_analytics_client_emits_safe_read_allowed_audit_log tests\\unit\\test_upstream_clients.py::test_lotus_analytics_client_emits_safe_read_denied_audit_log tests\\unit\\test_upstream_clients.py::test_lotus_analytics_client_emits_safe_unavailable_fanout_log -q
- python -m ruff check src\\app\\observability\\analytics_ui.py src\\app\\clients\\lotus_analytics_client.py tests\\unit\\test_analytics_ui_observability_contract.py tests\\unit\\test_upstream_clients.py

## Notes
- Protected diagnostics lookup audit remains planned until the protected diagnostics API exists and is certified.
- No API shape changes.