### PR TITLE
Use canonical performance capability keys

### DIFF
--- a/src/app/contracts/platform_capabilities.py
+++ b/src/app/contracts/platform_capabilities.py
@@ -98,13 +98,13 @@ class PlatformBootstrapVersioning(BaseModel):
         default=None,
         alias="sourcePolicyVersion",
         description="Single-source policy version when the descriptor depends on one source.",
-        examples=["pa-tenant-a-v4"],
+        examples=["lotus-performance-tenant-a-v4"],
     )
     source_policy_versions: dict[str, str] = Field(
         default_factory=dict,
         alias="sourcePolicyVersions",
         description="Source-policy versions keyed by gateway source name.",
-        examples=[{"lotus_core": "pas-v3", "lotus_performance": "pa-v4"}],
+        examples=[{"lotus_core": "pas-v3", "lotus_performance": "lotus-performance-v4"}],
     )
 
     model_config = {"populate_by_name": True}
@@ -240,7 +240,7 @@ class PlatformCapabilitiesNormalized(BaseModel):
         examples=[
             {
                 "lotus_core": "pas-v3",
-                "lotus_performance": "pa-v4",
+                "lotus_performance": "lotus-performance-v4",
                 "lotus_risk": "risk-v2",
             }
         ],
@@ -293,7 +293,7 @@ class PlatformCapabilitiesData(BaseModel):
                 "lotus_core": {"sourceService": "lotus-core", "policyVersion": "pas-v3"},
                 "lotus_performance": {
                     "sourceService": "lotus-performance",
-                    "policyVersion": "pa-v4",
+                    "policyVersion": "lotus-performance-v4",
                 },
                 "lotus_risk": {
                     "sourceService": "lotus-risk",

--- a/src/app/services/platform_capabilities_service.py
+++ b/src/app/services/platform_capabilities_service.py
@@ -268,13 +268,13 @@ class PlatformCapabilitiesService:
                 )
                 for key in (
                     "lotus_performance.analytics.twr",
-                    "pa.analytics.twr",
+                    "performance.analytics.twr",
                     "lotus_performance.analytics.mwr",
-                    "pa.analytics.mwr",
+                    "performance.analytics.mwr",
                     "lotus_performance.analytics.contribution",
-                    "pa.analytics.contribution",
+                    "performance.analytics.contribution",
                     "lotus_performance.analytics.attribution",
-                    "pa.analytics.attribution",
+                    "performance.analytics.attribution",
                 )
             ),
             "lotus_manage_lifecycle": self._feature_enabled(

--- a/tests/contract/test_platform_capabilities_contract.py
+++ b/tests/contract/test_platform_capabilities_contract.py
@@ -26,7 +26,7 @@ def test_platform_capabilities_contract_shape(monkeypatch):
             }
         return 200, {
             "contractVersion": "v1",
-            "sourceService": "performance-analytics",
+            "sourceService": "lotus-performance",
             "policyVersion": "lotus-performance-default-v1",
             "features": [],
             "workflows": [],

--- a/tests/e2e/test_platform_capabilities_live.py
+++ b/tests/e2e/test_platform_capabilities_live.py
@@ -32,7 +32,7 @@ def _assert_payload(payload: dict) -> None:
 
     passthrough = {
         "lotus_core": "lotus-core",
-        "lotus_performance": "performance-analytics",
+        "lotus_performance": "lotus-performance",
         "lotus_risk": "lotus-risk",
         "lotus_manage": "lotus-advise",
         "lotus_report": "lotus-report",

--- a/tests/e2e/test_workflow_journeys.py
+++ b/tests/e2e/test_workflow_journeys.py
@@ -16,12 +16,12 @@ def test_e2e_platform_capability_aggregation_and_health(monkeypatch) -> None:
             "supportedInputModes": ["pas_ref"],
         }
 
-    async def _pa(*args, **kwargs):
+    async def _performance(*args, **kwargs):
         return 200, {
-            "sourceService": "performance-analytics",
+            "sourceService": "lotus-performance",
             "contractVersion": "v1",
             "policyVersion": "lotus-performance-default-v1",
-            "features": [{"key": "pa.analytics.twr", "enabled": True}],
+            "features": [{"key": "performance.analytics.twr", "enabled": True}],
             "workflows": [{"workflow_key": "performance_snapshot", "enabled": True}],
             "supportedInputModes": ["pas_ref", "inline_bundle"],
         }
@@ -61,7 +61,7 @@ def test_e2e_platform_capability_aggregation_and_health(monkeypatch) -> None:
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_capabilities", _pas)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_effective_policy", _pas_policy)
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_capabilities", _pa
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_capabilities", _performance
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.get_capabilities", _dpm)
     monkeypatch.setattr("app.clients.reporting_client.ReportingClient.get_capabilities", _ras)
