### PR TITLE
Require caller context for performance summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ Important current parameter conventions:
 10. archived document metadata and download routes require caller context headers:
    `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; the gateway calls `lotus-archive` as
    `lotus-gateway` and does not expose archive storage locations
+11. Workbench performance summary reads require caller context headers:
+   `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional `X-Caller-Application`,
+   `X-Booking-Center-Code`, and `X-Role` preserve entitlement and audit posture for
+   front-office analytics reads
 
 Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -26,7 +26,13 @@ Use the seeded flagship mandate:
 Probe the split contracts:
 
 ```bash
-curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
+curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40" \
+  -H "X-Actor-Id: advisor-123" \
+  -H "X-Caller-Application: lotus-workbench" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -H "X-Booking-Center-Code: SG" \
+  -H "X-Role: advisor"
 
 curl "http://gateway.dev.lotus/api/v1/workbench/DEMO_ADV_USD_001/performance/details?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
 

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Path, Query, Response
+from typing import Annotated
+
+from fastapi import APIRouter, Header, Path, Query, Response
 
 from app.clients.advise_client import AdviseClient
 from app.clients.dpm_client import DpmClient
@@ -33,6 +35,7 @@ from app.contracts.workbench import (
 )
 from app.middleware.correlation import correlation_id_var
 from app.services.advisor_brief_service import AdvisorBriefService
+from app.services.caller_context import caller_context_headers
 from app.services.performance_workspace_service import PerformanceWorkspaceService
 from app.services.risk_workspace_service import RiskWorkspaceService
 from app.services.workbench_service import WorkbenchService
@@ -54,6 +57,25 @@ RISK_PERIOD_QUERY_DESCRIPTION = (
     "SI, YEAR, or EXPLICIT. Legacy aliases ONE_YEAR, THREE_YEAR, FIVE_YEAR, and ITD may be "
     "accepted for compatibility but are normalized before calling lotus-risk."
 )
+
+
+def _required_caller_context(
+    *,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> dict[str, str]:
+    return caller_context_headers(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
 
 
 def _service_signature() -> tuple[object, ...]:
@@ -690,7 +712,25 @@ async def get_performance_workspace_summary(
         ),
         examples=["2026-03-27"],
     ),
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[
+        str | None, Header(alias="X-Caller-Application")
+    ] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[
+        str | None, Header(alias="X-Booking-Center-Code")
+    ] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> PerformanceWorkspaceSummaryResponse:
+    _required_caller_context(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
     service = _performance_workspace_service()
     correlation_id = correlation_id_var.get()
     return await service.get_performance_workspace_summary(

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -713,14 +713,10 @@ async def get_performance_workspace_summary(
         examples=["2026-03-27"],
     ),
     actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
-    caller_application: Annotated[
-        str | None, Header(alias="X-Caller-Application")
-    ] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
     tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
     region: Annotated[str | None, Header(alias="X-Region")] = None,
-    booking_center_code: Annotated[
-        str | None, Header(alias="X-Booking-Center-Code")
-    ] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> PerformanceWorkspaceSummaryResponse:
     _required_caller_context(

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -23,6 +23,14 @@ from app.main import app
 from app.middleware.server_timing import append_server_timing_metric
 
 LOTUS_CORE_QUERY_CLIENT = "app.clients.lotus_core_query_client.LotusCoreQueryClient"
+CALLER_CONTEXT_HEADERS = {
+    "X-Actor-Id": "advisor_1",
+    "X-Caller-Application": "lotus-workbench",
+    "X-Tenant-Id": "tenant-sg",
+    "X-Region": "APAC",
+    "X-Booking-Center-Code": "SG",
+    "X-Role": "advisor",
+}
 
 
 async def _analytics_reference(*args, **kwargs):
@@ -1233,7 +1241,10 @@ def test_workbench_performance_summary_router(monkeypatch):
     )
 
     client = TestClient(app)
-    response = client.get("/api/v1/workbench/PF_1001/performance/summary?period=YTD")
+    response = client.get(
+        "/api/v1/workbench/PF_1001/performance/summary?period=YTD",
+        headers=CALLER_CONTEXT_HEADERS,
+    )
 
     assert response.status_code == 200
     assert response.headers["Server-Timing"].startswith("app;dur=")
@@ -1258,6 +1269,16 @@ def test_workbench_performance_summary_router(monkeypatch):
     assert body["evidence_view"]["calculations"][0]["calculation_role"] == "workspace_summary"
     assert "net_chart" not in body
     assert "contribution" not in body
+
+
+def test_workbench_performance_summary_router_requires_caller_context():
+    client = TestClient(app)
+    response = client.get("/api/v1/workbench/PF_1001/performance/summary?period=YTD")
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["code"] == "missing_caller_context"
+    assert detail["missing_headers"] == ["X-Actor-Id", "X-Tenant-Id", "X-Region"]
 
 
 def test_workbench_performance_details_router(monkeypatch):
@@ -1481,7 +1502,10 @@ def test_workbench_performance_summary_router_preserves_query_context(monkeypatc
         "&attribution_dimension=country&detail_basis=GROSS"
         "&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
         "&report_start_date=2026-01-01&report_end_date=2026-03-27",
-        headers={"X-Correlation-Id": "corr-performance-summary"},
+        headers={
+            **CALLER_CONTEXT_HEADERS,
+            "X-Correlation-Id": "corr-performance-summary",
+        },
     )
 
     assert response.status_code == 200

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -122,7 +122,13 @@ curl "http://127.0.0.1:8111/api/v1/foundation/portfolios/PF_1001/workspace"
 Performance summary:
 
 ```bash
-curl "http://127.0.0.1:8111/api/v1/workbench/DEMO_ADV_USD_001/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
+curl "http://127.0.0.1:8111/api/v1/workbench/DEMO_ADV_USD_001/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40" \
+  -H "X-Actor-Id: advisor-123" \
+  -H "X-Caller-Application: lotus-workbench" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -H "X-Booking-Center-Code: SG" \
+  -H "X-Role: advisor"
 ```
 
 Reporting summary:


### PR DESCRIPTION
## Summary
- Require governed caller-context headers on `GET /api/v1/workbench/{portfolio_id}/performance/summary` before serving the first RFC-0108 certified analytics read path.
- Reuse the existing Gateway caller-context helper so missing actor, tenant, or region returns the standard `missing_caller_context` 400 response.
- Update Workbench router tests and demo/API docs so examples include entitlement/audit headers.

## Local validation
- `python -m pytest tests\\integration\\test_workbench_router.py -q` passed: 33 tests.
- `python -m ruff check src\\app\\routers\\workbench.py tests\\integration\\test_workbench_router.py` passed.
- `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` ran and reported expected publication drift for `API-Surface.md` because repo-authored wiki source changed and has not yet been published.

## Merge order / runtime note
This Gateway route enforcement is paired with lotus-workbench PR #131, which makes the Workbench BFF inject governed caller-context defaults for browser requests. Merge Workbench #131 before or alongside this PR for live UI continuity.