### PR TITLE
RFC-0108 protected analytics diagnostics lookup

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -49,13 +49,15 @@ Current repository posture:
 10. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
 11. RFC-0108 analytics UI observability is active for selected Workbench performance and risk
     analytics paths: Gateway owns product-safe structured fan-out logs, bounded fan-out metrics,
-    degraded-source counters, and selected analytics read audit logs. Successful upstream reads
-    emit bounded `analytics_read_allowed` audit records, and upstream `401`/`403` responses emit
-    bounded `analytics_read_denied` audit records. Gateway analytics metrics are limited to
-    `operation`, `service`, `status_class`, and degraded `reason` labels; audit fields must stay
-    limited to route, panel, operation, state, reason, status class, region, and environment;
-    portfolio, client, holding, trace, correlation, request/response body, screen content, and raw
-    entitlement-failure fields remain forbidden.
+    degraded-source counters, selected analytics read audit logs, and a protected operator
+    diagnostics lookup under `/api/v1/analytics-ui/diagnostics/{support_reference}`. Successful
+    upstream reads emit bounded `analytics_read_allowed` audit records, upstream `401`/`403`
+    responses emit bounded `analytics_read_denied` audit records, and protected diagnostics
+    lookups emit bounded `protected_diagnostics_lookup` audit records. Gateway analytics metrics
+    are limited to `operation`, `service`, `status_class`, and degraded `reason` labels; audit
+    fields must stay limited to route, panel, operation, state, reason, status class, region, and
+    environment; portfolio, client, holding, trace, correlation, request/response body, screen
+    content, and raw entitlement-failure fields remain forbidden.
 
 ## Architecture And Module Map
 

--- a/src/app/contracts/analytics_diagnostics.py
+++ b/src/app/contracts/analytics_diagnostics.py
@@ -1,0 +1,93 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+ANALYTICS_DIAGNOSTICS_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "contractVersion": "analytics-ui-diagnostics.v1",
+    "supportReference": "gdiag-risk-summary-permission-blocked",
+    "route": "workbench-analytics",
+    "panel": "risk-summary",
+    "lookupStatus": "available",
+    "supportabilityState": "permission_blocked",
+    "auditEvent": "gateway.analytics.audit.protected_diagnostics_lookup",
+    "safeDimensions": {
+        "operation": "analytics.risk.calculate",
+        "service": "lotus-risk",
+        "state": "permission_blocked",
+        "reason": "upstream_authorization_denied",
+    },
+    "operatorGuidance": [
+        "Confirm caller entitlement and region posture in the authoritative upstream service.",
+        "Use correlation evidence from the protected operational log store, not dashboard labels.",
+    ],
+    "forbiddenFields": [
+        "portfolio_id",
+        "client_id",
+        "holding_id",
+        "trace_id",
+        "correlation_id",
+        "request_body",
+        "response_body",
+        "raw_entitlement_failure",
+    ],
+}
+
+
+class AnalyticsDiagnosticsResponse(BaseModel):
+    contract_version: str = Field(
+        default="analytics-ui-diagnostics.v1",
+        alias="contractVersion",
+        description="Version of the bounded analytics diagnostics lookup contract.",
+    )
+    support_reference: str = Field(
+        ...,
+        alias="supportReference",
+        description="Opaque safe support reference supplied by the operator.",
+        examples=["gdiag-risk-summary-permission-blocked"],
+    )
+    route: Literal["workbench-analytics"] = Field(
+        default="workbench-analytics",
+        description="Gateway analytics route family covered by this lookup.",
+    )
+    panel: str = Field(
+        ...,
+        description="Product-safe analytics panel classification resolved from the reference.",
+        examples=["risk-summary"],
+    )
+    lookup_status: Literal["available"] = Field(
+        default="available",
+        alias="lookupStatus",
+        description=(
+            "Lookup result state. Missing raw evidence is represented by guidance, not PII."
+        ),
+    )
+    supportability_state: str = Field(
+        ...,
+        alias="supportabilityState",
+        description="Governed supportability state for the referenced analytics posture.",
+        examples=["permission_blocked"],
+    )
+    audit_event: Literal["gateway.analytics.audit.protected_diagnostics_lookup"] = Field(
+        default="gateway.analytics.audit.protected_diagnostics_lookup",
+        alias="auditEvent",
+        description="Bounded audit event emitted for this protected lookup.",
+    )
+    safe_dimensions: dict[str, str] = Field(
+        ...,
+        alias="safeDimensions",
+        description="Metric-safe dimensions that may be used for operator triage.",
+    )
+    operator_guidance: list[str] = Field(
+        ...,
+        alias="operatorGuidance",
+        description="Bounded operator next steps that do not expose sensitive source payloads.",
+    )
+    forbidden_fields: list[str] = Field(
+        ...,
+        alias="forbiddenFields",
+        description=(
+            "Fields that must remain out of analytics labels, dashboards, and audit fields."
+        ),
+    )
+
+    model_config = {"populate_by_name": True}

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -10,6 +10,7 @@ from app.enterprise_readiness import (
     validate_enterprise_runtime_config,
 )
 from app.middleware.correlation import correlation_id_var, correlation_middleware, setup_logging