@@ -79,6 +79,7 @@ def test_e2e_platform_capability_aggregation_and_health(monkeypatch) -> None:
     assert set(body["sources"].keys()) == {
         "lotus_core",
         "lotus_performance",
+        "lotus_risk",
         "lotus_manage",
         "lotus_report",
     }
@@ -124,7 +125,7 @@ def test_e2e_workbench_sandbox_flow(monkeypatch) -> None:
             "net_delta_quantity": 2.0,
         }
 
-    async def _pa(*args, **kwargs):
+    async def _performance(*args, **kwargs):
         return 200, {"resultsByPeriod": {"YTD": {"net_cumulative_return": 1.5}}}
 
     async def _dpm_runs(*args, **kwargs):
@@ -140,7 +141,7 @@ def test_e2e_workbench_sandbox_flow(monkeypatch) -> None:
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_projected_positions", _pas_positions)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_projected_summary", _pas_summary)
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_stateful_twr", _pa
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_stateful_twr", _performance
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.simulate_proposal", _dpm_simulate)
@@ -267,7 +268,7 @@ def test_e2e_platform_capabilities_partial_failure_when_one_upstream_fails(
             "supportedInputModes": ["pas_ref"],
         }
 
-    async def _pa(*args, **kwargs):
+    async def _performance(*args, **kwargs):
         return 503, {"detail": "lotus-performance unavailable"}
 
     async def _dpm(*args, **kwargs):
@@ -304,7 +305,7 @@ def test_e2e_platform_capabilities_partial_failure_when_one_upstream_fails(
 
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_capabilities", _pas)
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_capabilities", _pa
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_capabilities", _performance
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.get_capabilities", _dpm)
     monkeypatch.setattr("app.clients.reporting_client.ReportingClient.get_capabilities", _ras)
@@ -378,7 +379,7 @@ def test_e2e_sandbox_policy_feedback_unavailable_when_dpm_simulation_fails(monke
             "net_delta_quantity": 1.0,
         }
 
-    async def _pa(*args, **kwargs):
+    async def _performance(*args, **kwargs):
         return 200, {"resultsByPeriod": {"YTD": {"net_cumulative_return": 1.2}}}
 
     async def _dpm_runs(*args, **kwargs):
@@ -394,7 +395,7 @@ def test_e2e_sandbox_policy_feedback_unavailable_when_dpm_simulation_fails(monke
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_projected_positions", _pas_positions)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_projected_summary", _pas_summary)
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_stateful_twr", _pa
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_stateful_twr", _performance
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.simulate_proposal", _dpm_simulate_failure)

--- a/tests/integration/test_platform_capabilities_router.py
+++ b/tests/integration/test_platform_capabilities_router.py
@@ -31,10 +31,10 @@ def test_platform_capabilities_router_success(monkeypatch):
                 "supportedInputModes": ["pas_ref"],
             }
         return 200, {
-            "sourceService": "performance-analytics",
+            "sourceService": "lotus-performance",
             "contractVersion": "v1",
             "policyVersion": "lotus-performance-default-v1",
-            "features": [{"key": "pa.analytics.twr", "enabled": True}],
+            "features": [{"key": "performance.analytics.twr", "enabled": True}],
             "workflows": [{"workflow_key": "performance_snapshot", "enabled": True}],
             "supportedInputModes": ["pas_ref", "inline_bundle"],
         }

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -72,7 +72,7 @@ def test_workbench_router_success(monkeypatch):
             },
         }
 
-    async def _pa(*args, **kwargs):
+    async def _performance(*args, **kwargs):
         return 200, {
             "results_by_period": {
                 "YTD": {"portfolio": {"summary": {"period_return": {"base": 2.5}}}}
@@ -96,7 +96,7 @@ def test_workbench_router_success(monkeypatch):
         f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_analytics_reference", _analytics_reference
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _pa
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _performance
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm)
 
@@ -157,7 +157,7 @@ def test_workbench_router_partial_failure(monkeypatch):
             },
         }
 
