### PR TITLE
Preserve portfolio supportability posture

### DIFF
--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-04-30T06:58:20Z",
+  "generated_at": "2026-04-30T09:51:21Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -352,43 +352,25 @@
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:1974:portfolio_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:2020:portfolio_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:1981:benchmark_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:2027:benchmark_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:1989:excess_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:2035:excess_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
       "finding": "src/app/contracts/portfolio.py:205:market_value_base: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:2065:portfolio_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:2070:benchmark_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:2077:excess_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
@@ -398,6 +380,24 @@
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:2111:portfolio_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-27"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:2116:benchmark_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-27"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:2123:excess_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-27"
     },
     {
       "finding": "src/app/contracts/portfolio.py:226:market_value_base: float | None = Field(",
@@ -736,214 +736,214 @@
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1263:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/portfolio_service.py:1267:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1287:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/portfolio_service.py:1291:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1363:float(quantize_performance(period_return)) if period_return is not None else None",
+      "finding": "src/app/services/portfolio_service.py:1367:float(quantize_performance(period_return)) if period_return is not None else None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1431:market_price=float(quantize_price(item.get(\"valuation\", {}).get(\"market_price\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1435:market_price=float(quantize_price(item.get(\"valuation\", {}).get(\"market_price\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1434:cost_basis_base=float(quantize_money(item.get(\"cost_basis\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1438:cost_basis_base=float(quantize_money(item.get(\"cost_basis\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1437:cost_basis_local=float(quantize_money(item.get(\"cost_basis_local\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1441:cost_basis_local=float(quantize_money(item.get(\"cost_basis_local\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1440:market_value_base=float(",
+      "finding": "src/app/services/portfolio_service.py:1444:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1452:market_value_local=float(",
+      "finding": "src/app/services/portfolio_service.py:1456:market_value_local=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1490:weight_pct=float(quantize_performance(float(item.get(\"weight\", 0)) * 100))",
+      "finding": "src/app/services/portfolio_service.py:1494:weight_pct=float(quantize_performance(float(item.get(\"weight\", 0)) * 100))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1507:market_value_base=float(",
+      "finding": "src/app/services/portfolio_service.py:1511:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1510:weight_pct=float(",
+      "finding": "src/app/services/portfolio_service.py:1514:weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1511:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
+      "finding": "src/app/services/portfolio_service.py:1515:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1568:cash_total += float(quantize_money(market_value or 0))",
+      "finding": "src/app/services/portfolio_service.py:1572:cash_total += float(quantize_money(market_value or 0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1570:return float(quantize_money(cash_total)), cash_count",
+      "finding": "src/app/services/portfolio_service.py:1574:return float(quantize_money(cash_total)), cash_count",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1588:price=float(quantize_price(item.get(\"price\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1592:price=float(quantize_price(item.get(\"price\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1591:gross_amount=float(quantize_money(item.get(\"gross_transaction_amount\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1595:gross_amount=float(quantize_money(item.get(\"gross_transaction_amount\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1595:net_cost_base=float(quantize_money(item.get(\"net_cost\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1599:net_cost_base=float(quantize_money(item.get(\"net_cost\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1737:accumulator[\"gross_amount_portfolio_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:1741:accumulator[\"gross_amount_portfolio_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1740:accumulator[\"gross_amount_reporting_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:1744:accumulator[\"gross_amount_reporting_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1767:accumulator[\"net_amount_portfolio_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:1771:accumulator[\"net_amount_portfolio_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1770:accumulator[\"net_amount_reporting_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:1774:accumulator[\"net_amount_reporting_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1778:portfolio_amount: float,",
+      "finding": "src/app/services/portfolio_service.py:1782:portfolio_amount: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1779:reporting_amount: float,",
+      "finding": "src/app/services/portfolio_service.py:1783:reporting_amount: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1783:float(accumulator[\"amount_portfolio_currency\"]) + portfolio_amount",
+      "finding": "src/app/services/portfolio_service.py:1787:float(accumulator[\"amount_portfolio_currency\"]) + portfolio_amount",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1786:float(accumulator[\"amount_reporting_currency\"]) + reporting_amount",
+      "finding": "src/app/services/portfolio_service.py:1790:float(accumulator[\"amount_reporting_currency\"]) + reporting_amount",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1809:def _activity_portfolio_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1813:def _activity_portfolio_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1816:def _activity_reporting_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1820:def _activity_reporting_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1833:def _income_net_portfolio_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1837:def _income_net_portfolio_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1843:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
+      "finding": "src/app/services/portfolio_service.py:1847:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1845:def _income_net_reporting_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1849:def _income_net_reporting_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1871:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
+      "finding": "src/app/services/portfolio_service.py:1875:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1884:def _absolute_money(self, value: Any) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1888:def _absolute_money(self, value: Any) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1887:return float(quantize_money(abs(float(value))))",
+      "finding": "src/app/services/portfolio_service.py:1891:return float(quantize_money(abs(float(value))))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1949:reporting_currency_amount=float(quantize_money(payload.get(reporting_key, 0))),",
+      "finding": "src/app/services/portfolio_service.py:1953:reporting_currency_amount=float(quantize_money(payload.get(reporting_key, 0))),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2472:return float(",
+      "finding": "src/app/services/portfolio_service.py:2476:return float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-27"
     },
     {
       "finding": "src/app/services/risk_workspace_service.py:1702:def _safe_float(value: Any) -> float | None:",

--- a/src/app/contracts/portfolio.py
+++ b/src/app/contracts/portfolio.py
@@ -910,6 +910,45 @@ class PortfolioReadinessBucket(BaseModel):
     )
 
 
+class PortfolioSupportabilitySummary(BaseModel):
+    feature_key: str = Field(
+        default="core.observability.portfolio_supportability",
+        description="RFC-0108 feature key for the source-owned portfolio supportability signal.",
+        examples=["core.observability.portfolio_supportability"],
+    )
+    state: str = Field(
+        description="Gateway-normalized supportability state for portfolio readiness composition.",
+        examples=["ready", "degraded"],
+    )
+    reason: str = Field(
+        description="Bounded source-authored reason code for the supportability state.",
+        examples=["portfolio_supportability_ready"],
+    )
+    freshness_bucket: str = Field(
+        description=(
+            "Gateway-normalized freshness bucket for analytics UI observability. "
+            "`current` from lotus-core is exposed as `fresh` for Workbench metric vocabulary."
+        ),
+        examples=["fresh", "stale", "unknown"],
+    )
+    ready_domains: int = Field(
+        description="Count of source readiness domains currently ready.",
+        examples=[4],
+    )
+    pending_domains: int = Field(
+        description="Count of source readiness domains currently pending.",
+        examples=[0],
+    )
+    blocked_domains: int = Field(
+        description="Count of source readiness domains currently blocked.",
+        examples=[0],
+    )
+    no_activity_domains: int = Field(
+        description="Count of source readiness domains with no activity.",
+        examples=[0],
+    )
+
+
 class PortfolioExceptionSummary(BaseModel):
     key: str = Field(
         description="Stable exception key used by the workspace to group attention items.",
@@ -1018,6 +1057,13 @@ class PortfolioReadinessResponse(BaseModel):
                 }
             ]
         ],
+    )
+    supportability: PortfolioSupportabilitySummary | None = Field(
+        default=None,
+        description=(
+            "Source-owned RFC-0108 portfolio supportability posture preserved from lotus-core "
+            "for Workbench freshness, degraded-state, and operational evidence."
+        ),
     )
     indicators: list[PortfolioReadinessIndicator] = Field(
         default_factory=list,

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -43,6 +43,7 @@ from app.contracts.portfolio import (
     PortfolioReadinessResponse,
     PortfolioRebalanceSummary,
     PortfolioSummary,
+    PortfolioSupportabilitySummary,
     PortfolioTopPosition,
     PortfolioTransactionLedgerResponse,
     PortfolioTransactionView,
@@ -608,6 +609,9 @@ class PortfolioService:
             reporting=self._parse_readiness_bucket((source_payload or {}).get("reporting")),
             blocking_reasons=self._parse_readiness_reasons(
                 (source_payload or {}).get("blocking_reasons")
+            ),
+            supportability=self._parse_portfolio_supportability(
+                (source_payload or {}).get("supportability")
             ),
             indicators=indicators,
         )
@@ -2566,6 +2570,39 @@ class PortfolioService:
             )
         return reasons
 
+    def _parse_portfolio_supportability(
+        self, payload: Any
+    ) -> PortfolioSupportabilitySummary | None:
+        if not isinstance(payload, dict):
+            return None
+        state = self._optional_str(payload.get("state"))
+        reason = self._optional_str(payload.get("reason"))
+        if state is None or reason is None:
+            return None
+        return PortfolioSupportabilitySummary(
+            feature_key=(
+                self._optional_str(payload.get("feature_key"))
+                or "core.observability.portfolio_supportability"
+            ),
+            state=state,
+            reason=reason,
+            freshness_bucket=self._map_portfolio_supportability_freshness(
+                payload.get("freshness_bucket")
+            ),
+            ready_domains=self._optional_int(payload.get("ready_domains")) or 0,
+            pending_domains=self._optional_int(payload.get("pending_domains")) or 0,
+            blocked_domains=self._optional_int(payload.get("blocked_domains")) or 0,
+            no_activity_domains=self._optional_int(payload.get("no_activity_domains")) or 0,
+        )
+
+    def _map_portfolio_supportability_freshness(self, value: Any) -> str:
+        normalized = str(value or "").strip().lower()
+        if normalized in {"fresh", "current"}:
+            return "fresh"
+        if normalized == "stale":
+            return "stale"
+        return "unknown"
+
     def _build_source_readiness_indicators(
         self, payload: dict[str, Any] | None, detailed_view: bool
     ) -> list[PortfolioReadinessIndicator]:
@@ -2846,6 +2883,14 @@ class PortfolioService:
             return None
         text = str(value).strip()
         return text or None
+
+    def _optional_int(self, value: Any) -> int | None:
+        if value is None or isinstance(value, bool):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
     def _resolve_portfolio_display_name(
         self, payload: dict[str, Any], *, fallback_portfolio_id: str

--- a/tests/contract/test_portfolio_contract.py
+++ b/tests/contract/test_portfolio_contract.py
@@ -352,6 +352,16 @@ def test_portfolio_readiness_and_workflow_contract_shapes() -> None:
                 "detail": "Reporting remains blocked until pricing is published.",
             }
         ],
+        supportability={
+            "feature_key": "core.observability.portfolio_supportability",
+            "state": "degraded",
+            "reason": "portfolio_supportability_pending",
+            "freshness_bucket": "fresh",
+            "ready_domains": 3,
+            "pending_domains": 1,
+            "blocked_domains": 0,
+            "no_activity_domains": 0,
+        },
         indicators=[
             {
                 "key": "holdings",
@@ -408,6 +418,8 @@ def test_portfolio_readiness_and_workflow_contract_shapes() -> None:
     assert readiness.pricing is not None
     assert readiness.pricing.reasons[0].code == "pricing_not_published"
     assert readiness.blocking_reasons[0].code == "awaiting_pricing"
+    assert readiness.supportability is not None
+    assert readiness.supportability.freshness_bucket == "fresh"
     assert insights.contract_version == "v1"
     assert insights.insights[0].key == "equity-concentration-high"
     assert insights.exception_summaries[0].key == "pricing"
@@ -784,6 +796,7 @@ def test_portfolio_openapi_contract_registered() -> None:
     assert workflow_launch_cue_schema["properties"]["label"]["description"]
     assert workflow_launch_cue_schema["properties"]["href"]["description"]
     assert readiness_schema["properties"]["blocking_reasons"]["description"]
+    assert readiness_schema["properties"]["supportability"]["description"]
     assert readiness_schema["properties"]["indicators"]["description"]
     assert readiness_schema["properties"]["correlation_id"]["description"]
     assert readiness_schema["properties"]["correlation_id"]["examples"] == [

--- a/tests/integration/test_portfolio_router.py
+++ b/tests/integration/test_portfolio_router.py
@@ -147,6 +147,16 @@ def test_portfolio_workspace_router(monkeypatch):
                     "detail": "Reporting remains blocked until pricing is published.",
                 }
             ],
+            "supportability": {
+                "feature_key": "core.observability.portfolio_supportability",
+                "state": "degraded",
+                "reason": "portfolio_supportability_pending",
+                "freshness_bucket": "current",
+                "ready_domains": 3,
+                "pending_domains": 1,
+                "blocked_domains": 0,
+                "no_activity_domains": 0,
+            },
         }
 
     async def _cashflow(*args, **kwargs):
@@ -314,6 +324,16 @@ def test_portfolio_readiness_router(monkeypatch):
                     "detail": "Reporting remains blocked until pricing is published.",
                 }
             ],
