### PR TITLE
Implement RFC-0108 Gateway supportability reconciliation

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -61,7 +61,10 @@ Current repository posture:
     limited to route, panel, operation, state, reason, status class, region, and environment;
     portfolio, client, holding, transaction, session, upload, trace, correlation, document,
     request/response body, screen content, raw prompt, model output, and raw entitlement-failure
-    fields remain forbidden.
+    fields remain forbidden. Gateway preserves upstream `metadata.calculation_supportability`
+    from `lotus-performance` and `lotus-risk` as product-safe source calculation posture for
+    evidence views, risk module supportability, fan-out state, and bounded degraded metrics without
+    recomputing domain calculation truth.
 
 ## Architecture And Module Map
 

--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -54,7 +54,9 @@ outputs.
 3. Gateway services must not perform authoritative portfolio valuation, performance attribution, risk
    concentration, advisory suitability, or reporting methodology calculations.
 4. `source_service`, supportability, readiness, and partial-failure metadata must survive composition
-   when the product surface depends on it.
+   when the product surface depends on it. Gateway preserves upstream
+   `metadata.calculation_supportability` from performance and risk calculations as product-safe
+   source calculation posture, but it does not recompute or override source-owned supportability.
 5. Any new upstream dependency must be classified into an RFC-0082 family before becoming a stable
    Workbench-facing contract.
 6. Transport optimization discussions start with query shape, payload shape, caching, export semantics,
@@ -85,9 +87,9 @@ This RFC-0082 documentation slice reflects current runtime behavior:
    `evidence_view` sourced from lotus-performance execution polling and lineage inventory.
 2. the performance `evidence_view` includes RFC-0108/RFC-0079-facing product context for as-of date,
    period, basis, benchmark, calculation scope, source services, freshness posture, methodology
-   references, calculation versions, coverage, fallbacks, and limitations. Gateway derives only
-   UI-safe evidence context from upstream payloads; it does not become the calculation or methodology
-   authority.
+   references, calculation versions, source calculation supportability, coverage, fallbacks, and
+   limitations. Gateway derives only UI-safe evidence context from upstream payloads; it does not
+   become the calculation or methodology authority.
 3. lineage artifact links presented to downstream clients are rewritten to a gateway-owned download
    route rather than exposing direct lotus-performance URLs.
 4. archived generated-document metadata and binary links are exposed through gateway-owned document

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-04-30T01:03:19Z",
+  "generated_at": "2026-04-30T06:58:20Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -178,25 +178,13 @@
       "review_by": "2026-09-28"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:450:begin_market_value: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:483:begin_market_value: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:455:end_market_value: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:470:flow_adjusted_end_market_value: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:485:net_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:488:end_market_value: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
@@ -208,55 +196,31 @@
       "review_by": "2026-09-28"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:490:gross_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:495:portfolio_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
       "finding": "src/app/contracts/performance_workspace.py:49:end_market_value: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-28"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:500:benchmark_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:503:flow_adjusted_end_market_value: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:507:active_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:518:net_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:512:cumulative_net_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:523:gross_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:517:cumulative_gross_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:522:cumulative_benchmark_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:527:cumulative_active_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:528:portfolio_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
@@ -268,19 +232,55 @@
       "review_by": "2026-09-28"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:532:annualized_net_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:533:benchmark_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:537:annualized_gross_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:540:active_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:542:annualized_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:545:cumulative_net_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-27"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:550:cumulative_gross_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-27"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:555:cumulative_benchmark_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-27"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:560:cumulative_active_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-27"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:565:annualized_net_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-27"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:570:annualized_gross_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-27"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:575:annualized_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
@@ -310,7 +310,7 @@
       "review_by": "2026-09-28"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:750:active_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:783:active_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
@@ -946,22 +946,22 @@
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:1655:def _safe_float(value: Any) -> float | None:",
+      "finding": "src/app/services/risk_workspace_service.py:1702:def _safe_float(value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-20"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:1659:return float(value)",
+      "finding": "src/app/services/risk_workspace_service.py:1706:return float(value)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-20"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:796:value=float(value) if isinstance(value, int | float) else None,",
+      "finding": "src/app/services/risk_workspace_service.py:804:value=float(value) if isinstance(value, int | float) else None,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-20"
+      "review_by": "2026-10-27"
     },
     {
       "finding": "src/app/services/workbench_service.py:318:current_weight_pct=float(",

--- a/src/app/contracts/performance_workspace.py
+++ b/src/app/contracts/performance_workspace.py
@@ -289,6 +289,32 @@ class PerformanceEvidenceUpstreamSnapshotView(BaseModel):
     )
 
 