-    async def _pa(*args, **kwargs):
+    async def _performance(*args, **kwargs):
         return 503, {"detail": "paused"}
 
     async def _dpm(*args, **kwargs):
@@ -169,7 +169,7 @@ def test_workbench_router_partial_failure(monkeypatch):
         f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_analytics_reference", _analytics_reference
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _pa
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _performance
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm)
 
@@ -211,7 +211,7 @@ def test_workbench_portfolio_360_router(monkeypatch):
             },
         }
 
-    async def _pa(*args, **kwargs):
+    async def _performance(*args, **kwargs):
         return 200, {
             "results_by_period": {
                 "YTD": {"portfolio": {"summary": {"period_return": {"base": 1.5}}}}
@@ -227,7 +227,7 @@ def test_workbench_portfolio_360_router(monkeypatch):
         f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_analytics_reference", _analytics_reference
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _pa
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _performance
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
 
@@ -342,14 +342,14 @@ def test_workbench_analytics_router(monkeypatch):
             "net_delta_quantity": 2.0,
         }
 
-    async def _pa(*args, **kwargs):
+    async def _performance(*args, **kwargs):
         return 200, {
             "results_by_period": {
                 "YTD": {"portfolio": {"summary": {"period_return": {"base": 1.5}}}}
             }
         }
 
-    async def _pa_workbench(*args, **kwargs):
+    async def _performance_workbench(*args, **kwargs):
         return 200, {
             "portfolioId": "PF_1001",
             "period": "YTD",
@@ -390,11 +390,11 @@ def test_workbench_analytics_router(monkeypatch):
         f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_analytics_reference", _analytics_reference
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _pa
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _performance
     )
     monkeypatch.setattr(
         "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_workbench_analytics",
-        _pa_workbench,
+        _performance_workbench,
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
 
@@ -2657,7 +2657,7 @@ def test_workbench_sandbox_changes_router(monkeypatch):
             "net_delta_quantity": 2.0,
         }
 
-    async def _pa(*args, **kwargs):
+    async def _performance(*args, **kwargs):
         return 200, {
             "results_by_period": {
                 "YTD": {"portfolio": {"summary": {"period_return": {"base": 1.5}}}}
@@ -2699,7 +2699,7 @@ def test_workbench_sandbox_changes_router(monkeypatch):
         f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_analytics_reference", _analytics_reference
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _pa
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _performance
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.simulate_proposal", _dpm_simulate)

--- a/tests/unit/test_foundation_service.py
+++ b/tests/unit/test_foundation_service.py
@@ -282,7 +282,7 @@ async def test_foundation_workspace_degrades_when_optional_upstreams_fail():
                 },
             },
         ),
-        analytics_client=_StubAnalyticsClient(503, {"detail": "pa unavailable"}),
+        analytics_client=_StubAnalyticsClient(503, {"detail": "lotus-performance unavailable"}),
         dpm_client=_StubDpmClient(500, {"detail": "dpm unavailable"}),
         reporting_client=_StubReportingClient(503, {"detail": "reporting unavailable"}),
     )

--- a/tests/unit/test_platform_capabilities_service.py
+++ b/tests/unit/test_platform_capabilities_service.py
@@ -180,9 +180,9 @@ async def test_platform_capabilities_all_sources_success():
             200,
             {
                 "sourceService": "lotus_performance",
-                "policyVersion": "pa-tenant-a-v4",
+                "policyVersion": "lotus-performance-tenant-a-v4",
                 "supportedInputModes": ["pas_ref", "inline_bundle"],
-                "features": [{"key": "pa.analytics.twr", "enabled": True}],
+                "features": [{"key": "performance.analytics.twr", "enabled": True}],
                 "workflows": [{"workflow_key": "performance_snapshot", "enabled": True}],
             },
         ),
