### PR TITLE
Expand Gateway fanout observability coverage

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -48,16 +48,19 @@ Current repository posture:
 9. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
 10. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
 11. RFC-0108 analytics UI observability is active for selected Workbench performance and risk
-    analytics paths: Gateway owns product-safe structured fan-out logs, bounded fan-out metrics,
-    degraded-source counters, selected analytics read audit logs, and a protected operator
-    diagnostics lookup under `/api/v1/analytics-ui/diagnostics/{support_reference}`. Successful
-    upstream reads emit bounded `analytics_read_allowed` audit records, upstream `401`/`403`
-    responses emit bounded `analytics_read_denied` audit records, and protected diagnostics
-    lookups emit bounded `protected_diagnostics_lookup` audit records. Gateway analytics metrics
-    are limited to `operation`, `service`, `status_class`, and degraded `reason` labels; audit
-    fields must stay limited to route, panel, operation, state, reason, status class, region, and
-    environment; portfolio, client, holding, trace, correlation, request/response body, screen
-    content, and raw entitlement-failure fields remain forbidden.
+    analytics paths, and has expanded fan-out coverage for central `lotus-manage`,
+    `lotus-report`, `lotus-archive`, and `lotus-ai` client seams. Gateway owns product-safe
+    structured fan-out logs, bounded fan-out metrics, degraded-source counters, selected analytics
+    read audit logs, and a protected operator diagnostics lookup under
+    `/api/v1/analytics-ui/diagnostics/{support_reference}`. Successful upstream reads emit bounded
+    `analytics_read_allowed` audit records, upstream `401`/`403` responses emit bounded
+    `analytics_read_denied` audit records, and protected diagnostics lookups emit bounded
+    `protected_diagnostics_lookup` audit records. Gateway analytics metrics are limited to
+    `operation`, `service`, `status_class`, and degraded `reason` labels; audit fields must stay
+    limited to route, panel, operation, state, reason, status class, region, and environment;
+    portfolio, client, holding, trace, correlation, document, request/response body, screen
+    content, raw prompt, model output, and raw entitlement-failure fields remain forbidden. Full
+    all-UI fan-out rollout remains open until the remaining direct core-query paths are migrated.
 
 ## Architecture And Module Map
 

--- a/src/app/clients/archive_client.py
+++ b/src/app/clients/archive_client.py
@@ -1,7 +1,13 @@
+import logging
 from typing import Any
 
-from app.clients.http_resilience import request_binary_with_retry, request_with_retry
+from app.clients.observed_fanout import (
+    request_observed_binary_fanout,
+    request_observed_fanout,
+)
 from app.middleware.correlation import propagation_headers
+
+logger = logging.getLogger("analytics_ui.gateway")
 
 
 class ArchiveClient:
@@ -28,7 +34,12 @@ class ArchiveClient:
         suffix = "/current" if current else ""
         url = f"{self._base_url}/documents/{document_id}{suffix}"
         headers = self._archive_headers(caller_headers, correlation_id)
-        return await request_with_retry(
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-archive",
+            operation=(
+                "archive.documents.current-metadata" if current else "archive.documents.metadata"
+            ),
             method="GET",
             url=url,
             timeout_seconds=self._timeout,
@@ -46,7 +57,10 @@ class ArchiveClient:
     ) -> tuple[int, bytes, dict[str, str], dict[str, Any]]:
         url = f"{self._base_url}/documents/{document_id}/download"
         headers = self._archive_headers(caller_headers, correlation_id)
