### PR TITLE
feat: preserve AI surface supportability in advisor brief

### DIFF
--- a/src/app/clients/lotus_ai_client.py
+++ b/src/app/clients/lotus_ai_client.py
@@ -154,6 +154,19 @@ class LotusAiClient:
             path=f"/platform/workflow-packs/runs/{run_id}/review-actions",
         )
 
+    async def get_observability_runtime_status(
+        self,
+        *,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._request(
+            operation="ai.observability.runtime-status",
+            method="GET",
+            headers=propagation_headers(correlation_id),
+            retry_timeout_exceptions=False,
+            path="/platform/observability/runtime-status",
+        )
+
     async def _request(
         self,
         *,

--- a/src/app/contracts/advisor_brief.py
+++ b/src/app/contracts/advisor_brief.py
@@ -126,6 +126,107 @@ class AdvisorBriefSupportabilityItem(BaseModel):
     )
 
 
+class AdvisorBriefAiSurfaceSupportabilityItem(BaseModel):
+    surface_id: str = Field(
+        description="Stable AI-backed product or workflow surface identifier.",
+        examples=["advisor_brief"],
+    )
+    owning_service: str = Field(
+        description="Domain service that owns the AI-backed surface contract.",
+        examples=["lotus-advise"],
+    )
+    workflow_authority_owner: str = Field(
+        description="Service retaining consequence-bearing workflow authority for the surface.",
+        examples=["lotus-advise"],
+    )
+    workflow_pack_ref: str = Field(
+        description="Workflow-pack version reference grounding the surface supportability item.",
+        examples=["advisor_brief.pack@v1"],
+    )
+    supportability_status: str = Field(
+        description="Bounded lotus-ai supportability posture for this AI-backed surface.",
+        examples=["ACTION_REQUIRED"],
+    )
+    model_posture: str = Field(
+        description="Bounded model/provider posture relevant to the AI-backed surface.",
+        examples=["degraded"],
+    )
+    latest_ready_run_id: str | None = Field(
+        default=None,
+        description="Latest ready workflow-pack run for this surface, when available.",
+    )
+    latest_action_required_run_id: str | None = Field(
+        default=None,
+        description="Latest action-required workflow-pack run for this surface, when available.",
+    )
+    no_sensitive_content_telemetry: bool = Field(
+        description="Whether lotus-ai reports bounded no-sensitive-content telemetry coverage.",
+    )
+    status_summary: list[str] = Field(
+        default_factory=list,
+        description="Bounded operator-facing supportability summary for this surface.",
+    )
+
+
+class AdvisorBriefAiSurfaceSupportability(BaseModel):
+    feature_key: str = Field(
+        default="ai.observability.ai_surface_supportability",
+        description="RFC-0108 feature key for lotus-ai AI-backed surface supportability.",
+        examples=["ai.observability.ai_surface_supportability"],
+    )
+    state: str = Field(
+        description="Gateway-normalized supportability state derived from lotus-ai posture.",
+        examples=["action_required"],
+    )
+    freshness_bucket: str = Field(
+        description="Gateway-normalized freshness bucket derived from lotus-ai freshness.",
+        examples=["fresh"],
+    )
+    posture: str = Field(
+        description="Raw bounded lotus-ai observability posture for AI-backed surfaces.",
+        examples=["degraded"],
+    )
+    freshness: str = Field(
+        description="Raw bounded lotus-ai freshness posture for AI-backed surfaces.",
+        examples=["current"],
+    )
+    metric_name: str = Field(
+        description="Prometheus metric emitted by lotus-ai for this supportability posture.",
+        examples=["lotus_ai_surface_supportability_state"],
+    )
+    supported_surface_count: int = Field(
+        ge=0,
+        description="Number of AI-backed surfaces represented in the source posture.",
+    )
+    executable_workflow_pack_count: int = Field(
+        ge=0,
+        description=(
+            "Number of executable workflow-pack versions represented in the source posture."
+        ),
+    )
+    action_required_surface_count: int = Field(
+        ge=0,
+        description="Number of represented AI-backed surfaces requiring operator action.",
+    )
+    unavailable_surface_count: int = Field(
+        ge=0,
+        description="Number of represented AI-backed surfaces with unavailable source posture.",
+    )
+    no_sensitive_content_telemetry: bool = Field(
+        description=(
+            "Whether all represented AI-backed surfaces have no-sensitive telemetry coverage."
+        ),
+    )
+    surfaces: list[AdvisorBriefAiSurfaceSupportabilityItem] = Field(
+        default_factory=list,
+        description="Bounded per-surface source supportability posture from lotus-ai.",
+    )
+    status_summary: list[str] = Field(
+        default_factory=list,
+        description="Bounded operator-facing source summary from lotus-ai.",
+    )
+
+
 class AdvisorBriefWorkflowPackRunFinding(BaseModel):
     finding_id: str = Field(
         description="Stable workflow-pack supportability finding identifier.",
@@ -584,6 +685,13 @@ class AdvisorBriefResponse(BaseModel):
     supportability: list[AdvisorBriefSupportabilityItem] = Field(
         default_factory=list,
         description="Supportability indicators for the brief and its underlying analytics.",
+    )
+    ai_surface_supportability: AdvisorBriefAiSurfaceSupportability | None = Field(
+        default=None,
+        description=(
+            "Source-backed lotus-ai AI surface supportability posture preserved from "
+            "GET /platform/observability/runtime-status for Workbench advisor-brief reads."
+        ),
     )
     ai_audit: dict[str, Any] = Field(
         default_factory=dict,

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -457,9 +457,7 @@ def _parse_ai_surface_supportability(
         ],
         status_summary=[
             summary
-            for summary in (
-                _safe_str(item) for item in _safe_list(source.get("status_summary"))
-            )
+            for summary in (_safe_str(item) for item in _safe_list(source.get("status_summary")))
             if summary
         ],
     )
@@ -497,9 +495,7 @@ def _parse_ai_surface_supportability_item(
         no_sensitive_content_telemetry=bool(item.get("no_sensitive_content_telemetry")),
         status_summary=[
             summary
-            for summary in (
-                _safe_str(item) for item in _safe_list(item.get("status_summary"))
-            )
+            for summary in (_safe_str(item) for item in _safe_list(item.get("status_summary")))
             if summary
         ],
     )

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -1490,8 +1490,6 @@ def _safe_int(value: Any) -> int:
         return 0
     if isinstance(value, int):
         return max(value, 0)
-    if isinstance(value, float):
-        return max(int(value), 0)
     return 0
 
 

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -7,6 +7,8 @@ from fastapi import HTTPException, status
 from app.clients.lotus_ai_client import LotusAiClient
 from app.contracts.advisor_brief import (
     AdvisorBriefActionItem,
+    AdvisorBriefAiSurfaceSupportability,
+    AdvisorBriefAiSurfaceSupportabilityItem,
     AdvisorBriefEvidenceRef,
     AdvisorBriefNarrativeItem,
     AdvisorBriefResponse,
@@ -293,6 +295,10 @@ class AdvisorBriefService:
             ai_audit=ai_audit,
             correlation_id=correlation_id,
         )
+        ai_surface_supportability = await _load_ai_surface_supportability(
+            lotus_ai_client=self._lotus_ai_client,
+            correlation_id=correlation_id,
+        )
 
         return AdvisorBriefResponse(
             correlation_id=correlation_id,
@@ -318,6 +324,7 @@ class AdvisorBriefService:
                 selected_performance=selected_performance,
             ),
             supportability=supportability,
+            ai_surface_supportability=ai_surface_supportability,
             ai_audit=ai_audit,
             ai_evidence=ai_evidence,
             workflow_pack_run=workflow_pack_run,
@@ -393,13 +400,129 @@ class AdvisorBriefService:
             ai_audit=brief.ai_audit,
             correlation_id=correlation_id,
         )
+        ai_surface_supportability = await _load_ai_surface_supportability(
+            lotus_ai_client=self._lotus_ai_client,
+            correlation_id=correlation_id,
+        )
         self.clear_cache()
         return brief.model_copy(
             update={
                 "workflow_pack_run": workflow_pack_run,
                 "workflow_pack_task_flow": workflow_pack_task_flow,
+                "ai_surface_supportability": ai_surface_supportability,
             }
         )
+
+
+async def _load_ai_surface_supportability(
+    *,
+    lotus_ai_client: LotusAiClient,
+    correlation_id: str,
+) -> AdvisorBriefAiSurfaceSupportability | None:
+    runtime_status, runtime_payload = await lotus_ai_client.get_observability_runtime_status(
+        correlation_id=correlation_id
+    )
+    if runtime_status != 200:
+        return None
+    source = _safe_dict(runtime_payload.get("ai_surface_supportability"))
+    if not source:
+        return None
+    return _parse_ai_surface_supportability(source=source)
+
+
+def _parse_ai_surface_supportability(
+    *,
+    source: dict[str, Any],
+) -> AdvisorBriefAiSurfaceSupportability:
+    posture = _safe_str(source.get("posture")) or "unavailable"
+    freshness = _safe_str(source.get("freshness")) or "unknown"
+    return AdvisorBriefAiSurfaceSupportability(
+        state=_normalize_ai_surface_supportability_state(posture),
+        freshness_bucket=_normalize_ai_surface_freshness_bucket(freshness),
+        posture=posture,
+        freshness=freshness,
+        metric_name=_safe_str(source.get("metric_name")) or "lotus_ai_surface_supportability_state",
+        supported_surface_count=_safe_int(source.get("supported_surface_count")),
+        executable_workflow_pack_count=_safe_int(source.get("executable_workflow_pack_count")),
+        action_required_surface_count=_safe_int(source.get("action_required_surface_count")),
+        unavailable_surface_count=_safe_int(source.get("unavailable_surface_count")),
+        no_sensitive_content_telemetry=bool(source.get("no_sensitive_content_telemetry")),
+        surfaces=[
+            surface
+            for surface in (
+                _parse_ai_surface_supportability_item(value=value)
+                for value in _safe_list(source.get("surfaces"))
+            )
+            if surface is not None
+        ],
+        status_summary=[
+            summary
+            for summary in (
+                _safe_str(item) for item in _safe_list(source.get("status_summary"))
+            )
+            if summary
+        ],
+    )
+
+
+def _parse_ai_surface_supportability_item(
+    *,
+    value: Any,
+) -> AdvisorBriefAiSurfaceSupportabilityItem | None:
+    item = _safe_dict(value)
+    surface_id = _safe_str(item.get("surface_id"))
+    owning_service = _safe_str(item.get("owning_service"))
+    workflow_authority_owner = _safe_str(item.get("workflow_authority_owner"))
+    workflow_pack_ref = _safe_str(item.get("workflow_pack_ref"))
+    supportability_status = _safe_str(item.get("supportability_status"))
+    model_posture = _safe_str(item.get("model_posture"))
+    if (
+        surface_id is None
+        or owning_service is None
+        or workflow_authority_owner is None
+        or workflow_pack_ref is None
+        or supportability_status is None
+        or model_posture is None
+    ):
+        return None
+    return AdvisorBriefAiSurfaceSupportabilityItem(
+        surface_id=surface_id,
+        owning_service=owning_service,
+        workflow_authority_owner=workflow_authority_owner,
+        workflow_pack_ref=workflow_pack_ref,
+        supportability_status=supportability_status,
+        model_posture=model_posture,
+        latest_ready_run_id=_safe_str(item.get("latest_ready_run_id")),
+        latest_action_required_run_id=_safe_str(item.get("latest_action_required_run_id")),
+        no_sensitive_content_telemetry=bool(item.get("no_sensitive_content_telemetry")),
+        status_summary=[
+            summary
+            for summary in (
+                _safe_str(item) for item in _safe_list(item.get("status_summary"))
+            )
+            if summary
+        ],
+    )
+
+
+def _normalize_ai_surface_supportability_state(posture: str) -> str:
+    normalized = posture.strip().lower()
+    if normalized == "healthy":
+        return "ready"
+    if normalized == "degraded":
+        return "action_required"
+    if normalized == "unavailable":
+        return "unsupported"
+    return "unknown"
+
+
+def _normalize_ai_surface_freshness_bucket(freshness: str) -> str:
+    normalized = freshness.strip().lower()
+    if normalized in {"current", "fresh", "ready"}:
+        return "fresh"
+    if normalized == "stale":
+        return "stale"
+    return "unknown"
 
 
 async def _load_advisor_brief_workflow_pack_run(
@@ -1364,6 +1487,16 @@ def _safe_str(value: Any) -> str | None:
     if isinstance(value, str) and value.strip():
         return value.strip()
     return None
+
+
+def _safe_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    return 0
 
 
 def _safe_error_detail(payload: dict[str, Any]) -> str:

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -164,10 +164,45 @@ class _StubLotusAiClient:
                 }
             ]
         }
