### PR TITLE
Add advisory supportability to advisor brief responses

### DIFF
--- a/src/app/clients/advise_client.py
+++ b/src/app/clients/advise_client.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.clients.observed_fanout import request_observed_fanout
+from app.middleware.correlation import propagation_headers
+
+logger = logging.getLogger("analytics_ui.gateway")
+
+
+class AdviseClient:
+    def __init__(
+        self,
+        base_url: str,
+        timeout_seconds: float,
+        max_retries: int = 2,
+        retry_backoff_seconds: float = 0.2,
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout_seconds
+        self._max_retries = max_retries
+        self._retry_backoff_seconds = retry_backoff_seconds
+
+    async def get_platform_capabilities(
+        self,
+        *,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-advise",
+            operation="advise.platform.capabilities",
+            method="GET",
+            url=f"{self._base_url}/platform/capabilities",
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=propagation_headers(correlation_id),
+        )

--- a/src/app/contracts/advisor_brief.py
+++ b/src/app/contracts/advisor_brief.py
@@ -227,6 +227,52 @@ class AdvisorBriefAiSurfaceSupportability(BaseModel):
     )
 
 
+class AdvisorBriefAdvisorySupportability(BaseModel):
+    feature_key: str = Field(
+        default="advise.observability.advisory_supportability",
+        description="RFC-0108 feature key for lotus-advise advisory supportability.",
+        examples=["advise.observability.advisory_supportability"],
+    )
+    state: str = Field(
+        description="Source-owned lotus-advise supportability state.",
+        examples=["ready"],
+    )
+    reason: str | None = Field(
+        default=None,
+        description="Bounded source-owned reason for the advisory supportability state.",
+        examples=["advisory_ready"],
+    )
+    freshness_bucket: str = Field(
+        description="Source-owned advisory supportability freshness bucket.",
+        examples=["current"],
+    )
+    dependency_count: int = Field(
+        ge=0,
+        description="Number of advisory dependency seams evaluated by lotus-advise.",
+    )
+    ready_dependency_count: int = Field(
+        ge=0,
+        description="Number of advisory dependency seams ready in lotus-advise.",
+    )
+    degraded_dependency_count: int = Field(
+        ge=0,
+        description="Number of advisory dependency seams degraded in lotus-advise.",
+    )
+    enabled_feature_count: int = Field(
+        ge=0,
+        description="Number of enabled advisory features included in source posture.",
+    )
+    ready_feature_count: int = Field(
+        ge=0,
+        description="Number of enabled advisory features ready in source posture.",
+    )
+    metric_name: str = Field(
+        default="lotus_advise_advisory_supportability_total",
+        description="Prometheus metric emitted by lotus-advise for this supportability posture.",
+        examples=["lotus_advise_advisory_supportability_total"],
+    )
+
+
 class AdvisorBriefWorkflowPackRunFinding(BaseModel):
     finding_id: str = Field(
         description="Stable workflow-pack supportability finding identifier.",
@@ -691,6 +737,13 @@ class AdvisorBriefResponse(BaseModel):
         description=(
             "Source-backed lotus-ai AI surface supportability posture preserved from "
             "GET /platform/observability/runtime-status for Workbench advisor-brief reads."
+        ),
+    )
+    advisory_supportability: AdvisorBriefAdvisorySupportability | None = Field(
+        default=None,
+        description=(
+            "Source-backed lotus-advise advisory supportability posture preserved from "
+            "GET /platform/capabilities for Workbench advisor-brief reads."
         ),
     )
     ai_audit: dict[str, Any] = Field(

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Path, Query, Response
 
+from app.clients.advise_client import AdviseClient
 from app.clients.dpm_client import DpmClient
 from app.clients.lotus_ai_client import LotusAiClient
 from app.clients.lotus_analytics_client import LotusAnalyticsClient
@@ -154,6 +155,12 @@ def _build_advisor_brief_service(
         lotus_ai_client=LotusAiClient(
             base_url=settings.ai_service_base_url,
             timeout_seconds=settings.ai_service_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+        advise_client=AdviseClient(
+            base_url=settings.decisioning_service_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -4,9 +4,11 @@ from typing import Any
 
 from fastapi import HTTPException, status
 
+from app.clients.advise_client import AdviseClient
 from app.clients.lotus_ai_client import LotusAiClient
 from app.contracts.advisor_brief import (
     AdvisorBriefActionItem,
+    AdvisorBriefAdvisorySupportability,
     AdvisorBriefAiSurfaceSupportability,
     AdvisorBriefAiSurfaceSupportabilityItem,
     AdvisorBriefEvidenceRef,
@@ -45,10 +47,12 @@ class AdvisorBriefService:
         *,
         performance_workspace_service: PerformanceWorkspaceService,
         lotus_ai_client: LotusAiClient,
+        advise_client: AdviseClient | None = None,
         cache_ttl_seconds: float = 30.0,
     ):
         self._performance_workspace_service = performance_workspace_service
         self._lotus_ai_client = lotus_ai_client
+        self._advise_client = advise_client
         self._response_cache = AsyncTtlCache[AdvisorBriefResponse](ttl_seconds=cache_ttl_seconds)
 
     def clear_cache(self) -> None:
@@ -299,6 +303,10 @@ class AdvisorBriefService:
             lotus_ai_client=self._lotus_ai_client,
             correlation_id=correlation_id,
         )
+        advisory_supportability = await _load_advisory_supportability(
+            advise_client=self._advise_client,
+            correlation_id=correlation_id,
+        )
 
         return AdvisorBriefResponse(
             correlation_id=correlation_id,
@@ -325,6 +333,7 @@ class AdvisorBriefService:
             ),
             supportability=supportability,
             ai_surface_supportability=ai_surface_supportability,
+            advisory_supportability=advisory_supportability,
             ai_audit=ai_audit,
             ai_evidence=ai_evidence,
             workflow_pack_run=workflow_pack_run,
@@ -404,14 +413,46 @@ class AdvisorBriefService:
             lotus_ai_client=self._lotus_ai_client,
             correlation_id=correlation_id,
         )
+        advisory_supportability = await _load_advisory_supportability(
+            advise_client=self._advise_client,
+            correlation_id=correlation_id,
+        )
         self.clear_cache()
         return brief.model_copy(
             update={
                 "workflow_pack_run": workflow_pack_run,
                 "workflow_pack_task_flow": workflow_pack_task_flow,
                 "ai_surface_supportability": ai_surface_supportability,
+                "advisory_supportability": advisory_supportability,
             }
         )
+
+
+async def _load_advisory_supportability(
+    *,
+    advise_client: AdviseClient | None,
+    correlation_id: str,
+) -> AdvisorBriefAdvisorySupportability | None:
+    if advise_client is None:
+        return None
+    status_code, payload = await advise_client.get_platform_capabilities(
+        correlation_id=correlation_id
+    )
+    if status_code != 200:
+        return None
+    supportability = _safe_dict(payload.get("supportability"))
+    if not supportability:
+        return None
+    return AdvisorBriefAdvisorySupportability(
+        state=_safe_str(supportability.get("state")) or "unknown",
+        reason=_safe_str(supportability.get("reason")),
+        freshness_bucket=_safe_str(supportability.get("freshness_bucket")) or "unknown",
+        dependency_count=_safe_int(supportability.get("dependency_count")),
+        ready_dependency_count=_safe_int(supportability.get("ready_dependency_count")),
+        degraded_dependency_count=_safe_int(supportability.get("degraded_dependency_count")),
+        enabled_feature_count=_safe_int(supportability.get("enabled_feature_count")),
+        ready_feature_count=_safe_int(supportability.get("ready_feature_count")),
+    )
 
 
 async def _load_ai_surface_supportability(

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -337,6 +337,36 @@ class _StubLotusAiClient:
         return self.observability_runtime_status_code, self.observability_runtime_payload
 
 
+class _StubAdviseClient:
+    def __init__(self, *, status_code: int = 200, payload: dict | None = None):
+        self.status_code = status_code
+        self.payload = payload or {
+            "features": [
+                {
+                    "key": "advise.observability.advisory_supportability",
+                    "enabled": True,
+                    "operational_ready": True,
+                    "owner_service": "ADVISORY",
+                }
+            ],
+            "supportability": {
+                "state": "ready",
+                "reason": "advisory_ready",
+                "freshness_bucket": "current",
+                "dependency_count": 5,
+                "ready_dependency_count": 5,
+                "degraded_dependency_count": 0,
+                "enabled_feature_count": 9,
+                "ready_feature_count": 9,
+            },
+        }
+        self.calls: list[dict[str, object]] = []
+
+    async def get_platform_capabilities(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.status_code, self.payload
+
+
 @pytest.mark.asyncio
 async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_actions():
     workspace_service = _StubPerformanceWorkspaceService(_build_workspace())
@@ -466,6 +496,66 @@ async def test_advisor_brief_service_returns_ai_summary_and_source_grounded_acti
         {"run_id": "packrun_advisor_brief_req-1", "correlation_id": "corr-1"}
     ]
     assert ai_client.observability_runtime_calls == [{"correlation_id": "corr-1"}]
+
+
+@pytest.mark.asyncio
+async def test_advisor_brief_service_preserves_advisory_supportability_source_posture():
+    workspace_service = _StubPerformanceWorkspaceService(_build_workspace())
+    advise_client = _StubAdviseClient()
+    service = AdvisorBriefService(
+        performance_workspace_service=workspace_service,
+        lotus_ai_client=_StubLotusAiClient(),
+        advise_client=advise_client,
+    )
+
+    response = await service.get_performance_advisor_brief(
+        portfolio_id="PF_1001",
+        correlation_id="corr-advise-supportability",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+    )
+
+    assert response.advisory_supportability is not None
+    assert response.advisory_supportability.model_dump(mode="json") == {
+        "feature_key": "advise.observability.advisory_supportability",
+        "state": "ready",
+        "reason": "advisory_ready",
+        "freshness_bucket": "current",
+        "dependency_count": 5,
+        "ready_dependency_count": 5,
+        "degraded_dependency_count": 0,
+        "enabled_feature_count": 9,
+        "ready_feature_count": 9,
+        "metric_name": "lotus_advise_advisory_supportability_total",
+    }
+    assert advise_client.calls == [{"correlation_id": "corr-advise-supportability"}]
+
+
+@pytest.mark.asyncio
+async def test_advisor_brief_service_omits_advisory_supportability_when_source_unavailable():
+    service = AdvisorBriefService(
+        performance_workspace_service=_StubPerformanceWorkspaceService(_build_workspace()),
+        lotus_ai_client=_StubLotusAiClient(),
+        advise_client=_StubAdviseClient(status_code=503, payload={"detail": "paused"}),
+    )
+
+    response = await service.get_performance_advisor_brief(
+        portfolio_id="PF_1001",
+        correlation_id="corr-advise-down",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+    )
+
+    assert response.status == "ready"
+    assert response.advisory_supportability is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a lotus-advise client for source-backed `GET /platform/capabilities` supportability
- preserve advisory supportability on advisor brief responses without making lotus-advise availability a hard dependency
- cover source-backed and unavailable-source behavior in advisor brief unit tests

## Local proof
- `make lint`
- `make typecheck`
- `python -m pytest tests\unit\test_advisor_brief_service.py tests\contract\test_platform_capabilities_contract.py tests\unit\test_config_defaults.py -q`
- `git diff --check`