### PR TITLE
Clean gateway manage and advise downstream split

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ It depends on:
 - `lotus-risk`
   stateful risk workspace analytics
 - `lotus-advise`
-  proposal and advisory workflow capability
+  proposal simulation, persisted proposal lifecycle, workflow, approval, and lineage capability
 - `lotus-manage`
-  management workflow capability when split routing is enabled
+  discretionary management run lookup, supportability summary, and platform capability posture
 - `lotus-report`
   reporting snapshot, summary, review payloads, durable report job lifecycle/search, and
   RFC-0104 batch materialization/status/control/operator-run APIs
@@ -250,6 +250,10 @@ Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 - key upstreams:
   `lotus-core`, `lotus-performance`, `lotus-risk`, `lotus-advise`, `lotus-manage`, `lotus-report`,
   `lotus-archive`, `lotus-ai`
+- downstream ownership rule:
+  proposal routes call `lotus-advise` `/advisory/proposals/*`; `lotus-manage` calls are limited to
+  `GET /api/v1/rebalance/runs`, `GET /api/v1/rebalance/supportability/summary`, and
+  `GET /api/v1/platform/capabilities`
 - contract rule:
   gateway may reshape, aggregate, and annotate upstream data for product use, but must not assume
   upstream business authority

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -32,6 +32,9 @@ Current repository posture:
 1. `lotus-gateway` is the primary backend contract for `lotus-workbench`,
 2. the repository is moving from thin pass-through behavior to a cleaner experience-API posture,
 3. performance, proposal, foundation, reporting, and capability aggregation routes are active,
+   with proposal simulation/lifecycle/workflow/approval/lineage routed to `lotus-advise`
+   `/advisory/proposals/*` and `lotus-manage` limited to versioned run lookup,
+   supportability summary, and capability posture endpoints,
 4. report job initiation/search/status/event-history/cancellation routes are active for
    gateway-first portfolio review report job workflows under `/api/v1/reports/portfolio-reviews`,
    `/api/v1/report-jobs`, and `/api/v1/report-jobs/*`,
@@ -49,7 +52,7 @@ Current repository posture:
 10. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
 11. RFC-0108 analytics UI observability is active for selected Workbench performance summary,
     risk summary, advisor-brief read, and advisor-brief review-action paths, and has expanded
-    fan-out coverage for central `lotus-manage`,
+    fan-out coverage for central `lotus-advise`, `lotus-manage`,
     `lotus-report`, `lotus-archive`, `lotus-ai`, direct `lotus-core` query/control-plane, and
     `lotus-core` ingestion client seams. Gateway owns product-safe
     structured fan-out logs, bounded fan-out metrics, degraded-source counters, selected analytics

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -9,7 +9,8 @@ Run deterministic lotus-gateway demos for:
 
 ## Prerequisites
 
-- lotus-manage running at `http://manage.dev.lotus`
+- lotus-advise running at `http://advise.dev.lotus`
+- lotus-manage running at `http://manage.dev.lotus` for run/supportability enrichment
 - lotus-gateway running at `http://gateway.dev.lotus`
 - lotus-core query running at `http://core-query.dev.lotus`
 - lotus-core ingestion running at `http://core-ingestion.dev.lotus`

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -6,7 +6,7 @@ Governance boundary:
 
 | RFC | Title | Status | File |
 | --- | --- | --- | --- |
-| RFC-0001 | lotus-manage-First lotus-gateway Proposal Simulation Slice | IMPLEMENTED | `docs/rfcs/RFC-0001-dpm-first-bff-proposal-simulation-slice.md` |
+| RFC-0001 | lotus-gateway Proposal Simulation Slice | IMPLEMENTED | `docs/rfcs/RFC-0001-dpm-first-bff-proposal-simulation-slice.md` |
 | RFC-0002 | lotus-gateway Proposal Workspace v1 (Create/List/Detail/Submit) | IMPLEMENTED | `docs/rfcs/RFC-0002-bff-proposal-workspace-v1.md` |
 | RFC-0003 | lotus-gateway Approval Chain v1 and Supportability Pass-Through | IMPLEMENTED | `docs/rfcs/RFC-0003-bff-approval-chain-and-supportability-pass-through.md` |
 | RFC-0004 | Platform Capabilities Aggregation Contract | IMPLEMENTED | `docs/rfcs/RFC-0004-platform-capabilities-aggregation-contract.md` |

--- a/docs/rfcs/RFC-0001-dpm-first-bff-proposal-simulation-slice.md
+++ b/docs/rfcs/RFC-0001-dpm-first-bff-proposal-simulation-slice.md
@@ -1,22 +1,25 @@
-# RFC-0001: lotus-manage-First lotus-gateway Proposal Simulation Slice
+# RFC-0001: lotus-gateway Proposal Simulation Slice
 
 - Status: IMPLEMENTED
 - Date: 2026-02-22
+- Current implementation note: superseded by the 2026-05-01 downstream ownership split.
+  Gateway now routes proposal simulation to `lotus-advise`
+  `POST /advisory/proposals/simulate`; `lotus-manage` is no longer a proposal upstream.
 
 ## Goal
 
-Scope lotus-gateway to lotus-manage first and deliver proposal simulation as the first production UX path.
+Deliver proposal simulation as the first production UX path behind `lotus-gateway`.
 
 ## Decision
 
 - lotus-gateway exposes `POST /api/v1/proposals/simulate`.
-- lotus-gateway forwards payload to lotus-manage `POST /rebalance/proposals/simulate`.
+- lotus-gateway forwards payload to `lotus-advise` `POST /advisory/proposals/simulate`.
 - lotus-gateway enforces correlation id propagation and idempotency handling.
 
 ## Out of Scope
 
 - Portfolio core and performance integrations in this phase.
-- Non-lotus-manage workflows.
+- Non-proposal workflows.
 
 ## Acceptance Criteria
 

--- a/docs/rfcs/RFC-0002-bff-proposal-workspace-v1.md
+++ b/docs/rfcs/RFC-0002-bff-proposal-workspace-v1.md
@@ -3,19 +3,26 @@
 - Status: IMPLEMENTED
 - Date: 2026-02-22
 - Depends on: RFC-0001
+- Current implementation note: superseded by the 2026-05-01 downstream ownership split.
+  Gateway proposal create, list, detail, version, workflow, approval, and lineage routes now call
+  `lotus-advise` `/advisory/proposals/*`; `lotus-manage` is limited to strategic management
+  run/supportability/capability endpoints.
 
 ## Goal
 
-Extend the lotus-manage-first lotus-gateway slice from simulation-only to a minimal end-to-end proposal workspace contract for UI integration.
+Extend the gateway proposal simulation slice to a minimal end-to-end proposal workspace contract
+for UI integration.
 
 ## Decision
 
 Expose and standardize these lotus-gateway endpoints:
 
-- `POST /api/v1/proposals` -> lotus-manage `POST /rebalance/proposals`
-- `GET /api/v1/proposals` -> lotus-manage `GET /rebalance/proposals`
-- `GET /api/v1/proposals/{proposal_id}` -> lotus-manage `GET /rebalance/proposals/{proposal_id}`
-- `POST /api/v1/proposals/{proposal_id}/submit` -> lotus-manage `POST /rebalance/proposals/{proposal_id}/transitions`
+- `POST /api/v1/proposals` -> `lotus-advise` `POST /advisory/proposals`
+- `GET /api/v1/proposals` -> `lotus-advise` `GET /advisory/proposals`
+- `GET /api/v1/proposals/{proposal_id}` -> `lotus-advise`
+  `GET /advisory/proposals/{proposal_id}`
+- `POST /api/v1/proposals/{proposal_id}/submit` -> `lotus-advise`
+  `POST /advisory/proposals/{proposal_id}/transitions`
 
 Submit mapping in lotus-gateway:
 
@@ -25,7 +32,7 @@ Submit mapping in lotus-gateway:
 ## Out of Scope
 
 - Full approval workflow and execution orchestration.
-- Multi-service aggregation beyond lotus-manage.
+- Multi-service aggregation beyond proposal workflow.
 
 ## Acceptance Criteria
 

--- a/docs/standards/data-model-ownership.md
+++ b/docs/standards/data-model-ownership.md
@@ -8,7 +8,9 @@
 
 - lotus-core is the source for core portfolio data.
 - lotus-performance is the source for advanced analytics.
-- lotus-manage is the source for advisory/discretionary workflow computations.
+- lotus-advise is the source for advisor-led proposal workflow computations.
+- lotus-manage is the source for discretionary management run lookup, supportability, and
+  capability posture consumed by gateway.
 - lotus-report is the source for reporting and aggregation outputs.
 
 ## Vocabulary

--- a/docs/standards/durability-consistency.md
+++ b/docs/standards/durability-consistency.md
@@ -8,7 +8,7 @@
 
 - Strong consistency:
   - proposal create/version/submit/approval/consent orchestration
-  - write-through lotus-manage workflow invocations
+  - write-through lotus-advise proposal workflow invocations
 - Eventual consistency:
   - read-side dashboards and analytics composition from lotus-core/lotus-performance/lotus-report
 
@@ -23,7 +23,8 @@
 
 ## Atomicity Boundaries
 
-- Business write transitions are delegated to authoritative domain services (lotus-manage/lotus-core).
+- Business write transitions are delegated to authoritative domain services
+  (`lotus-advise` for proposal workflow and `lotus-core` for portfolio simulation state).
 - lotus-gateway orchestration must fail fast on downstream write failure and never mask partial commits.
 - Evidence:
   - `src/app/clients/http_resilience.py`

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,19 +1,13 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-04-30T10:19:06Z",
+  "generated_at": "2026-05-01T14:58:49Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-08-24"
-    },
-    {
-      "finding": "src/app/config.py:54:risk_bff_cache_ttl_seconds: float = Field(default=15.0)",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-04"
     },
     {
       "finding": "src/app/contracts/foundation.py:105:cash_weight_pct: float = Field(",
@@ -964,106 +958,106 @@
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/workbench_service.py:318:current_weight_pct=float(",
+      "finding": "src/app/services/workbench_service.py:321:current_weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:321:proposed_weight_pct=float(",
+      "finding": "src/app/services/workbench_service.py:324:proposed_weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:373:float(quantize_performance(portfolio_return))",
+      "finding": "src/app/services/workbench_service.py:376:float(quantize_performance(portfolio_return))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:378:float(quantize_performance(benchmark_return))",
+      "finding": "src/app/services/workbench_service.py:381:float(quantize_performance(benchmark_return))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:383:float(quantize_performance(active_return)) if active_return is not None else None",
+      "finding": "src/app/services/workbench_service.py:386:float(quantize_performance(active_return)) if active_return is not None else None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:604:weight_pct = float(",
+      "finding": "src/app/services/workbench_service.py:607:weight_pct = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:624:def _parse_position_market_value(self, item: dict[str, Any]) -> float | None:",
+      "finding": "src/app/services/workbench_service.py:627:def _parse_position_market_value(self, item: dict[str, Any]) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:632:return float(quantize_money(value))",
+      "finding": "src/app/services/workbench_service.py:635:return float(quantize_money(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:647:return float(quantize_money(value))",
+      "finding": "src/app/services/workbench_service.py:650:return float(quantize_money(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:750:float(quantize_money(total_market_value_value))",
+      "finding": "src/app/services/workbench_service.py:753:float(quantize_money(total_market_value_value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:755:float(row.get(\"market_value_base\", 0.0))",
+      "finding": "src/app/services/workbench_service.py:758:float(row.get(\"market_value_base\", 0.0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:765:float(row.get(\"market_value_base\", 0.0))",
+      "finding": "src/app/services/workbench_service.py:768:float(row.get(\"market_value_base\", 0.0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:773:cash_weight = float(",
+      "finding": "src/app/services/workbench_service.py:776:cash_weight = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:894:def _optional_money(self, value: Any) -> float | None:",
+      "finding": "src/app/services/workbench_service.py:897:def _optional_money(self, value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:898:return float(quantize_money(value))",
+      "finding": "src/app/services/workbench_service.py:901:return float(quantize_money(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:902:def _ratio_to_pct(self, value: Any) -> float | None:",
+      "finding": "src/app/services/workbench_service.py:905:def _ratio_to_pct(self, value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     },
     {
-      "finding": "src/app/services/workbench_service.py:906:return float(quantize_performance(float(value) * 100.0))",
+      "finding": "src/app/services/workbench_service.py:909:return float(quantize_performance(float(value) * 100.0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-10-28"
     }
   ]
 }

