### PR TITLE
Enforce advisor brief caller context

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,10 +231,11 @@ Important current parameter conventions:
 10. archived document metadata and download routes require caller context headers:
    `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; the gateway calls `lotus-archive` as
    `lotus-gateway` and does not expose archive storage locations
-11. Workbench performance and risk summary reads require caller context headers:
+11. Workbench performance summary, risk summary, advisor-brief read, and advisor-brief review
+   action routes require caller context headers:
    `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional `X-Caller-Application`,
    `X-Booking-Center-Code`, and `X-Role` preserve entitlement and audit posture for
-   front-office analytics reads
+   front-office analytics reads and bounded advisor workflow actions
 
 Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -47,8 +47,9 @@ Current repository posture:
 8. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
 9. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
 10. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
-11. RFC-0108 analytics UI observability is active for selected Workbench performance and risk
-    analytics paths, and has expanded fan-out coverage for central `lotus-manage`,
+11. RFC-0108 analytics UI observability is active for selected Workbench performance summary,
+    risk summary, advisor-brief read, and advisor-brief review-action paths, and has expanded
+    fan-out coverage for central `lotus-manage`,
     `lotus-report`, `lotus-archive`, `lotus-ai`, direct `lotus-core` query/control-plane, and
     `lotus-core` ingestion client seams. Gateway owns product-safe
     structured fan-out logs, bounded fan-out metrics, degraded-source counters, selected analytics

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -1101,7 +1101,21 @@ async def get_performance_advisor_brief(
         description="Inclusive explicit end date for an EXPLICIT advisor-brief window.",
         examples=["2026-04-04"],
     ),
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> AdvisorBriefResponse:
+    _required_caller_context(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
     service = _advisor_brief_service()
     correlation_id = correlation_id_var.get()
     return await service.get_performance_advisor_brief(
@@ -1182,7 +1196,21 @@ async def post_performance_advisor_brief_review_action(
         description="Inclusive explicit end date for an EXPLICIT advisor-brief window.",
         examples=["2026-04-04"],
     ),
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> AdvisorBriefResponse:
+    _required_caller_context(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
     service = _advisor_brief_service()
     correlation_id = correlation_id_var.get()
     return await service.apply_performance_advisor_brief_review_action(

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -2390,7 +2390,8 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
         "?period=YTD&chart_frequency=monthly&detail_basis=NET"
         "&contribution_dimension=asset_class&attribution_dimension=asset_class"
         "&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40&report_start_date=2026-01-01"
-        "&report_end_date=2026-04-04"
+        "&report_end_date=2026-04-04",
+        headers=CALLER_CONTEXT_HEADERS,
     )
 
     assert response.status_code == 200
@@ -2418,6 +2419,16 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
     assert captured_call["benchmark_code"] == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert captured_call["explicit_start_date"] == "2026-01-01"
     assert captured_call["explicit_end_date"] == "2026-04-04"
+
+
+def test_workbench_performance_advisor_brief_router_requires_caller_context():
+    client = TestClient(app)
+    response = client.get("/api/v1/workbench/PF_1001/performance/advisor-brief?period=YTD")
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["code"] == "missing_caller_context"
+    assert detail["missing_headers"] == ["X-Actor-Id", "X-Tenant-Id", "X-Region"]
 
 
 def test_workbench_performance_advisor_brief_router_preserves_query_context(monkeypatch):
@@ -2488,7 +2499,7 @@ def test_workbench_performance_advisor_brief_router_preserves_query_context(monk
         "&attribution_dimension=country&detail_basis=GROSS"
         "&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
         "&report_start_date=2026-01-01&report_end_date=2026-03-27",
-        headers={"X-Correlation-Id": "corr-advisor-brief"},
+        headers={**CALLER_CONTEXT_HEADERS, "X-Correlation-Id": "corr-advisor-brief"},
     )
 
     assert response.status_code == 200
@@ -2618,7 +2629,10 @@ def test_workbench_performance_advisor_brief_review_action_router(monkeypatch):
         "&attribution_dimension=country&detail_basis=GROSS"
         "&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40"
         "&report_start_date=2026-01-01&report_end_date=2026-03-27",
-        headers={"X-Correlation-Id": "corr-advisor-brief-review"},
+        headers={
+            **CALLER_CONTEXT_HEADERS,
+            "X-Correlation-Id": "corr-advisor-brief-review",
+        },
         json={
             "action_type": "SUPERSEDE",
             "reviewed_by": "advisor_1",
@@ -2665,6 +2679,23 @@ def test_workbench_performance_advisor_brief_review_action_router(monkeypatch):
         "explicit_start_date": "2026-01-01",
         "explicit_end_date": "2026-03-27",
     }
+
+
+def test_workbench_performance_advisor_brief_review_action_requires_caller_context():
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/workbench/PF_1001/performance/advisor-brief/review-actions?period=YTD",
+        json={
+            "action_type": "ACCEPT",
+            "reviewed_by": "advisor_1",
+            "reason": "Approved for client discussion.",
+        },
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["code"] == "missing_caller_context"
+    assert detail["missing_headers"] == ["X-Actor-Id", "X-Tenant-Id", "X-Region"]
 
 
 def test_workbench_sandbox_changes_router(monkeypatch):

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -59,6 +59,10 @@
   `lotus-workbench` must not call `lotus-archive` directly
 - archived document routes require `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional
   `X-Booking-Center-Code` and `X-Role` are forwarded as caller context
+- Workbench performance summary, risk summary, advisor-brief read, and advisor-brief review-action
+  routes require `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional
+  `X-Caller-Application`, `X-Booking-Center-Code`, and `X-Role` preserve entitlement and audit
+  posture for RFC-0108 front-office analytics reads and workflow actions
 - legal-hold summary is returned as metadata for support posture; gateway retrieval does not expose
   legal-hold mutation, purge, retention mutation, or access-event routes
 - intake upload routes accept camelCase multipart aliases such as `entityType`, `sampleSize`, and
@@ -141,6 +145,32 @@ curl "http://127.0.0.1:8111/api/v1/workbench/DEMO_ADV_USD_001/risk/summary?perio
   -H "X-Region: APAC" \
   -H "X-Booking-Center-Code: SG" \
   -H "X-Role: advisor"
+```
+
+Advisor brief:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/workbench/DEMO_ADV_USD_001/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=BMK_PB_GLOBAL_BALANCED_60_40" \
+  -H "X-Actor-Id: advisor-123" \
+  -H "X-Caller-Application: lotus-workbench" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -H "X-Booking-Center-Code: SG" \
+  -H "X-Role: advisor"
+```
+
+Advisor brief review action:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/workbench/DEMO_ADV_USD_001/performance/advisor-brief/review-actions?period=YTD" \
+  -H "Content-Type: application/json" \
+  -H "X-Actor-Id: advisor-123" \
+  -H "X-Caller-Application: lotus-workbench" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -H "X-Booking-Center-Code: SG" \
+  -H "X-Role: advisor" \
+  -d "{\"action_type\":\"ACCEPT\",\"reviewed_by\":\"advisor-123\",\"reason\":\"Approved for client discussion.\"}"
 ```
 
 Reporting summary:

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -41,6 +41,10 @@
 - Gateway emits product-safe selected analytics read audit logs for upstream read outcomes:
   `gateway.analytics.audit.analytics_read_allowed` for successful upstream reads and
   `gateway.analytics.audit.analytics_read_denied` for `401` or `403` upstream denials.
+- Gateway requires caller context on the RFC-0108 certified Workbench read paths now enforced in
+  this repository: performance summary, risk summary, and advisor brief. The advisor-brief
+  review-action route also requires the same caller context because it records a bounded workflow
+  review action through the Gateway boundary.
 - Gateway exposes a protected operator lookup at
   `GET /api/v1/analytics-ui/diagnostics/{support_reference}`. It requires `X-Actor-Id`,
   `X-Tenant-Id`, `X-Region`, and an operator support role in `X-Role`.


### PR DESCRIPTION
## Summary
- enforce required caller-context headers on Workbench performance advisor-brief read and review-action routes
- add integration proof that missing `X-Actor-Id`, `X-Tenant-Id`, and `X-Region` are rejected before advisor-brief service execution
- update README, repository context, and wiki source with the RFC-0108 caller-context posture and copy-paste API examples

## Evidence
- `python -m pytest tests\integration\test_workbench_router.py::test_workbench_performance_advisor_brief_router tests\integration\test_workbench_router.py::test_workbench_performance_advisor_brief_router_requires_caller_context tests\integration\test_workbench_router.py::test_workbench_performance_advisor_brief_router_preserves_query_context tests\integration\test_workbench_router.py::test_workbench_performance_advisor_brief_review_action_router tests\integration\test_workbench_router.py::test_workbench_performance_advisor_brief_review_action_requires_caller_context -q` (5 passed)
- `python -m ruff check src\app\routers\workbench.py tests\integration\test_workbench_router.py` (passed)
- `git diff --check` (passed)
- `make lint` (passed)
- `make typecheck` (passed)
- `make check` (passed; 384 unit/contract tests passed)
- `make ci` (passed; 147 integration tests passed; 531 coverage tests passed at 88.57%; `pip-audit` no known vulnerabilities)
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway -AllowUnpublishedSourceChanges` (expected branch warning: source wiki differs from published wiki; publish after merge)

## Wiki
- Updates repo-local `wiki/` source. Publish after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-gateway`.