### PR TITLE
Audit advisor brief reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ Important current parameter conventions:
    `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional `X-Caller-Application`,
    `X-Booking-Center-Code`, and `X-Role` preserve entitlement and audit posture for
    front-office analytics reads and bounded advisor workflow actions
+12. Workbench advisor-brief reads emit product-safe RFC-0108 analytics read audit events with
+   `panel=advisor-brief` and `operation=advisor_brief.summary`; upstream `401` and `403` outcomes
+   are recorded as permission-blocked denials without portfolio, client, prompt, response-body,
+   trace, or raw entitlement fields
 
 Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -57,7 +57,9 @@ Current repository posture:
     `/api/v1/analytics-ui/diagnostics/{support_reference}`. Successful upstream reads emit bounded
     `analytics_read_allowed` audit records, upstream `401`/`403` responses emit bounded
     `analytics_read_denied` audit records, and protected diagnostics lookups emit bounded
-    `protected_diagnostics_lookup` audit records. Gateway analytics metrics are limited to
+    `protected_diagnostics_lookup` audit records. Advisor-brief read audit records use
+    `operation=advisor_brief.summary` and `panel=advisor-brief` without portfolio, client, prompt,
+    response-body, trace, or raw entitlement fields. Gateway analytics metrics are limited to
     `operation`, `service`, `status_class`, and degraded `reason` labels; audit fields must stay
     limited to route, panel, operation, state, reason, status class, region, and environment;
     portfolio, client, holding, transaction, session, upload, trace, correlation, document,

--- a/src/app/observability/analytics_ui.py
+++ b/src/app/observability/analytics_ui.py
@@ -505,6 +505,8 @@ def _list_count(value: object) -> int:
 
 
 def _panel_for_operation(operation: str) -> str:
+    if operation.startswith("advisor_brief."):
+        return "advisor-brief"
     if operation.startswith("analytics.risk."):
         return "risk-summary"
     if "workspace-summary" in operation:

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -1,6 +1,7 @@
+import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Header, Path, Query, Response
+from fastapi import APIRouter, Header, HTTPException, Path, Query, Response
 
 from app.clients.advise_client import AdviseClient
 from app.clients.dpm_client import DpmClient
@@ -34,6 +35,7 @@ from app.contracts.workbench import (
     WorkbenchSandboxStateResponse,
 )
 from app.middleware.correlation import correlation_id_var
+from app.observability.analytics_ui import emit_gateway_analytics_read_audit_log
 from app.services.advisor_brief_service import AdvisorBriefService
 from app.services.caller_context import caller_context_headers
 from app.services.performance_workspace_service import PerformanceWorkspaceService
@@ -41,6 +43,7 @@ from app.services.risk_workspace_service import RiskWorkspaceService
 from app.services.workbench_service import WorkbenchService
 
 router = APIRouter(prefix="/api/v1/workbench", tags=["workbench"])
+logger = logging.getLogger("analytics_ui.gateway")
 
 
 _WORKBENCH_SERVICE: WorkbenchService | None = None
@@ -57,6 +60,7 @@ RISK_PERIOD_QUERY_DESCRIPTION = (
     "SI, YEAR, or EXPLICIT. Legacy aliases ONE_YEAR, THREE_YEAR, FIVE_YEAR, and ITD may be "
     "accepted for compatibility but are normalized before calling lotus-risk."
 )
+ADVISOR_BRIEF_READ_OPERATION = "advisor_brief.summary"
 
 
 def _required_caller_context(
@@ -75,6 +79,14 @@ def _required_caller_context(
         region=region,
         booking_center_code=booking_center_code,
         role=role,
+    )
+
+
+def _emit_advisor_brief_read_audit(*, status_code: int) -> None:
+    emit_gateway_analytics_read_audit_log(
+        logger=logger,
+        operation=ADVISOR_BRIEF_READ_OPERATION,
+        status_code=status_code,
     )
 
 
@@ -1118,18 +1130,24 @@ async def get_performance_advisor_brief(
     )
     service = _advisor_brief_service()
     correlation_id = correlation_id_var.get()
-    return await service.get_performance_advisor_brief(
-        portfolio_id=portfolio_id,
-        correlation_id=correlation_id,
-        period=period,
-        chart_frequency=chart_frequency,
-        contribution_dimension=contribution_dimension,
-        attribution_dimension=attribution_dimension,
-        detail_basis=detail_basis,
-        benchmark_code=benchmark_code,
-        explicit_start_date=report_start_date,
-        explicit_end_date=report_end_date,
-    )
+    try:
+        response = await service.get_performance_advisor_brief(
+            portfolio_id=portfolio_id,
+            correlation_id=correlation_id,
+            period=period,
+            chart_frequency=chart_frequency,
+            contribution_dimension=contribution_dimension,
+            attribution_dimension=attribution_dimension,
+            detail_basis=detail_basis,
+            benchmark_code=benchmark_code,
+            explicit_start_date=report_start_date,
+            explicit_end_date=report_end_date,
+        )
+    except HTTPException as exc:
+        _emit_advisor_brief_read_audit(status_code=exc.status_code)
+        raise
+    _emit_advisor_brief_read_audit(status_code=200)
+    return response
 
 
 @router.post(

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from app.contracts.advisor_brief import (
@@ -31,6 +32,19 @@ CALLER_CONTEXT_HEADERS = {
     "X-Booking-Center-Code": "SG",
     "X-Role": "advisor",
 }
+
+
+def _advisor_brief_read_audit_records(records: list[Any]) -> list[Any]:
+    return [
+        record
+        for record in records
+        if getattr(record, "message", "")
+        in {
+            "gateway.analytics.audit.analytics_read_allowed",
+            "gateway.analytics.audit.analytics_read_denied",
+        }
+        and getattr(record, "extra_fields", {}).get("operation") == "advisor_brief.summary"
+    ]
 
 
 async def _analytics_reference(*args, **kwargs):
@@ -2270,7 +2284,8 @@ def test_workbench_performance_advisor_brief_openapi_contract():
     assert response_schema["example"]["partial_failures"][0]["reason"] == "UPSTREAM_TIMEOUT"
 
 
-def test_workbench_performance_advisor_brief_router(monkeypatch):
+def test_workbench_performance_advisor_brief_router(monkeypatch, caplog):
+    caplog.set_level("INFO", logger="analytics_ui.gateway")
     captured_call = {}
 
     async def _brief(*args, **kwargs):
@@ -2419,6 +2434,11 @@ def test_workbench_performance_advisor_brief_router(monkeypatch):
     assert captured_call["benchmark_code"] == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert captured_call["explicit_start_date"] == "2026-01-01"
     assert captured_call["explicit_end_date"] == "2026-04-04"
+    [audit_record] = _advisor_brief_read_audit_records(caplog.records)
+    assert audit_record.extra_fields["event"] == ("gateway.analytics.audit.analytics_read_allowed")
+    assert audit_record.extra_fields["panel"] == "advisor-brief"
+    assert audit_record.extra_fields["state"] == "ready"
+    assert "portfolio_id" not in audit_record.extra_fields
 
 
 def test_workbench_performance_advisor_brief_router_requires_caller_context():
@@ -2429,6 +2449,32 @@ def test_workbench_performance_advisor_brief_router_requires_caller_context():
     detail = response.json()["detail"]
     assert detail["code"] == "missing_caller_context"
     assert detail["missing_headers"] == ["X-Actor-Id", "X-Tenant-Id", "X-Region"]
+
+
+def test_workbench_performance_advisor_brief_router_audits_upstream_denial(monkeypatch, caplog):
+    caplog.set_level("INFO", logger="analytics_ui.gateway")
+
+    async def _brief(*args, **kwargs):  # noqa: ARG001
+        raise HTTPException(status_code=403, detail="restricted portfolio")
+
+    monkeypatch.setattr(
+        "app.services.advisor_brief_service.AdvisorBriefService.get_performance_advisor_brief",
+        _brief,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/workbench/PF_1001/performance/advisor-brief?period=YTD",
+        headers=CALLER_CONTEXT_HEADERS,
+    )
+
+    assert response.status_code == 403
+    [audit_record] = _advisor_brief_read_audit_records(caplog.records)
+    assert audit_record.extra_fields["event"] == ("gateway.analytics.audit.analytics_read_denied")
+    assert audit_record.extra_fields["panel"] == "advisor-brief"
+    assert audit_record.extra_fields["state"] == "permission_blocked"
+    assert audit_record.extra_fields["reason"] == "upstream_authorization_denied"
+    assert "portfolio_id" not in audit_record.extra_fields
 
 
 def test_workbench_performance_advisor_brief_router_preserves_query_context(monkeypatch):

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -63,6 +63,9 @@
   routes require `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional
   `X-Caller-Application`, `X-Booking-Center-Code`, and `X-Role` preserve entitlement and audit
   posture for RFC-0108 front-office analytics reads and workflow actions
