### PR TITLE
Implement RFC-0108 gateway fanout metrics

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -48,12 +48,14 @@ Current repository posture:
 9. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
 10. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
 11. RFC-0108 analytics UI observability is active for selected Workbench performance and risk
-    analytics paths: Gateway owns product-safe structured fan-out logs and selected analytics read
-    audit logs. Successful upstream reads emit bounded `analytics_read_allowed` audit records, and
-    upstream `401`/`403` responses emit bounded `analytics_read_denied` audit records. Audit
-    fields must stay limited to route, panel, operation, state, reason, status class, region, and
-    environment; portfolio, client, holding, trace, correlation, request/response body, screen
-    content, and raw entitlement-failure fields remain forbidden.
+    analytics paths: Gateway owns product-safe structured fan-out logs, bounded fan-out metrics,
+    degraded-source counters, and selected analytics read audit logs. Successful upstream reads
+    emit bounded `analytics_read_allowed` audit records, and upstream `401`/`403` responses emit
+    bounded `analytics_read_denied` audit records. Gateway analytics metrics are limited to
+    `operation`, `service`, `status_class`, and degraded `reason` labels; audit fields must stay
+    limited to route, panel, operation, state, reason, status class, region, and environment;
+    portfolio, client, holding, trace, correlation, request/response body, screen content, and raw
+    entitlement-failure fields remain forbidden.
 
 ## Architecture And Module Map
 