-        return await request_binary_with_retry(
+        return await request_observed_binary_fanout(
+            logger=logger,
+            service="lotus-archive",
+            operation="archive.documents.download",
             method="GET",
             url=url,
             timeout_seconds=self._timeout,

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -1,7 +1,10 @@
+import logging
 from typing import Any
 
-from app.clients.http_resilience import request_with_retry
+from app.clients.observed_fanout import request_observed_fanout
 from app.middleware.correlation import propagation_headers
+
+logger = logging.getLogger("analytics_ui.gateway")
 
 
 class DpmClient:
@@ -27,6 +30,7 @@ class DpmClient:
             "/api/v1/rebalance/proposals/simulate",
             body=body,
             headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="manage.rebalance.proposals.simulate",
         )
 
     async def create_proposal(
@@ -39,6 +43,7 @@ class DpmClient:
             "/api/v1/rebalance/proposals",
             body=body,
             headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="manage.rebalance.proposals.create",
         )
 
     async def list_proposals(
@@ -51,6 +56,7 @@ class DpmClient:
             "/api/v1/rebalance/proposals",
             params=cleaned_params,
             headers=self._headers(correlation_id),
+            operation="manage.rebalance.proposals.list",
         )
 
     async def list_runs(
@@ -63,6 +69,7 @@ class DpmClient:
             "/api/v1/rebalance/runs",
             params=cleaned_params,
             headers=self._headers(correlation_id),
+            operation="manage.rebalance.runs.list",
         )
 
     async def get_proposal(
@@ -75,6 +82,7 @@ class DpmClient:
             f"/api/v1/rebalance/proposals/{proposal_id}",
             params={"include_evidence": str(include_evidence).lower()},
             headers=self._headers(correlation_id),
+            operation="manage.rebalance.proposals.get",
         )
 
     async def get_proposal_version(
@@ -88,6 +96,7 @@ class DpmClient:
             f"/api/v1/rebalance/proposals/{proposal_id}/versions/{version_no}",
             params={"include_evidence": str(include_evidence).lower()},
             headers=self._headers(correlation_id),
+            operation="manage.rebalance.proposals.versions.get",
         )
 
     async def create_proposal_version(
@@ -101,6 +110,7 @@ class DpmClient:
             f"/api/v1/rebalance/proposals/{proposal_id}/versions",
             body=body,
             headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="manage.rebalance.proposals.versions.create",
         )
 
     async def transition_proposal(
@@ -114,6 +124,7 @@ class DpmClient:
             f"/api/v1/rebalance/proposals/{proposal_id}/transitions",
             body=body,
             headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="manage.rebalance.proposals.transition",
         )
 
     async def record_approval(
@@ -127,6 +138,7 @@ class DpmClient:
             f"/api/v1/rebalance/proposals/{proposal_id}/approvals",
             body=body,
             headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="manage.rebalance.proposals.approvals.record",
         )
 
     async def get_workflow_events(
@@ -138,6 +150,7 @@ class DpmClient:
             f"/api/v1/rebalance/proposals/{proposal_id}/workflow-events",
             params={},
             headers=self._headers(correlation_id),
+            operation="manage.rebalance.proposals.workflow-events",
         )
 
     async def get_approvals(
@@ -149,6 +162,7 @@ class DpmClient:
             f"/api/v1/rebalance/proposals/{proposal_id}/approvals",
             params={},
             headers=self._headers(correlation_id),
+            operation="manage.rebalance.proposals.approvals.list",
         )
 
     async def get_proposal_lineage(
@@ -160,6 +174,7 @@ class DpmClient:
             f"/api/v1/rebalance/proposals/{proposal_id}/lineage",
             params={},
             headers=self._headers(correlation_id),
+            operation="manage.rebalance.proposals.lineage",
         )
 
     async def get_capabilities(
@@ -172,6 +187,7 @@ class DpmClient:
             "/api/v1/platform/capabilities",
             params={"consumerSystem": consumer_system, "tenantId": tenant_id},
             headers=self._headers(correlation_id),
+            operation="manage.platform.capabilities",
         )
 
     def _headers(
@@ -189,9 +205,13 @@ class DpmClient:
         path: str,
         body: dict[str, Any],
         headers: dict[str, str],
+        operation: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}{path}"
-        return await request_with_retry(
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-manage",
+            operation=operation,
             method="POST",
             url=url,
             timeout_seconds=self._timeout,
@@ -206,9 +226,13 @@ class DpmClient:
         path: str,
         params: dict[str, Any],
         headers: dict[str, str],
+        operation: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}{path}"
-        return await request_with_retry(
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-manage",
+            operation=operation,
             method="GET",
             url=url,
             timeout_seconds=self._timeout,

--- a/src/app/clients/lotus_ai_client.py
+++ b/src/app/clients/lotus_ai_client.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
-from app.clients.http_resilience import request_with_retry
+from app.clients.observed_fanout import request_observed_fanout
 from app.middleware.correlation import propagation_headers
+
+logger = logging.getLogger("analytics_ui.gateway")
 
 
 class LotusAiClient:
@@ -46,15 +49,13 @@ class LotusAiClient:
         if expected_output_label:
             request_payload["expected_output_label"] = expected_output_label
 
-        return await request_with_retry(
+        return await self._request(
+            operation="ai.tasks.execute",
             method="POST",
-            url=f"{self._base_url}/ai/tasks/execute",
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             json_body=request_payload,
             headers=propagation_headers(correlation_id),
             retry_timeout_exceptions=False,
+            path="/ai/tasks/execute",
         )
 
     async def execute_workflow_pack(
@@ -68,12 +69,9 @@ class LotusAiClient:
         task_request: dict[str, Any],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        return await request_with_retry(
+        return await self._request(
+            operation="ai.workflow-packs.execute",
             method="POST",
-            url=f"{self._base_url}/platform/workflow-packs/execute",
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             json_body={
                 "pack_id": pack_id,
                 "version": version,
@@ -84,6 +82,7 @@ class LotusAiClient:
             },
             headers=propagation_headers(correlation_id),
             retry_timeout_exceptions=False,
+            path="/platform/workflow-packs/execute",
         )
 
     async def get_workflow_pack_run_consumer_view(
@@ -92,14 +91,12 @@ class LotusAiClient:
         run_id: str,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        return await request_with_retry(
+        return await self._request(
+            operation="ai.workflow-packs.runs.consumer-view",
             method="GET",
-            url=f"{self._base_url}/platform/workflow-packs/runs/{run_id}/consumer-view",
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             headers=propagation_headers(correlation_id),
             retry_timeout_exceptions=False,
+            path=f"/platform/workflow-packs/runs/{run_id}/consumer-view",
         )
 
     async def get_workflow_pack_run_operator_profile(
@@ -108,14 +105,12 @@ class LotusAiClient:
         run_id: str,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        return await request_with_retry(
+        return await self._request(
+            operation="ai.workflow-packs.runs.operator-profile",
             method="GET",
-            url=f"{self._base_url}/platform/workflow-packs/runs/{run_id}/operator-profile",
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             headers=propagation_headers(correlation_id),
             retry_timeout_exceptions=False,
+            path=f"/platform/workflow-packs/runs/{run_id}/operator-profile",
         )
 
     async def list_workflow_pack_task_flows(
@@ -134,15 +129,13 @@ class LotusAiClient:
             params["caller"] = caller
         if workflow_surface is not None:
             params["workflow_surface"] = workflow_surface
-        return await request_with_retry(
+        return await self._request(
+            operation="ai.workflow-packs.task-flows.list",
             method="GET",
-            url=f"{self._base_url}/platform/workflow-packs/task-flows",
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             params=params,
             headers=propagation_headers(correlation_id),
             retry_timeout_exceptions=False,
+            path="/platform/workflow-packs/task-flows",
         )
 
     async def apply_workflow_pack_run_review_action(
@@ -152,13 +145,37 @@ class LotusAiClient:
         correlation_id: str,
         request_payload: dict[str, Any],
     ) -> tuple[int, dict[str, Any]]:
-        return await request_with_retry(
+        return await self._request(
+            operation="ai.workflow-packs.runs.review-actions",
             method="POST",
-            url=f"{self._base_url}/platform/workflow-packs/runs/{run_id}/review-actions",
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             json_body=request_payload,
             headers=propagation_headers(correlation_id),
             retry_timeout_exceptions=False,
+            path=f"/platform/workflow-packs/runs/{run_id}/review-actions",
+        )
+
+    async def _request(
+        self,
+        *,
+        operation: str,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        json_body: dict[str, Any] | None = None,
+        retry_timeout_exceptions: bool = True,
+    ) -> tuple[int, dict[str, Any]]:
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-ai",
+            operation=operation,
+            method=method,
+            url=f"{self._base_url}{path}",
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            params=params,
+            headers=headers,
+            json_body=json_body,
+            retry_timeout_exceptions=retry_timeout_exceptions,
         )

--- a/src/app/clients/observed_fanout.py
+++ b/src/app/clients/observed_fanout.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.clients.http_resilience import request_binary_with_retry, request_with_retry
+from app.observability.analytics_ui import (
+    emit_gateway_analytics_fanout_log,
+    gateway_analytics_fanout_timer,
+)
+
+
+async def request_observed_fanout(
+    *,
+    logger: logging.Logger,
+    service: str,
+    operation: str,
+    method: str,
+    url: str,
+    timeout_seconds: float,
+    max_retries: int = 2,
+    backoff_seconds: float = 0.2,
+    retry_status_codes: set[int] | None = None,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    json_body: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None,
+    files: dict[str, Any] | None = None,
+    retry_timeout_exceptions: bool = True,
+) -> tuple[int, dict[str, Any]]:
+    started_at = gateway_analytics_fanout_timer()
+    status_code, payload = await request_with_retry(
+        method=method,
+        url=url,
+        timeout_seconds=timeout_seconds,
+        max_retries=max_retries,
+        backoff_seconds=backoff_seconds,
+        retry_status_codes=retry_status_codes,
+        params=params,
+        headers=headers,
+        json_body=json_body,
+        data=data,
+        files=files,
+        retry_timeout_exceptions=retry_timeout_exceptions,
+    )
+    emit_gateway_analytics_fanout_log(
+        logger=logger,
+        started_at=started_at,
+        service=service,
+        operation=operation,
+        status_code=status_code,
+        payload=payload,
+    )
+    return status_code, payload
+
+
+async def request_observed_binary_fanout(
+    *,
+    logger: logging.Logger,
+    service: str,
+    operation: str,
+    method: str,
+    url: str,
+    timeout_seconds: float,
+    max_retries: int = 2,
+    backoff_seconds: float = 0.2,
+    retry_status_codes: set[int] | None = None,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    retry_timeout_exceptions: bool = True,
+) -> tuple[int, bytes, dict[str, str], dict[str, Any]]:
+    started_at = gateway_analytics_fanout_timer()
+    status_code, content, response_headers, error_payload = await request_binary_with_retry(
+        method=method,
+        url=url,
+        timeout_seconds=timeout_seconds,
+        max_retries=max_retries,
+        backoff_seconds=backoff_seconds,
+        retry_status_codes=retry_status_codes,
+        params=params,
+        headers=headers,
+        retry_timeout_exceptions=retry_timeout_exceptions,
+    )
+    emit_gateway_analytics_fanout_log(
+        logger=logger,
+        started_at=started_at,
+        service=service,
+        operation=operation,
+        status_code=status_code,
+        payload=error_payload,
+    )
+    return status_code, content, response_headers, error_payload

--- a/src/app/clients/reporting_client.py
+++ b/src/app/clients/reporting_client.py
@@ -1,7 +1,10 @@
+import logging
 from typing import Any
 
-from app.clients.http_resilience import request_with_retry
+from app.clients.observed_fanout import request_observed_fanout
 from app.middleware.correlation import propagation_headers
+
+logger = logging.getLogger("analytics_ui.gateway")
 
 
 class ReportingClient:
@@ -26,12 +29,10 @@ class ReportingClient:
         url = f"{self._base_url}/aggregations/portfolios/{portfolio_id}"
         params = {"asOfDate": as_of_date, "live": "true"}
         headers = propagation_headers(correlation_id)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.aggregations.portfolio-snapshot",
             method="GET",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             params=params,
             headers=headers,
         )
@@ -45,12 +46,10 @@ class ReportingClient:
         url = f"{self._base_url}/integration/capabilities"
         params = {"consumerSystem": consumer_system, "tenantId": tenant_id}
         headers = propagation_headers(correlation_id)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.integration.capabilities",
             method="GET",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             params=params,
             headers=headers,
         )
@@ -63,12 +62,10 @@ class ReportingClient:
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/portfolios/{portfolio_id}/summary"
         headers = propagation_headers(correlation_id)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.portfolio.summary",
             method="POST",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             json_body=payload,
             headers=headers,
         )
@@ -81,12 +78,10 @@ class ReportingClient:
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/portfolios/{portfolio_id}/review"
         headers = propagation_headers(correlation_id)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.portfolio.review",
             method="POST",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             json_body=payload,
             headers=headers,
         )
@@ -103,12 +98,10 @@ class ReportingClient:
         headers = propagation_headers(correlation_id)
         headers["Idempotency-Key"] = idempotency_key
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.portfolio-review-jobs.submit",
             method="POST",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             json_body=payload,
             headers=headers,
         )
@@ -123,12 +116,10 @@ class ReportingClient:
         url = f"{self._base_url}/reports/jobs/{job_id}"
         headers = propagation_headers(correlation_id)
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.jobs.get",
             method="GET",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             headers=headers,
         )
 
@@ -142,12 +133,10 @@ class ReportingClient:
         url = f"{self._base_url}/reports/jobs"
         headers = propagation_headers(correlation_id)
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.jobs.list",
             method="GET",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             params=filters,
             headers=headers,
         )
@@ -162,12 +151,10 @@ class ReportingClient:
         url = f"{self._base_url}/reports/jobs/{job_id}/events"
         headers = propagation_headers(correlation_id)
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.jobs.events",
             method="GET",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             headers=headers,
         )
 
@@ -181,12 +168,10 @@ class ReportingClient:
         url = f"{self._base_url}/reports/jobs/{job_id}/lineage"
         headers = propagation_headers(correlation_id)
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.jobs.lineage",
             method="GET",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             headers=headers,
         )
 
@@ -200,12 +185,10 @@ class ReportingClient:
         url = f"{self._base_url}/reports/snapshots/{snapshot_id}"
         headers = propagation_headers(correlation_id)
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.snapshots.get",
             method="GET",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             headers=headers,
         )
 
@@ -219,12 +202,10 @@ class ReportingClient:
         url = f"{self._base_url}/reports/snapshots/{snapshot_id}/lineage"
         headers = propagation_headers(correlation_id)
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.snapshots.lineage",
             method="GET",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             headers=headers,
         )
 
