### PR TITLE
feat: carry manage supportability in portfolio workspace

### DIFF
--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-04-30T09:51:21Z",
+  "generated_at": "2026-04-30T10:19:06Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -352,28 +352,28 @@
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:2020:portfolio_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:2027:benchmark_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:2035:excess_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
       "finding": "src/app/contracts/portfolio.py:205:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:2067:portfolio_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-27"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:2074:benchmark_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-27"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:2082:excess_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-27"
     },
     {
       "finding": "src/app/contracts/portfolio.py:210:weight_pct: float | None = Field(",
@@ -382,19 +382,19 @@
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:2111:portfolio_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:2158:portfolio_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:2116:benchmark_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:2163:benchmark_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:2123:excess_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:2170:excess_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
@@ -736,211 +736,211 @@
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1267:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/portfolio_service.py:1289:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1291:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/portfolio_service.py:1313:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1367:float(quantize_performance(period_return)) if period_return is not None else None",
+      "finding": "src/app/services/portfolio_service.py:1389:float(quantize_performance(period_return)) if period_return is not None else None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1435:market_price=float(quantize_price(item.get(\"valuation\", {}).get(\"market_price\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1521:market_price=float(quantize_price(item.get(\"valuation\", {}).get(\"market_price\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1438:cost_basis_base=float(quantize_money(item.get(\"cost_basis\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1524:cost_basis_base=float(quantize_money(item.get(\"cost_basis\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1441:cost_basis_local=float(quantize_money(item.get(\"cost_basis_local\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1527:cost_basis_local=float(quantize_money(item.get(\"cost_basis_local\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1444:market_value_base=float(",
+      "finding": "src/app/services/portfolio_service.py:1530:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1456:market_value_local=float(",
+      "finding": "src/app/services/portfolio_service.py:1542:market_value_local=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1494:weight_pct=float(quantize_performance(float(item.get(\"weight\", 0)) * 100))",
+      "finding": "src/app/services/portfolio_service.py:1580:weight_pct=float(quantize_performance(float(item.get(\"weight\", 0)) * 100))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1511:market_value_base=float(",
+      "finding": "src/app/services/portfolio_service.py:1597:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1514:weight_pct=float(",
+      "finding": "src/app/services/portfolio_service.py:1600:weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1515:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
+      "finding": "src/app/services/portfolio_service.py:1601:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1572:cash_total += float(quantize_money(market_value or 0))",
+      "finding": "src/app/services/portfolio_service.py:1658:cash_total += float(quantize_money(market_value or 0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1574:return float(quantize_money(cash_total)), cash_count",
+      "finding": "src/app/services/portfolio_service.py:1660:return float(quantize_money(cash_total)), cash_count",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1592:price=float(quantize_price(item.get(\"price\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1678:price=float(quantize_price(item.get(\"price\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1595:gross_amount=float(quantize_money(item.get(\"gross_transaction_amount\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1681:gross_amount=float(quantize_money(item.get(\"gross_transaction_amount\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1599:net_cost_base=float(quantize_money(item.get(\"net_cost\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1685:net_cost_base=float(quantize_money(item.get(\"net_cost\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1741:accumulator[\"gross_amount_portfolio_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:1827:accumulator[\"gross_amount_portfolio_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1744:accumulator[\"gross_amount_reporting_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:1830:accumulator[\"gross_amount_reporting_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1771:accumulator[\"net_amount_portfolio_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:1857:accumulator[\"net_amount_portfolio_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1774:accumulator[\"net_amount_reporting_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:1860:accumulator[\"net_amount_reporting_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1782:portfolio_amount: float,",
+      "finding": "src/app/services/portfolio_service.py:1868:portfolio_amount: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1783:reporting_amount: float,",
+      "finding": "src/app/services/portfolio_service.py:1869:reporting_amount: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1787:float(accumulator[\"amount_portfolio_currency\"]) + portfolio_amount",
+      "finding": "src/app/services/portfolio_service.py:1873:float(accumulator[\"amount_portfolio_currency\"]) + portfolio_amount",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1790:float(accumulator[\"amount_reporting_currency\"]) + reporting_amount",
+      "finding": "src/app/services/portfolio_service.py:1876:float(accumulator[\"amount_reporting_currency\"]) + reporting_amount",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1813:def _activity_portfolio_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1899:def _activity_portfolio_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1820:def _activity_reporting_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1906:def _activity_reporting_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1837:def _income_net_portfolio_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1923:def _income_net_portfolio_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1847:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
+      "finding": "src/app/services/portfolio_service.py:1933:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1849:def _income_net_reporting_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1935:def _income_net_reporting_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1875:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
+      "finding": "src/app/services/portfolio_service.py:1961:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1888:def _absolute_money(self, value: Any) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1974:def _absolute_money(self, value: Any) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1891:return float(quantize_money(abs(float(value))))",
+      "finding": "src/app/services/portfolio_service.py:1977:return float(quantize_money(abs(float(value))))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1953:reporting_currency_amount=float(quantize_money(payload.get(reporting_key, 0))),",
+      "finding": "src/app/services/portfolio_service.py:2039:reporting_currency_amount=float(quantize_money(payload.get(reporting_key, 0))),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2476:return float(",
+      "finding": "src/app/services/portfolio_service.py:2562:return float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -72,6 +72,17 @@ class DpmClient:
             operation="manage.rebalance.runs.list",
         )
 
+    async def get_supportability_summary(
+        self,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            "/api/v1/rebalance/supportability/summary",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.supportability.summary",
+        )
+
     async def get_proposal(
         self,
         proposal_id: str,

--- a/src/app/contracts/portfolio.py
+++ b/src/app/contracts/portfolio.py
@@ -763,6 +763,46 @@ class PortfolioPerformanceSummary(BaseModel):
     )
 
 
+class PortfolioRebalanceSupportabilitySummary(BaseModel):
+    feature_key: str = Field(
+        default="manage.observability.action_register_supportability",
+        description=(
+            "Capability key for the manage action-register supportability posture carried "
+            "through the portfolio workspace contract."
+        ),
+        examples=["manage.observability.action_register_supportability"],
+    )
+    state: str = Field(
+        description="Manage action-register supportability state.",
+        examples=["healthy"],
+    )
+    reason: str | None = Field(
+        default=None,
+        description="Machine-readable reason for degraded or unavailable supportability.",
+        examples=["action_register_current"],
+    )
+    freshness_bucket: str | None = Field(
+        default=None,
+        description="Freshness bucket reported by lotus-manage for action-register evidence.",
+        examples=["fresh"],
+    )
+    run_count: int | None = Field(
+        default=None,
+        description="Count of rebalance runs considered by the supportability summary.",
+        examples=[4],
+    )
+    operation_count: int | None = Field(
+        default=None,
+        description="Count of action-register operations considered by the summary.",
+        examples=[12],
+    )
+    workflow_decision_count: int | None = Field(
+        default=None,
+        description="Count of workflow decisions considered by the supportability summary.",
+        examples=[3],
+    )
+
+
 class PortfolioRebalanceSummary(BaseModel):
     status: str = Field(
         description="Latest rebalance workflow status returned by lotus-manage or decisioning.",
@@ -777,6 +817,13 @@ class PortfolioRebalanceSummary(BaseModel):
         default=None,
         description="Identifier of the latest rebalance run when an upstream run exists.",
         examples=["rr_100"],
+    )
+    supportability: PortfolioRebalanceSupportabilitySummary | None = Field(
+        default=None,
+        description=(
+            "Source-backed lotus-manage action-register supportability posture used by "
+            "operators to understand whether rebalance action evidence is current."
+        ),
     )
 
 

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -42,6 +42,7 @@ from app.contracts.portfolio import (
     PortfolioReadinessReason,
     PortfolioReadinessResponse,
     PortfolioRebalanceSummary,
+    PortfolioRebalanceSupportabilitySummary,
     PortfolioSummary,
     PortfolioSupportabilitySummary,
     PortfolioTopPosition,
@@ -419,6 +420,19 @@ class PortfolioService:
             ),
         )
 
+    async def _get_workspace_rebalance_supportability_result(
+        self,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]] | None:
+        if self._dpm_client is None:
+            return None
+        return await self._get_cached_upstream_result(
+            ("workspace_rebalance_supportability",),
+            lambda: self._dpm_client.get_supportability_summary(
+                correlation_id=correlation_id,
+            ),
+        )
+
     async def get_portfolio_catalog(self, correlation_id: str) -> PortfolioCatalogResponse:
         status_code, payload = await self._lotus_core_query_client.list_portfolios(
             correlation_id=correlation_id
@@ -481,7 +495,11 @@ class PortfolioService:
                 as_of_date=effective_as_of_date,
             ),
         )
-        performance_result, rebalance_result = await asyncio.gather(
+        (
+            performance_result,
+            rebalance_result,
+            rebalance_supportability_result,
+        ) = await asyncio.gather(
             self._get_workspace_performance_result(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
@@ -489,6 +507,9 @@ class PortfolioService:
             ),
             self._get_workspace_rebalance_result(
                 portfolio_id=portfolio_id,
+                correlation_id=correlation_id,
+            ),
+            self._get_workspace_rebalance_supportability_result(
                 correlation_id=correlation_id,
             ),
         )
@@ -517,6 +538,7 @@ class PortfolioService:
         )
         rebalance = self._parse_workspace_rebalance(
             rebalance_result,
+            rebalance_supportability_result,
             warnings,
             partial_failures,
         )
@@ -1373,11 +1395,17 @@ class PortfolioService:
     def _parse_workspace_rebalance(
         self,
         result: tuple[int, dict[str, Any]] | None,
+        supportability_result: tuple[int, dict[str, Any]] | None,
         warnings: list[str],
         partial_failures: list[PortfolioPartialFailure],
     ) -> PortfolioRebalanceSummary | None:
+        supportability = self._parse_workspace_rebalance_supportability(
+            supportability_result,
+            warnings,
+            partial_failures,
+        )
         if result is None:
-            return None
+            return self._rebalance_summary_from_supportability("NO_RUNS", supportability)
         payload = self._optional_payload(
             result,
             "lotus-manage",
@@ -1386,17 +1414,75 @@ class PortfolioService:
             partial_failures,
         )
         if payload is None:
-            return None
+            return self._rebalance_summary_from_supportability("UNKNOWN", supportability)
         items = payload.get("items", [])
         if not isinstance(items, list) or not items:
-            return None
+            return self._rebalance_summary_from_supportability("NO_RUNS", supportability)
         latest = items[0]
         if not isinstance(latest, dict):
-            return None
+            return self._rebalance_summary_from_supportability("UNKNOWN", supportability)
         return PortfolioRebalanceSummary(
             status=str(latest.get("status", "UNKNOWN")),
             last_run_at_utc=self._optional_str(latest.get("created_at")),
             last_rebalance_run_id=self._optional_str(latest.get("rebalance_run_id")),
+            supportability=supportability,
+        )
+
+    def _rebalance_summary_from_supportability(
+        self,
+        status_value: str,
+        supportability: PortfolioRebalanceSupportabilitySummary | None,
+    ) -> PortfolioRebalanceSummary | None:
+        if supportability is None:
+            return None
+        return PortfolioRebalanceSummary(
+            status=status_value,
+            last_run_at_utc=None,
+            last_rebalance_run_id=None,
+            supportability=supportability,
+        )
+
+    def _parse_workspace_rebalance_supportability(
+        self,
+        result: tuple[int, dict[str, Any]] | None,
+        warnings: list[str],
+        partial_failures: list[PortfolioPartialFailure],
+    ) -> PortfolioRebalanceSupportabilitySummary | None:
+        if result is None:
+            return None
+        payload = self._optional_payload(
+            result,
+            "lotus-manage",
+            "PORTFOLIO_REBALANCE_SUPPORTABILITY_UNAVAILABLE",
+            warnings,
+            partial_failures,
+        )
+        if payload is None:
+            return None
+        supportability_payload = payload.get("supportability", payload)
+        if not isinstance(supportability_payload, dict):
+            warnings.append("PORTFOLIO_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
+            partial_failures.append(
+                PortfolioPartialFailure(
+                    source_service="lotus-manage",
+                    error_code="PORTFOLIO_REBALANCE_SUPPORTABILITY_UNAVAILABLE",
+                    detail="lotus-manage supportability summary did not include an object payload",
+                )
+            )
+            return None
+        return PortfolioRebalanceSupportabilitySummary(
+            feature_key=(
+                self._optional_str(supportability_payload.get("feature_key"))
+                or "manage.observability.action_register_supportability"
+            ),
+            state=str(supportability_payload.get("state") or "unknown"),
+            reason=self._optional_str(supportability_payload.get("reason")),
+            freshness_bucket=self._optional_str(supportability_payload.get("freshness_bucket")),
+            run_count=self._optional_int(supportability_payload.get("run_count")),
+            operation_count=self._optional_int(supportability_payload.get("operation_count")),
+            workflow_decision_count=self._optional_int(
+                supportability_payload.get("workflow_decision_count")
+            ),
         )
 
     def _parse_operations(

--- a/tests/integration/test_portfolio_router.py
+++ b/tests/integration/test_portfolio_router.py
@@ -44,6 +44,19 @@ def stub_portfolio_workspace_enrichments(monkeypatch):
             ]
         }
 
+    async def _rebalance_supportability(*args, **kwargs):
+        return 200, {
+            "supportability": {
+                "feature_key": "manage.observability.action_register_supportability",
+                "state": "healthy",
+                "reason": "action_register_current",
+                "freshness_bucket": "fresh",
+                "run_count": 4,
+                "operation_count": 12,
+                "workflow_decision_count": 3,
+            }
+        }
+
     monkeypatch.setattr(
         f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_analytics_reference",
         _analytics_reference,
@@ -53,6 +66,10 @@ def stub_portfolio_workspace_enrichments(monkeypatch):
         _twr,
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _rebalance_runs)
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_supportability_summary",
+        _rebalance_supportability,
+    )
 
 
 def test_portfolio_catalog_router(monkeypatch):
@@ -215,6 +232,15 @@ def test_portfolio_workspace_router(monkeypatch):
     assert body["performance"]["period"] == "YTD"
     assert body["performance"]["return_pct"] == 2.5
     assert body["rebalance"]["status"] == "PENDING_REVIEW"
+    assert body["rebalance"]["supportability"] == {
+        "feature_key": "manage.observability.action_register_supportability",
+        "state": "healthy",
+        "reason": "action_register_current",
+        "freshness_bucket": "fresh",
+        "run_count": 4,
+        "operation_count": 12,
+        "workflow_decision_count": 3,
+    }
     assert body["control_capabilities"]["historical_snapshots"]["state"] == "partial"
     assert (
         body["control_capabilities"]["historical_snapshots"]["module_capabilities"][-2]["module"]

--- a/tests/unit/test_portfolio_service.py
+++ b/tests/unit/test_portfolio_service.py
@@ -413,6 +413,20 @@ class _StubDpmClient:
             ]
         }
 