@@ -242,7 +242,7 @@ async def test_platform_capabilities_all_sources_success():
     assert response.data.normalized.module_health["lotus_core"] == "available"
     assert response.data.normalized.policy_versions_by_source == {
         "lotus_core": "pas-tenant-a-v3",
-        "lotus_performance": "pa-tenant-a-v4",
+        "lotus_performance": "lotus-performance-tenant-a-v4",
         "lotus_risk": "risk-tenant-a-v2",
         "lotus_manage": "dpm-tenant-a-v2",
         "lotus_report": "ras-tenant-a-v1",
@@ -267,7 +267,7 @@ async def test_platform_capabilities_all_sources_success():
     assert shell_bootstrap.versioning.capability_contract_version == "v1"
     assert shell_bootstrap.versioning.source_policy_versions == {
         "lotus_core": "pas-tenant-a-v3",
-        "lotus_performance": "pa-tenant-a-v4",
+        "lotus_performance": "lotus-performance-tenant-a-v4",
         "lotus_risk": "risk-tenant-a-v2",
         "lotus_manage": "dpm-tenant-a-v2",
         "lotus_report": "ras-tenant-a-v1",
@@ -401,8 +401,8 @@ async def test_platform_capabilities_normalization_handles_malformed_feature_sha
             200,
             {
                 "sourceService": "lotus_performance",
-                "policyVersion": "pa-v1",
-                "features": [{"key": "pa.analytics.twr", "enabled": False}],
+                "policyVersion": "lotus-performance-v1",
+                "features": [{"key": "performance.analytics.twr", "enabled": False}],
                 "workflows": [{"workflow_key": "performance_snapshot", "enabled": True}],
             },
         ),
@@ -499,7 +499,9 @@ def test_platform_capabilities_feature_and_workflow_skip_non_dict_entries():
         contract_version="v1",
     )
     sources = {
-        "lotus_performance": {"features": ["bad", {"key": "pa.analytics.twr", "enabled": True}]},
+        "lotus_performance": {
+            "features": ["bad", {"key": "performance.analytics.twr", "enabled": True}]
+        },
         "lotus_manage": {
             "workflows": ["bad", {"workflow_key": "proposal_lifecycle", "enabled": True}]
         },
@@ -508,7 +510,7 @@ def test_platform_capabilities_feature_and_workflow_skip_non_dict_entries():
         service._feature_enabled(
             sources=sources,
             source_name="lotus_performance",
-            feature_keys=("pa.analytics.twr",),
+            feature_keys=("performance.analytics.twr",),
         )
         is True
     )
@@ -542,7 +544,7 @@ async def test_platform_capabilities_uses_service_specific_upstream_capability_c
         200,
         {
             "sourceService": "lotus_performance",
-            "policyVersion": "pa-v1",
+            "policyVersion": "lotus-performance-v1",
             "features": [],
             "workflows": [],
         },