+class PerformanceSourceSupportabilityView(BaseModel):
+    key: str = Field(
+        description="Gateway-owned key for the source supportability posture.",
+        examples=["source_calculation"],
+    )
+    state: str = Field(
+        description="Product-safe calculation supportability state reported by lotus-performance.",
+        examples=["supported"],
+    )
+    reason: str | None = Field(
+        default=None,
+        description="Source-owned supportability reason or freshness qualification.",
+        examples=["Source calculation supportability was confirmed upstream."],
+    )
+    freshness_bucket: str | None = Field(
+        default=None,
+        description="Product-safe freshness bucket reported by the source calculation service.",
+        examples=["fresh"],
+    )
+    source_service: str | None = Field(
+        default=None,
+        description="Domain service that owns the supportability posture.",
+        examples=["lotus-performance"],
+    )
+
+
 class PerformanceCalculationEvidenceView(BaseModel):
     calculation_role: str = Field(
         description="Gateway-owned role label for the calculation evidence item.",
@@ -418,6 +444,13 @@ class PerformanceEvidenceView(BaseModel):
     calculations: list[PerformanceCalculationEvidenceView] = Field(
         default_factory=list,
         description="Calculation-scoped execution and lineage evidence items exposed by gateway.",
+    )
+    source_supportability: list[PerformanceSourceSupportabilityView] = Field(
+        default_factory=list,
+        description=(
+            "Product-safe source calculation supportability entries carried through from "
+            "lotus-performance response metadata."
+        ),
     )
 
 

--- a/src/app/observability/analytics_ui.py
+++ b/src/app/observability/analytics_ui.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from prometheus_client import Counter, Histogram
 
+from app.services.source_supportability import extract_calculation_supportability
+
 ANALYTICS_UI_ALLOWED_LABELS = frozenset(
     {
         "route",
@@ -414,6 +416,14 @@ def _resolve_gateway_analytics_state(*, status_code: int, payload: Mapping[str, 
 
 
 def _resolve_supportability_state(payload: Mapping[str, Any]) -> str | None:
+    calculation_supportability = extract_calculation_supportability(payload)
+    if calculation_supportability is not None:
+        if calculation_supportability.state in {"ready", "supported"}:
+            return "ready"
+        if calculation_supportability.state in {"partial", "stale"}:
+            return "partial"
+        return "degraded"
+
     supportability = payload.get("supportability")
     if isinstance(supportability, list):
         states = {
@@ -435,6 +445,13 @@ def _resolve_supportability_state(payload: Mapping[str, Any]) -> str | None:
 def _resolve_gateway_analytics_reason(
     *, status_code: int, payload: Mapping[str, Any]
 ) -> str | None:
+    calculation_supportability = extract_calculation_supportability(payload)
+    if calculation_supportability is not None and calculation_supportability.state not in {
+        "ready",
+        "supported",
+    }:
+        return calculation_supportability.reason or calculation_supportability.state.upper()
+
     warnings = payload.get("warnings")
     if isinstance(warnings, list) and warnings:
         return str(warnings[0])
@@ -500,9 +517,15 @@ def _panel_for_operation(operation: str) -> str:
 def _safe_dimension(value: str | None, *, default: str) -> str:
     if not value:
         return default
-    cleaned = "".join(
-        character
-        for character in value.strip().lower()
-        if character.isalnum() or character in {"-", "_", "."}
-    )
+    previous_was_separator = False
+    characters: list[str] = []
+    for character in value.strip().lower():
+        if character.isalnum() or character in {"_", "."}:
+            characters.append(character)
+            previous_was_separator = False
+            continue
+        if character in {"-", " ", "/"} and not previous_was_separator:
+            characters.append("-")
+            previous_was_separator = True
+    cleaned = "".join(characters).strip("-")
     return cleaned[:64] or default

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -32,6 +32,7 @@ from app.contracts.performance_workspace import (
     PerformanceHorizonComparisonResponse,
     PerformanceHorizonComparisonRow,
     PerformanceModuleCapability,
+    PerformanceSourceSupportabilityView,
     PerformanceWorkspaceCapabilities,
     PerformanceWorkspaceDetailsResponse,
     PerformanceWorkspaceResponse,
@@ -47,6 +48,10 @@ from app.contracts.workbench import WorkbenchOverviewResponse, WorkbenchPartialF
 from app.middleware.server_timing import server_timing_span
 from app.precision_policy import quantize_performance
 from app.services.async_ttl_cache import AsyncTtlCache
+from app.services.source_supportability import (
+    extract_calculation_supportability,
+    source_supportability_reason,
+)
 from app.services.workbench_service import WorkbenchService
 
 STANDARD_PERIOD_ANALYSES = (
@@ -679,6 +684,11 @@ class PerformanceWorkspaceService:
                     self._extract_calculation_id_from_result(attribution_detail_result),
                 ),
             ],
+            source_results=[
+                workspace_summary_result,
+                contribution_detail_result,
+                attribution_detail_result,
+            ],
             warnings=warnings,
             partial_failures=partial_failures,
         )
@@ -915,9 +925,11 @@ class PerformanceWorkspaceService:
         contract_version: str,
         correlation_id: str,
         calculations: Sequence[tuple[str, str | None]],
+        source_results: Sequence[GatheredResult | None],
         warnings: list[str],
         partial_failures: list[WorkbenchPartialFailure],
     ) -> PerformanceEvidenceView | None:
+        source_supportability = self._build_source_supportability(source_results)
         requested_items = [
             (role, calculation_id)
             for role, calculation_id in calculations
@@ -934,6 +946,7 @@ class PerformanceWorkspaceService:
                 contract_version=contract_version,
                 limitations=["No durable calculation evidence is available."],
                 calculations=[],
+                source_supportability=source_supportability,
             )
 
         evidence_items = await asyncio.gather(
@@ -976,21 +989,32 @@ class PerformanceWorkspaceService:
                     "from lotus-performance."
                 ],
                 calculations=evidence_items,
+                source_supportability=source_supportability,
             )
         if complete_count == len(evidence_items):
-            return self._build_performance_evidence_view(
-                state="supported",
-                reason=(
+            evidence_state = self._resolve_evidence_state(
+                evidence_state="supported",
+                source_supportability=source_supportability,
+            )
+            evidence_reason = self._resolve_evidence_reason(
+                evidence_state=evidence_state,
+                supported_reason=(
                     "Execution status, upstream lineage, and artifact inventory "
                     "are exposed for the current performance view."
                 ),
+                source_supportability=source_supportability,
+            )
+            return self._build_performance_evidence_view(
+                state=evidence_state,
+                reason=evidence_reason,
                 as_of_date=as_of_date,
                 period=period,
                 basis=basis,
                 benchmark_code=benchmark_code,
                 contract_version=contract_version,
-                limitations=[],
+                limitations=[] if evidence_state == "supported" else [evidence_reason],
                 calculations=evidence_items,
+                source_supportability=source_supportability,
             )
 
         warnings.append("PERFORMANCE_EVIDENCE_PARTIAL")
@@ -1020,6 +1044,7 @@ class PerformanceWorkspaceService:
                 "or unavailable lineage evidence."
             ],
             calculations=evidence_items,
+            source_supportability=source_supportability,
         )
 
     def _build_performance_evidence_view(
@@ -1034,8 +1059,16 @@ class PerformanceWorkspaceService:
         contract_version: str,
         limitations: list[str],
         calculations: Sequence[PerformanceCalculationEvidenceView],
+        source_supportability: Sequence[PerformanceSourceSupportabilityView],
     ) -> PerformanceEvidenceView:
-        source_services = ["lotus-performance"] if calculations else []
+        source_services = sorted(
+            {service for service in ["lotus-performance"] if calculations}
+            | {
+                item.source_service
+                for item in source_supportability
+                if item.source_service is not None
+            }
+        )
         upstream_dates = {
             snapshot.as_of_date
             for item in calculations
@@ -1088,7 +1121,74 @@ class PerformanceWorkspaceService:
             generated_at=None,
             reason=reason,
             calculations=list(calculations),
+            source_supportability=list(source_supportability),
         )
+
+    def _build_source_supportability(
+        self,
+        source_results: Sequence[GatheredResult | None],
+    ) -> list[PerformanceSourceSupportabilityView]:
+        items: list[PerformanceSourceSupportabilityView] = []
+        seen: set[tuple[str, str, str | None]] = set()
+        for result in source_results:
+            if result is None or isinstance(result, BaseException):
+                continue
+            status_code, payload = result
+            if status_code >= 400 or not isinstance(payload, Mapping):
+                continue
+            source_supportability = extract_calculation_supportability(payload)
+            if source_supportability is None:
+                continue
+            key = (
+                source_supportability.state,
+                source_supportability.reason or "",
+                source_supportability.freshness_bucket,
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            items.append(
+                PerformanceSourceSupportabilityView(
+                    key="source_calculation",
+                    state=source_supportability.performance_evidence_state,
+                    reason=source_supportability_reason(
+                        source_supportability,
+                        default_ready_reason=(
+                            "Source calculation supportability was confirmed upstream."
+                        ),
+                    ),
+                    freshness_bucket=source_supportability.freshness_bucket,
+                    source_service=source_supportability.source_service or "lotus-performance",
+                )
+            )
+        return items
+
+    def _resolve_evidence_state(
+        self,
+        *,
+        evidence_state: str,
+        source_supportability: Sequence[PerformanceSourceSupportabilityView],
+    ) -> str:
+        states = {item.state for item in source_supportability}
+        if states & {"unavailable"}:
+            return "unavailable"
+        if states - {"supported"}:
+            return "partial"
+        return evidence_state
+
+    def _resolve_evidence_reason(
+        self,
+        *,
+        evidence_state: str,
+        supported_reason: str,
+        source_supportability: Sequence[PerformanceSourceSupportabilityView],
+    ) -> str:
+        if evidence_state == "supported":
+            return supported_reason
+        for item in source_supportability:
+            if item.state != "supported" and item.reason:
+                return item.reason
+        return "Source calculation supportability is partial or unavailable upstream."
 
     async def _fetch_calculation_evidence(
         self,

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -51,6 +51,10 @@ from app.contracts.risk_workspace import (
 )
 from app.contracts.workbench import WorkbenchPartialFailure
 from app.services.async_ttl_cache import AsyncTtlCache
+from app.services.source_supportability import (
+    extract_calculation_supportability,
+    source_supportability_reason,
+)
 
 _SUMMARY_METRICS = [
     "VOLATILITY",
@@ -743,6 +747,10 @@ def _map_summary_response(
                 )
             )
     supportability.extend(_metric_dependency_supportability(metric_states, benchmark_code))
+    _append_source_calculation_supportability(
+        supportability=supportability,
+        upstream_payload=upstream_payload,
+    )
     state: RiskModuleState = (
         "partial" if any(item.state != "ready" for item in supportability) else "ready"
     )
@@ -897,13 +905,17 @@ def _map_concentration_response(
             source_service="lotus-risk",
         ),
     ]
+    _append_source_calculation_supportability(
+        supportability=supportability,
+        upstream_payload=upstream_payload,
+    )
     return WorkbenchRiskConcentrationResponse(
         correlation_id=correlation_id,
         portfolio_id=portfolio_id,
         period=period,
         as_of_date=as_of_date,
         benchmark_code=benchmark_code,
-        state="ready" if issuer_state == "ready" else "partial",
+        state="ready" if all(item.state == "ready" for item in supportability) else "partial",
         payload=WorkbenchRiskConcentrationPayload(
             portfolio_concentration=WorkbenchPortfolioConcentration.model_validate(
                 required_blocks["portfolio_concentration"]
@@ -1072,6 +1084,10 @@ def _map_drawdown_response(
             ),
         ]
     )
+    _append_source_calculation_supportability(
+        supportability=supportability,
+        upstream_payload=upstream_payload,
+    )
 
     state: RiskModuleState = (
         "partial" if any(item.state != "ready" for item in supportability) else "ready"
@@ -1176,6 +1192,10 @@ def _map_rolling_response(
             source_service="lotus-risk",
         ),
     ]
+    _append_source_calculation_supportability(
+        supportability=supportability,
+        upstream_payload=upstream_payload,
+    )
 
     if isinstance(results, dict):
         for key, value in results.items():
@@ -1326,6 +1346,10 @@ def _map_attribution_response(
         attribution_type=attribution_type,
         grouping_dimension=grouping_dimension,
     )
+    _append_source_calculation_supportability(
+        supportability=supportability,
+        upstream_payload=upstream_payload,
+    )
 
     if isinstance(results, dict):
         for key, value in results.items():
@@ -1442,6 +1466,29 @@ def _map_attribution_response(
         warnings=sorted(set(warnings)),
         partial_failures=partial_failures,
         metadata=metadata,
+    )
+
+
+def _append_source_calculation_supportability(
+    *,
+    supportability: list[WorkbenchRiskSupportabilityItem],
+    upstream_payload: dict[str, Any],
+) -> None:
+    source_supportability = extract_calculation_supportability(upstream_payload)
+    if source_supportability is None:
+        return
+
+    supportability.append(
+        WorkbenchRiskSupportabilityItem(
+            key="source_calculation",
+            label="Source calculation",
+            state=cast(Any, source_supportability.risk_contract_state),
+            reason=source_supportability_reason(
+                source_supportability,
+                default_ready_reason="Source calculation supportability was confirmed upstream.",
+            ),
+            source_service=source_supportability.source_service or "lotus-risk",
+        )
     )
 
 

--- a/src/app/services/source_supportability.py
+++ b/src/app/services/source_supportability.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SourceCalculationSupportability:
+    state: str
+    reason: str | None
+    freshness_bucket: str | None
+    source_service: str | None
+
+    @property
+    def risk_contract_state(self) -> str:
+        if self.state in {"ready", "supported"}:
+            return "ready"
+        if self.state in {"blocked"}:
+            return "blocked"
+        if self.state in {"unavailable", "error"}:
+            return "unavailable"
+        return "partial"
+
+    @property
+    def performance_evidence_state(self) -> str:
+        if self.state in {"ready", "supported"}:
+            return "supported"
+        if self.state in {"unavailable", "error"}:
+            return "unavailable"
+        return "partial"
+
+
+def extract_calculation_supportability(
+    payload: Mapping[str, Any],
+) -> SourceCalculationSupportability | None:
+    raw = payload.get("calculation_supportability")
+    if not isinstance(raw, Mapping):
+        metadata = payload.get("metadata")
+        if isinstance(metadata, Mapping):
+            raw = metadata.get("calculation_supportability")
+
+    if not isinstance(raw, Mapping):
+        return None
+
+    state = _normalize_state(raw.get("state") or raw.get("supportability_state"))
+    if state is None:
+        return None
+
+    return SourceCalculationSupportability(
+        state=state,
+        reason=_safe_text(raw.get("reason") or raw.get("message")),
+        freshness_bucket=_safe_text(raw.get("freshness_bucket")),
+        source_service=_safe_text(raw.get("source_service")),
+    )
+
+
+def source_supportability_reason(
+    supportability: SourceCalculationSupportability,
+    *,
+    default_ready_reason: str,
+) -> str:
+    if supportability.reason:
+        return supportability.reason
+    if supportability.freshness_bucket:
+        return f"Source calculation supportability freshness is {supportability.freshness_bucket}."
+    return default_ready_reason
+
+
+def _normalize_state(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower().replace("-", "_")
+    if normalized in {"supported", "ok", "complete"}:
+        return "ready"
+    if normalized in {
+        "ready",
+        "partial",
+        "stale",
+        "degraded",
+        "unavailable",
+        "unsupported",
+        "blocked",
+        "error",
+    }:
+        return normalized
+    return None
+
+
+def _safe_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None

--- a/tests/unit/test_analytics_ui_observability_contract.py
+++ b/tests/unit/test_analytics_ui_observability_contract.py
@@ -17,6 +17,7 @@ from app.observability.analytics_ui import (
     GATEWAY_ANALYTICS_UI_LOG_EVENTS,
     GATEWAY_ANALYTICS_UI_METRIC_FAMILIES,
     GATEWAY_ANALYTICS_UI_STRUCTURED_LOG_FIELDS,
+    emit_gateway_analytics_fanout_log,
     emit_gateway_protected_diagnostics_audit_log,
     is_analytics_ui_state,
     record_gateway_analytics_fanout_metrics,
@@ -281,6 +282,64 @@ def test_record_gateway_analytics_fanout_metrics_records_safe_labels() -> None:
                 "operation": "analytics.risk.calculate",
                 "service": "lotus-risk",
                 "reason": "upstream_unavailable",
+            },
+        )
+        == before_degraded_count + 1
+    )
+
+
+def test_gateway_fanout_logs_use_source_calculation_supportability(caplog) -> None:
+    import logging
+
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    logger = logging.getLogger("analytics_ui.gateway")
+    before_degraded_count = _sample_value(
+        GATEWAY_ANALYTICS_DEGRADED_TOTAL,
+        "lotus_gateway_analytics_degraded_total",
+        {
+            "operation": "performance.workspace-summary",
+            "service": "lotus-performance",
+            "reason": "source-data-window-stale",
+        },
+    )
+
+    emit_gateway_analytics_fanout_log(
+        logger=logger,
+        started_at=0.0,
+        service="lotus-performance",
+        operation="performance.workspace-summary",
+        status_code=200,
+        payload={
+            "metadata": {
+                "calculation_supportability": {
+                    "state": "stale",
+                    "reason": "Source data window stale",
+                    "freshness_bucket": "stale",
+                    "source_service": "lotus-performance",
+                }
+            }
+        },
+    )
+
+    record = next(
+        record
+        for record in caplog.records
+        if record.name == "analytics_ui.gateway"
+        and record.message == "gateway.analytics.fanout.degraded"
+    )
+    assert record.extra_fields["state"] == "partial"
+    assert record.extra_fields["supportability_state"] == "partial"
+    assert record.extra_fields["reason"] == "Source data window stale"
+    assert "portfolio_id" not in record.extra_fields
+
+    assert (
+        _sample_value(
+            GATEWAY_ANALYTICS_DEGRADED_TOTAL,
+            "lotus_gateway_analytics_degraded_total",
+            {
+                "operation": "performance.workspace-summary",
+                "service": "lotus-performance",
+                "reason": "source-data-window-stale",
             },
         )
         == before_degraded_count + 1

--- a/tests/unit/test_performance_workspace_service.py
+++ b/tests/unit/test_performance_workspace_service.py
@@ -1133,6 +1133,7 @@ async def test_performance_workspace_service_returns_workspace_summary_contract(
     }
     assert response.evidence_view.fallbacks == []
     assert response.evidence_view.limitations == []
+    assert response.evidence_view.source_supportability == []
     assert (
         response.evidence_view.calculations[0]
         .artifacts[0]
@@ -1204,6 +1205,53 @@ async def test_performance_workspace_service_projects_summary_contract():
     assert analytics_client.workspace_summary_calls[0]["include_detail_blocks"] is False
     assert not hasattr(response, "net_chart")
     assert not hasattr(response, "contribution")
+
+
+@pytest.mark.asyncio
+async def test_performance_workspace_summary_preserves_source_calculation_supportability():
+    class _StaleSupportabilityAnalyticsClient(_StubAnalyticsClient):
+        async def get_workspace_summary(self, **kwargs):
+            status_code, payload = await super().get_workspace_summary(**kwargs)
+            payload["metadata"] = {
+                "calculation_supportability": {
+                    "state": "stale",
+                    "reason": "Source data window stale",
+                    "freshness_bucket": "stale",
+                    "source_service": "lotus-performance",
+                }
+            }
+            return status_code, payload
+
+    service = PerformanceWorkspaceService(
+        workbench_service=_StubWorkbenchService(),
+        analytics_client=_StaleSupportabilityAnalyticsClient(),
+        lotus_core_query_client=_StubLotusCoreQueryClient(),
+    )
+
+    response = await service.get_performance_workspace_summary(
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-performance",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+    )
+
+    assert response.evidence_view is not None
+    assert response.evidence_view.state == "partial"
+    assert response.evidence_view.reason == "Source data window stale"
+    assert response.evidence_view.limitations == ["Source data window stale"]
+    assert response.capabilities.evidence.state == "partial"
+    assert response.capabilities.evidence.reason == "Source data window stale"
+    assert response.evidence_view.source_supportability[0].model_dump() == {
+        "key": "source_calculation",
+        "state": "partial",
+        "reason": "Source data window stale",
+        "freshness_bucket": "stale",
+        "source_service": "lotus-performance",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_risk_workspace_service.py
+++ b/tests/unit/test_risk_workspace_service.py
@@ -36,6 +36,14 @@ class _StubRiskClient:
                     },
                 }
             },
+            "metadata": {
+                "calculation_supportability": {
+                    "state": "ready",
+                    "reason": "Source calculation supportability was confirmed upstream.",
+                    "freshness_bucket": "fresh",
+                    "source_service": "lotus-risk",
+                }
+            },
         }
         self.concentration_payload: dict = {
             "source_service": "lotus-risk",
@@ -101,6 +109,12 @@ class _StubRiskClient:
                 "enrichment_policy": "merge_caller_then_core",
                 "include_cash_positions": True,
                 "include_zero_quantity_positions": False,
+                "calculation_supportability": {
+                    "state": "ready",
+                    "reason": "Source calculation supportability was confirmed upstream.",
+                    "freshness_bucket": "fresh",
+                    "source_service": "lotus-risk",
+                },
             },
         }
         self.drawdown_payload: dict = {
@@ -324,7 +338,11 @@ async def test_risk_summary_uses_stateful_request_and_maps_supportability() -> N
         "portfolio_returns": "ready",
         "benchmark_returns": "ready",
         "risk_free_series": "ready",
+        "source_calculation": "ready",
     }
+    source_support = {item.key: item for item in response.supportability}["source_calculation"]
+    assert source_support.source_service == "lotus-risk"
+    assert source_support.reason == "Source calculation supportability was confirmed upstream."
     risk_free_support = {item.key: item for item in response.supportability}["risk_free_series"]
     assert "zero risk-free" not in (risk_free_support.reason or "").lower()
     assert "risk-free series" in (risk_free_support.reason or "").lower()
@@ -356,6 +374,34 @@ async def test_risk_summary_reports_partial_when_benchmark_metrics_have_errors()
     ][0]
     assert tracking_error.state == "partial"
     assert tracking_error.reason == "benchmark returns unavailable"
+
+
+@pytest.mark.asyncio
+async def test_risk_summary_preserves_source_calculation_supportability() -> None:
+    client = _StubRiskClient()
+    client.calculate_payload["metadata"]["calculation_supportability"] = {
+        "state": "stale",
+        "reason": "Risk source data window stale",
+        "freshness_bucket": "stale",
+        "source_service": "lotus-risk",
+    }
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    response = await service.get_summary(
+        portfolio_id="PF_1",
+        correlation_id="corr-1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-04",
+        reporting_currency="USD",
+    )
+
+    assert response.state == "partial"
+    source_support = {item.key: item for item in response.supportability}["source_calculation"]
+    assert source_support.state == "partial"
+    assert source_support.reason == "Risk source data window stale"
+    assert source_support.source_service == "lotus-risk"
 
 
 @pytest.mark.asyncio
@@ -391,6 +437,7 @@ async def test_risk_concentration_uses_stateful_request_and_maps_issuer_supporta
         "issuer_enrichment": "partial",
         "issuer_grouping": "ready",
         "valuation_basis": "ready",
+        "source_calculation": "ready",
     }
 
 

--- a/tests/unit/test_source_supportability.py
+++ b/tests/unit/test_source_supportability.py
@@ -1,0 +1,59 @@
+from app.services.source_supportability import (
+    extract_calculation_supportability,
+    source_supportability_reason,
+)
+
+
+def test_extract_calculation_supportability_reads_nested_metadata() -> None:
+    supportability = extract_calculation_supportability(
+        {
+            "metadata": {
+                "calculation_supportability": {
+                    "state": "stale",
+                    "reason": "Source data window stale",
+                    "freshness_bucket": "stale",
+                    "source_service": "lotus-performance",
+                }
+            }
+        }
+    )
+
+    assert supportability is not None
+    assert supportability.state == "stale"
+    assert supportability.risk_contract_state == "partial"
+    assert supportability.performance_evidence_state == "partial"
+    assert supportability.reason == "Source data window stale"
+    assert supportability.freshness_bucket == "stale"
+    assert supportability.source_service == "lotus-performance"
+
+
+def test_extract_calculation_supportability_reads_top_level_legacy_shape() -> None:
+    supportability = extract_calculation_supportability(
+        {
+            "calculation_supportability": {
+                "supportability_state": "complete",
+                "freshness_bucket": "fresh",
+            }
+        }
+    )
+
+    assert supportability is not None
+    assert supportability.state == "ready"
+    assert supportability.risk_contract_state == "ready"
+    assert supportability.performance_evidence_state == "supported"
+    assert (
+        source_supportability_reason(
+            supportability,
+            default_ready_reason="Source calculation supportability was confirmed upstream.",
+        )
+        == "Source calculation supportability freshness is fresh."
+    )
+
+
+def test_extract_calculation_supportability_rejects_unknown_state() -> None:
+    assert (
+        extract_calculation_supportability(
+            {"metadata": {"calculation_supportability": {"state": "caller-owned"}}}
+        )
+        is None
+    )

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -69,6 +69,8 @@
   `lotus_gateway_analytics_degraded_total`. Labels are bounded to operation/service/status class
   and degraded reason; portfolio, client, document, transaction, session, upload, trace,
   correlation, request, response, raw prompt, and model output content are not metric labels.
+  Performance and risk upstream `metadata.calculation_supportability` is folded into Gateway
+  fan-out state and degraded reason labels using the same bounded label contract.
 - analytics UI protected diagnostics lookup is gateway-first under
   `/api/v1/analytics-ui/diagnostics/{support_reference}`. It requires `X-Actor-Id`,
   `X-Tenant-Id`, `X-Region`, and an operator support role in `X-Role`; it returns only safe panel,

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -51,9 +51,12 @@
 2. RFC-0082 governs how upstream dependency families are classified
 3. supportability, readiness, and partial-failure metadata should survive composition
 4. performance `evidence_view` payloads expose UI-safe product context for as-of date, period,
-   basis, benchmark, source services, freshness, methodology, calculation versions, coverage,
-   fallbacks, and limitations; `lotus-performance` remains the calculation, lineage, and methodology
-   authority
-5. advisor-brief responses preserve `lotus-ai` workflow-pack run posture and task-flow lineage but do not make gateway the review-state or task-flow authority
-6. archived document retrieval is product-facing only through gateway document routes; Workbench
+   basis, benchmark, source services, freshness, methodology, calculation versions, source
+   calculation supportability, coverage, fallbacks, and limitations; `lotus-performance` remains
+   the calculation, lineage, and methodology authority
+5. risk workspace module payloads preserve source calculation supportability from `lotus-risk`
+   alongside dependency-specific supportability entries; Gateway does not recompute risk
+   supportability
+6. advisor-brief responses preserve `lotus-ai` workflow-pack run posture and task-flow lineage but do not make gateway the review-state or task-flow authority
+7. archived document retrieval is product-facing only through gateway document routes; Workbench
    does not call `lotus-archive` directly


### PR DESCRIPTION
## Summary

- Preserve upstream `metadata.calculation_supportability` from `lotus-performance` and `lotus-risk` through Gateway product-safe contracts.
- Fold source calculation supportability into analytics fan-out state, bounded degraded metrics, performance evidence views, and risk module supportability.
- Document the Gateway RFC-0082/RFC-0108 supportability reconciliation posture and refresh the monetary-float guard baseline after line shifts.

## Local Evidence

- `python -m pytest tests\unit\test_source_supportability.py tests\unit\test_analytics_ui_observability_contract.py tests\unit\test_risk_workspace_service.py tests\unit\test_performance_workspace_service.py -q` -> 74 passed
- `python -m ruff check src\app\observability\analytics_ui.py src\app\services\source_supportability.py src\app\services\risk_workspace_service.py src\app\services\performance_workspace_service.py src\app\contracts\performance_workspace.py tests\unit\test_source_supportability.py tests\unit\test_analytics_ui_observability_contract.py tests\unit\test_risk_workspace_service.py tests\unit\test_performance_workspace_service.py` -> passed
- `python -m mypy src\app\observability\analytics_ui.py src\app\services\source_supportability.py src\app\services\risk_workspace_service.py src\app\services\performance_workspace_service.py src\app\contracts\performance_workspace.py` -> passed
- `make check` -> passed: lint, format, monetary-float guard, mypy, workbench contract, 377 unit/contract tests
- `make ci` -> passed: lint, format, monetary-float guard, mypy, workbench contract, migration smoke, 143 integration tests, 520 unit/contract/integration tests with 88.76% coverage, pip audit
- `git diff --check` -> passed
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` -> expected drift before merge for repo-authored wiki changes: `API-Surface.md`, `Integrations.md`; publish after merge, then re-run check-only

## Tiering

- Repository profile: Experience API.
- PR-blocking local evidence: Feature Lane and PR Merge Gate equivalent via `make ci`.
- Platform end-to-end / Workbench browser proof remains the next slice after this Gateway reconciliation lands.