@@ -238,12 +219,10 @@ class ReportingClient:
         url = f"{self._base_url}/reports/jobs/{job_id}/cancel"
         headers = propagation_headers(correlation_id)
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.jobs.cancel",
             method="POST",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             headers=headers,
         )
 
@@ -259,12 +238,10 @@ class ReportingClient:
         headers = propagation_headers(correlation_id)
         headers["Idempotency-Key"] = idempotency_key
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.batches.create",
             method="POST",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             json_body=payload,
             headers=headers,
         )
@@ -279,12 +256,10 @@ class ReportingClient:
         url = f"{self._base_url}/reports/batches/{batch_id}"
         headers = propagation_headers(correlation_id)
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.batches.get",
             method="GET",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             headers=headers,
         )
 
@@ -300,12 +275,10 @@ class ReportingClient:
         url = f"{self._base_url}/reports/batches/{batch_id}:{action}"
         headers = propagation_headers(correlation_id)
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation=f"report.batches.{action}",
             method="POST",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             json_body=payload,
             headers=headers,
         )
@@ -319,12 +292,10 @@ class ReportingClient:
         url = f"{self._base_url}/reports/batch-schedules"
         headers = propagation_headers(correlation_id)
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.batch-schedules.list",
             method="GET",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
             headers=headers,
         )
 