+            "supportability": {
+                "feature_key": "core.observability.portfolio_supportability",
+                "state": "degraded",
+                "reason": "portfolio_supportability_pending",
+                "freshness_bucket": "current",
+                "ready_domains": 3,
+                "pending_domains": 1,
+                "blocked_domains": 0,
+                "no_activity_domains": 0,
+            },
         }
 
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio", _get_portfolio)
@@ -335,6 +355,16 @@ def test_portfolio_readiness_router(monkeypatch):
     assert body["pricing"]["status"] == "Pending"
     assert body["pricing"]["reasons"][0]["code"] == "pricing_not_published"
     assert body["blocking_reasons"][0]["code"] == "awaiting_pricing"
+    assert body["supportability"] == {
+        "feature_key": "core.observability.portfolio_supportability",
+        "state": "degraded",
+        "reason": "portfolio_supportability_pending",
+        "freshness_bucket": "fresh",
+        "ready_domains": 3,
+        "pending_domains": 1,
+        "blocked_domains": 0,
+        "no_activity_domains": 0,
+    }
 
 
 def test_portfolio_readiness_router_preserves_upstream_bad_request(monkeypatch):

--- a/tests/unit/test_portfolio_service.py
+++ b/tests/unit/test_portfolio_service.py
@@ -72,6 +72,16 @@ class _StubLotusCoreQueryClient:
                     "detail": "Reporting remains blocked until pricing is published.",
                 }
             ],