+    async def get_supportability_summary(self, correlation_id: str):
+        _ = correlation_id
+        return 200, {
+            "supportability": {
+                "feature_key": "manage.observability.action_register_supportability",
+                "state": "healthy",
+                "reason": "action_register_current",
+                "freshness_bucket": "fresh",
+                "run_count": 4,
+                "operation_count": 12,
+                "workflow_decision_count": 3,
+            }
+        }
+
 
 @pytest.mark.asyncio
 async def test_portfolio_catalog_is_sorted_and_mapped():
@@ -513,6 +527,17 @@ async def test_portfolio_workspace_uses_aum_and_cash_balance_reporting():
     assert response.performance.return_pct == 2.5
     assert response.rebalance is not None
     assert response.rebalance.status == "PENDING_REVIEW"
+    assert response.rebalance.supportability is not None
+    assert (
+        response.rebalance.supportability.feature_key
+        == "manage.observability.action_register_supportability"
+    )
+    assert response.rebalance.supportability.state == "healthy"
+    assert response.rebalance.supportability.reason == "action_register_current"
+    assert response.rebalance.supportability.freshness_bucket == "fresh"
+    assert response.rebalance.supportability.run_count == 4
+    assert response.rebalance.supportability.operation_count == 12
+    assert response.rebalance.supportability.workflow_decision_count == 3
     assert response.control_capabilities.historical_snapshots.state == "partial"
     assert (
         response.control_capabilities.historical_snapshots.earliest_available_as_of_date
@@ -547,6 +572,62 @@ async def test_portfolio_workspace_uses_aum_and_cash_balance_reporting():
     assert (
         response.control_capabilities.reporting_currency_restatement.module_capabilities[-2].state
         == "unsupported"
+    )
+
+
+@pytest.mark.asyncio
+async def test_portfolio_workspace_preserves_rebalance_supportability_without_latest_run():
+    class _NoRunDpmClient(_StubDpmClient):
+        async def list_runs(self, params: dict[str, object], correlation_id: str):
+            _ = params, correlation_id
+            return 200, {"items": []}
+
+    service = PortfolioService(
+        _StubLotusCoreQueryClient(),
+        analytics_client=_StubAnalyticsClient(),
+        dpm_client=_NoRunDpmClient(),
+    )
+
+    response = await service.get_portfolio_workspace(
+        portfolio_id="PF_1001",
+        correlation_id="corr-2-no-run",
+    )
+
+    assert response.rebalance is not None
+    assert response.rebalance.status == "NO_RUNS"
+    assert response.rebalance.last_rebalance_run_id is None
+    assert response.rebalance.supportability is not None
+    assert response.rebalance.supportability.state == "healthy"
+    assert response.rebalance.supportability.freshness_bucket == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_portfolio_workspace_records_rebalance_supportability_partial_failure():
+    class _UnavailableSupportabilityDpmClient(_StubDpmClient):
+        async def get_supportability_summary(self, correlation_id: str):
+            _ = correlation_id
+            return 503, {"detail": "manage supportability temporarily unavailable"}
+
+    service = PortfolioService(
+        _StubLotusCoreQueryClient(),
+        analytics_client=_StubAnalyticsClient(),
+        dpm_client=_UnavailableSupportabilityDpmClient(),
+    )
+
+    response = await service.get_portfolio_workspace(
+        portfolio_id="PF_1001",
+        correlation_id="corr-2-supportability-failure",
+    )
+
+    assert response.rebalance is not None
+    assert response.rebalance.status == "PENDING_REVIEW"
+    assert response.rebalance.supportability is None
+    assert "PORTFOLIO_REBALANCE_SUPPORTABILITY_UNAVAILABLE" in response.warnings
+    assert any(
+        failure.source_service == "lotus-manage"
+        and failure.error_code == "PORTFOLIO_REBALANCE_SUPPORTABILITY_UNAVAILABLE"
+        and failure.detail == "manage supportability temporarily unavailable"
+        for failure in response.partial_failures
     )
 
 

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1607,6 +1607,11 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
             "http://dpm/api/v1/rebalance/runs",
         ),
         (
+            "get_supportability_summary",
+            {"correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/supportability/summary",
+        ),
+        (
             "get_proposal",
             {"proposal_id": "PR-1", "include_evidence": True, "correlation_id": "corr-5"},
             "http://dpm/api/v1/rebalance/proposals/PR-1",


### PR DESCRIPTION
## Summary
- add the lotus-manage action-register supportability summary route to the Gateway DPM client
- carry source-backed manage supportability on the portfolio workspace rebalance summary
- preserve optional-section degradation with partial failures when supportability is unavailable
- refresh the monetary float allowlist after formatter line-number churn only

## Validation
- python -m pytest tests\\unit\\test_portfolio_service.py::test_portfolio_workspace_uses_aum_and_cash_balance_reporting tests\\unit\\test_portfolio_service.py::test_portfolio_workspace_preserves_rebalance_supportability_without_latest_run tests\\unit\\test_portfolio_service.py::test_portfolio_workspace_records_rebalance_supportability_partial_failure tests\\integration\\test_portfolio_router.py::test_portfolio_workspace_router tests\\unit\\test_upstream_clients.py::test_dpm_client_all_routes -q
- python -m mypy src\\app\\clients\\dpm_client.py src\\app\\contracts\\portfolio.py src\\app\\services\\portfolio_service.py
- make lint
- git diff --check

## RFC-0108
Advances manage.observability.action_register_supportability Gateway reconciliation by exposing the source supportability posture through the portfolio workspace contract.