@@ -338,12 +309,34 @@ class ReportingClient:
         url = f"{self._base_url}/reports/batch-schedules:run-due"
         headers = propagation_headers(correlation_id)
         headers.update(caller_headers)
-        return await request_with_retry(
+        return await self._request(
+            operation="report.batch-schedules.run-due",
             method="POST",
+            url=url,
+            json_body=payload,
+            headers=headers,
+        )
+
+    async def _request(
+        self,
+        *,
+        operation: str,
+        method: str,
+        url: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> tuple[int, dict[str, Any]]:
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-report",
+            operation=operation,
+            method=method,
             url=url,
             timeout_seconds=self._timeout,
             max_retries=self._max_retries,
             backoff_seconds=self._retry_backoff_seconds,
-            json_body=payload,
+            params=params,
             headers=headers,
+            json_body=json_body,
         )

--- a/src/app/observability/analytics_ui.py
+++ b/src/app/observability/analytics_ui.py
@@ -45,6 +45,8 @@ ANALYTICS_UI_FORBIDDEN_FIELDS = frozenset(
         "screen_content",
         "request_body",
         "response_body",
+        "raw_prompt",
+        "model_output",
         "raw_entitlement_failure",
     }
 )

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -96,6 +96,17 @@ def _patch_async_client(monkeypatch):
     monkeypatch.setattr("httpx.AsyncClient", _FakeAsyncClient)
 
 