+        self.observability_runtime_status_code = 200
+        self.observability_runtime_payload = {
+            "ai_surface_supportability": {
+                "posture": "degraded",
+                "freshness": "current",
+                "supported_surface_count": 3,
+                "executable_workflow_pack_count": 3,
+                "action_required_surface_count": 3,
+                "unavailable_surface_count": 0,
+                "no_sensitive_content_telemetry": False,
+                "metric_name": "lotus_ai_surface_supportability_state",
+                "surfaces": [
+                    {
+                        "surface_id": "advisor_brief",
+                        "owning_service": "lotus-advise",
+                        "workflow_authority_owner": "lotus-advise",
+                        "workflow_pack_ref": "advisor_brief.pack@v1",
+                        "supportability_status": "ACTION_REQUIRED",
+                        "model_posture": "degraded",
+                        "latest_ready_run_id": None,
+                        "latest_action_required_run_id": "packrun_advisor_brief_req-1",
+                        "no_sensitive_content_telemetry": False,
+                        "status_summary": [
+                            "advisor_brief is grounded in workflow-pack runtime source "
+                            "`advisor_brief.pack@v1`."
+                        ],
+                    }
+                ],
+                "status_summary": [
+                    "AI surface supportability is sourced from workflow-pack runtime, "
+                    "provider operations, and safety runtime."
+                ],
+            }
+        }
         self.execute_calls: list[dict[str, object]] = []
         self.consumer_view_calls: list[dict[str, object]] = []
         self.operator_profile_calls: list[dict[str, object]] = []
         self.task_flow_calls: list[dict[str, object]] = []