--- a/src/app/clients/advise_client.py
+++ b/src/app/clients/advise_client.py
@@ -38,3 +38,206 @@ class AdviseClient:
             backoff_seconds=self._retry_backoff_seconds,
             headers=propagation_headers(correlation_id),
         )
+
+    async def get_capabilities(
+        self,
+        consumer_system: str,
+        tenant_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        _ = consumer_system, tenant_id
+        return await self.get_platform_capabilities(correlation_id=correlation_id)
+
+    async def simulate_proposal(
+        self,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/advisory/proposals/simulate",
+            body=body,
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="advise.advisory.proposals.simulate",
+        )
+
+    async def create_proposal(
+        self,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/advisory/proposals",
+            body=body,
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="advise.advisory.proposals.create",
+        )
+
+    async def list_proposals(
+        self,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        cleaned_params = {key: value for key, value in params.items() if value is not None}
+        return await self._get(
+            "/advisory/proposals",
+            params=cleaned_params,
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.list",
+        )
+
+    async def get_proposal(
+        self,
+        proposal_id: str,
+        include_evidence: bool,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/{proposal_id}",
+            params={"include_evidence": str(include_evidence).lower()},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.get",
+        )
+
+    async def get_proposal_version(
+        self,
+        proposal_id: str,
+        version_no: int,
+        include_evidence: bool,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/{proposal_id}/versions/{version_no}",
+            params={"include_evidence": str(include_evidence).lower()},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.versions.get",
+        )
+
+    async def create_proposal_version(
+        self,
+        proposal_id: str,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/proposals/{proposal_id}/versions",
+            body=body,
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="advise.advisory.proposals.versions.create",
+        )
+
+    async def transition_proposal(
+        self,
+        proposal_id: str,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/proposals/{proposal_id}/transitions",
+            body=body,
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="advise.advisory.proposals.transition",
+        )
+
+    async def record_approval(
+        self,
+        proposal_id: str,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/proposals/{proposal_id}/approvals",
+            body=body,
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="advise.advisory.proposals.approvals.record",
+        )
+
+    async def get_workflow_events(
+        self,
+        proposal_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/{proposal_id}/workflow-events",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.workflow-events",
+        )
+
+    async def get_approvals(
+        self,
+        proposal_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/{proposal_id}/approvals",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.approvals.list",
+        )
+
+    async def get_proposal_lineage(
+        self,
+        proposal_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/{proposal_id}/lineage",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.lineage",
+        )
+
+    def _headers(
+        self,
+        correlation_id: str,
+        extras: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        headers = propagation_headers(correlation_id)
+        if extras:
+            headers.update(extras)
+        return headers
+
+    async def _post(
+        self,
+        path: str,
+        body: dict[str, Any],
+        headers: dict[str, str],
+        operation: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-advise",
+            operation=operation,
+            method="POST",
+            url=f"{self._base_url}{path}",
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            json_body=body,
+            headers=headers,
+        )
+
+    async def _get(
+        self,
+        path: str,
+        params: dict[str, Any],
+        headers: dict[str, str],
+        operation: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-advise",
+            operation=operation,
+            method="GET",
+            url=f"{self._base_url}{path}",
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            params=params,
+            headers=headers,
+        )

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -20,45 +20,6 @@ class DpmClient:
         self._max_retries = max_retries
         self._retry_backoff_seconds = retry_backoff_seconds
 
-    async def simulate_proposal(
-        self,
-        body: dict[str, Any],
-        idempotency_key: str,
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
-        return await self._post(
-            "/api/v1/rebalance/proposals/simulate",
-            body=body,
-            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
-            operation="manage.rebalance.proposals.simulate",
-        )
-
-    async def create_proposal(
-        self,
-        body: dict[str, Any],
-        idempotency_key: str,
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
-        return await self._post(
-            "/api/v1/rebalance/proposals",
-            body=body,
-            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
-            operation="manage.rebalance.proposals.create",
-        )
-
-    async def list_proposals(
-        self,
-        params: dict[str, Any],
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
-        cleaned_params = {key: value for key, value in params.items() if value is not None}
-        return await self._get(
-            "/api/v1/rebalance/proposals",
-            params=cleaned_params,
-            headers=self._headers(correlation_id),
-            operation="manage.rebalance.proposals.list",
-        )
-
     async def list_runs(
         self,
         params: dict[str, Any],
@@ -83,111 +44,6 @@ class DpmClient:
             operation="manage.rebalance.supportability.summary",
         )
 
-    async def get_proposal(
-        self,
-        proposal_id: str,
-        include_evidence: bool,
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
-        return await self._get(
-            f"/api/v1/rebalance/proposals/{proposal_id}",
-            params={"include_evidence": str(include_evidence).lower()},
-            headers=self._headers(correlation_id),
-            operation="manage.rebalance.proposals.get",
-        )
-
-    async def get_proposal_version(
-        self,
-        proposal_id: str,
-        version_no: int,
-        include_evidence: bool,
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
-        return await self._get(
-            f"/api/v1/rebalance/proposals/{proposal_id}/versions/{version_no}",
-            params={"include_evidence": str(include_evidence).lower()},
-            headers=self._headers(correlation_id),
-            operation="manage.rebalance.proposals.versions.get",
-        )
-
-    async def create_proposal_version(
-        self,
-        proposal_id: str,
-        body: dict[str, Any],
-        idempotency_key: str,
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
-        return await self._post(
-            f"/api/v1/rebalance/proposals/{proposal_id}/versions",
-            body=body,
-            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
-            operation="manage.rebalance.proposals.versions.create",
-        )
-
-    async def transition_proposal(
-        self,
-        proposal_id: str,
-        body: dict[str, Any],
-        idempotency_key: str,
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
-        return await self._post(
-            f"/api/v1/rebalance/proposals/{proposal_id}/transitions",
-            body=body,
-            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
-            operation="manage.rebalance.proposals.transition",
-        )
-
-    async def record_approval(
-        self,
-        proposal_id: str,
-        body: dict[str, Any],
-        idempotency_key: str,
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
-        return await self._post(
-            f"/api/v1/rebalance/proposals/{proposal_id}/approvals",
-            body=body,
-            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
-            operation="manage.rebalance.proposals.approvals.record",
-        )
-
-    async def get_workflow_events(
-        self,
-        proposal_id: str,
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
-        return await self._get(
-            f"/api/v1/rebalance/proposals/{proposal_id}/workflow-events",
-            params={},
-            headers=self._headers(correlation_id),
-            operation="manage.rebalance.proposals.workflow-events",
-        )
-
-    async def get_approvals(
-        self,
-        proposal_id: str,
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
-        return await self._get(
-            f"/api/v1/rebalance/proposals/{proposal_id}/approvals",
-            params={},
-            headers=self._headers(correlation_id),
-            operation="manage.rebalance.proposals.approvals.list",
-        )
-
-    async def get_proposal_lineage(
-        self,
-        proposal_id: str,
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
-        return await self._get(
-            f"/api/v1/rebalance/proposals/{proposal_id}/lineage",
-            params={},
-            headers=self._headers(correlation_id),
-            operation="manage.rebalance.proposals.lineage",
-        )
-
     async def get_capabilities(
         self,
         consumer_system: str,
@@ -210,27 +66,6 @@ class DpmClient:
         if extras:
             headers.update(extras)
         return headers
-
-    async def _post(
-        self,
-        path: str,
-        body: dict[str, Any],
-        headers: dict[str, str],
-        operation: str,
-    ) -> tuple[int, dict[str, Any]]:
-        url = f"{self._base_url}{path}"
-        return await request_observed_fanout(
-            logger=logger,
-            service="lotus-manage",
-            operation=operation,
-            method="POST",
-            url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
-            json_body=body,
-            headers=headers,
-        )
 
     async def _get(
         self,

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -44,7 +44,6 @@ class Settings(BaseSettings):
     render_service_base_url: str = Field(default="http://render.dev.lotus")
     archive_service_base_url: str = Field(default="http://archive.dev.lotus")
     management_service_base_url: str = Field(default="http://manage.dev.lotus")
-    manage_split_enabled: bool = Field(default=True)
     upstream_timeout_seconds: float = Field(default=3.0)
     performance_analytics_timeout_seconds: float = Field(default=15.0)
     ai_service_timeout_seconds: float = Field(default=45.0)

--- a/src/app/contracts/proposals.py
+++ b/src/app/contracts/proposals.py
@@ -126,7 +126,7 @@ class ProposalSimulationData(BaseModel):
 
 class ProposalCreateRequest(BaseModel):
     body: dict[str, Any] = Field(
-        description="Opaque proposal-create request payload forwarded unchanged to lotus-manage.",
+        description="Opaque proposal-create request payload forwarded unchanged to lotus-advise.",
         examples=[
             {
                 "portfolio_id": "PF_1001",
@@ -140,7 +140,7 @@ class ProposalCreateRequest(BaseModel):
 class ProposalVersionCreateRequest(BaseModel):
     body: dict[str, Any] = Field(
         description=(
-            "Opaque proposal-version request payload forwarded unchanged to lotus-manage."
+            "Opaque proposal-version request payload forwarded unchanged to lotus-advise."
         ),
         examples=[
             {
@@ -555,13 +555,13 @@ class ProposalListEnvelopeResponse(ProposalEnvelopeBase):
 
 class ProposalDetailEnvelopeResponse(ProposalEnvelopeBase):
     data: ProposalDetailData = Field(
-        description="Current proposal detail payload returned by lotus-manage."
+        description="Current proposal detail payload returned by lotus-advise."
     )
 
 
 class ProposalVersionEnvelopeResponse(ProposalEnvelopeBase):
     data: ProposalVersionData = Field(
-        description="Immutable proposal-version payload returned by lotus-manage."
+        description="Immutable proposal-version payload returned by lotus-advise."
     )
 
 
@@ -656,7 +656,7 @@ class ProposalEnvelopeResponse(ProposalEnvelopeBase):
     data: dict[str, Any] = Field(
         default_factory=dict,
         description=(
-            "Opaque lotus-manage proposal payload returned unchanged by gateway for write actions."
+            "Opaque lotus-advise proposal payload returned unchanged by gateway for write actions."
         ),
         examples=[{"proposal": {"proposal_id": "pp_1", "current_state": "DRAFT"}}],
     )

--- a/src/app/routers/foundation.py
+++ b/src/app/routers/foundation.py
@@ -16,11 +16,6 @@ router = APIRouter(prefix="/api/v1/foundation", tags=["foundation"])
 
 
 def _foundation_service() -> FoundationService:
-    dpm_base_url = (
-        settings.management_service_base_url
-        if settings.manage_split_enabled
-        else settings.decisioning_service_base_url
-    )
     return FoundationService(
         lotus_core_query_client=LotusCoreQueryClient(
             base_url=settings.portfolio_data_query_base_url,
@@ -36,7 +31,7 @@ def _foundation_service() -> FoundationService:
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
         dpm_client=DpmClient(
-            base_url=dpm_base_url,
+            base_url=settings.management_service_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,

--- a/src/app/routers/platform.py
+++ b/src/app/routers/platform.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Header, Query
 
+from app.clients.advise_client import AdviseClient
 from app.clients.dpm_client import DpmClient
 from app.clients.lotus_analytics_client import LotusAnalyticsClient
 from app.clients.lotus_core_query_client import LotusCoreQueryClient
@@ -14,8 +15,14 @@ router = APIRouter(prefix="/api/v1/platform", tags=["platform"])
 
 def _platform_capabilities_service() -> PlatformCapabilitiesService:
     return PlatformCapabilitiesService(
-        dpm_client=DpmClient(
+        advise_client=AdviseClient(
             base_url=settings.decisioning_service_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+        manage_client=DpmClient(
+            base_url=settings.management_service_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
@@ -45,16 +52,6 @@ def _platform_capabilities_service() -> PlatformCapabilitiesService:
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
-        manage_client=(
-            DpmClient(
-                base_url=settings.management_service_base_url,
-                timeout_seconds=settings.upstream_timeout_seconds,
-                max_retries=settings.upstream_max_retries,
-                retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
-            )
-            if settings.manage_split_enabled
-            else None
-        ),
         contract_version=settings.contract_version,
     )
 
@@ -64,8 +61,8 @@ def _platform_capabilities_service() -> PlatformCapabilitiesService:
     response_model=PlatformCapabilitiesResponse,
     summary="Get Aggregated Platform Capabilities",
     description=(
-        "Aggregates lotus-core, lotus-performance, lotus-risk, lotus-manage, and "
-        "lotus-report integration capabilities into one "
+        "Aggregates lotus-core, lotus-performance, lotus-risk, lotus-advise, "
+        "lotus-manage, and lotus-report integration capabilities into one "
         "lotus-gateway contract for UI feature control, shell bootstrap, and "
         "workflow negotiation. Gateway fans out to upstream capability and policy "
         "sources concurrently, applies a bounded per-source timeout, and returns "

--- a/src/app/routers/portfolio.py
+++ b/src/app/routers/portfolio.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Query
 
+from app.clients.advise_client import AdviseClient
 from app.clients.dpm_client import DpmClient
 from app.clients.lotus_analytics_client import LotusAnalyticsClient
 from app.clients.lotus_core_query_client import LotusCoreQueryClient
@@ -42,11 +43,7 @@ _PORTFOLIO_SERVICE = PortfolioService(
         retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
     ),
     dpm_client=DpmClient(
-        base_url=(
-            settings.management_service_base_url
-            if settings.manage_split_enabled
-            else settings.decisioning_service_base_url
-        ),
+        base_url=settings.management_service_base_url,
         timeout_seconds=settings.upstream_timeout_seconds,
         max_retries=settings.upstream_max_retries,
         retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
@@ -64,7 +61,6 @@ def _service_signature() -> tuple[object, ...]:
         settings.performance_analytics_base_url,
         settings.management_service_base_url,
         settings.decisioning_service_base_url,
-        settings.manage_split_enabled,
         settings.upstream_timeout_seconds,
         settings.performance_analytics_timeout_seconds,
         settings.upstream_max_retries,
@@ -90,11 +86,13 @@ def _build_performance_workspace_service() -> PerformanceWorkspaceService:
                 retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
             ),
             dpm_client=DpmClient(
-                base_url=(
-                    settings.management_service_base_url
-                    if settings.manage_split_enabled
-                    else settings.decisioning_service_base_url
-                ),
+                base_url=settings.management_service_base_url,
+                timeout_seconds=settings.upstream_timeout_seconds,
+                max_retries=settings.upstream_max_retries,
+                retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+            ),
+            advise_client=AdviseClient(
+                base_url=settings.decisioning_service_base_url,
                 timeout_seconds=settings.upstream_timeout_seconds,
                 max_retries=settings.upstream_max_retries,
                 retry_backoff_seconds=settings.upstream_retry_backoff_seconds,

--- a/src/app/routers/proposals.py
+++ b/src/app/routers/proposals.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Header, Path, Query
 
-from app.clients.dpm_client import DpmClient
+from app.clients.advise_client import AdviseClient
 from app.config import settings
 from app.contracts.proposals import (
     ProposalApprovalActionRequest,
@@ -25,10 +25,9 @@ router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
 def _proposal_service() -> ProposalService:
-    base_url = settings.decisioning_service_base_url
     return ProposalService(
-        dpm_client=DpmClient(
-            base_url=base_url,
+        advise_client=AdviseClient(
+            base_url=settings.decisioning_service_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
@@ -41,7 +40,7 @@ def _proposal_service() -> ProposalService:
     response_model=ProposalSimulateResponse,
     summary="Simulate Proposal",
     description=(
-        "Runs proposal simulation through lotus-manage using a caller-supplied idempotency key "
+        "Runs proposal simulation through lotus-advise using a caller-supplied idempotency key "
         "to protect against duplicate submission."
     ),
 )
@@ -67,7 +66,7 @@ async def simulate_proposal(
     response_model=ProposalCreateEnvelopeResponse,
     summary="Create Proposal",
     description=(
-        "Creates a new advisory proposal draft in lotus-manage using a caller-supplied "
+        "Creates a new advisory proposal draft in lotus-advise using a caller-supplied "
         "idempotency key."
     ),
 )
@@ -93,7 +92,7 @@ async def create_proposal(
     response_model=ProposalListEnvelopeResponse,
     summary="List Proposals",
     description=(
-        "Lists advisory proposals from lotus-manage using optional portfolio, workflow-state, "
+        "Lists advisory proposals from lotus-advise using optional portfolio, workflow-state, "
         "creator, and creation-window filters."
     ),
 )
@@ -159,7 +158,7 @@ async def list_proposals(
 async def get_proposal(
     proposal_id: str = Path(
         ...,
-        description="Gateway-visible proposal identifier returned by lotus-manage.",
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
         examples=["pp_1"],
     ),
     include_evidence: bool = Query(
@@ -186,7 +185,7 @@ async def get_proposal(
 async def get_proposal_version(
     proposal_id: str = Path(
         ...,
-        description="Gateway-visible proposal identifier returned by lotus-manage.",
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
         examples=["pp_1"],
     ),
     version_no: int = Path(
@@ -222,7 +221,7 @@ async def create_proposal_version(
     request: ProposalVersionCreateRequest,
     proposal_id: str = Path(
         ...,
-        description="Gateway-visible proposal identifier returned by lotus-manage.",
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
         examples=["pp_1"],
     ),
     idempotency_key: str = Header(
@@ -251,7 +250,7 @@ async def submit_proposal(
     request: ProposalSubmitRequest,
     proposal_id: str = Path(
         ...,
-        description="Gateway-visible proposal identifier returned by lotus-manage.",
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
         examples=["pp_1"],
     ),
     idempotency_key: str = Header(
@@ -284,7 +283,7 @@ async def approve_risk(
     request: ProposalApprovalActionRequest,
     proposal_id: str = Path(
         ...,
-        description="Gateway-visible proposal identifier returned by lotus-manage.",
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
         examples=["pp_1"],
     ),
     idempotency_key: str = Header(
@@ -316,7 +315,7 @@ async def approve_compliance(
     request: ProposalApprovalActionRequest,
     proposal_id: str = Path(
         ...,
-        description="Gateway-visible proposal identifier returned by lotus-manage.",
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
         examples=["pp_1"],
     ),
     idempotency_key: str = Header(
@@ -348,7 +347,7 @@ async def record_client_consent(
     request: ProposalApprovalActionRequest,
     proposal_id: str = Path(
         ...,
-        description="Gateway-visible proposal identifier returned by lotus-manage.",
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
         examples=["pp_1"],
     ),
     idempotency_key: str = Header(
@@ -379,7 +378,7 @@ async def record_client_consent(
 async def get_workflow_events(
     proposal_id: str = Path(
         ...,
-        description="Gateway-visible proposal identifier returned by lotus-manage.",
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
         examples=["pp_1"],
     ),
 ) -> ProposalWorkflowEventsEnvelopeResponse:
@@ -400,7 +399,7 @@ async def get_workflow_events(
 async def get_approvals(
     proposal_id: str = Path(
         ...,
-        description="Gateway-visible proposal identifier returned by lotus-manage.",
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
         examples=["pp_1"],
     ),
 ) -> ProposalApprovalsEnvelopeResponse:
@@ -421,7 +420,7 @@ async def get_approvals(
 async def get_proposal_lineage(
     proposal_id: str = Path(
         ...,
-        description="Gateway-visible proposal identifier returned by lotus-manage.",
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
         examples=["pp_1"],
     ),
 ) -> ProposalLineageEnvelopeResponse:

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -99,7 +99,6 @@ def _service_signature() -> tuple[object, ...]:
         settings.ai_service_base_url,
         settings.management_service_base_url,
         settings.decisioning_service_base_url,
-        settings.manage_split_enabled,
         settings.upstream_timeout_seconds,
         settings.performance_analytics_timeout_seconds,
         settings.ai_service_timeout_seconds,
@@ -127,11 +126,13 @@ def _build_workbench_service() -> WorkbenchService:
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
         dpm_client=DpmClient(
-            base_url=(
-                settings.management_service_base_url
-                if settings.manage_split_enabled
-                else settings.decisioning_service_base_url
-            ),
+            base_url=settings.management_service_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+        advise_client=AdviseClient(
+            base_url=settings.decisioning_service_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,

--- a/src/app/services/platform_capabilities_service.py
+++ b/src/app/services/platform_capabilities_service.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import datetime, timezone
 from typing import Any, cast
 
+from app.clients.advise_client import AdviseClient
 from app.clients.dpm_client import DpmClient
 from app.clients.lotus_analytics_client import LotusAnalyticsClient
 from app.clients.lotus_core_query_client import LotusCoreQueryClient
@@ -26,6 +27,7 @@ class PlatformCapabilitiesService:
     _PRIMARY_CAPABILITY_SOURCES = (
         "lotus_core",
         "lotus_performance",
+        "lotus_advise",
         "lotus_manage",
         "lotus_report",
     )
@@ -41,21 +43,30 @@ class PlatformCapabilitiesService:
 
     def __init__(
         self,
-        dpm_client: DpmClient,
         lotus_core_query_client: LotusCoreQueryClient,
         analytics_client: LotusAnalyticsClient,
         reporting_client: ReportingClient,
         contract_version: str,
         source_timeout_seconds: float = 1.0,
         risk_client: LotusAnalyticsClient | None = None,
+        advise_client: AdviseClient | None = None,
         manage_client: DpmClient | None = None,
+        dpm_client: Any | None = None,
     ):
-        self._dpm_client = dpm_client
+        if advise_client is None:
+            if dpm_client is None:
+                raise ValueError("PlatformCapabilitiesService requires an advise_client")
+            advise_client = dpm_client
+        if manage_client is None:
+            if dpm_client is None:
+                raise ValueError("PlatformCapabilitiesService requires a manage_client")
+            manage_client = dpm_client
+        self._advise_client = advise_client
+        self._manage_client = manage_client
         self._lotus_core_query_client = lotus_core_query_client
         self._analytics_client = analytics_client
         self._reporting_client = reporting_client
         self._risk_client = risk_client
-        self._manage_client = manage_client
         self._contract_version = contract_version
         self._source_timeout_seconds = source_timeout_seconds
 
@@ -66,7 +77,6 @@ class PlatformCapabilitiesService:
         correlation_id: str,
     ) -> PlatformCapabilitiesResponse:
         evaluated_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-        manage_capabilities_client = self._manage_client or self._dpm_client
         tasks: list[Any] = [
             self._with_timeout(
                 self._lotus_core_query_client.get_capabilities(
@@ -83,7 +93,14 @@ class PlatformCapabilitiesService:
                 )
             ),
             self._with_timeout(
-                manage_capabilities_client.get_capabilities(
+                self._advise_client.get_capabilities(
+                    consumer_system=consumer_system,
+                    tenant_id=tenant_id,
+                    correlation_id=correlation_id,
+                )
+            ),
+            self._with_timeout(
+                self._manage_client.get_capabilities(
                     consumer_system=consumer_system,
                     tenant_id=tenant_id,
                     correlation_id=correlation_id,
@@ -119,7 +136,7 @@ class PlatformCapabilitiesService:
 
         sources: dict[str, dict[str, Any]] = {}
         errors: list[CapabilitySourceError] = []
-        for service_name, result in zip(self._PRIMARY_CAPABILITY_SOURCES, results[:4], strict=True):
+        for service_name, result in zip(self._PRIMARY_CAPABILITY_SOURCES, results[:5], strict=True):
             if isinstance(result, BaseException):
                 errors.append(
                     CapabilitySourceError(
@@ -144,7 +161,7 @@ class PlatformCapabilitiesService:
             sources[service_name] = payload
 
         lotus_core_policy_payload: dict[str, Any] | None = None
-        lotus_core_policy_result = results[4]
+        lotus_core_policy_result = results[5]
         if isinstance(lotus_core_policy_result, BaseException):
             errors.append(
                 CapabilitySourceError(
@@ -169,7 +186,7 @@ class PlatformCapabilitiesService:
                 lotus_core_policy_payload = policy_payload
 
         optional_result_map: dict[str, Any] = {}
-        for index, source in enumerate(optional_sources, start=5):
+        for index, source in enumerate(optional_sources, start=6):
             optional_result_map[source] = results[index]
 
         self._merge_optional_source(
@@ -268,11 +285,12 @@ class PlatformCapabilitiesService:
                     "performance.analytics.attribution",
                 )
             ),
-            "lotus_manage_lifecycle": self._feature_enabled(
+            "lotus_advise_lifecycle": self._feature_enabled(
                 sources=sources,
-                source_name="lotus_manage",
+                source_name="lotus_advise",
                 feature_keys=(
-                    "lotus_manage.proposals.lifecycle",
+                    "lotus_advise.proposals.lifecycle",
+                    "advise.proposals.lifecycle",
                     "dpm.proposals.lifecycle",
                 ),
             ),
@@ -316,12 +334,12 @@ class PlatformCapabilitiesService:
                 feature_enabled["lotus_core_intake"] or feature_enabled["lotus_core_snapshot"]
             ),
             "analytics_studio": feature_enabled["lotus_performance_analytics"],
-            "advisory_pipeline": feature_enabled["lotus_manage_lifecycle"],
-            "scenario_builder": feature_enabled["lotus_manage_lifecycle"],
+            "advisory_pipeline": feature_enabled["lotus_advise_lifecycle"],
+            "scenario_builder": feature_enabled["lotus_advise_lifecycle"],
             "decision_console": (
                 feature_enabled["lotus_core_snapshot"]
                 and (
-                    feature_enabled["lotus_manage_lifecycle"]
+                    feature_enabled["lotus_advise_lifecycle"]
                     or feature_enabled["lotus_manage_support"]
                 )
             ),
@@ -337,12 +355,12 @@ class PlatformCapabilitiesService:
         workflow_flags = {
             "proposal_lifecycle": self._workflow_enabled(
                 sources=sources,
-                source_name="lotus_manage",
+                source_name="lotus_advise",
                 workflow_key="proposal_lifecycle",
             ),
             "proposal_approval_flow": self._workflow_enabled(
                 sources=sources,
-                source_name="lotus_manage",
+                source_name="lotus_advise",
                 workflow_key="proposal_approval_flow",
             ),
             "portfolio_bulk_onboarding": self._workflow_enabled(
@@ -478,7 +496,7 @@ class PlatformCapabilitiesService:
                     label="Proposal",
                     href="/proposals",
                     enabled=navigation["proposal_workspace"],
-                    dependency_source="lotus_manage",
+                    dependency_source="lotus_advise",
                     module_health=module_health,
                     policy_versions_by_source=policy_versions_by_source,
                     error_services=error_services,
@@ -493,7 +511,7 @@ class PlatformCapabilitiesService:
                     label="Advisory",
                     href="/recommendations",
                     enabled=navigation["advisory_workspace"],
-                    dependency_source="lotus_manage",
+                    dependency_source="lotus_advise",
                     module_health=module_health,
                     policy_versions_by_source=policy_versions_by_source,
                     error_services=error_services,

--- a/src/app/services/proposal_service.py
+++ b/src/app/services/proposal_service.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from fastapi import HTTPException, status
 
-from app.clients.dpm_client import DpmClient
+from app.clients.advise_client import AdviseClient
 from app.config import settings
 from app.contracts.proposals import (
     ProposalApprovalsData,
@@ -27,8 +27,8 @@ from app.contracts.proposals import (
 
 
 class ProposalService:
-    def __init__(self, dpm_client: DpmClient):
-        self._dpm_client = dpm_client
+    def __init__(self, advise_client: AdviseClient):
+        self._advise_client = advise_client
 
     async def simulate_proposal(
         self,
@@ -36,7 +36,7 @@ class ProposalService:
         idempotency_key: str,
         correlation_id: str,
     ) -> ProposalSimulateResponse:
-        upstream_status, upstream_payload = await self._dpm_client.simulate_proposal(
+        upstream_status, upstream_payload = await self._advise_client.simulate_proposal(
             body=body,
             idempotency_key=idempotency_key,
             correlation_id=correlation_id,
@@ -60,7 +60,7 @@ class ProposalService:
         idempotency_key: str,
         correlation_id: str,
     ) -> ProposalCreateEnvelopeResponse:
-        upstream_status, upstream_payload = await self._dpm_client.create_proposal(
+        upstream_status, upstream_payload = await self._advise_client.create_proposal(
             body=body,
             idempotency_key=idempotency_key,
             correlation_id=correlation_id,
@@ -77,7 +77,7 @@ class ProposalService:
         filters: dict[str, Any],
         correlation_id: str,
     ) -> ProposalListEnvelopeResponse:
-        upstream_status, upstream_payload = await self._dpm_client.list_proposals(
+        upstream_status, upstream_payload = await self._advise_client.list_proposals(
             params=filters,
             correlation_id=correlation_id,
         )
@@ -94,7 +94,7 @@ class ProposalService:
         include_evidence: bool,
         correlation_id: str,
     ) -> ProposalDetailEnvelopeResponse:
-        upstream_status, upstream_payload = await self._dpm_client.get_proposal(
+        upstream_status, upstream_payload = await self._advise_client.get_proposal(
             proposal_id=proposal_id,
             include_evidence=include_evidence,
             correlation_id=correlation_id,
@@ -113,7 +113,7 @@ class ProposalService:
         include_evidence: bool,
         correlation_id: str,
     ) -> ProposalVersionEnvelopeResponse:
-        upstream_status, upstream_payload = await self._dpm_client.get_proposal_version(
+        upstream_status, upstream_payload = await self._advise_client.get_proposal_version(
             proposal_id=proposal_id,
             version_no=version_no,
             include_evidence=include_evidence,
@@ -133,7 +133,7 @@ class ProposalService:
         idempotency_key: str,
         correlation_id: str,
     ) -> ProposalCreateEnvelopeResponse:
-        upstream_status, upstream_payload = await self._dpm_client.create_proposal_version(
+        upstream_status, upstream_payload = await self._advise_client.create_proposal_version(
             proposal_id=proposal_id,
             body=body,
             idempotency_key=idempotency_key,
@@ -171,7 +171,7 @@ class ProposalService:
         if related_version_no is not None:
             transition_body["related_version_no"] = related_version_no
 
-        upstream_status, upstream_payload = await self._dpm_client.transition_proposal(
+        upstream_status, upstream_payload = await self._advise_client.transition_proposal(
             proposal_id=proposal_id,
             body=transition_body,
             idempotency_key=idempotency_key,
@@ -252,7 +252,7 @@ class ProposalService:
         proposal_id: str,
         correlation_id: str,
     ) -> ProposalWorkflowEventsEnvelopeResponse:
-        upstream_status, upstream_payload = await self._dpm_client.get_workflow_events(
+        upstream_status, upstream_payload = await self._advise_client.get_workflow_events(
             proposal_id=proposal_id,
             correlation_id=correlation_id,
         )
@@ -268,7 +268,7 @@ class ProposalService:
         proposal_id: str,
         correlation_id: str,
     ) -> ProposalApprovalsEnvelopeResponse:
-        upstream_status, upstream_payload = await self._dpm_client.get_approvals(
+        upstream_status, upstream_payload = await self._advise_client.get_approvals(
             proposal_id=proposal_id,
             correlation_id=correlation_id,
         )
@@ -284,7 +284,7 @@ class ProposalService:
         proposal_id: str,
         correlation_id: str,
     ) -> ProposalLineageEnvelopeResponse:
-        upstream_status, upstream_payload = await self._dpm_client.get_proposal_lineage(
+        upstream_status, upstream_payload = await self._advise_client.get_proposal_lineage(
             proposal_id=proposal_id,
             correlation_id=correlation_id,
         )
@@ -316,7 +316,7 @@ class ProposalService:
         if related_version_no is not None:
             payload["related_version_no"] = related_version_no
 
-        upstream_status, upstream_payload = await self._dpm_client.record_approval(
+        upstream_status, upstream_payload = await self._advise_client.record_approval(
             proposal_id=proposal_id,
             body=payload,
             idempotency_key=idempotency_key,

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 from fastapi import HTTPException, status
 
+from app.clients.advise_client import AdviseClient
 from app.clients.dpm_client import DpmClient
 from app.clients.lotus_analytics_client import LotusAnalyticsClient
 from app.clients.lotus_core_query_client import LotusCoreQueryClient
@@ -40,10 +41,12 @@ class WorkbenchService:
         lotus_core_query_client: LotusCoreQueryClient,
         analytics_client: LotusAnalyticsClient,
         dpm_client: DpmClient,
+        advise_client: AdviseClient | None = None,
     ):
         self._lotus_core_query_client = lotus_core_query_client
         self._analytics_client = analytics_client
         self._dpm_client = dpm_client
+        self._advise_client = cast(AdviseClient, advise_client or dpm_client)
 
     async def get_workbench_overview(
         self,
@@ -688,38 +691,38 @@ class WorkbenchService:
             "proposed_trades": [],
         }
         idempotency_key = f"sandbox-{session_id}-{session_version}"
-        dpm_status, dpm_payload = await self._dpm_client.simulate_proposal(
+        advise_status, advise_payload = await self._advise_client.simulate_proposal(
             body=simulate_payload,
             idempotency_key=idempotency_key,
             correlation_id=correlation_id,
         )
-        if dpm_status >= status.HTTP_400_BAD_REQUEST:
-            warnings.append("MANAGE_POLICY_SIMULATION_UNAVAILABLE")
+        if advise_status >= status.HTTP_400_BAD_REQUEST:
+            warnings.append("ADVISE_PROPOSAL_SIMULATION_UNAVAILABLE")
             partial_failures.append(
                 WorkbenchPartialFailure(
-                    source_service="lotus-manage",
-                    error_code=f"HTTP_{dpm_status}",
-                    detail=str(dpm_payload.get("detail", dpm_payload)),
+                    source_service="lotus-advise",
+                    error_code=f"HTTP_{advise_status}",
+                    detail=str(advise_payload.get("detail", advise_payload)),
                 )
             )
             return WorkbenchPolicyFeedback(
                 status="UNAVAILABLE",
-                detail="Policy simulation unavailable",
-                raw=dpm_payload if isinstance(dpm_payload, dict) else None,
+                detail="Proposal simulation unavailable",
+                raw=advise_payload if isinstance(advise_payload, dict) else None,
             )
 
-        gate_decision = dpm_payload.get("gate_decision")
+        gate_decision = advise_payload.get("gate_decision")
         if isinstance(gate_decision, dict):
             gate_status = str(gate_decision.get("status", "UNKNOWN"))
             return WorkbenchPolicyFeedback(
                 status=gate_status,
                 detail=str(gate_decision.get("reason_code", "")) or None,
-                raw=dpm_payload,
+                raw=advise_payload,
             )
         return WorkbenchPolicyFeedback(
-            status=str(dpm_payload.get("status", "AVAILABLE")),
+            status=str(advise_payload.get("status", "AVAILABLE")),
             detail=None,
-            raw=dpm_payload,
+            raw=advise_payload,
         )
 
     def _parse_lotus_core_snapshot(

--- a/tests/contract/test_platform_capabilities_contract.py
+++ b/tests/contract/test_platform_capabilities_contract.py
@@ -67,6 +67,7 @@ def test_platform_capabilities_contract_shape(monkeypatch):
     monkeypatch.setattr(
         "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_capabilities", _analytics
     )
+    monkeypatch.setattr("app.clients.advise_client.AdviseClient.get_capabilities", _dpm)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.get_capabilities", _dpm)
     monkeypatch.setattr("app.clients.reporting_client.ReportingClient.get_capabilities", _ras)
 
@@ -102,6 +103,7 @@ def test_platform_capabilities_contract_shape(monkeypatch):
     assert payload["normalized"]["shellBootstrap"]["evidence"]["lineageSources"] == [
         "lotus_core",
         "lotus_performance",
+        "lotus_advise",
         "lotus_manage",
         "lotus_report",
         "lotus_risk",
@@ -113,6 +115,7 @@ def test_platform_capabilities_contract_shape(monkeypatch):
         "lotus_core": "lotus-core-default-v1",
         "lotus_performance": "lotus-performance-default-v1",
         "lotus_risk": "lotus-risk-default-v1",
+        "lotus_advise": "lotus-manage-default-v1",
         "lotus_manage": "lotus-manage-default-v1",
         "lotus_report": "lotus-report-default-v1",
     }
@@ -130,6 +133,7 @@ def test_platform_capabilities_contract_shape(monkeypatch):
         "lotus_core",
         "lotus_performance",
         "lotus_risk",
+        "lotus_advise",
         "lotus_manage",
         "lotus_report",
     ):

--- a/tests/e2e/test_workflow_journeys.py
+++ b/tests/e2e/test_workflow_journeys.py
@@ -63,6 +63,7 @@ def test_e2e_platform_capability_aggregation_and_health(monkeypatch) -> None:
     monkeypatch.setattr(
         "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_capabilities", _performance
     )
+    monkeypatch.setattr("app.clients.advise_client.AdviseClient.get_capabilities", _dpm)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.get_capabilities", _dpm)
     monkeypatch.setattr("app.clients.reporting_client.ReportingClient.get_capabilities", _ras)
 
@@ -80,6 +81,7 @@ def test_e2e_platform_capability_aggregation_and_health(monkeypatch) -> None:
         "lotus_core",
         "lotus_performance",
         "lotus_risk",
+        "lotus_advise",
         "lotus_manage",
         "lotus_report",
     }
@@ -144,7 +146,7 @@ def test_e2e_workbench_sandbox_flow(monkeypatch) -> None:
         "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_stateful_twr", _performance
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
-    monkeypatch.setattr("app.clients.dpm_client.DpmClient.simulate_proposal", _dpm_simulate)
+    monkeypatch.setattr("app.clients.advise_client.AdviseClient.simulate_proposal", _dpm_simulate)
 
     client = TestClient(app)
     created = client.post(
@@ -167,7 +169,31 @@ def test_e2e_workbench_sandbox_flow(monkeypatch) -> None:
 def test_e2e_proposal_transition_flow(monkeypatch) -> None:
     async def _create(self, body, idempotency_key, correlation_id):  # noqa: ANN001
         _ = self, body, idempotency_key, correlation_id
-        return 200, {"proposal": {"proposal_id": "pp_1", "current_state": "DRAFT"}}
+        return 200, {
+            "proposal": {
+                "proposal_id": "pp_1",
+                "portfolio_id": "PF_1001",
+                "current_state": "DRAFT",
+                "current_version_no": 1,
+            },
+            "version": {
+                "proposal_version_id": "ppv_1",
+                "proposal_id": "pp_1",
+                "version_no": 1,
+                "status_at_creation": "READY",
+                "proposal_result": {"proposal_run_id": "pr_1", "status": "READY"},
+            },
+            "latest_workflow_event": {
+                "event_id": "pwe_1",
+                "proposal_id": "pp_1",
+                "event_type": "CREATED",
+                "from_state": None,
+                "to_state": "DRAFT",
+                "actor_id": "advisor_1",
+                "occurred_at": "2026-02-19T12:00:00+00:00",
+                "reason": {},
+            },
+        }
 
     async def _transition(  # noqa: ANN001
         self, proposal_id, body, idempotency_key, correlation_id
@@ -178,11 +204,21 @@ def test_e2e_proposal_transition_flow(monkeypatch) -> None:
         return 200, {
             "proposal_id": "pp_1",
             "current_state": "RISK_REVIEW",
-            "event_type": body["event_type"],
+            "latest_workflow_event": {
+                "event_id": "pwe_2",
+                "proposal_id": "pp_1",
+                "event_type": body["event_type"],
+                "from_state": "DRAFT",
+                "to_state": "RISK_REVIEW",
+                "actor_id": "advisor_1",
+                "occurred_at": "2026-02-19T12:01:00+00:00",
+                "reason": {},
+            },
+            "approval": None,
         }
 
-    monkeypatch.setattr("app.clients.dpm_client.DpmClient.create_proposal", _create)
-    monkeypatch.setattr("app.clients.dpm_client.DpmClient.transition_proposal", _transition)
+    monkeypatch.setattr("app.clients.advise_client.AdviseClient.create_proposal", _create)
+    monkeypatch.setattr("app.clients.advise_client.AdviseClient.transition_proposal", _transition)
 
     client = TestClient(app)
     created = client.post(
@@ -307,6 +343,7 @@ def test_e2e_platform_capabilities_partial_failure_when_one_upstream_fails(
     monkeypatch.setattr(
         "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_capabilities", _performance
     )
+    monkeypatch.setattr("app.clients.advise_client.AdviseClient.get_capabilities", _dpm)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.get_capabilities", _dpm)
     monkeypatch.setattr("app.clients.reporting_client.ReportingClient.get_capabilities", _ras)
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_effective_policy", _pas_policy)
@@ -398,7 +435,9 @@ def test_e2e_sandbox_policy_feedback_unavailable_when_dpm_simulation_fails(monke
         "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_stateful_twr", _performance
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
-    monkeypatch.setattr("app.clients.dpm_client.DpmClient.simulate_proposal", _dpm_simulate_failure)
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.simulate_proposal", _dpm_simulate_failure
+    )
 
     client = TestClient(app)
     created = client.post(
@@ -417,4 +456,4 @@ def test_e2e_sandbox_policy_feedback_unavailable_when_dpm_simulation_fails(monke
     assert updated.status_code == 200
     payload = updated.json()
     assert payload["policy_feedback"]["status"] == "UNAVAILABLE"
-    assert "MANAGE_POLICY_SIMULATION_UNAVAILABLE" in payload["warnings"]
+    assert "ADVISE_PROPOSAL_SIMULATION_UNAVAILABLE" in payload["warnings"]

--- a/tests/integration/test_platform_capabilities_router.py
+++ b/tests/integration/test_platform_capabilities_router.py
@@ -82,6 +82,7 @@ def test_platform_capabilities_router_success(monkeypatch):
     monkeypatch.setattr(
         "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_capabilities", _analytics
     )
+    monkeypatch.setattr("app.clients.advise_client.AdviseClient.get_capabilities", _dpm)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.get_capabilities", _dpm)
     monkeypatch.setattr("app.clients.reporting_client.ReportingClient.get_capabilities", _ras)
 
@@ -97,6 +98,7 @@ def test_platform_capabilities_router_success(monkeypatch):
         "lotus_core",
         "lotus_performance",
         "lotus_risk",
+        "lotus_advise",
         "lotus_manage",
         "lotus_report",
     }
@@ -113,6 +115,7 @@ def test_platform_capabilities_router_success(monkeypatch):
         "lotus_core": "lotus-core-default-v1",
         "lotus_performance": "lotus-performance-default-v1",
         "lotus_risk": "lotus-risk-default-v1",
+        "lotus_advise": "lotus-manage-default-v1",
         "lotus_manage": "lotus-manage-default-v1",
         "lotus_report": "lotus-report-default-v1",
     }
@@ -123,6 +126,7 @@ def test_platform_capabilities_router_success(monkeypatch):
     assert shell_bootstrap["evidence"]["lineageSources"] == [
         "lotus_core",
         "lotus_performance",
+        "lotus_advise",
         "lotus_manage",
         "lotus_report",
         "lotus_risk",
@@ -131,6 +135,7 @@ def test_platform_capabilities_router_success(monkeypatch):
         "lotus_core": "lotus-core-default-v1",
         "lotus_performance": "lotus-performance-default-v1",
         "lotus_risk": "lotus-risk-default-v1",
+        "lotus_advise": "lotus-manage-default-v1",
         "lotus_manage": "lotus-manage-default-v1",
         "lotus_report": "lotus-report-default-v1",
     }
@@ -285,6 +290,7 @@ def test_platform_capabilities_router_partial_failure(monkeypatch):
     monkeypatch.setattr(
         "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_capabilities", _analytics
     )
+    monkeypatch.setattr("app.clients.advise_client.AdviseClient.get_capabilities", _dpm)
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.get_capabilities", _dpm)
     monkeypatch.setattr("app.clients.reporting_client.ReportingClient.get_capabilities", _ras)
 
@@ -297,7 +303,7 @@ def test_platform_capabilities_router_partial_failure(monkeypatch):
     body = response.json()["data"]
     assert body["partialFailure"] is True
     assert set(body["sources"].keys()) == {"lotus_core"}
-    assert len(body["errors"]) == 5
+    assert len(body["errors"]) == 6
     assert body["normalized"]["navigation"]["analytics_studio"] is False
     assert body["normalized"]["navigation"]["portfolio_workspace"] is True
     assert body["normalized"]["navigation"]["performance_workspace"] is False
@@ -316,6 +322,7 @@ def test_platform_capabilities_router_partial_failure(monkeypatch):
     assert shell_bootstrap["evidence"]["lineageSources"] == [
         "lotus_core",
         "lotus_performance",
+        "lotus_advise",
         "lotus_manage",
         "lotus_report",
         "lotus_risk",

--- a/tests/integration/test_proposals_router.py
+++ b/tests/integration/test_proposals_router.py
@@ -38,7 +38,7 @@ def test_proposal_simulate_success(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.simulate_proposal",
+        "app.clients.advise_client.AdviseClient.simulate_proposal",
         _fake_simulate_proposal,
     )
 
@@ -76,7 +76,7 @@ def test_proposal_simulate_forwards_upstream_error(monkeypatch):
         return 409, {"detail": "conflict"}
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.simulate_proposal",
+        "app.clients.advise_client.AdviseClient.simulate_proposal",
         _fake_simulate_proposal,
     )
 
@@ -128,7 +128,7 @@ def test_proposal_create_success(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.create_proposal",
+        "app.clients.advise_client.AdviseClient.create_proposal",
         _fake_create_proposal,
     )
 
@@ -178,7 +178,7 @@ def test_proposal_list_success(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.list_proposals",
+        "app.clients.advise_client.AdviseClient.list_proposals",
         _fake_list_proposals,
     )
 
@@ -202,7 +202,7 @@ def test_proposal_list_preserves_query_context(monkeypatch):
         return 200, {"items": [], "next_cursor": "pp_00042"}
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.list_proposals",
+        "app.clients.advise_client.AdviseClient.list_proposals",
         _fake_list_proposals,
     )
 
@@ -258,7 +258,7 @@ def test_get_proposal_success(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.get_proposal",
+        "app.clients.advise_client.AdviseClient.get_proposal",
         _fake_get_proposal,
     )
 
@@ -300,7 +300,7 @@ def test_get_proposal_preserves_query_context(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.get_proposal",
+        "app.clients.advise_client.AdviseClient.get_proposal",
         _fake_get_proposal,
     )
 
@@ -341,7 +341,7 @@ def test_get_proposal_version_success(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.get_proposal_version",
+        "app.clients.advise_client.AdviseClient.get_proposal_version",
         _fake_get_proposal_version,
     )
 
@@ -376,7 +376,7 @@ def test_get_proposal_version_preserves_query_context(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.get_proposal_version",
+        "app.clients.advise_client.AdviseClient.get_proposal_version",
         _fake_get_proposal_version,
     )
 
@@ -432,7 +432,7 @@ def test_create_proposal_version_success(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.create_proposal_version",
+        "app.clients.advise_client.AdviseClient.create_proposal_version",
         _fake_create_proposal_version,
     )
 
@@ -486,7 +486,7 @@ def test_submit_proposal_success(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.transition_proposal",
+        "app.clients.advise_client.AdviseClient.transition_proposal",
         _fake_transition_proposal,
     )
 
@@ -520,7 +520,7 @@ def test_submit_proposal_forwards_upstream_error(monkeypatch):
         return 409, {"detail": "STATE_CONFLICT"}
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.transition_proposal",
+        "app.clients.advise_client.AdviseClient.transition_proposal",
         _fake_transition_proposal,
     )
 
@@ -568,7 +568,7 @@ def test_approve_risk_success(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.record_approval",
+        "app.clients.advise_client.AdviseClient.record_approval",
         _fake_record_approval,
     )
 
@@ -617,7 +617,7 @@ def test_approve_compliance_success(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.record_approval",
+        "app.clients.advise_client.AdviseClient.record_approval",
         _fake_record_approval,
     )
 
@@ -663,7 +663,7 @@ def test_record_client_consent_success(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.record_approval",
+        "app.clients.advise_client.AdviseClient.record_approval",
         _fake_record_approval,
     )
 
@@ -743,11 +743,11 @@ def test_workflow_events_and_approvals_success(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.get_workflow_events",
+        "app.clients.advise_client.AdviseClient.get_workflow_events",
         _fake_get_workflow_events,
     )
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.get_approvals",
+        "app.clients.advise_client.AdviseClient.get_approvals",
         _fake_get_approvals,
     )
 
@@ -787,7 +787,7 @@ def test_proposal_lineage_success(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.get_proposal_lineage",
+        "app.clients.advise_client.AdviseClient.get_proposal_lineage",
         _fake_get_proposal_lineage,
     )
 
@@ -820,7 +820,7 @@ def test_proposal_lineage_preserves_query_context(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.get_proposal_lineage",
+        "app.clients.advise_client.AdviseClient.get_proposal_lineage",
         _fake_get_proposal_lineage,
     )
 
@@ -857,11 +857,11 @@ def test_workflow_events_and_approvals_preserve_query_context(monkeypatch):
         return 200, {"proposal_id": proposal_id, "current_state": "DRAFT", "approvals": []}
 
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.get_workflow_events",
+        "app.clients.advise_client.AdviseClient.get_workflow_events",
         _fake_get_workflow_events,
     )
     monkeypatch.setattr(
-        "app.clients.dpm_client.DpmClient.get_approvals",
+        "app.clients.advise_client.AdviseClient.get_approvals",
         _fake_get_approvals,
     )
 

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -2833,7 +2833,7 @@ def test_workbench_sandbox_changes_router(monkeypatch):
         "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _performance
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
-    monkeypatch.setattr("app.clients.dpm_client.DpmClient.simulate_proposal", _dpm_simulate)
+    monkeypatch.setattr("app.clients.advise_client.AdviseClient.simulate_proposal", _dpm_simulate)
 
     client = TestClient(app)
     created = client.post(

--- a/tests/unit/test_platform_capabilities_service.py
+++ b/tests/unit/test_platform_capabilities_service.py
@@ -140,17 +140,26 @@ class _DelayedStubClient(_StubClient):
 @pytest.mark.asyncio
 async def test_platform_capabilities_all_sources_success():
     service = PlatformCapabilitiesService(
-        dpm_client=_StubClient(
+        advise_client=_StubClient(
+            200,
+            {
+                "sourceService": "lotus_advise",
+                "policyVersion": "advise-tenant-a-v2",
+                "supportedInputModes": ["pas_ref", "inline_bundle"],
+                "features": [
+                    {"key": "advise.proposals.lifecycle", "enabled": True},
+                ],
+                "workflows": [{"workflow_key": "proposal_lifecycle", "enabled": True}],
+            },
+        ),
+        manage_client=_StubClient(
             200,
             {
                 "sourceService": "lotus_manage",
-                "policyVersion": "dpm-tenant-a-v2",
-                "supportedInputModes": ["pas_ref", "inline_bundle"],
-                "features": [
-                    {"key": "dpm.proposals.lifecycle", "enabled": True},
-                    {"key": "dpm.support.run_apis", "enabled": True},
-                ],
-                "workflows": [{"workflow_key": "proposal_lifecycle", "enabled": True}],
+                "policyVersion": "manage-tenant-a-v2",
+                "supportedInputModes": ["pas_ref"],
+                "features": [{"key": "dpm.support.run_apis", "enabled": True}],
+                "workflows": [],
             },
         ),
         lotus_core_query_client=_StubClient(
@@ -223,6 +232,7 @@ async def test_platform_capabilities_all_sources_success():
         "lotus_core",
         "lotus_performance",
         "lotus_risk",
+        "lotus_advise",
         "lotus_manage",
         "lotus_report",
     }
@@ -244,7 +254,8 @@ async def test_platform_capabilities_all_sources_success():
         "lotus_core": "pas-tenant-a-v3",
         "lotus_performance": "lotus-performance-tenant-a-v4",
         "lotus_risk": "risk-tenant-a-v2",
-        "lotus_manage": "dpm-tenant-a-v2",
+        "lotus_advise": "advise-tenant-a-v2",
+        "lotus_manage": "manage-tenant-a-v2",
         "lotus_report": "ras-tenant-a-v1",
     }
     assert response.data.normalized.lotus_core_policy_diagnostics["available"] is True
@@ -260,6 +271,7 @@ async def test_platform_capabilities_all_sources_success():
     assert shell_bootstrap.evidence.lineage_sources == [
         "lotus_core",
         "lotus_performance",
+        "lotus_advise",
         "lotus_manage",
         "lotus_report",
         "lotus_risk",
@@ -269,7 +281,8 @@ async def test_platform_capabilities_all_sources_success():
         "lotus_core": "pas-tenant-a-v3",
         "lotus_performance": "lotus-performance-tenant-a-v4",
         "lotus_risk": "risk-tenant-a-v2",
-        "lotus_manage": "dpm-tenant-a-v2",
+        "lotus_advise": "advise-tenant-a-v2",
+        "lotus_manage": "manage-tenant-a-v2",
         "lotus_report": "ras-tenant-a-v1",
     }
     assert shell_bootstrap.caching.cache_mode == "request_scoped_composition"
@@ -323,7 +336,7 @@ async def test_platform_capabilities_partial_failure_on_error():
 
     assert response.data.partial_failure is True
     assert set(response.data.sources.keys()) == {"lotus_core"}
-    assert len(response.data.errors) == 5
+    assert len(response.data.errors) == 6
     assert response.data.normalized.navigation["analytics_studio"] is False
     assert response.data.normalized.navigation["advisory_pipeline"] is False
     assert response.data.normalized.navigation["portfolio_workspace"] is True
@@ -333,12 +346,14 @@ async def test_platform_capabilities_partial_failure_on_error():
     assert response.data.normalized.navigation["advisory_workspace"] is False
     assert response.data.normalized.module_health["lotus_performance"] == "unavailable"
     assert response.data.normalized.module_health["lotus_risk"] == "unavailable"
+    assert response.data.normalized.module_health["lotus_advise"] == "unavailable"
     assert response.data.normalized.module_health["lotus_manage"] == "unavailable"
     assert response.data.normalized.module_health["lotus_report"] == "unavailable"
     assert response.data.normalized.policy_versions_by_source == {
         "lotus_core": "pas-tenant-default-v1",
         "lotus_performance": "unknown",
         "lotus_risk": "unknown",
+        "lotus_advise": "unknown",
         "lotus_manage": "unknown",
         "lotus_report": "unknown",
     }
@@ -502,7 +517,7 @@ def test_platform_capabilities_feature_and_workflow_skip_non_dict_entries():
         "lotus_performance": {
             "features": ["bad", {"key": "performance.analytics.twr", "enabled": True}]
         },
-        "lotus_manage": {
+        "lotus_advise": {
             "workflows": ["bad", {"workflow_key": "proposal_lifecycle", "enabled": True}]
         },
     }
@@ -516,7 +531,7 @@ def test_platform_capabilities_feature_and_workflow_skip_non_dict_entries():
     )
     assert (
         service._workflow_enabled(
-            sources=sources, source_name="lotus_manage", workflow_key="proposal_lifecycle"
+            sources=sources, source_name="lotus_advise", workflow_key="proposal_lifecycle"
         )
         is True
     )
@@ -534,6 +549,7 @@ def test_platform_capabilities_module_health_marks_unknown_sources():
     assert health["lotus_core"] == "available"
     assert health["lotus_performance"] == "unknown"
     assert health["lotus_risk"] == "unknown"
+    assert health["lotus_advise"] == "unknown"
     assert health["lotus_manage"] == "unknown"
     assert health["lotus_report"] == "unknown"
 
@@ -710,11 +726,17 @@ async def test_platform_capabilities_timeout_budget_preserves_partial_response()
 
 
 @pytest.mark.asyncio
-async def test_platform_capabilities_manage_split_uses_manage_as_authoritative_source():
-    legacy_decisioning_client = _RecordingStubClient(
-        503,
+async def test_platform_capabilities_keeps_advise_and_manage_capabilities_separate():
+    advise_client = _RecordingStubClient(
+        200,
         {
-            "detail": "legacy decisioning should not be used for split manage capabilities",
+            "sourceService": "lotus_advise",
+            "policyVersion": "advise-v2",
+            "features": [{"key": "advise.proposals.lifecycle", "enabled": True}],
+            "workflows": [
+                {"workflow_key": "proposal_approval_flow", "enabled": True},
+                {"workflow_key": "proposal_lifecycle", "enabled": True},
+            ],
         },
     )
     manage_client = _RecordingStubClient(
@@ -725,16 +747,12 @@ async def test_platform_capabilities_manage_split_uses_manage_as_authoritative_s
             "supportedInputModes": ["inline_bundle", "pas_ref"],
             "features": [
                 {"key": "dpm.support.run_apis", "enabled": True},
-                {"key": "dpm.proposals.lifecycle", "enabled": True},
             ],
-            "workflows": [
-                {"workflow_key": "proposal_approval_flow", "enabled": True},
-                {"workflow_key": "proposal_lifecycle", "enabled": True},
-            ],
+            "workflows": [],
         },
     )
     service = PlatformCapabilitiesService(
-        dpm_client=legacy_decisioning_client,
+        advise_client=advise_client,
         lotus_core_query_client=_StubClient(
             200,
             {"sourceService": "lotus_core", "features": [], "workflows": []},
@@ -758,9 +776,16 @@ async def test_platform_capabilities_manage_split_uses_manage_as_authoritative_s
     )
 
     lotus_manage = response.data.sources["lotus_manage"]
+    lotus_advise = response.data.sources["lotus_advise"]
     assert response.data.partial_failure is False
     assert response.data.errors == []
-    assert legacy_decisioning_client.calls == []
+    assert advise_client.calls == [
+        {
+            "correlation_id": "corr-manage-merge",
+            "consumer_system": "lotus-gateway",
+            "tenant_id": "default",
+        }
+    ]
     assert manage_client.calls == [
         {
             "correlation_id": "corr-manage-merge",
@@ -768,16 +793,11 @@ async def test_platform_capabilities_manage_split_uses_manage_as_authoritative_s
             "tenant_id": "default",
         }
     ]
+    assert lotus_advise["policyVersion"] == "advise-v2"
     assert lotus_manage["policyVersion"] == "manage-split-v2"
     assert lotus_manage["supportedInputModes"] == ["inline_bundle", "pas_ref"]
-    assert lotus_manage["features"] == [
-        {"key": "dpm.support.run_apis", "enabled": True},
-        {"key": "dpm.proposals.lifecycle", "enabled": True},
-    ]
-    assert lotus_manage["workflows"] == [
-        {"workflow_key": "proposal_approval_flow", "enabled": True},
-        {"workflow_key": "proposal_lifecycle", "enabled": True},
-    ]
+    assert lotus_manage["features"] == [{"key": "dpm.support.run_apis", "enabled": True}]
+    assert lotus_manage["workflows"] == []
     assert response.data.normalized.workflow_flags["proposal_lifecycle"] is True
     assert response.data.normalized.workflow_flags["proposal_approval_flow"] is True
 
@@ -785,12 +805,22 @@ async def test_platform_capabilities_manage_split_uses_manage_as_authoritative_s
 @pytest.mark.asyncio
 async def test_platform_capabilities_normalizes_live_snake_case_capability_metadata():
     service = PlatformCapabilitiesService(
-        dpm_client=_StubClient(
+        advise_client=_StubClient(
+            200,
+            {
+                "source_service": "lotus-advise",
+                "policy_version": "advise.policy.v1",
+                "supported_input_modes": ["portfolio_id", "inline_bundle"],
+                "features": [],
+                "workflows": [],
+            },
+        ),
+        manage_client=_StubClient(
             200,
             {
                 "source_service": "lotus-manage",
-                "policy_version": "dpm.policy.v1",
-                "supported_input_modes": ["portfolio_id", "inline_bundle"],
+                "policy_version": "manage.policy.v1",
+                "supported_input_modes": ["portfolio_id"],
                 "features": [],
                 "workflows": [],
             },
@@ -848,7 +878,8 @@ async def test_platform_capabilities_normalizes_live_snake_case_capability_metad
     assert normalized.input_modes_by_source == {
         "lotus_core": ["lotus_core_ref"],
         "lotus_performance": ["stateful", "stateless"],
-        "lotus_manage": ["portfolio_id", "inline_bundle"],
+        "lotus_advise": ["portfolio_id", "inline_bundle"],
+        "lotus_manage": ["portfolio_id"],
         "lotus_report": ["portfolio_id"],
         "lotus_risk": ["stateless", "stateful", "simulation"],
     }
@@ -863,7 +894,8 @@ async def test_platform_capabilities_normalizes_live_snake_case_capability_metad
     assert normalized.policy_versions_by_source == {
         "lotus_core": "tenant-default-v1",
         "lotus_performance": "tenant-default-v1",
-        "lotus_manage": "dpm.policy.v1",
+        "lotus_advise": "advise.policy.v1",
+        "lotus_manage": "manage.policy.v1",
         "lotus_report": "ras-default-v1",
         "lotus_risk": "risk.v1",
     }

--- a/tests/unit/test_proposal_service.py
+++ b/tests/unit/test_proposal_service.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException
 from app.services.proposal_service import ProposalService
 
 
-class _FakeDpmClient:
+class _FakeAdviseClient:
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict]] = []
 
@@ -280,7 +280,7 @@ class _FakeDpmClient:
         }
 
 
-class _FakeDpmErrorClient(_FakeDpmClient):
+class _FakeAdviseErrorClient(_FakeAdviseClient):
     async def record_approval(
         self, proposal_id: str, body: dict, idempotency_key: str, correlation_id: str
     ):
@@ -290,8 +290,8 @@ class _FakeDpmErrorClient(_FakeDpmClient):
 
 @pytest.mark.asyncio
 async def test_simulate_proposal_wraps_typed_simulation_payload() -> None:
-    client = _FakeDpmClient()
-    service = ProposalService(dpm_client=client)
+    client = _FakeAdviseClient()
+    service = ProposalService(advise_client=client)
 
     result = await service.simulate_proposal(
         body={"portfolio_snapshot": {"portfolio_id": "PF_1001"}},
@@ -309,8 +309,8 @@ async def test_simulate_proposal_wraps_typed_simulation_payload() -> None:
 
 @pytest.mark.asyncio
 async def test_submit_proposal_maps_risk_transition() -> None:
-    client = _FakeDpmClient()
-    service = ProposalService(dpm_client=client)
+    client = _FakeAdviseClient()
+    service = ProposalService(advise_client=client)
 
     result = await service.submit_proposal(
         proposal_id="pp_1",
@@ -333,8 +333,8 @@ async def test_submit_proposal_maps_risk_transition() -> None:
 
 @pytest.mark.asyncio
 async def test_approve_compliance_maps_approval_payload() -> None:
-    client = _FakeDpmClient()
-    service = ProposalService(dpm_client=client)
+    client = _FakeAdviseClient()
+    service = ProposalService(advise_client=client)
 
     result = await service.approve_compliance(
         proposal_id="pp_1",
@@ -357,8 +357,8 @@ async def test_approve_compliance_maps_approval_payload() -> None:
 
 @pytest.mark.asyncio
 async def test_list_proposals_wraps_typed_envelope() -> None:
-    client = _FakeDpmClient()
-    service = ProposalService(dpm_client=client)
+    client = _FakeAdviseClient()
+    service = ProposalService(advise_client=client)
 
     result = await service.list_proposals(
         filters={"portfolio_id": "PF_1001", "limit": 10},
@@ -372,8 +372,8 @@ async def test_list_proposals_wraps_typed_envelope() -> None:
 
 @pytest.mark.asyncio
 async def test_create_proposal_and_version_wrap_typed_envelopes() -> None:
-    client = _FakeDpmClient()
-    service = ProposalService(dpm_client=client)
+    client = _FakeAdviseClient()
+    service = ProposalService(advise_client=client)
 
     async def _fake_create_proposal(body: dict, idempotency_key: str, correlation_id: str):
         _ = body, idempotency_key, correlation_id
@@ -463,8 +463,8 @@ async def test_create_proposal_and_version_wrap_typed_envelopes() -> None:
 
 @pytest.mark.asyncio
 async def test_get_proposal_and_version_wrap_typed_envelopes() -> None:
-    client = _FakeDpmClient()
-    service = ProposalService(dpm_client=client)
+    client = _FakeAdviseClient()
+    service = ProposalService(advise_client=client)
 
     detail = await service.get_proposal(
         proposal_id="pp_1",
@@ -487,8 +487,8 @@ async def test_get_proposal_and_version_wrap_typed_envelopes() -> None:
 
 @pytest.mark.asyncio
 async def test_get_workflow_events_and_approvals_wrap_typed_envelopes() -> None:
-    client = _FakeDpmClient()
-    service = ProposalService(dpm_client=client)
+    client = _FakeAdviseClient()
+    service = ProposalService(advise_client=client)
 
     events = await service.get_workflow_events(proposal_id="pp_1", correlation_id="corr_3")
     approvals = await service.get_approvals(proposal_id="pp_1", correlation_id="corr_3")
@@ -501,8 +501,8 @@ async def test_get_workflow_events_and_approvals_wrap_typed_envelopes() -> None:
 
 @pytest.mark.asyncio
 async def test_get_proposal_lineage_wraps_envelope() -> None:
-    client = _FakeDpmClient()
-    service = ProposalService(dpm_client=client)
+    client = _FakeAdviseClient()
+    service = ProposalService(advise_client=client)
 
     lineage = await service.get_proposal_lineage(proposal_id="pp_1", correlation_id="corr_3")
 
@@ -513,7 +513,7 @@ async def test_get_proposal_lineage_wraps_envelope() -> None:
 
 @pytest.mark.asyncio
 async def test_approval_upstream_error_passthrough() -> None:
-    service = ProposalService(dpm_client=_FakeDpmErrorClient())
+    service = ProposalService(advise_client=_FakeAdviseErrorClient())
 
     try:
         await service.approve_risk(

--- a/tests/unit/test_router_upstream_selection.py
+++ b/tests/unit/test_router_upstream_selection.py
@@ -10,43 +10,41 @@ def test_proposals_router_targets_advisory_base_url(monkeypatch):
     monkeypatch.setattr(
         "app.routers.proposals.settings.management_service_base_url", "http://manage:8000"
     )
-    monkeypatch.setattr("app.routers.proposals.settings.manage_split_enabled", True)
-
     service = _proposal_service()
-    assert service._dpm_client._base_url == "http://advise:8000"
+    assert service._advise_client._base_url == "http://advise:8000"
 
 
-def test_workbench_router_targets_manage_when_split_enabled(monkeypatch):
+def test_workbench_router_targets_manage_for_runs_and_advise_for_proposals(monkeypatch):
     monkeypatch.setattr(
         "app.routers.workbench.settings.decisioning_service_base_url", "http://advise:8000"
     )
     monkeypatch.setattr(
         "app.routers.workbench.settings.management_service_base_url", "http://manage:8000"
     )
-    monkeypatch.setattr("app.routers.workbench.settings.manage_split_enabled", True)
-
     service = _workbench_service()
     assert service._dpm_client._base_url == "http://manage:8000"
+    assert service._advise_client._base_url == "http://advise:8000"
 
 
-def test_workbench_router_targets_advisory_when_split_disabled(monkeypatch):
+def test_workbench_router_cache_signature_changes_on_manage_or_advise_url(monkeypatch):
     monkeypatch.setattr(
         "app.routers.workbench.settings.decisioning_service_base_url", "http://advise:8000"
     )
     monkeypatch.setattr(
         "app.routers.workbench.settings.management_service_base_url", "http://manage:8000"
     )
-    monkeypatch.setattr("app.routers.workbench.settings.manage_split_enabled", False)
-
     service = _workbench_service()
-    assert service._dpm_client._base_url == "http://advise:8000"
+    assert service._dpm_client._base_url == "http://manage:8000"
+    assert service._advise_client._base_url == "http://advise:8000"
 
 
-def test_platform_capabilities_manage_client_obeys_split_flag(monkeypatch):
-    monkeypatch.setattr("app.routers.platform.settings.manage_split_enabled", True)
+def test_platform_capabilities_keeps_manage_and_advise_clients_separate(monkeypatch):
+    monkeypatch.setattr(
+        "app.routers.platform.settings.decisioning_service_base_url", "http://advise:8000"
+    )
+    monkeypatch.setattr(
+        "app.routers.platform.settings.management_service_base_url", "http://manage:8000"
+    )
     service = _platform_capabilities_service()
-    assert service._manage_client is not None
-
-    monkeypatch.setattr("app.routers.platform.settings.manage_split_enabled", False)
-    service = _platform_capabilities_service()
-    assert service._manage_client is None
+    assert service._advise_client._base_url == "http://advise:8000"
+    assert service._manage_client._base_url == "http://manage:8000"

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -4,6 +4,7 @@ import logging
 import httpx
 import pytest
 
+from app.clients.advise_client import AdviseClient
 from app.clients.archive_client import ArchiveClient
 from app.clients.dpm_client import DpmClient
 from app.clients.lotus_ai_client import LotusAiClient
@@ -1579,29 +1580,6 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
     ("method_name", "kwargs", "expected_url"),
     [
         (
-            "simulate_proposal",
-            {
-                "body": {"portfolio_id": "P1"},
-                "idempotency_key": "idem-1",
-                "correlation_id": "corr-5",
-            },
-            "http://dpm/api/v1/rebalance/proposals/simulate",
-        ),
-        (
-            "create_proposal",
-            {
-                "body": {"portfolio_id": "P1"},
-                "idempotency_key": "idem-2",
-                "correlation_id": "corr-5",
-            },
-            "http://dpm/api/v1/rebalance/proposals",
-        ),
-        (
-            "list_proposals",
-            {"params": {"portfolio_id": "P1", "status": None}, "correlation_id": "corr-5"},
-            "http://dpm/api/v1/rebalance/proposals",
-        ),
-        (
             "list_runs",
             {"params": {"portfolio_id": "P1", "status": None}, "correlation_id": "corr-5"},
             "http://dpm/api/v1/rebalance/runs",
@@ -1610,66 +1588,6 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
             "get_supportability_summary",
             {"correlation_id": "corr-5"},
             "http://dpm/api/v1/rebalance/supportability/summary",
-        ),
-        (
-            "get_proposal",
-            {"proposal_id": "PR-1", "include_evidence": True, "correlation_id": "corr-5"},
-            "http://dpm/api/v1/rebalance/proposals/PR-1",
-        ),
-        (
-            "get_proposal_version",
-            {
-                "proposal_id": "PR-1",
-                "version_no": 2,
-                "include_evidence": False,
-                "correlation_id": "corr-5",
-            },
-            "http://dpm/api/v1/rebalance/proposals/PR-1/versions/2",
-        ),
-        (
-            "create_proposal_version",
-            {
-                "proposal_id": "PR-1",
-                "body": {"changes": []},
-                "idempotency_key": "idem-3",
-                "correlation_id": "corr-5",
-            },
-            "http://dpm/api/v1/rebalance/proposals/PR-1/versions",
-        ),
-        (
-            "transition_proposal",
-            {
-                "proposal_id": "PR-1",
-                "body": {"event": "submit"},
-                "idempotency_key": "idem-transition-1",
-                "correlation_id": "corr-5",
-            },
-            "http://dpm/api/v1/rebalance/proposals/PR-1/transitions",
-        ),
-        (
-            "record_approval",
-            {
-                "proposal_id": "PR-1",
-                "body": {"decision": "approve"},
-                "idempotency_key": "idem-approval-1",
-                "correlation_id": "corr-5",
-            },
-            "http://dpm/api/v1/rebalance/proposals/PR-1/approvals",
-        ),
-        (
-            "get_workflow_events",
-            {"proposal_id": "PR-1", "correlation_id": "corr-5"},
-            "http://dpm/api/v1/rebalance/proposals/PR-1/workflow-events",
-        ),
-        (
-            "get_approvals",
-            {"proposal_id": "PR-1", "correlation_id": "corr-5"},
-            "http://dpm/api/v1/rebalance/proposals/PR-1/approvals",
-        ),
-        (
-            "get_proposal_lineage",
-            {"proposal_id": "PR-1", "correlation_id": "corr-5"},
-            "http://dpm/api/v1/rebalance/proposals/PR-1/lineage",
         ),
         (
             "get_capabilities",
@@ -1682,7 +1600,7 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
         ),
     ],
 )
-async def test_dpm_client_all_routes(method_name, kwargs, expected_url):
+async def test_dpm_client_manage_routes(method_name, kwargs, expected_url):
     client = DpmClient(base_url="http://dpm", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"ok": True})
 
@@ -1691,15 +1609,118 @@ async def test_dpm_client_all_routes(method_name, kwargs, expected_url):
     assert status_code == 200
     assert payload["ok"] is True
     assert _FakeAsyncClient.calls[0]["url"] == expected_url
-    methods_with_idempotency = {
-        "simulate_proposal",
-        "create_proposal",
-        "create_proposal_version",
-        "transition_proposal",
-        "record_approval",
-    }
-    if method_name in methods_with_idempotency:
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "kwargs", "expected_url"),
+    [
+        (
+            "simulate_proposal",
+            {
+                "body": {"portfolio_id": "P1"},
+                "idempotency_key": "idem-1",
+                "correlation_id": "corr-5",
+            },
+            "http://advise/advisory/proposals/simulate",
+        ),
+        (
+            "create_proposal",
+            {
+                "body": {"portfolio_id": "P1"},
+                "idempotency_key": "idem-2",
+                "correlation_id": "corr-5",
+            },
+            "http://advise/advisory/proposals",
+        ),
+        (
+            "list_proposals",
+            {"params": {"portfolio_id": "P1", "status": None}, "correlation_id": "corr-5"},
+            "http://advise/advisory/proposals",
+        ),
+        (
+            "get_proposal",
+            {"proposal_id": "PR-1", "include_evidence": True, "correlation_id": "corr-5"},
+            "http://advise/advisory/proposals/PR-1",
+        ),
+        (
+            "get_proposal_version",
+            {
+                "proposal_id": "PR-1",
+                "version_no": 2,
+                "include_evidence": False,
+                "correlation_id": "corr-5",
+            },
+            "http://advise/advisory/proposals/PR-1/versions/2",
+        ),
+        (
+            "create_proposal_version",
+            {
+                "proposal_id": "PR-1",
+                "body": {"changes": []},
+                "idempotency_key": "idem-3",
+                "correlation_id": "corr-5",
+            },
+            "http://advise/advisory/proposals/PR-1/versions",
+        ),
+        (
+            "transition_proposal",
+            {
+                "proposal_id": "PR-1",
+                "body": {"event": "submit"},
+                "idempotency_key": "idem-transition-1",
+                "correlation_id": "corr-5",
+            },
+            "http://advise/advisory/proposals/PR-1/transitions",
+        ),
+        (
+            "record_approval",
+            {
+                "proposal_id": "PR-1",
+                "body": {"decision": "approve"},
+                "idempotency_key": "idem-approval-1",
+                "correlation_id": "corr-5",
+            },
+            "http://advise/advisory/proposals/PR-1/approvals",
+        ),
+        (
+            "get_workflow_events",
+            {"proposal_id": "PR-1", "correlation_id": "corr-5"},
+            "http://advise/advisory/proposals/PR-1/workflow-events",
+        ),
+        (
+            "get_approvals",
+            {"proposal_id": "PR-1", "correlation_id": "corr-5"},
+            "http://advise/advisory/proposals/PR-1/approvals",
+        ),
+        (
+            "get_proposal_lineage",
+            {"proposal_id": "PR-1", "correlation_id": "corr-5"},
+            "http://advise/advisory/proposals/PR-1/lineage",
+        ),
+    ],
+)
+async def test_advise_client_proposal_routes(method_name, kwargs, expected_url):
+    client = AdviseClient(base_url="http://advise", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"ok": True})
+
+    method = getattr(client, method_name)
+    status_code, payload = await method(**kwargs)
+    assert status_code == 200
+    assert payload["ok"] is True
+    assert _FakeAsyncClient.calls[0]["url"] == expected_url
+    if "idempotency_key" in kwargs:
         assert _FakeAsyncClient.calls[0]["headers"]["Idempotency-Key"] == kwargs["idempotency_key"]
+
+
+@pytest.mark.asyncio
+async def test_dpm_client_has_no_stale_proposal_routes():
+    client = DpmClient(base_url="http://dpm", timeout_seconds=2.0)
+
+    assert not hasattr(client, "simulate_proposal")
+    assert not hasattr(client, "create_proposal")
+    assert not hasattr(client, "list_proposals")
+    assert not hasattr(client, "get_proposal")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -502,8 +502,8 @@ async def test_evaluate_policy_feedback_handles_dpm_failure():
         partial_failures=partial_failures,
     )
     assert feedback.status == "UNAVAILABLE"
-    assert warnings == ["MANAGE_POLICY_SIMULATION_UNAVAILABLE"]
-    assert partial_failures[0].source_service == "lotus-manage"
+    assert warnings == ["ADVISE_PROPOSAL_SIMULATION_UNAVAILABLE"]
+    assert partial_failures[0].source_service == "lotus-advise"
 
 
 @pytest.mark.asyncio

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -73,9 +73,13 @@
 - selected lookup filters remain snake_case, such as `cif_id`, `booking_center`, `product_type`,
   and `instrument_page_limit`
 - proposal writes require `Idempotency-Key`
+- proposal simulation, create, list, detail, version, workflow-event, approval, and lineage routes
+  call `lotus-advise` `/advisory/proposals/*`; they do not call `lotus-manage`
+- gateway calls `lotus-manage` only for discretionary management run lookup, supportability
+  summary, and capability posture through versioned `/api/v1/*` paths
 - `/metrics` includes RFC-0108 gateway analytics fan-out metrics for selected Workbench analytics
-  operations plus the central `lotus-manage`, `lotus-report`, `lotus-archive`, `lotus-ai`, direct
-  `lotus-core` query/control-plane, and `lotus-core` ingestion client seams:
+  operations plus the central `lotus-advise`, `lotus-manage`, `lotus-report`, `lotus-archive`,
+  `lotus-ai`, direct `lotus-core` query/control-plane, and `lotus-core` ingestion client seams:
   `lotus_gateway_analytics_fanout_duration_seconds` and
   `lotus_gateway_analytics_degraded_total`. Labels are bounded to operation/service/status class
   and degraded reason; portfolio, client, document, transaction, session, upload, trace,

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -14,9 +14,12 @@
 - `lotus-risk`
   stateful risk workspace analytics
 - `lotus-advise`
-  proposal and advisory workflow
+  proposal simulation, proposal persistence, workflow events, approvals, and lineage through
+  `/advisory/proposals/*`
 - `lotus-manage`
-  split-routing management workflows when enabled
+  discretionary management run lookup, supportability summary, and capabilities only:
+  `GET /api/v1/rebalance/runs`, `GET /api/v1/rebalance/supportability/summary`, and
+  `GET /api/v1/platform/capabilities`
 - `lotus-report`
   reporting snapshot, summary, and review payloads
 - `lotus-archive`
@@ -60,3 +63,5 @@
 6. advisor-brief responses preserve `lotus-ai` workflow-pack run posture and task-flow lineage but do not make gateway the review-state or task-flow authority
 7. archived document retrieval is product-facing only through gateway document routes; Workbench
    does not call `lotus-archive` directly
+8. Workbench and other product clients consume `lotus-gateway`; they do not call `lotus-advise` or
+   `lotus-manage` directly for proposal or management workflow data


### PR DESCRIPTION
## Summary
- split proposal/advisory calls out of DpmClient into AdviseClient using lotus-advise /advisory/proposals/* paths
- constrain DpmClient and router wiring to lotus-manage strategic /api/v1 run, supportability, and capability paths
- update platform capabilities, Workbench sandbox policy feedback, docs, wiki source, and regression tests for the new downstream ownership truth

Closes #132.
Closes #178.

## lotus-manage paths still called
- GET /api/v1/rebalance/runs
- GET /api/v1/rebalance/supportability/summary
- GET /api/v1/platform/capabilities

## lotus-advise paths now called
- POST /advisory/proposals/simulate
- POST /advisory/proposals
- GET /advisory/proposals
- GET /advisory/proposals/{proposal_id}
- GET /advisory/proposals/{proposal_id}/versions/{version_no}
- POST /advisory/proposals/{proposal_id}/versions
- POST /advisory/proposals/{proposal_id}/transitions
- POST /advisory/proposals/{proposal_id}/approvals
- GET /advisory/proposals/{proposal_id}/workflow-events
- GET /advisory/proposals/{proposal_id}/approvals
- GET /advisory/proposals/{proposal_id}/lineage
- GET /platform/capabilities

## Evidence
- python -m pytest tests\\unit\\test_upstream_clients.py tests\\unit\\test_proposal_service.py tests\\unit\\test_platform_capabilities_service.py tests\\unit\\test_workbench_service.py tests\\unit\\test_workbench_service_additional.py tests\\integration\\test_proposals_router.py tests\\integration\\test_platform_capabilities_router.py tests\\contract\\test_platform_capabilities_contract.py tests\\e2e\\test_workflow_journeys.py -q (175 passed)
- make check (ruff, format, monetary-float-guard, mypy, OpenAPI contract gate, 385 unit/contract tests)
- make test-integration (148 passed)
- python -m pytest tests\\e2e\\test_workflow_journeys.py -q (7 passed)
- git diff --check
- powershell -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway (expected pre-merge drift: API-Surface.md, Integrations.md)

## Known local limitation
- make test-e2e includes live upstream tests and failed because gateway.dev.lotus was not running locally: WinError 10061 connection refused. The non-live e2e workflow suite passed.