--- a/src/app/observability/analytics_ui.py
+++ b/src/app/observability/analytics_ui.py
@@ -6,6 +6,8 @@ import time
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+from prometheus_client import Counter, Histogram
+
 ANALYTICS_UI_ALLOWED_LABELS = frozenset(
     {
         "route",
@@ -84,6 +86,18 @@ ANALYTICS_UI_AUDIT_EVENT_TYPES = frozenset(
 GATEWAY_ANALYTICS_UI_METRIC_FAMILIES = (
     "lotus_gateway_analytics_fanout_duration_seconds",
     "lotus_gateway_analytics_degraded_total",
+)
+
+GATEWAY_ANALYTICS_FANOUT_DURATION_SECONDS = Histogram(
+    "lotus_gateway_analytics_fanout_duration_seconds",
+    "Duration of Gateway analytics upstream fan-out calls.",
+    ("operation", "service", "status_class"),
+)
+
+GATEWAY_ANALYTICS_DEGRADED_TOTAL = Counter(
+    "lotus_gateway_analytics_degraded_total",
+    "Count of degraded Gateway analytics upstream fan-out calls.",
+    ("operation", "service", "reason"),
 )
 
 GATEWAY_ANALYTICS_UI_LOG_EVENTS = (
@@ -244,8 +258,33 @@ def emit_gateway_analytics_fanout_log(
         status_code=status_code,
         payload=payload,
     )
+    record_gateway_analytics_fanout_metrics(fields)
     event = str(fields["event"])
     logger.info(event, extra={"extra_fields": fields})
+
+
+def record_gateway_analytics_fanout_metrics(fields: Mapping[str, object]) -> None:
+    validated_fields = validate_gateway_analytics_ui_log_fields(fields)
+    operation = str(validated_fields["operation"])
+    service = str(validated_fields["service"])
+    status_class = str(validated_fields["status_class"])
+    duration_ms = validated_fields["duration_ms"]
+    if not isinstance(duration_ms, int | float):
+        raise ValueError("Analytics UI fan-out duration_ms must be numeric")
+    GATEWAY_ANALYTICS_FANOUT_DURATION_SECONDS.labels(
+        operation=operation,
+        service=service,
+        status_class=status_class,
+    ).observe(float(duration_ms) / 1000)
+
+    if validated_fields.get("event") == "gateway.analytics.fanout.degraded":
+        GATEWAY_ANALYTICS_DEGRADED_TOTAL.labels(
+            operation=operation,
+            service=service,
+            reason=_safe_dimension(
+                str(validated_fields.get("reason") or "unknown"), default="unknown"
+            ),
+        ).inc()
 
 
 def emit_gateway_analytics_read_audit_log(

--- a/tests/unit/test_analytics_ui_observability_contract.py
+++ b/tests/unit/test_analytics_ui_observability_contract.py
@@ -10,12 +10,15 @@ from app.observability.analytics_ui import (
     ANALYTICS_UI_SEVERITY_LEVELS,
     ANALYTICS_UI_STATE_VOCABULARY,
     ANALYTICS_UI_TRACE_ATTRIBUTES,
+    GATEWAY_ANALYTICS_DEGRADED_TOTAL,
+    GATEWAY_ANALYTICS_FANOUT_DURATION_SECONDS,
     GATEWAY_ANALYTICS_UI_AUDIT_LOG_EVENTS,
     GATEWAY_ANALYTICS_UI_AUDIT_LOG_FIELDS,
     GATEWAY_ANALYTICS_UI_LOG_EVENTS,
     GATEWAY_ANALYTICS_UI_METRIC_FAMILIES,
     GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS,
     is_analytics_ui_state,
+    record_gateway_analytics_fanout_metrics,
     validate_analytics_ui_attributes,
     validate_analytics_ui_labels,
     validate_gateway_analytics_ui_audit_log_fields,
@@ -28,6 +31,10 @@ def test_gateway_metric_families_are_explicitly_scoped_to_gateway() -> None:
         "lotus_gateway_analytics_fanout_duration_seconds",
         "lotus_gateway_analytics_degraded_total",
     )
+    duration_labels = GATEWAY_ANALYTICS_FANOUT_DURATION_SECONDS._labelnames
+    degraded_labels = GATEWAY_ANALYTICS_DEGRADED_TOTAL._labelnames
+    assert duration_labels == ("operation", "service", "status_class")
+    assert degraded_labels == ("operation", "service", "reason")
 
 
 def test_state_vocabulary_matches_governed_analytics_ui_states() -> None:
@@ -181,3 +188,91 @@ def test_validate_gateway_analytics_ui_audit_log_fields_accepts_bounded_runtime_
     assert fields["state"] == "permission_blocked"
     assert "portfolio_id" not in fields
     assert "raw_entitlement_failure" not in fields
+
+
+def test_record_gateway_analytics_fanout_metrics_records_safe_labels() -> None:
+    before_duration_count = _sample_value(
+        GATEWAY_ANALYTICS_FANOUT_DURATION_SECONDS,
+        "lotus_gateway_analytics_fanout_duration_seconds_count",
+        {
+            "operation": "analytics.risk.calculate",
+            "service": "lotus-risk",
+            "status_class": "5xx",
+        },
+    )
+    before_degraded_count = _sample_value(
+        GATEWAY_ANALYTICS_DEGRADED_TOTAL,
+        "lotus_gateway_analytics_degraded_total",
+        {
+            "operation": "analytics.risk.calculate",
+            "service": "lotus-risk",
+            "reason": "upstream_unavailable",
+        },
+    )
+
+    record_gateway_analytics_fanout_metrics(
+        {
+            "event": "gateway.analytics.fanout.degraded",
+            "route": "workbench-analytics",
+            "service": "lotus-risk",
+            "operation": "analytics.risk.calculate",
+            "state": "degraded",
+            "reason": "UPSTREAM_UNAVAILABLE",
+            "status_class": "5xx",
+            "duration_ms": 125.0,
+            "warning_count": 0,
+            "partial_failure_count": 0,
+        }
+    )
+
+    assert (
+        _sample_value(
+            GATEWAY_ANALYTICS_FANOUT_DURATION_SECONDS,
+            "lotus_gateway_analytics_fanout_duration_seconds_count",
+            {
+                "operation": "analytics.risk.calculate",
+                "service": "lotus-risk",
+                "status_class": "5xx",
+            },
+        )
+        == before_duration_count + 1
+    )
+    assert (
+        _sample_value(
+            GATEWAY_ANALYTICS_DEGRADED_TOTAL,
+            "lotus_gateway_analytics_degraded_total",
+            {
+                "operation": "analytics.risk.calculate",
+                "service": "lotus-risk",
+                "reason": "upstream_unavailable",
+            },
+        )
+        == before_degraded_count + 1
+    )
+
+
+def test_record_gateway_analytics_fanout_metrics_rejects_sensitive_labels() -> None:
+    with pytest.raises(ValueError, match="forbidden field"):
+        record_gateway_analytics_fanout_metrics(
+            {
+                "event": "gateway.analytics.fanout.degraded",
+                "route": "workbench-analytics",
+                "service": "lotus-risk",
+                "operation": "analytics.risk.calculate",
+                "state": "degraded",
+                "reason": "UPSTREAM_UNAVAILABLE",
+                "status_class": "5xx",
+                "duration_ms": 125.0,
+                "warning_count": 0,
+                "partial_failure_count": 0,
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            }
+        )
+
+
+def _sample_value(collector: object, sample_name: str, labels: dict[str, str]) -> float:
+    for metric in collector.collect():
+        for sample in metric.samples:
+            if sample.name == sample_name and dict(sample.labels) == labels:
+                return float(sample.value)
+    return 0.0

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -61,6 +61,11 @@
 - selected lookup filters remain snake_case, such as `cif_id`, `booking_center`, `product_type`,
   and `instrument_page_limit`
 - proposal writes require `Idempotency-Key`
+- `/metrics` includes RFC-0108 gateway analytics fan-out metrics for selected Workbench analytics
+  operations: `lotus_gateway_analytics_fanout_duration_seconds` and
+  `lotus_gateway_analytics_degraded_total`. Labels are bounded to operation/service/status class
+  and degraded reason; portfolio, client, trace, correlation, request, and response content are not
+  metric labels.
 
 ## Request examples
 

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -22,20 +22,23 @@
 
 - RFC-0108 analytics UI observability vocabulary is code-owned in
   `src/app/observability/analytics_ui.py`.
-- The module defines allowed labels, forbidden fields, state vocabulary, and planned gateway
-  metric-family names before analytics fan-out metrics are emitted.
+- The module defines allowed labels, forbidden fields, state vocabulary, and gateway analytics
+  metric-family names.
 - Do not add gateway analytics metric labels outside that contract.
 - `portfolio_id`, `client_id`, `client_name`, `holding_id`, `transaction_id`, `trace_id`,
   `correlation_id`, request bodies, response bodies, and raw entitlement failures must not become
   metric labels or structured telemetry dimensions.
 - Gateway emits product-safe structured fan-out logs for selected Workbench performance and risk
   analytics operations.
+- Gateway emits `lotus_gateway_analytics_fanout_duration_seconds` with bounded `operation`,
+  `service`, and `status_class` labels for selected Workbench analytics fan-out operations.
+- Gateway emits `lotus_gateway_analytics_degraded_total` with bounded `operation`, `service`, and
+  `reason` labels when selected Workbench analytics fan-out is partial, degraded, or failed.
 - Gateway emits product-safe selected analytics read audit logs for upstream read outcomes:
   `gateway.analytics.audit.analytics_read_allowed` for successful upstream reads and
   `gateway.analytics.audit.analytics_read_denied` for `401` or `403` upstream denials.
-- Gateway analytics fan-out metrics, degraded-source counters, dashboard claims, Workbench
-  attention events outside the Workbench surface, and protected diagnostics lookup audit remain
-  planned until later RFC-0108 slices promote them with evidence.
+- Dashboard claims, Workbench attention events outside the Workbench surface, and protected
+  diagnostics lookup audit remain planned until later RFC-0108 slices promote them with evidence.
 
 ## Practical probes
 


### PR DESCRIPTION
## Summary
- emits `lotus_gateway_analytics_fanout_duration_seconds` for selected Workbench analytics fan-out
- emits `lotus_gateway_analytics_degraded_total` for selected degraded/partial/failed analytics fan-out
- keeps metric labels bounded to operation/service/status-class and degraded reason, with no portfolio/client/trace/correlation/body labels
- updates gateway repo context and wiki source to document the metric posture

## Evidence
- `python -m pytest tests\unit\test_analytics_ui_observability_contract.py tests\unit\test_upstream_clients.py -q` -> 70 passed
- `python -m ruff check src\app\observability\analytics_ui.py tests\unit\test_analytics_ui_observability_contract.py` -> passed
- `git diff --check` -> passed with Windows CRLF warnings only

## Wiki
- Repo-local `wiki/API-Surface.md` and `wiki/Operations-Runbook.md` changed.
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` currently reports expected published-wiki drift for those files; publish after merge.