+- Workbench advisor-brief reads emit bounded analytics read audit records with
+  `operation=advisor_brief.summary` and `panel=advisor-brief`; upstream authorization denials are
+  recorded as permission-blocked without restricted identifiers or raw entitlement text
 - legal-hold summary is returned as metadata for support posture; gateway retrieval does not expose
   legal-hold mutation, purge, retention mutation, or access-event routes
 - intake upload routes accept camelCase multipart aliases such as `entityType`, `sampleSize`, and

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -45,6 +45,10 @@
   this repository: performance summary, risk summary, and advisor brief. The advisor-brief
   review-action route also requires the same caller context because it records a bounded workflow
   review action through the Gateway boundary.
+- Advisor-brief read audit records use `operation=advisor_brief.summary` and
+  `panel=advisor-brief`. Treat `analytics_read_denied` with `reason=upstream_authorization_denied`
+  as a permission-blocked read and investigate upstream entitlement posture without expecting
+  portfolio, client, prompt, response-body, trace, or raw entitlement details in the audit fields.
 - Gateway exposes a protected operator lookup at
   `GET /api/v1/analytics-ui/diagnostics/{support_reference}`. It requires `X-Actor-Id`,
   `X-Tenant-Id`, `X-Region`, and an operator support role in `X-Role`.


### PR DESCRIPTION
## Summary
- emit route-level RFC-0108 analytics read audit records for Workbench advisor-brief reads using `operation=advisor_brief.summary`
- map advisor-brief audit operations to the bounded `advisor-brief` panel instead of `unknown`
- prove both allowed and upstream-denied advisor-brief read audit paths avoid restricted identifiers
- update README, repository context, and wiki source with the new audit posture

## Evidence
- `python -m pytest tests\integration\test_workbench_router.py::test_workbench_performance_advisor_brief_router tests\integration\test_workbench_router.py::test_workbench_performance_advisor_brief_router_audits_upstream_denial -q` (2 passed)
- `python -m ruff check src\app\routers\workbench.py src\app\observability\analytics_ui.py tests\integration\test_workbench_router.py` (passed)
- `git diff --check` (passed)
- `make lint` (passed)
- `make typecheck` (passed)
- `make check` (passed; 384 unit/contract tests passed)
- `make ci` (passed; 148 integration tests passed; 532 coverage tests passed at 88.59%; `pip-audit` no known vulnerabilities)
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway -AllowUnpublishedSourceChanges` (expected branch warning: source wiki differs from published wiki; publish after merge)

## Wiki
- Updates repo-local `wiki/` source. Publish after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-gateway`.