+from app.routers.analytics_diagnostics import router as analytics_diagnostics_router
 from app.routers.archive_documents import router as archive_documents_router
 from app.routers.domain_products import router as domain_products_router
 from app.routers.foundation import router as foundation_router
@@ -60,6 +61,12 @@ app = FastAPI(
                 "Gateway-facing archived document metadata and controlled download APIs."
             ),
         },
+        {
+            "name": "Analytics Diagnostics",
+            "description": (
+                "Protected operator analytics UI diagnostics lookup with bounded audit posture."
+            ),
+        },
     ],
 )
 setup_logging()
@@ -79,6 +86,7 @@ app.include_router(reporting_jobs_router)
 app.include_router(reporting_batches_router)
 app.include_router(reporting_schedules_router)
 app.include_router(archive_documents_router)
+app.include_router(analytics_diagnostics_router)
 
 
 @app.get("/health")

--- a/src/app/observability/analytics_ui.py
+++ b/src/app/observability/analytics_ui.py
@@ -108,6 +108,7 @@ GATEWAY_ANALYTICS_UI_LOG_EVENTS = (
 GATEWAY_ANALYTICS_UI_AUDIT_LOG_EVENTS = (
     "gateway.analytics.audit.analytics_read_allowed",
     "gateway.analytics.audit.analytics_read_denied",
+    "gateway.analytics.audit.protected_diagnostics_lookup",
 )
 
 GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS = (
@@ -300,6 +301,29 @@ def emit_gateway_analytics_read_audit_log(
     if not fields:
         return
     logger.info(str(fields["event"]), extra={"extra_fields": fields})
+
+
+def emit_gateway_protected_diagnostics_audit_log(
+    *,
+    logger: logging.Logger,
+    status_code: int,
+    reason: str,
+) -> None:
+    fields = {
+        "event": "gateway.analytics.audit.protected_diagnostics_lookup",
+        "route": "workbench-analytics",
+        "panel": "protected-diagnostics",
+        "operation": "analytics-ui.protected-diagnostics.lookup",
+        "state": "ready" if 0 < status_code < 400 else "permission_blocked",
+        "reason": reason,
+        "status_class": _status_class(status_code),
+        "region": _safe_dimension(os.getenv("LOTUS_REGION"), default="unknown"),
+        "environment": _safe_dimension(os.getenv("LOTUS_ENVIRONMENT"), default="local"),
+    }
+    logger.info(
+        "gateway.analytics.audit.protected_diagnostics_lookup",
+        extra={"extra_fields": validate_gateway_analytics_ui_audit_log_fields(fields)},
+    )
 
 
 def _gateway_analytics_fanout_fields(

--- a/src/app/routers/analytics_diagnostics.py
+++ b/src/app/routers/analytics_diagnostics.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import Annotated
+
+from fastapi import APIRouter, Header, HTTPException, Path, status
+
+from app.contracts.analytics_diagnostics import (
+    ANALYTICS_DIAGNOSTICS_RESPONSE_EXAMPLE,
+    AnalyticsDiagnosticsResponse,
+)
+from app.observability.analytics_ui import (
+    ANALYTICS_UI_FORBIDDEN_FIELDS,
+    emit_gateway_protected_diagnostics_audit_log,
+)
+from app.services.caller_context import caller_context_headers
+
+logger = logging.getLogger("analytics_ui.gateway")
+
+router = APIRouter(prefix="/api/v1/analytics-ui", tags=["Analytics Diagnostics"])
+
+_SAFE_SUPPORT_REFERENCE = re.compile(r"^gdiag-[A-Za-z0-9][A-Za-z0-9_.:-]{1,121}$")
+_AUTHORIZED_OPERATOR_ROLES = {
+    "admin",
+    "ops",
+    "operations",
+    "operator",
+    "support",
+    "support_operator",
+}
+
+
+@router.get(
+    "/diagnostics/{support_reference}",
+    response_model=AnalyticsDiagnosticsResponse,
+    summary="Resolve protected analytics diagnostics posture",
+    description=(
+        "Resolve an opaque analytics UI support reference into product-safe operator posture. "
+        "This endpoint requires governed caller context plus an operator role and returns only "
+        "bounded dimensions, supportability state, and runbook guidance. It must not expose raw "
+        "portfolio, client, holding, trace, correlation, request, response, or entitlement data."
+    ),
+    openapi_extra={
+        "responses": {
+            "200": {
+                "content": {"application/json": {"example": ANALYTICS_DIAGNOSTICS_RESPONSE_EXAMPLE}}
+            }
+        }
+    },
+)
+async def lookup_analytics_diagnostics(
+    support_reference: Annotated[
+        str,
+        Path(
+            description=(
+                "Opaque safe analytics support reference. Raw portfolio, client, holding, "
+                "trace, correlation, request, response, and entitlement identifiers are rejected."
+            ),
+            examples=["gdiag-risk-summary-permission-blocked"],
+        ),
+    ],
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> AnalyticsDiagnosticsResponse:
+    try:
+        caller_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        )
+    except HTTPException:
+        emit_gateway_protected_diagnostics_audit_log(
+            logger=logger,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            reason="missing_caller_context",
+        )
+        raise
+
+    normalized_role = (role or "").strip().lower().replace("-", "_")
+    if normalized_role not in _AUTHORIZED_OPERATOR_ROLES:
+        emit_gateway_protected_diagnostics_audit_log(
+            logger=logger,
+            status_code=status.HTTP_403_FORBIDDEN,
+            reason="operator_role_required",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "operator_role_required",
+                "message": "Analytics diagnostics lookup requires an operator support role.",
+            },
+        )
+
+    if not _SAFE_SUPPORT_REFERENCE.fullmatch(support_reference):
+        emit_gateway_protected_diagnostics_audit_log(
+            logger=logger,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            reason="invalid_support_reference",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "invalid_support_reference",
+                "message": "Support reference must be opaque and product-safe.",
+            },
+        )
+
+    response = _resolve_support_reference(support_reference)
+    emit_gateway_protected_diagnostics_audit_log(
+        logger=logger,
+        status_code=status.HTTP_200_OK,
+        reason="lookup_succeeded",
+    )
+    return response
+
+
+def _resolve_support_reference(support_reference: str) -> AnalyticsDiagnosticsResponse:
+    normalized = support_reference.lower()
+    if "risk" in normalized:
+        panel = "risk-summary"
+        operation = "analytics.risk.calculate"
+        service = "lotus-risk"
+    elif "performance" in normalized:
+        panel = "performance-summary"
+        operation = "performance.workspace-summary"
+        service = "lotus-performance"
+    else:
+        panel = "unknown"
+        operation = "analytics-ui.lookup"
+        service = "unknown"
+
+    if "permission" in normalized or "denied" in normalized or "blocked" in normalized:
+        supportability_state = "permission_blocked"
+        reason = "upstream_authorization_denied"
+    elif "degraded" in normalized or "partial" in normalized:
+        supportability_state = "degraded"
+        reason = "upstream_partial_or_degraded"
+    else:
+        supportability_state = "ready"
+        reason = "safe_reference_resolved"
+
+    return AnalyticsDiagnosticsResponse(
+        supportReference=support_reference,
+        panel=panel,
+        supportabilityState=supportability_state,
+        safeDimensions={
+            "operation": operation,
+            "service": service,
+            "state": supportability_state,
+            "reason": reason,
+        },
+        operatorGuidance=_operator_guidance(supportability_state),
+        forbiddenFields=sorted(ANALYTICS_UI_FORBIDDEN_FIELDS),
+    )
+
+
+def _operator_guidance(supportability_state: str) -> list[str]:
+    if supportability_state == "permission_blocked":
+        return [
+            "Confirm caller entitlement and region posture in the authoritative upstream service.",
+            (
+                "Use protected operational evidence for correlation lookup; do not add identifiers "
+                "to dashboard labels."
+            ),
+        ]
+    if supportability_state == "degraded":
+        return [
+            (
+                "Check upstream service health and partial-failure posture for the safe operation "
+                "dimension."
+            ),
+            "Escalate with bounded service, operation, state, and reason only.",
+        ]
+    return [
+        (
+            "Use the safe dimensions to locate the relevant analytics panel and upstream service "
+            "posture."
+        ),
+        (
+            "Keep raw request, response, trace, correlation, and client identifiers out of "
+            "analytics UI telemetry."
+        ),
+    ]

--- a/tests/integration/test_analytics_diagnostics_router.py
+++ b/tests/integration/test_analytics_diagnostics_router.py
@@ -1,0 +1,133 @@
+import logging
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _operator_headers(**overrides: str) -> dict[str, str]:
+    headers = {
+        "X-Actor-Id": "support-operator-1",
+        "X-Tenant-Id": "tenant-sg",
+        "X-Region": "APAC",
+        "X-Role": "support-operator",
+        "X-Correlation-Id": "corr-protected-diagnostics",
+    }
+    headers.update(overrides)
+    return headers
+
+
+def test_protected_analytics_diagnostics_lookup_returns_product_safe_posture(caplog):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/analytics-ui/diagnostics/gdiag-risk-summary-permission-blocked",
+        headers=_operator_headers(),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["contractVersion"] == "analytics-ui-diagnostics.v1"
+    assert body["panel"] == "risk-summary"
+    assert body["supportabilityState"] == "permission_blocked"
+    assert body["safeDimensions"] == {
+        "operation": "analytics.risk.calculate",
+        "service": "lotus-risk",
+        "state": "permission_blocked",
+        "reason": "upstream_authorization_denied",
+    }
+    assert body["auditEvent"] == "gateway.analytics.audit.protected_diagnostics_lookup"
+    assert "portfolio_id" in body["forbiddenFields"]
+    assert "correlation_id" in body["forbiddenFields"]
+    assert "PB_SG_GLOBAL_BAL_001" not in str(body)
+    assert "trace-" not in str(body)
+
+    audit_record = _protected_diagnostics_record(caplog.records)
+    assert audit_record.extra_fields["event"] == (
+        "gateway.analytics.audit.protected_diagnostics_lookup"
+    )
+    assert audit_record.extra_fields["reason"] == "lookup_succeeded"
+    assert "support_reference" not in audit_record.extra_fields
+
+
+def test_protected_analytics_diagnostics_lookup_requires_operator_role(caplog):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/analytics-ui/diagnostics/gdiag-risk-summary-permission-blocked",
+        headers=_operator_headers(**{"X-Role": "advisor"}),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "operator_role_required"
+    audit_record = _protected_diagnostics_record(caplog.records)
+    assert audit_record.extra_fields["state"] == "permission_blocked"
+    assert audit_record.extra_fields["reason"] == "operator_role_required"
+
+
+def test_protected_analytics_diagnostics_lookup_requires_caller_context(caplog):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/analytics-ui/diagnostics/gdiag-risk-summary-permission-blocked",
+        headers={"X-Role": "support-operator"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "missing_caller_context"
+    audit_record = _protected_diagnostics_record(caplog.records)
+    assert audit_record.extra_fields["reason"] == "missing_caller_context"
+    assert "actor_id" not in audit_record.extra_fields
+
+
+def test_protected_analytics_diagnostics_lookup_rejects_unsafe_reference(caplog):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/analytics-ui/diagnostics/bad%20reference",
+        headers=_operator_headers(),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "invalid_support_reference"
+    audit_record = _protected_diagnostics_record(caplog.records)
+    assert audit_record.extra_fields["reason"] == "invalid_support_reference"
+
+
+def test_protected_analytics_diagnostics_lookup_rejects_raw_identifier_reference(caplog):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/analytics-ui/diagnostics/PB_SG_GLOBAL_BAL_001",
+        headers=_operator_headers(),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "invalid_support_reference"
+    audit_record = _protected_diagnostics_record(caplog.records)
+    assert audit_record.extra_fields["reason"] == "invalid_support_reference"
+
+
+def test_protected_analytics_diagnostics_lookup_is_documented_in_openapi():
+    schema = app.openapi()
+    route = schema["paths"]["/api/v1/analytics-ui/diagnostics/{support_reference}"]["get"]
+
+    assert route["tags"] == ["Analytics Diagnostics"]
+    assert route["summary"] == "Resolve protected analytics diagnostics posture"
+    assert route["responses"]["200"]["content"]["application/json"]["example"]["auditEvent"] == (
+        "gateway.analytics.audit.protected_diagnostics_lookup"
+    )
+
+
+def _protected_diagnostics_record(records):
+    return next(
+        record
+        for record in records
+        if record.name == "analytics_ui.gateway"
+        and record.message == "gateway.analytics.audit.protected_diagnostics_lookup"
+    )

--- a/tests/unit/test_analytics_ui_observability_contract.py
+++ b/tests/unit/test_analytics_ui_observability_contract.py
@@ -17,6 +17,7 @@ from app.observability.analytics_ui import (
     GATEWAY_ANALYTICS_UI_LOG_EVENTS,
     GATEWAY_ANALYTICS_UI_METRIC_FAMILIES,
     GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS,
+    emit_gateway_protected_diagnostics_audit_log,
     is_analytics_ui_state,
     record_gateway_analytics_fanout_metrics,
     validate_analytics_ui_attributes,
@@ -51,6 +52,7 @@ def test_gateway_log_events_and_severity_vocabularies_are_explicit() -> None:
     assert GATEWAY_ANALYTICS_UI_AUDIT_LOG_EVENTS == (
         "gateway.analytics.audit.analytics_read_allowed",
         "gateway.analytics.audit.analytics_read_denied",
+        "gateway.analytics.audit.protected_diagnostics_lookup",
     )
     assert ANALYTICS_UI_SEVERITY_LEVELS == {
         "info",
@@ -188,6 +190,40 @@ def test_validate_gateway_analytics_ui_audit_log_fields_accepts_bounded_runtime_
     assert fields["state"] == "permission_blocked"
     assert "portfolio_id" not in fields
     assert "raw_entitlement_failure" not in fields
+
+
+def test_protected_diagnostics_audit_log_uses_bounded_fields(caplog) -> None:
+    import logging
+
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    logger = logging.getLogger("analytics_ui.gateway")
+
+    emit_gateway_protected_diagnostics_audit_log(
+        logger=logger,
+        status_code=200,
+        reason="lookup_succeeded",
+    )
+
+    record = next(
+        record
+        for record in caplog.records
+        if record.name == "analytics_ui.gateway"
+        and record.message == "gateway.analytics.audit.protected_diagnostics_lookup"
+    )
+    fields = record.extra_fields
+    assert fields == {
+        "event": "gateway.analytics.audit.protected_diagnostics_lookup",
+        "route": "workbench-analytics",
+        "panel": "protected-diagnostics",
+        "operation": "analytics-ui.protected-diagnostics.lookup",
+        "state": "ready",
+        "reason": "lookup_succeeded",
+        "status_class": "2xx",
+        "region": "unknown",
+        "environment": "local",
+    }
+    assert "support_reference" not in fields
+    assert "trace_id" not in fields
 
 
 def test_record_gateway_analytics_fanout_metrics_records_safe_labels() -> None:

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -21,6 +21,7 @@
 - `GET /api/v1/report-batch-schedules` and `POST /api/v1/report-batch-schedules:run-due`
 - `GET /api/v1/documents/{document_id}`
 - `GET /api/v1/documents/{document_id}/download`
+- `GET /api/v1/analytics-ui/diagnostics/{support_reference}`
 - `/health`, `/health/live`, `/health/ready`, `/metrics`, `/docs`
 
 ## Current contract notes
@@ -66,6 +67,11 @@
   `lotus_gateway_analytics_degraded_total`. Labels are bounded to operation/service/status class
   and degraded reason; portfolio, client, trace, correlation, request, and response content are not
   metric labels.
+- analytics UI protected diagnostics lookup is gateway-first under
+  `/api/v1/analytics-ui/diagnostics/{support_reference}`. It requires `X-Actor-Id`,
+  `X-Tenant-Id`, `X-Region`, and an operator support role in `X-Role`; it returns only safe panel,
+  operation, service, state, reason, forbidden-field, and operator-guidance posture and emits
+  `gateway.analytics.audit.protected_diagnostics_lookup`.
 
 ## Request examples
 
@@ -219,6 +225,16 @@ curl "http://127.0.0.1:8111/api/v1/documents/doc_example/download" \
   -H "X-Booking-Center-Code: SG" \
   -H "X-Role: advisor" \
   --output portfolio-review.pdf
+```
+
+Analytics diagnostics protected lookup:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/analytics-ui/diagnostics/gdiag-risk-summary-permission-blocked" \
+  -H "X-Actor-Id: support-operator-1" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -H "X-Role: support-operator"
 ```
 
 Proposal creation:

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -37,8 +37,17 @@
 - Gateway emits product-safe selected analytics read audit logs for upstream read outcomes:
   `gateway.analytics.audit.analytics_read_allowed` for successful upstream reads and
   `gateway.analytics.audit.analytics_read_denied` for `401` or `403` upstream denials.
-- Dashboard claims, Workbench attention events outside the Workbench surface, and protected
-  diagnostics lookup audit remain planned until later RFC-0108 slices promote them with evidence.
+- Gateway exposes a protected operator lookup at
+  `GET /api/v1/analytics-ui/diagnostics/{support_reference}`. It requires `X-Actor-Id`,
+  `X-Tenant-Id`, `X-Region`, and an operator support role in `X-Role`.
+- Protected analytics diagnostics lookups emit
+  `gateway.analytics.audit.protected_diagnostics_lookup` with only bounded audit fields:
+  route, panel, operation, state, reason, status class, region, and environment.
+- The diagnostics response resolves opaque safe support references into panel, operation, service,
+  supportability state, and operator guidance. It must not expose portfolio, client, holding,
+  trace, correlation, request, response, or raw entitlement-failure identifiers.
+- Dashboard claims and Workbench attention events outside the Workbench surface remain planned
+  until later RFC-0108 slices promote them with evidence.
 
 ## Practical probes
 
@@ -46,6 +55,11 @@
 curl http://127.0.0.1:8111/health/ready
 curl "http://127.0.0.1:8111/api/v1/foundation/portfolios/PF_1001/workspace"
 curl "http://127.0.0.1:8111/api/v1/platform/capabilities?consumerSystem=lotus-workbench&tenantId=default"
+curl "http://127.0.0.1:8111/api/v1/analytics-ui/diagnostics/gdiag-risk-summary-permission-blocked" \
+  -H "X-Actor-Id: support-operator-1" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -H "X-Role: support-operator"
 ```
 
 ## Key references


### PR DESCRIPTION
## Summary
- add protected operator analytics diagnostics lookup under /api/v1/analytics-ui/diagnostics/{support_reference}
- emit bounded gateway.analytics.audit.protected_diagnostics_lookup audit events
- document the operator contract in repo context and wiki source

## Validation
- python -m ruff check src\\app\\observability\\analytics_ui.py src\\app\\contracts\\analytics_diagnostics.py src\\app\\routers\\analytics_diagnostics.py tests\\unit\\test_analytics_ui_observability_contract.py tests\\integration\\test_analytics_diagnostics_router.py
- python -m ruff format --check src\\app\\observability\\analytics_ui.py src\\app\\contracts\\analytics_diagnostics.py src\\app\\routers\\analytics_diagnostics.py tests\\unit\\test_analytics_ui_observability_contract.py tests\\integration\\test_analytics_diagnostics_router.py
- python -m mypy src\\app\\observability\\analytics_ui.py src\\app\\contracts\\analytics_diagnostics.py src\\app\\routers\\analytics_diagnostics.py
- python -m pytest tests\\unit\\test_analytics_ui_observability_contract.py tests\\integration\\test_analytics_diagnostics_router.py tests\\contract\\test_workbench_contract.py -q
- python scripts\\migration_contract_check.py --mode no-schema
- make check

## Wiki
- Updated repo-local wiki source. Sync-RepoWikis.ps1 -CheckOnly reports expected drift for API-Surface.md and Operations-Runbook.md until this PR merges and wiki is published.