+        self.observability_runtime_calls: list[dict[str, object]] = []
         self.review_action_calls: list[dict[str, object]] = []
         self.review_action_status_code = 200
         self.review_action_payload = {
@@ -297,6 +332,10 @@ class _StubLotusAiClient:
         self.task_flow_calls.append(kwargs)
         return self.task_flow_status_code, self.task_flow_payload
 
+    async def get_observability_runtime_status(self, **kwargs):
+        self.observability_runtime_calls.append(kwargs)
+        return self.observability_runtime_status_code, self.observability_runtime_payload
+
 
 @pytest.mark.asyncio
 async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_actions():
@@ -339,6 +378,15 @@ async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_acti
     assert response.workflow_pack_task_flow.review_states == {
         "packrun_advisor_brief_req-1": "AWAITING_REVIEW",
     }
+    assert response.ai_surface_supportability is not None
+    assert response.ai_surface_supportability.feature_key == (
+        "ai.observability.ai_surface_supportability"
+    )
+    assert response.ai_surface_supportability.state == "action_required"
+    assert response.ai_surface_supportability.freshness_bucket == "fresh"
+    assert response.ai_surface_supportability.metric_name == "lotus_ai_surface_supportability_state"
+    assert response.ai_surface_supportability.surfaces[0].surface_id == "advisor_brief"
+    assert response.ai_surface_supportability.surfaces[0].owning_service == "lotus-advise"
     assert ai_client.task_flow_calls == [
         {
             "correlation_id": "corr-1",
@@ -417,6 +465,7 @@ async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_acti
     assert ai_client.operator_profile_calls == [
         {"run_id": "packrun_advisor_brief_req-1", "correlation_id": "corr-1"}
     ]
+    assert ai_client.observability_runtime_calls == [{"correlation_id": "corr-1"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- fetch lotus-ai observability runtime posture through the observed fan-out client
- preserve ai.observability.ai_surface_supportability on advisor-brief responses
- keep advisor-brief usable when the supportability runtime posture is unavailable

## Validation
- python -m pytest tests\\unit\\test_advisor_brief_service.py tests\\unit\\test_upstream_clients.py::test_lotus_ai_client_calls_explicit_workflow_pack_execution_contract tests\\integration\\test_workbench_router.py::test_workbench_performance_advisor_brief_router -q
- python -m mypy src\\app\\clients\\lotus_ai_client.py src\\app\\contracts\\advisor_brief.py src\\app\\services\\advisor_brief_service.py
- python -m ruff check src\\app\\clients\\lotus_ai_client.py src\\app\\contracts\\advisor_brief.py src\\app\\services\\advisor_brief_service.py tests\\unit\\test_advisor_brief_service.py
- git diff --check

## Wiki
- no wiki source change; API behavior extends existing advisor-brief supportability response metadata