+def _fanout_records(records, *, service: str):
+    return [
+        record
+        for record in records
+        if record.name == "analytics_ui.gateway"
+        and record.message
+        in {"gateway.analytics.fanout.completed", "gateway.analytics.fanout.degraded"}
+        and record.extra_fields["service"] == service
+    ]
+
+
 @pytest.mark.asyncio
 async def test_lotus_analytics_client_calls_and_payload_handling():
     client = LotusAnalyticsClient(base_url="http://lotus-performance", timeout_seconds=2.0)
@@ -408,6 +419,41 @@ async def test_lotus_ai_client_calls_task_execution_contract_with_correlation_he
         },
         "expected_output_label": "EXPLANATION_ONLY",
     }
+
+
+@pytest.mark.asyncio
+async def test_lotus_ai_client_emits_safe_fanout_metrics_without_prompt_content(caplog):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    client = LotusAiClient(base_url="http://ai", timeout_seconds=3.0)
+    _FakeAsyncClient.queue_json(
+        503,
+        {
+            "detail": "upstream communication failure",
+            "raw_prompt": "sensitive prompt text",
+            "model_output": "sensitive generated output",
+        },
+    )
+
+    status, payload = await client.execute_task(
+        task_id="explain.v1",
+        caller_app="lotus-gateway",
+        correlation_id="corr-ai-observed",
+        context_summary="Advisor brief context",
+        context_payload={"portfolio_id": "PF_1001"},
+        source_refs=["lotus-gateway:workbench:PF_1001:performance-summary:YTD"],
+    )
+
+    assert status == 503
+    assert payload["detail"] == "upstream communication failure"
+    [record] = _fanout_records(caplog.records, service="lotus-ai")
+    fields = record.extra_fields
+    assert fields["event"] == "gateway.analytics.fanout.degraded"
+    assert fields["operation"] == "ai.tasks.execute"
+    assert fields["status_class"] == "5xx"
+    assert fields["reason"] == "UPSTREAM_UNAVAILABLE"
+    assert "raw_prompt" not in fields
+    assert "model_output" not in fields
+    assert "portfolio_id" not in fields
 
 
 @pytest.mark.asyncio
