### PR TITLE
Preserve report evidence supportability in batch APIs

### DIFF
--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -1143,6 +1143,17 @@ BATCH_HANDLE_RESPONSE_EXAMPLE: dict[str, Any] = {
     "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
     "idempotency_key": "batch-portfolio-review-2026-04-22",
     "item_count": 1,
+    "supportability": {
+        "feature_key": "report.observability.evidence_surface_supportability",
+        "state": "ready",
+        "reason": "evidence_surface_ready",
+        "freshness_bucket": "current",
+        "evidence_feature_count": 14,
+        "ready_evidence_feature_count": 14,
+        "degraded_evidence_feature_count": 0,
+        "workflow_count": 4,
+        "ready_workflow_count": 4,
+    },
 }
 
 BATCH_STATUS_RESPONSE_EXAMPLE: dict[str, Any] = {
@@ -1241,6 +1252,7 @@ BATCH_WORKER_RUN_RESPONSE_EXAMPLE: dict[str, Any] = {
         }
     ],
     "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+    "supportability": BATCH_HANDLE_RESPONSE_EXAMPLE["supportability"],
 }
 
 BATCH_SCHEDULE_LIST_RESPONSE_EXAMPLE: dict[str, Any] = {
@@ -1408,6 +1420,53 @@ class BatchCreateRequest(BaseModel):
     )
 
 
+class ReportingEvidenceSurfaceSupportability(BaseModel):
+    feature_key: str = Field(
+        "report.observability.evidence_surface_supportability",
+        description="RFC-0108 feature key for lotus-report evidence-surface supportability.",
+    )
+    state: str = Field(
+        ...,
+        description="Bounded supportability state published by lotus-report.",
+        examples=["ready"],
+    )
+    reason: str = Field(
+        ...,
+        description="Bounded reason code explaining the evidence-surface posture.",
+        examples=["evidence_surface_ready"],
+    )
+    freshness_bucket: str = Field(
+        ...,
+        description="Bounded freshness bucket for evidence-surface supportability.",
+        examples=["current"],
+    )
+    evidence_feature_count: int = Field(
+        0,
+        ge=0,
+        description="Number of evidence-surface feature keys reviewed by lotus-report.",
+    )
+    ready_evidence_feature_count: int = Field(
+        0,
+        ge=0,
+        description="Number of evidence-surface feature keys currently ready.",
+    )
+    degraded_evidence_feature_count: int = Field(
+        0,
+        ge=0,
+        description="Number of evidence-surface feature keys currently degraded.",
+    )
+    workflow_count: int = Field(
+        0,
+        ge=0,
+        description="Number of report workflows included in the supportability posture.",
+    )
+    ready_workflow_count: int = Field(
+        0,
+        ge=0,
+        description="Number of report workflows currently ready.",
+    )
+
+
 class BatchHandleResponse(BaseModel):
     batch_id: str = Field(..., description="Opaque durable batch identifier.")
     status: BatchStatus = Field(..., description="Current product-safe batch status.")
@@ -1420,6 +1479,13 @@ class BatchHandleResponse(BaseModel):
         description="Caller-supplied idempotency key associated with this batch request.",
     )
     item_count: int = Field(..., ge=0, description="Number of materialized portfolio items.")
+    supportability: ReportingEvidenceSurfaceSupportability | None = Field(
+        default=None,
+        description=(
+            "lotus-report evidence-surface supportability posture captured from "
+            "GET /integration/capabilities for Workbench reporting operator reads."
+        ),
+    )
 
 
 class BatchItemStatusResponse(BaseModel):
@@ -1482,6 +1548,13 @@ class BatchStatusResponse(BaseModel):
     failed_at: datetime | None = Field(default=None, description="UTC batch failure timestamp.")
     correlation_id: str = Field(..., description="Correlation identifier captured at creation.")
     trace_id: str = Field(..., description="Distributed trace identifier captured at creation.")
+    supportability: ReportingEvidenceSurfaceSupportability | None = Field(
+        default=None,
+        description=(
+            "lotus-report evidence-surface supportability posture captured from "
+            "GET /integration/capabilities for Workbench reporting operator reads."
+        ),
+    )
 
 
 class BatchControlResponse(BaseModel):
@@ -1572,6 +1645,13 @@ class BatchWorkerRunResponse(BaseModel):
         description="Per-item execution outcomes.",
     )
     status_url: str = Field(..., description="Gateway-relative URL for batch status retrieval.")
