### PR TITLE
Require caller context for risk summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Important current parameter conventions:
 10. archived document metadata and download routes require caller context headers:
    `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; the gateway calls `lotus-archive` as
    `lotus-gateway` and does not expose archive storage locations
-11. Workbench performance summary reads require caller context headers:
+11. Workbench performance and risk summary reads require caller context headers:
    `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional `X-Caller-Application`,
    `X-Booking-Center-Code`, and `X-Role` preserve entitlement and audit posture for
    front-office analytics reads

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -372,7 +372,21 @@ async def get_workbench_risk_summary(
         description="Reporting currency used for stateful risk and risk-free-rate sourcing.",
         examples=["USD"],
     ),
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> WorkbenchRiskSummaryResponse:
+    _required_caller_context(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
     service = _risk_workspace_service()
     correlation_id = correlation_id_var.get()
     return await service.get_summary(

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -534,7 +534,7 @@ def test_workbench_risk_summary_router_uses_stateful_gateway_contract(monkeypatc
         "/api/v1/workbench/PF_RISK_SUMMARY/risk/summary"
         "?period=YTD&detail_basis=NET&benchmark_code=BMK_1"
         "&as_of_date=2026-04-04&reporting_currency=USD",
-        headers={"X-Correlation-Id": "corr-risk-summary"},
+        headers={**CALLER_CONTEXT_HEADERS, "X-Correlation-Id": "corr-risk-summary"},
     )
 
     assert response.status_code == 200
@@ -556,6 +556,20 @@ def test_workbench_risk_summary_router_uses_stateful_gateway_contract(monkeypatc
     assert body["partial_failures"] == []
     assert captured_payload["stateful_input"]["periods"] == [{"type": "YTD", "name": "YTD"}]
     assert captured_payload["stateful_input"]["reporting_currency"] == "USD"
+
+
+def test_workbench_risk_summary_router_requires_caller_context():
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/workbench/PF_RISK_SUMMARY/risk/summary"
+        "?period=YTD&detail_basis=NET&benchmark_code=BMK_1"
+        "&as_of_date=2026-04-04&reporting_currency=USD",
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["code"] == "missing_caller_context"
+    assert detail["missing_headers"] == ["X-Actor-Id", "X-Tenant-Id", "X-Region"]
 
 
 def test_workbench_risk_summary_router_defaults_reporting_currency_for_risk_free_sourcing(
@@ -596,7 +610,10 @@ def test_workbench_risk_summary_router_defaults_reporting_currency_for_risk_free
     response = client.get(
         "/api/v1/workbench/PF_RISK_SUMMARY_DEFAULT/risk/summary"
         "?period=YTD&detail_basis=NET&benchmark_code=BMK_1&as_of_date=2026-04-04",
-        headers={"X-Correlation-Id": "corr-risk-summary-default-currency"},
+        headers={
+            **CALLER_CONTEXT_HEADERS,
+            "X-Correlation-Id": "corr-risk-summary-default-currency",
+        },
     )
 
     assert response.status_code == 200
@@ -633,7 +650,7 @@ def test_workbench_risk_summary_router_sends_canonical_trailing_period_to_risk(m
         "/api/v1/workbench/PF_RISK_SUMMARY/risk/summary"
         "?period=3Y&detail_basis=NET&benchmark_code=BMK_1"
         "&as_of_date=2026-04-04&reporting_currency=USD",
-        headers={"X-Correlation-Id": "corr-risk-summary-3y"},
+        headers={**CALLER_CONTEXT_HEADERS, "X-Correlation-Id": "corr-risk-summary-3y"},
     )
 
     assert response.status_code == 200

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -131,6 +131,18 @@ curl "http://127.0.0.1:8111/api/v1/workbench/DEMO_ADV_USD_001/performance/summar
   -H "X-Role: advisor"
 ```
 
+Risk summary:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/workbench/DEMO_ADV_USD_001/risk/summary?period=YTD&detail_basis=NET&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40&reporting_currency=USD" \
+  -H "X-Actor-Id: advisor-123" \
+  -H "X-Caller-Application: lotus-workbench" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -H "X-Booking-Center-Code: SG" \
+  -H "X-Role: advisor"
+```
+
 Reporting summary:
 
 ```bash


### PR DESCRIPTION
## Summary
- require governed caller-context headers on `GET /api/v1/workbench/{portfolio_id}/risk/summary`
- reuse the existing Workbench caller-context certification helper and error shape
- update integration tests plus README/wiki API source so operators have the required headers and runnable examples

## Validation
- `python -m pytest tests\integration\test_workbench_router.py -q` passed: 34 tests
- `make lint` passed
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reported expected source/publication drift for `API-Surface.md`

## RFC-0108 posture
This extends the entitlement-certified read-path pattern from performance summary to risk summary. Browser flows are covered by the Workbench BFF caller-context defaults in sgajbi/lotus-workbench#131.