@@ -1673,6 +1719,33 @@ async def test_dpm_client_non_json_and_non_dict_payload_handling():
 
 
 @pytest.mark.asyncio
+async def test_dpm_client_emits_safe_fanout_metrics_for_manage_routes(caplog):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    client = DpmClient(base_url="http://dpm", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(503, {"detail": "upstream unavailable", "portfolio_id": "P1"})
+
+    status_code, payload = await client.list_runs(
+        params={"portfolio_id": "P1"},
+        correlation_id="corr-dpm-observed",
+    )
+
+    assert status_code == 503
+    assert payload["detail"] == "upstream unavailable"
+    [record] = _fanout_records(caplog.records, service="lotus-manage")
+    fields = record.extra_fields
+    assert fields["event"] == "gateway.analytics.fanout.degraded"
+    assert fields["route"] == "workbench-analytics"
+    assert fields["service"] == "lotus-manage"
+    assert fields["operation"] == "manage.rebalance.runs.list"
+    assert fields["state"] == "degraded"
+    assert fields["reason"] == "UPSTREAM_UNAVAILABLE"
+    assert fields["status_class"] == "5xx"
+    assert "portfolio_id" not in fields
+    assert "request_body" not in fields
+    assert "response_body" not in fields
+
+
+@pytest.mark.asyncio
 async def test_reporting_client_handles_non_dict_payload():
     client = ReportingClient(base_url="http://ras", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, [{"metric": "market_value_base"}])
@@ -1931,6 +2004,38 @@ async def test_reporting_client_summary_review_non_json_payloads():
 
 
 @pytest.mark.asyncio
+async def test_reporting_client_emits_safe_fanout_metrics_without_runtime_ids(caplog):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    client = ReportingClient(base_url="http://ras", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(
+        200,
+        {
+            "state": "partial",
+            "partial_failures": [{"source_service": "lotus-report"}],
+            "request_body": {"portfolio_id": "P1"},
+        },
+    )
+
+    status_code, payload = await client.get_report_job(
+        job_id="rjob_sensitive_1",
+        caller_headers={"X-Actor-Id": "advisor-123"},
+        correlation_id="corr-report-observed",
+    )
+
+    assert status_code == 200
+    assert payload["state"] == "partial"
+    [record] = _fanout_records(caplog.records, service="lotus-report")
+    fields = record.extra_fields
+    assert fields["event"] == "gateway.analytics.fanout.degraded"
+    assert fields["operation"] == "report.jobs.get"
+    assert fields["state"] == "partial"
+    assert fields["status_class"] == "2xx"
+    assert fields["partial_failure_count"] == 1
+    assert "rjob_sensitive_1" not in fields.values()
+    assert "portfolio_id" not in fields
+
+
+@pytest.mark.asyncio
 async def test_archive_client_metadata_and_download_routes_forward_archive_context():
     client = ArchiveClient(base_url="http://archive", timeout_seconds=2.0)
     caller_headers = {
@@ -2018,6 +2123,37 @@ async def test_archive_client_download_returns_error_payload_without_binary_leak
     assert b"document_binary_missing" in content
     assert headers["content-type"] == "application/json"
     assert error_payload["error"]["code"] == "document_binary_missing"
+
+
+@pytest.mark.asyncio
+async def test_archive_client_emits_safe_binary_fanout_metrics(caplog):
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    client = ArchiveClient(base_url="http://archive", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(
+        404,
+        {"error": {"code": "document_binary_missing", "document_id": "doc_sensitive_1"}},
+    )
+
+    status_code, _, _, error_payload = await client.download_document(
+        document_id="doc_sensitive_1",
+        caller_headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+        },
+        correlation_id="corr-archive-observed",
+    )
+
+    assert status_code == 404
+    assert error_payload["error"]["code"] == "document_binary_missing"
+    [record] = _fanout_records(caplog.records, service="lotus-archive")
+    fields = record.extra_fields
+    assert fields["operation"] == "archive.documents.download"
+    assert fields["status_class"] == "4xx"
+    assert fields["state"] == "error"
+    assert fields["error_category"] == "upstream_error"
+    assert "doc_sensitive_1" not in fields.values()
+    assert "document_id" not in fields
 
 
 @pytest.mark.asyncio

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -63,10 +63,12 @@
   and `instrument_page_limit`
 - proposal writes require `Idempotency-Key`
 - `/metrics` includes RFC-0108 gateway analytics fan-out metrics for selected Workbench analytics
-  operations: `lotus_gateway_analytics_fanout_duration_seconds` and
+  operations plus the central `lotus-manage`, `lotus-report`, `lotus-archive`, and `lotus-ai`
+  client seams: `lotus_gateway_analytics_fanout_duration_seconds` and
   `lotus_gateway_analytics_degraded_total`. Labels are bounded to operation/service/status class
-  and degraded reason; portfolio, client, trace, correlation, request, and response content are not
-  metric labels.
+  and degraded reason; portfolio, client, document, trace, correlation, request, response, raw
+  prompt, and model output content are not metric labels. Remaining direct core-query paths stay
+  planned for later RFC-0108 Slice 13 rollout.
 - analytics UI protected diagnostics lookup is gateway-first under
   `/api/v1/analytics-ui/diagnostics/{support_reference}`. It requires `X-Actor-Id`,
   `X-Tenant-Id`, `X-Region`, and an operator support role in `X-Role`; it returns only safe panel,

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -25,15 +25,18 @@
 - The module defines allowed labels, forbidden fields, state vocabulary, and gateway analytics
   metric-family names.
 - Do not add gateway analytics metric labels outside that contract.
-- `portfolio_id`, `client_id`, `client_name`, `holding_id`, `transaction_id`, `trace_id`,
-  `correlation_id`, request bodies, response bodies, and raw entitlement failures must not become
-  metric labels or structured telemetry dimensions.
+- `portfolio_id`, `client_id`, `client_name`, `holding_id`, `transaction_id`, `document_id`,
+  `trace_id`, `correlation_id`, request bodies, response bodies, raw prompts, model output, and
+  raw entitlement failures must not become metric labels or structured telemetry dimensions.
 - Gateway emits product-safe structured fan-out logs for selected Workbench performance and risk
   analytics operations.
+- Gateway also emits product-safe fan-out logs and metrics through the central `lotus-manage`,
+  `lotus-report`, `lotus-archive`, and `lotus-ai` client seams. Remaining direct core-query paths
+  stay planned for later RFC-0108 Slice 13 rollout.
 - Gateway emits `lotus_gateway_analytics_fanout_duration_seconds` with bounded `operation`,
-  `service`, and `status_class` labels for selected Workbench analytics fan-out operations.
+  `service`, and `status_class` labels for implemented Gateway fan-out operations.
 - Gateway emits `lotus_gateway_analytics_degraded_total` with bounded `operation`, `service`, and
-  `reason` labels when selected Workbench analytics fan-out is partial, degraded, or failed.
+  `reason` labels when implemented Gateway fan-out is partial, degraded, or failed.
 - Gateway emits product-safe selected analytics read audit logs for upstream read outcomes:
   `gateway.analytics.audit.analytics_read_allowed` for successful upstream reads and
   `gateway.analytics.audit.analytics_read_denied` for `401` or `403` upstream denials.


### PR DESCRIPTION
## Summary
- Adds a shared observed fan-out request wrapper for Gateway upstream clients.
- Expands RFC-0108 Gateway fan-out metrics/logs from selected performance/risk analytics into central `lotus-manage`, `lotus-report`, `lotus-archive`, and `lotus-ai` client seams.
- Uses explicit bounded operation labels for dynamic paths so job/proposal/document/run ids never become metric labels.
- Extends forbidden analytics UI telemetry fields to raw prompts and model output, and updates repo context/wiki source.

## Validation
- `python -m pytest tests\unit\test_analytics_ui_observability_contract.py tests\unit\test_upstream_clients.py -q`
- `python -m ruff check src\app\clients\observed_fanout.py src\app\clients\dpm_client.py src\app\clients\reporting_client.py src\app\clients\archive_client.py src\app\clients\lotus_ai_client.py src\app\observability\analytics_ui.py tests\unit\test_upstream_clients.py`
- `python -m mypy src\app\clients\observed_fanout.py src\app\clients\dpm_client.py src\app\clients\reporting_client.py src\app\clients\archive_client.py src\app\clients\lotus_ai_client.py src\app\observability\analytics_ui.py`
- `make check`
- `make migration-smoke`
- `make test-integration`
- `make test-coverage`
- `make security-audit`
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` fails before merge as expected because repo-authored wiki source intentionally differs from published wiki until merge and publication.

## Residual RFC-0108 scope
- Remaining direct core-query Gateway paths are still planned before `gateway.analytics.observability.all_ui_fanout_paths` can be promoted to fully implemented.