@@ -673,7 +675,7 @@ async def test_platform_capabilities_timeout_budget_preserves_partial_response()
             200,
             {
                 "sourceService": "lotus_performance",
-                "features": [{"key": "pa.analytics.twr", "enabled": True}],
+                "features": [{"key": "performance.analytics.twr", "enabled": True}],
                 "workflows": [],
             },
             delay_seconds=0.25,

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -98,8 +98,8 @@ def _patch_async_client(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_lotus_analytics_client_calls_and_payload_handling():
-    client = LotusAnalyticsClient(base_url="http://pa", timeout_seconds=2.0)
-    _FakeAsyncClient.queue_json(200, {"sourceService": "pa"})
+    client = LotusAnalyticsClient(base_url="http://lotus-performance", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"sourceService": "lotus-performance"})
     _FakeAsyncClient.queue_json(
         200,
         {
@@ -134,7 +134,7 @@ async def test_lotus_analytics_client_calls_and_payload_handling():
     )
 
     assert status_one == 200
-    assert payload_one["sourceService"] == "pa"
+    assert payload_one["sourceService"] == "lotus-performance"
     assert status_two == 200
     assert (
         payload_two["results_by_period"]["YTD"]["portfolio"]["summary"]["period_return"]["base"]
@@ -142,13 +142,13 @@ async def test_lotus_analytics_client_calls_and_payload_handling():
     )
     assert status_three == 200
     assert payload_three["allocationBuckets"][0]["bucketKey"] == "EQUITY"
-    assert _FakeAsyncClient.calls[0]["url"] == "http://pa/integration/capabilities"
+    assert _FakeAsyncClient.calls[0]["url"] == "http://lotus-performance/integration/capabilities"
     assert _FakeAsyncClient.calls[0]["params"] == {
         "consumer_system": "lotus-gateway",
         "tenant_id": "default",
     }
-    assert _FakeAsyncClient.calls[1]["url"] == "http://pa/performance/twr"
-    assert _FakeAsyncClient.calls[2]["url"] == "http://pa/analytics/workbench"
+    assert _FakeAsyncClient.calls[1]["url"] == "http://lotus-performance/performance/twr"
+    assert _FakeAsyncClient.calls[2]["url"] == "http://lotus-performance/analytics/workbench"
     assert _FakeAsyncClient.calls[1]["json"]["portfolio_id"] == "P1"
     assert _FakeAsyncClient.calls[1]["json"]["report_end_date"] == "2026-02-24"
     assert _FakeAsyncClient.calls[1]["json"]["stateful_input"] == {}
@@ -1094,8 +1094,8 @@ async def test_lotus_core_query_client_fetches_benchmark_assignment():
 
 @pytest.mark.asyncio
 async def test_lotus_analytics_client_non_json_and_non_dict_payload_handling():
-    client = LotusAnalyticsClient(base_url="http://pa", timeout_seconds=2.0)
-    _FakeAsyncClient.queue_text(503, "pa unavailable")
+    client = LotusAnalyticsClient(base_url="http://lotus-performance", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_text(503, "lotus-performance unavailable")
     _FakeAsyncClient.queue_json(200, ["analytics"])
 
     status_one, payload_one = await client.get_capabilities(
@@ -1109,7 +1109,7 @@ async def test_lotus_analytics_client_non_json_and_non_dict_payload_handling():
     )
 
     assert status_one == 503
-    assert payload_one["detail"] == "pa unavailable"
+    assert payload_one["detail"] == "lotus-performance unavailable"
     assert status_two == 200
     assert payload_two["detail"] == ["analytics"]
     assert _FakeAsyncClient.calls[0]["params"] == {
@@ -1120,7 +1120,7 @@ async def test_lotus_analytics_client_non_json_and_non_dict_payload_handling():
 
 @pytest.mark.asyncio
 async def test_lotus_core_query_client_endpoints_and_non_json_response_handling():
-    client = LotusCoreQueryClient(base_url="http://pas", timeout_seconds=2.0)
+    client = LotusCoreQueryClient(base_url="http://lotus-performances", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"portfolio_id": "P1"})
     _FakeAsyncClient.queue_json(200, {"positions": [{"security_id": "EQ_1"}]})
     _FakeAsyncClient.queue_json(200, {"transactions": [{"transaction_id": "TX_1"}]})
@@ -1171,15 +1171,20 @@ async def test_lotus_core_query_client_endpoints_and_non_json_response_handling(
     )
     assert status_summary == 503
     assert payload_summary["detail"] == "service unavailable"
-    assert _FakeAsyncClient.calls[0]["url"] == "http://pas/portfolios/P1"
-    assert _FakeAsyncClient.calls[1]["url"] == "http://pas/portfolios/P1/positions"
-    assert _FakeAsyncClient.calls[2]["url"] == "http://pas/portfolios/P1/transactions"
-    assert _FakeAsyncClient.calls[3]["url"] == "http://pas/portfolios/P1/cashflow-projection"
+    assert _FakeAsyncClient.calls[0]["url"] == "http://lotus-performances/portfolios/P1"
+    assert _FakeAsyncClient.calls[1]["url"] == "http://lotus-performances/portfolios/P1/positions"
+    assert (
+        _FakeAsyncClient.calls[2]["url"] == "http://lotus-performances/portfolios/P1/transactions"
+    )
+    assert (
+        _FakeAsyncClient.calls[3]["url"]
+        == "http://lotus-performances/portfolios/P1/cashflow-projection"
+    )
 
 
 @pytest.mark.asyncio
 async def test_lotus_core_query_client_transaction_route_supports_advanced_filters_and_sorting():
-    client = LotusCoreQueryClient(base_url="http://pas", timeout_seconds=2.0)
+    client = LotusCoreQueryClient(base_url="http://lotus-performances", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"transactions": [{"transaction_id": "TX_1"}]})
 
     status_code, payload = await client.get_portfolio_transactions(
@@ -1206,7 +1211,9 @@ async def test_lotus_core_query_client_transaction_route_supports_advanced_filte
 
     assert status_code == 200
     assert payload["transactions"][0]["transaction_id"] == "TX_1"
-    assert _FakeAsyncClient.calls[0]["url"] == "http://pas/portfolios/P1/transactions"
+    assert (
+        _FakeAsyncClient.calls[0]["url"] == "http://lotus-performances/portfolios/P1/transactions"
+    )
     assert _FakeAsyncClient.calls[0]["params"] == {
         "limit": 25,
         "skip": 5,
@@ -1230,7 +1237,7 @@ async def test_lotus_core_query_client_transaction_route_supports_advanced_filte
 
 @pytest.mark.asyncio
 async def test_lotus_core_query_client_cash_balances_uses_strategic_holdings_route():
-    client = LotusCoreQueryClient(base_url="http://pas", timeout_seconds=2.0)
+    client = LotusCoreQueryClient(base_url="http://lotus-performances", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"cash_accounts": []})
 
     status_code, payload = await client.get_portfolio_cash_balances(
@@ -1242,7 +1249,9 @@ async def test_lotus_core_query_client_cash_balances_uses_strategic_holdings_rou
 
     assert status_code == 200
     assert payload["cash_accounts"] == []
-    assert _FakeAsyncClient.calls[0]["url"] == "http://pas/portfolios/P1/cash-balances"
+    assert (
+        _FakeAsyncClient.calls[0]["url"] == "http://lotus-performances/portfolios/P1/cash-balances"
+    )
     assert _FakeAsyncClient.calls[0]["params"] == {
         "as_of_date": "2026-03-27",
         "reporting_currency": "SGD",
@@ -1251,7 +1260,7 @@ async def test_lotus_core_query_client_cash_balances_uses_strategic_holdings_rou
 
 @pytest.mark.asyncio
 async def test_lotus_core_query_client_core_endpoints():
-    client = LotusCoreQueryClient(base_url="http://pas", timeout_seconds=2.0)
+    client = LotusCoreQueryClient(base_url="http://lotus-performances", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"sourceService": "pas"})
     _FakeAsyncClient.queue_json(200, {"allowedSections": ["OVERVIEW"]})
     _FakeAsyncClient.queue_json(200, {"portfolios": []})
@@ -1290,17 +1299,19 @@ async def test_lotus_core_query_client_core_endpoints():
         )
     )[0] == 200
     assert (await client.list_instruments(limit=10, correlation_id="corr-3"))[0] == 200
-    assert _FakeAsyncClient.calls[0]["url"] == "http://pas/integration/capabilities"
+    assert _FakeAsyncClient.calls[0]["url"] == "http://lotus-performances/integration/capabilities"
     assert _FakeAsyncClient.calls[0]["params"] == {
         "consumer_system": "lotus-gateway",
         "tenant_id": "default",
     }
-    assert _FakeAsyncClient.calls[1]["url"] == "http://pas/integration/policy/effective"
+    assert (
+        _FakeAsyncClient.calls[1]["url"] == "http://lotus-performances/integration/policy/effective"
+    )
     assert _FakeAsyncClient.calls[1]["params"] == {
         "consumer_system": "lotus-gateway",
         "tenant_id": "default",
     }
-    assert _FakeAsyncClient.calls[3]["url"] == "http://pas/lookups/portfolios"
+    assert _FakeAsyncClient.calls[3]["url"] == "http://lotus-performances/lookups/portfolios"
     assert _FakeAsyncClient.calls[3]["params"] == {}
     assert _FakeAsyncClient.calls[4]["json"] == {
         "as_of_date": "2026-02-24",
@@ -1309,13 +1320,13 @@ async def test_lotus_core_query_client_core_endpoints():
     }
     assert (
         _FakeAsyncClient.calls[5]["url"]
-        == "http://pas/integration/portfolios/P1/analytics/reference"
+        == "http://lotus-performances/integration/portfolios/P1/analytics/reference"
     )
 
 
 @pytest.mark.asyncio
 async def test_lotus_core_query_client_lookup_routes_preserve_filter_query_params():
-    client = LotusCoreQueryClient(base_url="http://pas", timeout_seconds=2.0)
+    client = LotusCoreQueryClient(base_url="http://lotus-performances", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"items": [{"id": "PF_1", "label": "PF_1"}]})
     _FakeAsyncClient.queue_json(200, {"items": [{"id": "SEC_1", "label": "SEC_1"}]})
     _FakeAsyncClient.queue_json(200, {"items": [{"id": "USD", "label": "USD"}]})