+            "supportability": {
+                "feature_key": "core.observability.portfolio_supportability",
+                "state": "degraded",
+                "reason": "portfolio_supportability_pending",
+                "freshness_bucket": "current",
+                "ready_domains": 3,
+                "pending_domains": 1,
+                "blocked_domains": 0,
+                "no_activity_domains": 0,
+            },
         }
 
     async def get_portfolio_analytics_reference(
@@ -589,6 +599,12 @@ async def test_portfolio_readiness_returns_compact_indicators():
     assert response.pricing is not None
     assert response.pricing.reasons[0].code == "pricing_not_published"
     assert response.blocking_reasons[0].code == "awaiting_pricing"
+    assert response.supportability is not None
+    assert response.supportability.feature_key == "core.observability.portfolio_supportability"
+    assert response.supportability.state == "degraded"
+    assert response.supportability.reason == "portfolio_supportability_pending"
+    assert response.supportability.freshness_bucket == "fresh"
+    assert response.supportability.pending_domains == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- preserve lotus-core portfolio readiness `supportability` on Gateway `/api/v1/portfolio/portfolios/{portfolio_id}/readiness`
- normalize lotus-core `current` freshness into Workbench analytics UI vocabulary as `fresh`
- add contract, service, unit, and router proof for source-backed portfolio supportability posture

## Validation
- `python -m pytest tests/unit/test_portfolio_service.py::test_portfolio_readiness_returns_compact_indicators tests/integration/test_portfolio_router.py::test_portfolio_readiness_router tests/contract/test_portfolio_contract.py::test_portfolio_readiness_and_workflow_contract_shapes tests/contract/test_portfolio_contract.py::test_portfolio_openapi_contract_registered -q` (4 passed)
- `python -m ruff check src/app/contracts/portfolio.py src/app/services/portfolio_service.py tests/unit/test_portfolio_service.py tests/integration/test_portfolio_router.py tests/contract/test_portfolio_contract.py`
- `python -m mypy src/app/contracts/portfolio.py src/app/services/portfolio_service.py`
- `git diff --check`

## RFC-0108
This advances the `core.observability.portfolio_supportability` residual by carrying source-owned readiness supportability through the experience API without recomputing domain truth in Gateway.