+    supportability: ReportingEvidenceSurfaceSupportability | None = Field(
+        default=None,
+        description=(
+            "lotus-report evidence-surface supportability posture captured from "
+            "GET /integration/capabilities for Workbench reporting operator reads."
+        ),
+    )
 
 
 class BatchScheduleSummaryResponse(BaseModel):

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -194,6 +194,69 @@ def _rewrite_batch_status_url(payload: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def _fallback_evidence_surface_supportability(reason: str) -> dict[str, Any]:
+    return {
+        "feature_key": "report.observability.evidence_surface_supportability",
+        "state": "partial",
+        "reason": reason,
+        "freshness_bucket": "unknown",
+        "evidence_feature_count": 0,
+        "ready_evidence_feature_count": 0,
+        "degraded_evidence_feature_count": 0,
+        "workflow_count": 0,
+        "ready_workflow_count": 0,
+    }
+
+
+def _normalize_evidence_surface_supportability(payload: dict[str, Any]) -> dict[str, Any]:
+    raw_supportability = payload.get("supportability")
+    if not isinstance(raw_supportability, dict):
+        return _fallback_evidence_surface_supportability("evidence_surface_supportability_missing")
+
+    return {
+        **_fallback_evidence_surface_supportability("evidence_surface_supportability_unknown"),
+        **raw_supportability,
+        "feature_key": "report.observability.evidence_surface_supportability",
+    }
+
+
+async def _get_evidence_surface_supportability(
+    *,
+    correlation_id: str,
+    consumer_system: str,
+    tenant_id: str | None,
+) -> dict[str, Any]:
+    status_code, payload = await _reporting_client().get_capabilities(
+        consumer_system=consumer_system,
+        tenant_id=tenant_id or "default",
+        correlation_id=correlation_id,
+    )
+    if status_code >= status.HTTP_400_BAD_REQUEST:
+        return _fallback_evidence_surface_supportability(
+            "evidence_surface_supportability_unavailable"
+        )
+    return _normalize_evidence_surface_supportability(payload)
+
+
+async def _attach_evidence_surface_supportability(
+    payload: dict[str, Any],
+    *,
+    correlation_id: str,
+    tenant_id: str | None,
+) -> dict[str, Any]:
+    try:
+        supportability = await _get_evidence_surface_supportability(
+            correlation_id=correlation_id,
+            consumer_system="lotus-gateway",
+            tenant_id=tenant_id,
+        )
+    except Exception:
+        supportability = _fallback_evidence_surface_supportability(
+            "evidence_surface_supportability_exception"
+        )
+    return {**payload, "supportability": supportability}
+
+
 def _raise_report_batch_error(status_code: int, payload: dict[str, Any]) -> None:
     detail = payload.get("detail") if isinstance(payload, dict) else None
     error_code = detail.get("code") if isinstance(detail, dict) else None
@@ -997,6 +1060,7 @@ async def create_report_batch(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> BatchHandleResponse:
+    correlation_id = correlation_id_var.get()
     if not idempotency_key:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1013,10 +1077,15 @@ async def create_report_batch(
             booking_center_code=booking_center_code,
             role=role,
         ),
-        correlation_id=correlation_id_var.get(),
+        correlation_id=correlation_id,
     )
     _raise_report_batch_error(status_code, payload)
-    return BatchHandleResponse.model_validate(_rewrite_batch_status_url(payload))
+    response_payload = await _attach_evidence_surface_supportability(
+        _rewrite_batch_status_url(payload),
+        correlation_id=correlation_id,
+        tenant_id=tenant_id,
+    )
+    return BatchHandleResponse.model_validate(response_payload)
 
 
 @batches_router.get(
@@ -1055,6 +1124,7 @@ async def get_report_batch_status(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> BatchStatusResponse:
+    correlation_id = correlation_id_var.get()
     status_code, payload = await _reporting_client().get_report_batch(
         batch_id=batch_id,
         caller_headers=_context_headers(
@@ -1065,10 +1135,15 @@ async def get_report_batch_status(
             booking_center_code=booking_center_code,
             role=role,
         ),
-        correlation_id=correlation_id_var.get(),
+        correlation_id=correlation_id,
     )
     _raise_report_batch_error(status_code, payload)
-    return BatchStatusResponse.model_validate(payload)
+    response_payload = await _attach_evidence_surface_supportability(
+        payload,
+        correlation_id=correlation_id,
+        tenant_id=tenant_id,
+    )
+    return BatchStatusResponse.model_validate(response_payload)
 
 
 async def _control_batch(
@@ -1310,6 +1385,7 @@ async def run_report_batch_once(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> BatchWorkerRunResponse:
+    correlation_id = correlation_id_var.get()
     status_code, payload = await _reporting_client().control_report_batch(
         batch_id=batch_id,
         action="run-once",
@@ -1321,11 +1397,16 @@ async def run_report_batch_once(
             booking_center_code=booking_center_code,
             role=role,
         ),
-        correlation_id=correlation_id_var.get(),
+        correlation_id=correlation_id,
         payload=request.model_dump(exclude_none=True, mode="json"),
     )
     _raise_report_batch_error(status_code, payload)
-    return BatchWorkerRunResponse.model_validate(_rewrite_batch_status_url(payload))
+    response_payload = await _attach_evidence_surface_supportability(
+        _rewrite_batch_status_url(payload),
+        correlation_id=correlation_id,
+        tenant_id=tenant_id,
+    )
+    return BatchWorkerRunResponse.model_validate(response_payload)
 
 
 @schedules_router.get(

--- a/tests/contract/test_reporting_contract.py
+++ b/tests/contract/test_reporting_contract.py
@@ -113,8 +113,7 @@ def test_reporting_contract_shapes() -> None:
     assert batch.status_url == "/api/v1/report-batches/rbch_1"
     assert batch.supportability is not None
     assert (
-        batch.supportability.feature_key
-        == "report.observability.evidence_surface_supportability"
+        batch.supportability.feature_key == "report.observability.evidence_surface_supportability"
     )
     assert batch_status.items[0].portfolio_id == "PB_SG_GLOBAL_BAL_001"
     assert batch_run.report_job_ids == ["rjob_1"]

--- a/tests/contract/test_reporting_contract.py
+++ b/tests/contract/test_reporting_contract.py
@@ -51,6 +51,16 @@ def test_reporting_contract_shapes() -> None:
         status_url="/api/v1/report-batches/rbch_1",
         idempotency_key="idem-batch-1",
         item_count=1,
+        supportability={
+            "state": "ready",
+            "reason": "evidence_surface_ready",
+            "freshness_bucket": "current",
+            "evidence_feature_count": 14,
+            "ready_evidence_feature_count": 14,
+            "degraded_evidence_feature_count": 0,
+            "workflow_count": 4,
+            "ready_workflow_count": 4,
+        },
     )
     batch_status = BatchStatusResponse(
         batch_id="rbch_1",
@@ -101,6 +111,11 @@ def test_reporting_contract_shapes() -> None:
     )
 
     assert batch.status_url == "/api/v1/report-batches/rbch_1"
+    assert batch.supportability is not None
+    assert (
+        batch.supportability.feature_key
+        == "report.observability.evidence_surface_supportability"
+    )
     assert batch_status.items[0].portfolio_id == "PB_SG_GLOBAL_BAL_001"
     assert batch_run.report_job_ids == ["rjob_1"]
 
@@ -269,6 +284,7 @@ def test_reporting_openapi_contract_registered() -> None:
         "BatchCreateRequest",
         "PortfolioBatchCandidate",
         "BatchHandleResponse",
+        "ReportingEvidenceSurfaceSupportability",
         "BatchStatusResponse",
         "BatchItemStatusResponse",
         "BatchControlResponse",

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -1037,6 +1037,23 @@ def test_report_batch_gateway_routes_forward_context_and_rewrite_status_urls(mon
         assert correlation_id == "corr-gateway-batch"
         return 200, _batch_status_payload()
 
+    async def _mock_get_capabilities(self, *, consumer_system, tenant_id, correlation_id):
+        calls.append(("capabilities", tenant_id, {"consumer_system": consumer_system}))
+        assert correlation_id == "corr-gateway-batch"
+        return 200, {
+            "sourceService": "lotus-report",
+            "supportability": {
+                "state": "ready",
+                "reason": "evidence_surface_ready",
+                "freshness_bucket": "current",
+                "evidence_feature_count": 14,
+                "ready_evidence_feature_count": 14,
+                "degraded_evidence_feature_count": 0,
+                "workflow_count": 4,
+                "ready_workflow_count": 4,
+            },
+        }
+
     async def _mock_control_batch(
         self,
         *,
@@ -1107,6 +1124,10 @@ def test_report_batch_gateway_routes_forward_context_and_rewrite_status_urls(mon
         "app.clients.reporting_client.ReportingClient.control_report_batch",
         _mock_control_batch,
     )
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.get_capabilities",
+        _mock_get_capabilities,
+    )
 
     client = TestClient(app)
     create_response = client.post(
@@ -1134,8 +1155,20 @@ def test_report_batch_gateway_routes_forward_context_and_rewrite_status_urls(mon
 
     assert create_response.status_code == 202
     assert create_response.json()["status_url"] == "/api/v1/report-batches/rbch_1"
+    assert create_response.json()["supportability"] == {
+        "feature_key": "report.observability.evidence_surface_supportability",
+        "state": "ready",
+        "reason": "evidence_surface_ready",
+        "freshness_bucket": "current",
+        "evidence_feature_count": 14,
+        "ready_evidence_feature_count": 14,
+        "degraded_evidence_feature_count": 0,
+        "workflow_count": 4,
+        "ready_workflow_count": 4,
+    }
     assert status_response.status_code == 200
     assert status_response.json()["items"][0]["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
+    assert status_response.json()["supportability"]["state"] == "ready"
     assert pause_response.json()["status"] == "paused"
     assert resume_response.json()["status"] == "running"
     assert cancel_response.json()["status"] == "cancelled"
@@ -1144,17 +1177,26 @@ def test_report_batch_gateway_routes_forward_context_and_rewrite_status_urls(mon
     assert recovery_response.json()["recovered_count"] == 1
     assert run_response.json()["status_url"] == "/api/v1/report-batches/rbch_1"
     assert run_response.json()["report_job_ids"] == ["rjob_1"]
-    assert calls[0][0:2] == ("create", "idem-batch-1")
-    assert calls[0][2]["X-Caller-Application"] == "lotus-gateway"
-    assert calls[0][2]["X-Actor-Id"] == "operator-123"
-    assert calls[1][0:2] == ("get", "rbch_1")
-    assert [call[0] for call in calls[2:]] == [
+    assert run_response.json()["supportability"]["feature_key"] == (
+        "report.observability.evidence_surface_supportability"
+    )
+    batch_calls = [call for call in calls if call[0] != "capabilities"]
+    assert batch_calls[0][0:2] == ("create", "idem-batch-1")
+    assert batch_calls[0][2]["X-Caller-Application"] == "lotus-gateway"
+    assert batch_calls[0][2]["X-Actor-Id"] == "operator-123"
+    assert batch_calls[1][0:2] == ("get", "rbch_1")
+    assert [call[0] for call in batch_calls[2:]] == [
         "pause",
         "resume",
         "cancel",
         "retry-failed",
         "recover-expired-leases",
         "run-once",
+    ]
+    assert [call for call in calls if call[0] == "capabilities"] == [
+        ("capabilities", "tenant-sg", {"consumer_system": "lotus-gateway"}),
+        ("capabilities", "tenant-sg", {"consumer_system": "lotus-gateway"}),
+        ("capabilities", "tenant-sg", {"consumer_system": "lotus-gateway"}),
     ]
 
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -45,6 +45,10 @@
 - report batch materialization, status, pause, resume, cancel, retry-failed,
   recover-expired-leases, and bounded run-once operator actions are gateway-first under
   `/api/v1/report-batches`; `lotus-report` remains the batch lifecycle and execution authority
+- report batch materialization, status, and bounded run-once responses preserve
+  `supportability.feature_key=report.observability.evidence_surface_supportability` from
+  `lotus-report` integration capabilities so Workbench can record report evidence-surface
+  freshness and supportability without direct service coupling
 - report batch schedule list and run-due actions are gateway-first under
   `/api/v1/report-batch-schedules`; schedules remain config-backed in `lotus-report`, and gateway
   does not expose schedule CRUD or scheduler registry management


### PR DESCRIPTION
## Summary
- Adds Gateway report-batch response supportability for report.observability.evidence_surface_supportability from lotus-report integration capabilities.
- Preserves bounded fallback supportability when the capability read is unavailable.
- Updates reporting API wiki source for the new operator-facing contract field.

## Evidence
- python -m pytest tests\\contract\\test_reporting_contract.py tests\\integration\\test_reporting_router.py -q
- python -m mypy src\\app\\contracts\\reporting.py src\\app\\routers\\reporting.py
- python -m ruff check src\\app\\contracts\\reporting.py src\\app\\routers\\reporting.py tests\\contract\\test_reporting_contract.py tests\\integration\\test_reporting_router.py
- git diff --check

## Wiki
- Updated repo-local wiki/API-Surface.md.
- Pre-merge wiki check expected to report repo-authored source ahead of published wiki until after merge.