@@ -1347,20 +1358,20 @@ async def test_lotus_core_query_client_lookup_routes_preserve_filter_query_param
         )
     )[0] == 200
 
-    assert _FakeAsyncClient.calls[0]["url"] == "http://pas/lookups/portfolios"
+    assert _FakeAsyncClient.calls[0]["url"] == "http://lotus-performances/lookups/portfolios"
     assert _FakeAsyncClient.calls[0]["params"] == {
         "client_id": "CIF_1001",
         "booking_center_code": "SG",
         "q": "Alpha",
         "limit": 25,
     }
-    assert _FakeAsyncClient.calls[1]["url"] == "http://pas/lookups/instruments"
+    assert _FakeAsyncClient.calls[1]["url"] == "http://lotus-performances/lookups/instruments"
     assert _FakeAsyncClient.calls[1]["params"] == {
         "limit": 50,
         "product_type": "EQUITY",
         "q": "Apple",
     }
-    assert _FakeAsyncClient.calls[2]["url"] == "http://pas/lookups/currencies"
+    assert _FakeAsyncClient.calls[2]["url"] == "http://lotus-performances/lookups/currencies"
     assert _FakeAsyncClient.calls[2]["params"] == {
         "instrument_page_limit": 500,
         "source": "ALL",
@@ -1408,7 +1419,7 @@ async def test_lotus_core_query_client_capability_routes_use_canonical_snake_cas
 
 @pytest.mark.asyncio
 async def test_lotus_core_query_client_non_dict_payload_branch():
-    client = LotusCoreQueryClient(base_url="http://pas", timeout_seconds=2.0)
+    client = LotusCoreQueryClient(base_url="http://lotus-performances", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, ["not-dict"])
     status_code, payload = await client.list_portfolios(correlation_id="corr-3")
     assert status_code == 200
@@ -1417,7 +1428,9 @@ async def test_lotus_core_query_client_non_dict_payload_branch():
 
 @pytest.mark.asyncio
 async def test_pas_ingestion_client_upload_paths():
-    client = LotusCoreIngestionClient(base_url="http://pas-ingest", timeout_seconds=2.0)
+    client = LotusCoreIngestionClient(
+        base_url="http://lotus-performances-ingest", timeout_seconds=2.0
+    )
     _FakeAsyncClient.queue_json(202, {"status": "accepted"})
     _FakeAsyncClient.queue_json(200, {"columns": ["portfolio_id"]})
     _FakeAsyncClient.queue_json(201, {"importedRows": 10})
@@ -1444,8 +1457,13 @@ async def test_pas_ingestion_client_upload_paths():
     assert status_ingest == 202
     assert status_preview == 200
     assert status_commit == 201
-    assert _FakeAsyncClient.calls[1]["url"] == "http://pas-ingest/ingest/uploads/preview"
-    assert _FakeAsyncClient.calls[2]["url"] == "http://pas-ingest/ingest/uploads/commit"
+    assert (
+        _FakeAsyncClient.calls[1]["url"]
+        == "http://lotus-performances-ingest/ingest/uploads/preview"
+    )
+    assert (
+        _FakeAsyncClient.calls[2]["url"] == "http://lotus-performances-ingest/ingest/uploads/commit"
+    )
     assert _FakeAsyncClient.calls[1]["data"] == {
         "entity_type": "transactions",
         "sample_size": "5",
@@ -1459,7 +1477,9 @@ async def test_pas_ingestion_client_upload_paths():
 
 @pytest.mark.asyncio
 async def test_pas_ingestion_client_non_dict_and_text_payload_handling():
-    client = LotusCoreIngestionClient(base_url="http://pas-ingest", timeout_seconds=2.0)
+    client = LotusCoreIngestionClient(
+        base_url="http://lotus-performances-ingest", timeout_seconds=2.0
+    )
     _FakeAsyncClient.queue_json(200, [{"preview": "row"}])
     _FakeAsyncClient.queue_text(503, "ingestion unavailable")
 
@@ -1493,7 +1513,9 @@ async def test_pas_ingestion_client_non_dict_and_text_payload_handling():
 
 @pytest.mark.asyncio
 async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
-    client = LotusCoreIngestionClient(base_url="http://pas-ingest", timeout_seconds=2.0)
+    client = LotusCoreIngestionClient(
+        base_url="http://lotus-performances-ingest", timeout_seconds=2.0
+    )
     _FakeAsyncClient.queue_json(202, {"status": "accepted"})
 
     status_ingest, _ = await client.ingest_portfolio_bundle(
@@ -2065,8 +2087,8 @@ async def test_lotus_core_query_client_support_routes_use_control_plane_contract
 
 @pytest.mark.asyncio
 async def test_lotus_analytics_client_capabilities_supports_nondefault_consumer_and_tenant():
-    client = LotusAnalyticsClient(base_url="http://pa", timeout_seconds=2.0)
-    _FakeAsyncClient.queue_json(200, {"sourceService": "pa"})
+    client = LotusAnalyticsClient(base_url="http://lotus-performance", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"sourceService": "lotus-performance"})
 
     status_code, payload = await client.get_capabilities(
         consumer_system="lotus-workbench",
@@ -2075,8 +2097,8 @@ async def test_lotus_analytics_client_capabilities_supports_nondefault_consumer_
     )
 
     assert status_code == 200
-    assert payload["sourceService"] == "pa"
-    assert _FakeAsyncClient.calls[0]["url"] == "http://pa/integration/capabilities"
+    assert payload["sourceService"] == "lotus-performance"
+    assert _FakeAsyncClient.calls[0]["url"] == "http://lotus-performance/integration/capabilities"
     assert _FakeAsyncClient.calls[0]["params"] == {
         "consumer_system": "lotus-workbench",
         "tenant_id": "tenant-a",

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -140,12 +140,12 @@ def _build_service() -> tuple[
     _StubDpmClient,
 ]:
     pas = _StubLotusCoreQueryClient()
-    pa = _StubLotusAnalyticsClient()
+    performance = _StubLotusAnalyticsClient()
     dpm = _StubDpmClient()
     return (
-        WorkbenchService(lotus_core_query_client=pas, analytics_client=pa, dpm_client=dpm),
+        WorkbenchService(lotus_core_query_client=pas, analytics_client=performance, dpm_client=dpm),
         pas,
-        pa,
+        performance,
         dpm,
     )
 
@@ -422,8 +422,8 @@ async def test_apply_sandbox_changes_without_policy_evaluation():
 
 @pytest.mark.asyncio
 async def test_get_workbench_analytics_raises_on_pa_error():
-    service, _, pa, _ = _build_service()
-    pa.analytics_status = 503
+    service, _, performance, _ = _build_service()
+    performance.analytics_status = 503
     with pytest.raises(HTTPException) as exc:
         await service.get_workbench_analytics(
             portfolio_id="P1",
@@ -438,8 +438,8 @@ async def test_get_workbench_analytics_raises_on_pa_error():
 
 @pytest.mark.asyncio
 async def test_get_workbench_analytics_raises_on_invalid_payload_shape():
-    service, _, pa, _ = _build_service()
-    pa.analytics_payload = {
+    service, _, performance, _ = _build_service()
+    performance.analytics_payload = {
         "allocationBuckets": [{"bucketKey": "EQ", "currentQuantity": "bad-number"}],
         "topChanges": [],
         "riskProxy": {},
@@ -459,8 +459,8 @@ async def test_get_workbench_analytics_raises_on_invalid_payload_shape():
 
 @pytest.mark.asyncio
 async def test_get_workbench_analytics_ignores_legacy_risk_proxy_payload():
-    service, _, pa, _ = _build_service()
-    pa.analytics_payload = {
+    service, _, performance, _ = _build_service()
+    performance.analytics_payload = {
         "allocationBuckets": [],
         "topChanges": [],
         "riskProxy": {"hhiCurrent": 9999.0, "hhiProposed": 9999.0, "hhiDelta": 0.0},
@@ -615,8 +615,8 @@ def test_parse_dpm_snapshot_without_created_at_keeps_last_run_null():
 
 @pytest.mark.asyncio
 async def test_workbench_analytics_reports_controlled_risk_gap_until_risk_bff_exists():
-    service, _, pa, _ = _build_service()
-    pa.analytics_payload = {
+    service, _, performance, _ = _build_service()
+    performance.analytics_payload = {
         "allocationBuckets": [],
         "topChanges": [],
         "riskProxy": {"hhiCurrent": 100.0, "hhiProposed": 100.0, "hhiDelta": 0.0},


### PR DESCRIPTION
## Summary
- Updates gateway platform-capability normalization from old `pa.analytics.*` performance feature keys to canonical `performance.analytics.*` keys.
- Cleans performance capability contract examples and tests from `pa-v*`, `performance-analytics`, and local `_pa` fixture naming where they referred to lotus-performance.
- Keeps unrelated `pas` core fixtures unchanged.

## Evidence
- `make check` -> passed, including ruff, format check, monetary-float guard, mypy, contract test, and 362 unit/contract tests.
- Focused gateway capability/workbench tests -> passed.
- `git diff --check` -> passed.
- `rg -n "\bpa\b|_pa\b|\bPA\b" src tests docs wiki README.md` -> no matches.
- `rg -n "\bpa\." lotus-performance lotus-gateway lotus-platform` -> no public `pa.*` feature-key matches.

## Wiki
No gateway wiki source change in this PR.