### PR TITLE
docs: align Gateway proof-pack composition RFC

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -21,5 +21,5 @@ Governance boundary:
 | RFC-0013 | Workbench Position Valuation Fields | IMPLEMENTED | `docs/rfcs/RFC-0013-workbench-position-valuation-fields.md` |
 | RFC-0014 | Experience API Foundation and Pre-Live Replacement Strategy | PROPOSED | `docs/rfcs/RFC-0014-experience-api-foundation-and-prelive-replacement-strategy.md` |
 | RFC-0015 | Foundation Workspace Experience Contract | IMPLEMENTED | `docs/rfcs/RFC-0015-foundation-workspace-experience-contract.md` |
-| RFC-0098 | DPM Command Center Composition Contract | PROPOSED | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
+| RFC-0098 | DPM Command Center Composition Contract | PROPOSED - RFC-0040 PROOF-PACK OWNERSHIP ALIGNED | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -21,4 +21,5 @@ Governance boundary:
 | RFC-0013 | Workbench Position Valuation Fields | IMPLEMENTED | `docs/rfcs/RFC-0013-workbench-position-valuation-fields.md` |
 | RFC-0014 | Experience API Foundation and Pre-Live Replacement Strategy | PROPOSED | `docs/rfcs/RFC-0014-experience-api-foundation-and-prelive-replacement-strategy.md` |
 | RFC-0015 | Foundation Workspace Experience Contract | IMPLEMENTED | `docs/rfcs/RFC-0015-foundation-workspace-experience-contract.md` |
+| RFC-0098 | DPM Command Center Composition Contract | PROPOSED | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
 

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -1,0 +1,499 @@
+# RFC-0098: DPM Command Center Composition Contract
+
+| Metadata | Details |
+| --- | --- |
+| **Status** | PROPOSED |
+| **Created** | 2026-05-03 |
+| **Owner** | lotus-gateway |
+| **Primary Consumers** | lotus-workbench, future client demo and operations surfaces |
+| **Depends On** | lotus-manage RFC-0037, lotus-manage RFC-0038, lotus-core RFC-0087, Gateway RFC-0082, Gateway RFC-0108, Workbench RFC-0098 |
+| **Doc Location** | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
+
+---
+
+## 0. Executive Summary
+
+`lotus-manage` RFC-0038 delivered the backend foundation for mandate digital twin, mandate health,
+and DPM command-center readiness. The full business outcome is not realized until the front-office
+experience can see the full mandate picture: source readiness from `lotus-core`, DPM operating
+state from `lotus-manage`, risk posture from `lotus-risk`, performance posture from
+`lotus-performance`, report/proof-pack posture from `lotus-report`, archived evidence from
+`lotus-archive`, and governed narrative support from `lotus-ai`.
+
+This RFC defines the Gateway composition contract that makes that outcome possible without turning
+`lotus-manage` into a mega-orchestrator and without making `lotus-workbench` call every domain
+service directly. Gateway owns the product-facing experience API. Domain apps remain authoritative
+for their own data products.
+
+The target is a private-banking-grade DPM command-center contract that a portfolio manager, CIO
+desk, investment control team, operations team, and client-demo team can trust.
+
+---
+
+## 1. Business Outcomes
+
+The RFC must deliver these business outcomes:
+
+1. **Single command-center contract for discretionary mandates**
+   Workbench receives one governed Gateway payload for the DPM command center instead of stitching
+   multiple raw service contracts in the browser.
+2. **Daily book-control readiness**
+   Portfolio managers can see which mandates are ready, which are drifting, which are blocked by
+   data or policy, and which require PM, CIO, compliance, or operations action.
+3. **Faster diagnosis of mandate issues**
+   The contract explains whether the issue comes from source data, mandate drift, risk, performance,
+   liquidity, tax, restrictions, workflow, or proof-pack readiness.
+4. **Clear accountability by domain**
+   Each figure and state carries source ownership so business users and operations know which
+   service is authoritative and where remediation belongs.
+5. **Client-demo-grade story**
+   The same contract supports demo and pre-sales material showing how Lotus turns source data,
+   analytics, risk, and DPM workflow into a coherent discretionary management cockpit.
+6. **Enterprise data mesh posture**
+   Every domain input keeps provenance, freshness, supportability, degradation reason, and bounded
+   observability metadata.
+
+---
+
+## 2. Problem Statement
+
+RFC-0038 made `lotus-manage` capable of exposing DPM mandate health and command-center primitives.
+However, a business-grade DPM command center needs more than manage-side health:
+
+1. `lotus-core` owns source-of-record portfolio, holdings, model binding, tax lots, eligibility,
+   market data readiness, and source lineage.
+2. `lotus-manage` owns DPM operating posture, mandate digital twin, rebalance readiness, drift,
+   constraints, action recommendations, and workflow state.
+3. `lotus-risk` owns risk analytics such as concentration, drawdown, active risk, stress, and
+   risk attribution.
+4. `lotus-performance` owns performance analytics such as return path, contribution, attribution,
+   benchmark-relative underperformance, and horizon trends.
+5. `lotus-report` owns proof-pack and report-batch materialization.
+6. `lotus-archive` owns immutable generated-document metadata and controlled downloads.
+7. `lotus-ai` owns governed narrative generation and task-flow posture when AI support is used.
+8. `lotus-workbench` owns the user experience, not domain authority.
+
+If Workbench calls each service directly, the product surface becomes brittle, inconsistent, and
+hard to certify. If `lotus-manage` calls every analytics service directly, manage becomes
+over-coupled and starts owning analytics it should not own. Gateway is the correct composition
+boundary.
+
+---
+
+## 3. Architecture Direction
+
+### 3.1 Target Architecture
+
+```mermaid
+flowchart LR
+    Core[lotus-core<br/>source data products] --> Gateway[lotus-gateway<br/>DPM command-center contract]
+    Manage[lotus-manage<br/>mandate health and DPM operating state] --> Gateway
+    Risk[lotus-risk<br/>risk analytics data products] --> Gateway
+    Performance[lotus-performance<br/>performance analytics data products] --> Gateway
+    Report[lotus-report<br/>proof packs and report batches] --> Gateway
+    Archive[lotus-archive<br/>document metadata and downloads] --> Gateway
+    AI[lotus-ai<br/>governed narrative and task-flow posture] --> Gateway
+    Gateway --> Workbench[lotus-workbench<br/>DPM command center]
+```
+
+### 3.2 Ownership Principles
+
+1. Gateway composes and shapes product-facing contracts.
+2. Gateway does not compute domain analytics that belong to upstream apps.
+3. Gateway does not hide upstream degradation. It normalizes it into product-safe supportability.
+4. Gateway preserves source lineage and calculation supportability where upstream provides it.
+5. Gateway keeps bounded audit, metrics, and diagnostic posture under RFC-0108 rules.
+6. Gateway should replace pre-live endpoint clutter with one strategic DPM command-center family.
+
+### 3.3 Runtime Boundary
+
+Workbench should consume Gateway only for this command center. Workbench must not call raw
+`lotus-core`, `lotus-manage`, `lotus-risk`, `lotus-performance`, `lotus-report`, `lotus-archive`,
+or `lotus-ai` APIs for this workflow.
+
+---
+
+## 4. App-by-App Responsibilities
+
+| App | Responsibility in command center | Must provide | Must not do |
+| --- | --- | --- | --- |
+| `lotus-core` | Source-of-record portfolio data product owner | portfolio snapshot, holdings, model binding, tax lots, market data coverage, eligibility, source readiness, lineage | DPM health scoring or UI composition |
+| `lotus-manage` | DPM mandate operating layer | mandate digital twin, health score, drift, constraints, execution readiness, action queue, rebalance/run posture | risk/performance calculation ownership |
+| `lotus-risk` | Certified risk analytics owner | concentration, drawdown, stress, liquidity risk, active risk, risk attribution, supportability | DPM action recommendation ownership |
+| `lotus-performance` | Certified performance analytics owner | return path, contribution, attribution, benchmark-relative performance, horizon trend, calculation supportability | risk or DPM workflow ownership |
+| `lotus-report` | Proof-pack and report-batch owner | latest proof-pack readiness, batch status, report generation posture, materialization history | command-center composition |
+| `lotus-archive` | Evidence archive owner | immutable document metadata, controlled download refs, retention posture | analytics or workflow decisioning |
+| `lotus-ai` | Governed narrative and task-flow owner | optional PM narrative, explanation draft, task-flow posture, handoff refs | source-of-truth analytics |
+| `lotus-gateway` | Product-facing composition boundary | stable DPM command-center API, degraded-state normalization, source attribution, bounded observability | domain calculation ownership |
+| `lotus-workbench` | User experience owner | command-center UI, workflow affordances, drill-down, evidence trail, demo screens | raw service stitching or fake data |
+
+---
+
+## 5. Strategic API Contract
+
+### 5.1 Endpoint Family
+
+Gateway should expose one strategic DPM command-center family:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /api/v1/dpm/command-center` | PM book-level command-center summary across mandates. |
+| `GET /api/v1/dpm/command-center/mandates/{portfolio_id}` | Single mandate command-center detail for Workbench route entry. |
+| `GET /api/v1/dpm/command-center/mandates/{portfolio_id}/evidence` | Evidence/provenance bundle for support drawer and proof-pack handoff. |
+| `POST /api/v1/dpm/command-center/mandates/{portfolio_id}/actions/simulate` | Gateway-shaped handoff into `lotus-manage` rebalance simulation when user acts from the command center. |
+
+No duplicate legacy DPM command-center endpoints should be added. Any old downstream consumer should
+move to this family because Lotus is still pre-live for this app surface.
+
+### 5.2 Query Parameters
+
+All read endpoints should support:
+
+| Parameter | Type | Required | Description | Example |
+| --- | --- | --- | --- | --- |
+| `as_of_date` | date | no | Business date for source and analytics posture. Defaults to canonical date in demo proof or latest supported business date in runtime. | `2026-04-10` |
+| `region` | string | no | Front-office region or booking center context. | `SG` |
+| `relationship_manager_id` | string | no | Optional filter for book ownership. | `RM-PRIVATEBANK-01` |
+| `mandate_state` | string | no | Filter by `ready`, `attention_required`, `blocked`, `stale`, `degraded`. | `attention_required` |
+| `include` | array | no | Optional modules: `core`, `manage`, `risk`, `performance`, `reporting`, `ai`, `evidence`. | `core,manage,risk,performance` |
+
+### 5.3 Book-Level Response Shape
+
+The book-level response should be product-facing, not a raw merge of upstream payloads.
+
+```json
+{
+  "portfolio_book": {
+    "book_id": "DPM-SG-GLOBAL-BALANCED",
+    "as_of_date": "2026-04-10",
+    "currency": "USD",
+    "mandate_count": 126,
+    "ready_count": 91,
+    "attention_required_count": 27,
+    "blocked_count": 8
+  },
+  "summary": {
+    "overall_state": "attention_required",
+    "primary_reason": "27 mandates require review; 8 are blocked by source-data or policy readiness.",
+    "highest_priority_dimension": "mandate_drift",
+    "next_best_operating_action": "Review attention-required mandates by severity and rebalance readiness."
+  },
+  "mandates": [
+    {
+      "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+      "client_segment": "Private Banking",
+      "mandate_name": "Singapore Global Balanced DPM",
+      "mandate_state": "attention_required",
+      "health_score": 82.4,
+      "health_band": "watch",
+      "primary_exception": "equity_overweight_drift",
+      "rebalance_readiness": "ready_for_simulation",
+      "risk_state": "within_limits",
+      "performance_state": "underperforming_benchmark",
+      "source_readiness": "ready",
+      "latest_action": "simulate_rebalance"
+    }
+  ],
+  "supportability": {
+    "state": "ready",
+    "degraded_sources": [],
+    "blocked_sources": [],
+    "freshness": {
+      "core": "ready",
+      "manage": "ready",
+      "risk": "ready",
+      "performance": "ready",
+      "report": "ready"
+    }
+  },
+  "lineage": {
+    "contract": "DpmCommandCenter:v1",
+    "source_systems": ["lotus-core", "lotus-manage", "lotus-risk", "lotus-performance", "lotus-report"],
+    "correlation_id": "dpm-command-center-20260410-001"
+  }
+}
+```
+
+### 5.4 Single-Mandate Detail Shape
+
+The single mandate response should contain these sections:
+
+1. `mandate_identity`
+   portfolio id, mandate id, model portfolio id, policy version, review cadence, PM ownership,
+   booking center, currency, benchmark, client segment.
+2. `command_summary`
+   overall state, business explanation, health score, priority action, severity, due date.
+3. `core_source_state`
+   holdings readiness, market data coverage, eligibility, tax lots, model binding, freshness.
+4. `dpm_operating_state`
+   digital twin status, drift, constraints, cash needs, restrictions, rebalance readiness, workflow
+   gates, active run refs.
+5. `risk_posture`
+   risk state, concentration, drawdown, liquidity, stress, active-risk signal, unavailable/degraded
+   reasons.
+6. `performance_posture`
+   return path, contribution, attribution, benchmark-relative signal, horizon trend,
+   unavailable/degraded reasons.
+7. `proof_and_reporting`
+   latest proof pack, report batch state, archive refs.
+8. `recommended_actions`
+   review, simulate, approve, defer, investigate source data, investigate risk, investigate
+   performance, generate proof pack.
+9. `evidence_refs`
+   source system refs, data product ids, calculation supportability, generated document refs.
+10. `observability`
+   bounded support reference, route, panel, upstream status class, degraded source labels.
+
+---
+
+## 6. Supportability and Degradation Model
+
+Gateway must return a useful payload even when some upstreams are degraded. It should use a common
+state taxonomy:
+
+| State | Meaning | Workbench behavior |
+| --- | --- | --- |
+| `ready` | Required data and calculations are available. | Render the module as actionable. |
+| `attention_required` | Data is available but business posture requires PM review. | Promote the exception and next action. |
+| `degraded` | Optional or secondary input is unavailable, but the core command-center view is usable. | Render the module with explanation and no fake values. |
+| `blocked` | Required input is missing or invalid. | Block dependent actions and show remediation owner. |
+| `stale` | Input is outside freshness tolerance. | Mark stale and prevent time-sensitive actions. |
+| `not_supported` | Capability is intentionally unavailable for the mandate or region. | Render a truthful unavailable state. |
+
+Supportability must identify:
+
+1. affected module,
+2. upstream owner,
+3. reason code,
+4. business impact,
+5. blocked action, if any,
+6. remediation route.
+
+---
+
+## 7. Data Mesh and Enterprise Requirements
+
+Every composed response must carry:
+
+1. domain product identity where available,
+2. source system,
+3. as-of date,
+4. freshness timestamp,
+5. calculation supportability,
+6. source lineage,
+7. contract version,
+8. support reference,
+9. bounded audit event,
+10. metrics labels limited to approved low-cardinality values.
+
+Forbidden in logs, metrics, or diagnostics:
+
+1. client name,
+2. raw holdings list,
+3. transaction details,
+4. prompt text,
+5. model output,
+6. raw entitlement state,
+7. request or response body,
+8. trace ids exposed to unauthorized users.
+
+---
+
+## 8. OpenAPI and Certification Requirements
+
+All new Gateway endpoints must be certified before they can be called by Workbench:
+
+1. grouped under `DPM Command Center`,
+2. endpoint description explains what, when, why, and how to use it,
+3. request parameters include type, description, allowed values, and examples,
+4. every response attribute has description, type, and example,
+5. full ready, degraded, blocked, and stale examples,
+6. error examples for upstream timeout, authorization failure, missing portfolio, and unsupported
+   mandate,
+7. response schemas avoid `Any` and untyped dictionaries,
+8. endpoint tests prove examples remain valid,
+9. no duplicate aliases or compatibility routes,
+10. vocabulary aligns with Lotus API vocabulary governance.
+
+---
+
+## 9. Implementation Slices
+
+### Slice 0: RFC and Contract Alignment
+
+1. Finalize this RFC with Workbench RFC-0098.
+2. Confirm exact upstream endpoints and supported modules.
+3. Validate that `lotus-manage` RFC-0038 outputs are sufficient for manage-side health.
+4. Identify missing risk/performance/report fields as upstream issues, not local Gateway hacks.
+
+Acceptance:
+
+1. RFC has app-by-app responsibility map.
+2. Workbench RFC references this RFC as its only command-center data source.
+3. Missing upstream fields are listed with owner and required reason.
+
+### Slice 1: Composition Models and Client Boundaries
+
+1. Add typed Gateway models for command-center summary, mandate detail, evidence refs, and
+   supportability.
+2. Add dedicated upstream client methods for only the required service endpoints.
+3. Keep fan-out bounded and timeout-governed.
+4. Preserve upstream supportability without recomputation.
+
+Acceptance:
+
+1. Unit tests prove model parsing and degraded states.
+2. Contract tests prove no raw upstream payload leak.
+3. Typecheck and lint pass.
+
+### Slice 2: Book-Level Command Center Endpoint
+
+1. Implement `GET /api/v1/dpm/command-center`.
+2. Compose book-level mandate posture from manage plus source supportability from core.
+3. Add optional risk/performance/report modules when requested.
+4. Return partial-ready payloads with source-level degradation.
+
+Acceptance:
+
+1. Ready, degraded, blocked, and stale cases tested.
+2. Empty book and unauthorized book cases tested.
+3. OpenAPI examples validate.
+
+### Slice 3: Single-Mandate Detail Endpoint
+
+1. Implement `GET /api/v1/dpm/command-center/mandates/{portfolio_id}`.
+2. Compose mandate identity, manage state, risk, performance, reporting, and evidence refs.
+3. Preserve domain ownership labels per section.
+4. Add action affordances based on manage readiness and supportability.
+
+Acceptance:
+
+1. Canonical portfolio `PB_SG_GLOBAL_BAL_001` returns a complete detail contract in live proof.
+2. Missing optional analytics degrade cleanly.
+3. Blocked source readiness prevents simulate action.
+
+### Slice 4: Evidence Endpoint and Proof-Pack Handoff
+
+1. Implement `GET /api/v1/dpm/command-center/mandates/{portfolio_id}/evidence`.
+2. Include source refs, calculation supportability, generated report refs, archive refs, and
+   support references.
+3. Do not expose raw holdings, raw report content, raw prompts, or model outputs.
+
+Acceptance:
+
+1. Evidence contract supports Workbench drawer and sales/demo explanation.
+2. Archive links are controlled Gateway links.
+3. Audit tests prove protected fields are absent.
+
+### Slice 5: Simulate Action Handoff
+
+1. Implement `POST /api/v1/dpm/command-center/mandates/{portfolio_id}/actions/simulate`.
+2. Route to `lotus-manage` stateful rebalance simulation.
+3. Require Gateway to verify source readiness and mandate action eligibility before handoff.
+4. Return a product-friendly action result with run refs and next action.
+
+Acceptance:
+
+1. Ready state calls manage and returns run refs.
+2. Blocked state does not call manage.
+3. Idempotency and replay posture are tested where manage supports it.
+
+### Slice 6: Observability, Security, and Governance
+
+1. Add RFC-0108-aligned fan-out logs and metrics.
+2. Add bounded audit events for allowed reads, denied reads, protected diagnostics, and action
+   handoff.
+3. Add security and entitlement checks consistent with existing Gateway contracts.
+4. Add diagnostics lookup without leaking raw payloads.
+
+Acceptance:
+
+1. Metrics labels are low-cardinality.
+2. Audit records exclude forbidden fields.
+3. Unauthorized users receive product-safe errors.
+
+### Slice 7: Canonical Proof and Test Pyramid
+
+1. Add unit tests for model mapping and supportability.
+2. Add integration tests for composed Gateway behavior.
+3. Add contract tests for Workbench-facing payload stability.
+4. Add live canonical validation for `PB_SG_GLOBAL_BAL_001`.
+5. Capture request/response evidence in non-git tracked output.
+
+Acceptance:
+
+1. Feature lane and PR merge gate pass.
+2. Canonical live stack proves core, manage, risk, performance, report, and archive composition or
+   truthful degradation.
+3. No unsupported Workbench panel claim is made from backend-only proof.
+
+### Slice 8: Documentation, Wiki, and Closure
+
+1. Update README, repository context, RFC index, and wiki.
+2. Add business-facing documentation with diagrams.
+3. Add operator runbook for troubleshooting degraded command-center sources.
+4. Record supported features only after implementation proof.
+
+Acceptance:
+
+1. Wiki is useful to business, engineering, sales, marketing, and operations.
+2. `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` passes before merge.
+3. Post-merge wiki publish is completed.
+
+---
+
+## 10. Testing Strategy
+
+| Layer | Coverage |
+| --- | --- |
+| Unit | model normalization, supportability mapping, action affordance logic, upstream error mapping |
+| Contract | response schema stability, OpenAPI examples, forbidden-field checks, vocabulary checks |
+| Integration | composed route behavior with mocked upstreams, partial readiness, blocked action flows |
+| E2E/live | canonical core/manage/risk/performance/report/archive composition for `PB_SG_GLOBAL_BAL_001` |
+| Observability | audit events, metrics labels, diagnostics lookup, denied-read posture |
+
+Tests must validate figures and states, not only status codes.
+
+---
+
+## 11. Risks and Controls
+
+| Risk | Control |
+| --- | --- |
+| Gateway becomes a domain calculation layer | Preserve upstream ownership and only compose product state. |
+| Workbench bypasses Gateway | Workbench RFC-0098 requires Gateway-only consumption. |
+| Partial upstream outages create misleading UI | Use explicit degraded, blocked, stale, and not-supported states. |
+| Sensitive data leaks into diagnostics | Apply RFC-0108 audit and metrics restrictions. |
+| API sprawl | Create one strategic endpoint family and remove/avoid duplicates. |
+| Demo claims exceed implementation truth | Promote supported features only after live evidence. |
+
+---
+
+## 12. Definition of Done
+
+This RFC is complete only when:
+
+1. all strategic Gateway DPM command-center endpoints are implemented and certified,
+2. OpenAPI is complete with examples and attribute descriptions,
+3. Workbench consumes this Gateway contract without direct raw service calls,
+4. canonical live proof passes for `PB_SG_GLOBAL_BAL_001`,
+5. source degradation is truthful and action-blocking where required,
+6. audit, metrics, diagnostics, and entitlement checks meet Gateway standards,
+7. README, wiki, RFC index, and supported-features material are updated,
+8. all CI lanes pass,
+9. post-merge wiki publication is complete,
+10. no duplicate command-center endpoints remain.
+
+---
+
+## 13. Relationship to Workbench RFC-0098
+
+This RFC defines the backend composition contract. Workbench RFC-0098 defines the user experience.
+The two RFCs must be implemented as a coordinated delivery program:
+
+1. Gateway owns the certified payload.
+2. Workbench owns layout, workflow, interaction, and evidence presentation.
+3. Domain apps own their respective source products.
+4. Platform canonical automation owns repeatable proof and demo seed posture.
+
+The business outcome is not complete until both RFCs are implemented and validated together.

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -2,13 +2,13 @@
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | PROPOSED - IMPLEMENTATION READY |
+| **Status** | PROPOSED - RFC-0040 PROOF-PACK OWNERSHIP ALIGNED |
 | **Created** | 2026-05-03 |
 | **Last Tightened** | 2026-05-03 |
 | **Owner** | `lotus-gateway` |
 | **Primary Consumer** | `lotus-workbench` DPM mandate command center |
 | **Business Sponsor Persona** | DPM head, portfolio manager, CIO desk, investment control, operations, sales/pre-sales |
-| **Depends On** | `lotus-manage` RFC-0037, `lotus-manage` RFC-0038, `lotus-core` RFC-0087, Gateway RFC-0082, Gateway RFC-0108, Workbench RFC-0098 |
+| **Depends On** | `lotus-manage` RFC-0037, `lotus-manage` RFC-0038, `lotus-manage` RFC-0040, `lotus-core` RFC-0087, Gateway RFC-0082, Gateway RFC-0108, Workbench RFC-0098 |
 | **Doc Location** | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
 | **Implementation Branch** | TBD when implementation begins |
 
@@ -25,9 +25,11 @@ that brings together:
 2. mandate health, drift, constraints, action posture, and rebalance readiness from `lotus-manage`,
 3. risk posture from `lotus-risk`,
 4. performance posture from `lotus-performance`,
-5. proof-pack and reporting posture from `lotus-report`,
-6. archived evidence metadata and controlled document access from `lotus-archive`,
-7. governed narrative and task-flow posture from `lotus-ai` where AI support is enabled.
+5. proof-pack authority, readiness, Markdown, report-input, and AI-evidence handoff posture from
+   `lotus-manage` RFC-0040,
+6. report materialization posture from `lotus-report`,
+7. archived evidence metadata and controlled document access from `lotus-archive`,
+8. governed narrative and task-flow posture from `lotus-ai` where AI support is enabled.
 
 This RFC makes `lotus-gateway` the certified composition boundary for that business view.
 `lotus-manage` must not become a mega-orchestrator for risk and performance, and
@@ -105,11 +107,13 @@ command center requires the full front-office context:
    attribution.
 4. `lotus-performance` owns returns, contribution, attribution, benchmark-relative posture, and
    performance methodology supportability.
-5. `lotus-report` owns proof-pack and reporting batch lifecycle.
-6. `lotus-archive` owns generated-document metadata, controlled download, retention, legal-hold,
+5. `lotus-manage` owns proof-pack generation, immutable proof-pack JSON, section states, hashes,
+   Markdown, report-input payloads, and AI-evidence payloads under RFC-0040.
+6. `lotus-report` owns report materialization and reporting batch lifecycle.
+7. `lotus-archive` owns generated-document metadata, controlled download, retention, legal-hold,
    and access audit.
-7. `lotus-ai` owns optional governed narrative generation and task-flow posture.
-8. `lotus-workbench` owns the product experience and must render Gateway truth.
+8. `lotus-ai` owns optional governed narrative generation and task-flow posture.
+9. `lotus-workbench` owns the product experience and must render Gateway truth.
 
 If Workbench stitches every service directly, the product becomes brittle and uncertifiable. If
 `lotus-manage` calls risk/performance/report/archive/AI directly for the command-center screen,
@@ -139,7 +143,7 @@ Gateway is the correct experience API and composition boundary.
 2. Gateway does not calculate risk. That belongs to `lotus-risk`.
 3. Gateway does not calculate performance. That belongs to `lotus-performance`.
 4. Gateway does not own source portfolio data. That belongs to `lotus-core`.
-5. Gateway does not generate proof packs. That belongs to `lotus-report`.
+5. Gateway does not generate, hash, or reconstruct proof packs. That belongs to `lotus-manage`.
 6. Gateway does not own archived documents. That belongs to `lotus-archive`.
 7. Gateway does not generate investment narratives. That belongs to `lotus-ai`.
 8. Gateway does not implement the UI. That belongs to `lotus-workbench`.
@@ -157,7 +161,8 @@ flowchart LR
     Manage[lotus-manage<br/>mandate health and DPM operating state] --> Gateway
     Risk[lotus-risk<br/>risk analytics data products] --> Gateway
     Performance[lotus-performance<br/>performance analytics data products] --> Gateway
-    Report[lotus-report<br/>proof packs and report batches] --> Gateway
+    ManageProof[lotus-manage<br/>proof packs and handoff inputs] --> Gateway
+    Report[lotus-report<br/>report materialization and batches] --> Gateway
     Archive[lotus-archive<br/>document metadata and downloads] --> Gateway
     AI[lotus-ai<br/>governed narrative and task-flow posture] --> Gateway
     Gateway --> Workbench[lotus-workbench<br/>DPM command center]
@@ -187,7 +192,8 @@ meaning.
 | Manage health/action state | Mandate Operating State |
 | Risk calculations | Risk Posture |
 | Performance calculations | Performance Posture |
-| Report batches/proof packs | Proof and Reporting |
+| Manage proof packs and handoff inputs | Proof-Pack Evidence |
+| Report materialization and batches | Reporting |
 | Archive records | Evidence Archive |
 | AI workflow/task flow | Narrative Support |
 
@@ -200,10 +206,10 @@ Gateway must retain source ownership in evidence and operations sections.
 | App | Responsibility in command center | Required contribution | Gateway handling | Must not do |
 | --- | --- | --- | --- | --- |
 | `lotus-core` | Source-of-record portfolio data products | portfolio snapshot, mandate binding, model target, eligibility, tax lots, market data coverage, DPM source readiness, lineage | source readiness, mandate identity, source evidence | DPM health scoring or UI composition |
-| `lotus-manage` | DPM mandate operating layer | digital twin, health score, health dimensions, exceptions, action eligibility, rebalance readiness, simulation handoff refs | DPM operating state and action affordances | risk/performance calculation ownership |
+| `lotus-manage` | DPM mandate operating layer and proof-pack authority | digital twin, health score, health dimensions, exceptions, action eligibility, rebalance readiness, simulation handoff refs, proof-pack JSON, section states, hashes, Markdown, report-input payload, AI-evidence payload | DPM operating state, action affordances, proof-pack evidence module | risk/performance calculation ownership, report rendering, AI memo generation |
 | `lotus-risk` | Certified risk analytics | concentration, drawdown, liquidity/stress where available, active risk, risk attribution, calculation supportability | risk posture and degraded risk state | DPM workflow ownership |
 | `lotus-performance` | Certified performance analytics | return path, contribution, attribution, benchmark-relative performance, horizon trend, calculation supportability | performance posture and degraded performance state | DPM workflow ownership |
-| `lotus-report` | Proof pack and report lifecycle | latest proof pack, report batch status, materialization status, recovery state | proof/reporting module | command-center composition |
+| `lotus-report` | Report materialization lifecycle | report batch status, materialization status, recovery state, generated report refs | reporting module | proof-pack authority or command-center composition |
 | `lotus-archive` | Generated-document archive | document metadata, controlled download links, retention/access posture | evidence archive refs only | analytics or workflow decisioning |
 | `lotus-ai` | Governed narrative support | optional PM narrative, task-flow posture, handoff refs | optional narrative support module | source-of-truth analytics or action authority |
 | `lotus-gateway` | Experience API | stable DPM command-center contract, supportability normalization, audit, metrics, diagnostics | owns product contract | domain calculation ownership |
@@ -226,7 +232,8 @@ for missing fields rather than inventing local synthetic truth.
 | Rebalance readiness | simulation eligibility, blocked reasons, active run refs | `lotus-manage` | yes | simulate action disabled |
 | Risk posture | concentration, drawdown, liquidity/stress if available, risk attribution | `lotus-risk` | no for first route availability, yes for gold business proof | risk module degraded/not-supported |
 | Performance posture | return path, contribution, attribution, benchmark-relative signals | `lotus-performance` | no for first route availability, yes for gold business proof | performance module degraded/not-supported |
-| Proof/reporting | proof pack readiness, report batch status, latest report refs | `lotus-report` | no for first route availability, yes before demo claim | proof module degraded/not-supported |
+| Proof-pack evidence | proof-pack readiness, section states, hashes, Markdown, report-input readiness, AI-evidence readiness | `lotus-manage` RFC-0040 | no for first route availability, yes before demo claim | proof module degraded/not-supported |
+| Reporting | report batch status, materialization state, latest report refs | `lotus-report` | no for first route availability, yes before report-demo claim | reporting module degraded/not-supported |
 | Archive evidence | generated document metadata, controlled download refs | `lotus-archive` | no for first route availability, yes when proof refs exist | archive refs omitted with reason |
 | Narrative support | bounded PM summary, AI task-flow posture | `lotus-ai` | no | narrative module omitted unless requested and available |
 
@@ -291,6 +298,43 @@ Gateway implementation must not begin until it validates the current manage Open
 construction endpoint family and confirms whether additional downstream action fields are required
 for Workbench. Missing fields should be raised against `lotus-manage`; Gateway must not infer them.
 
+### 8.0A RFC-0040 Proof-Pack Realization Addendum
+
+RFC-0098 must also realize `lotus-manage` RFC-0040 proof-pack contracts after manage contracts are
+stable. Gateway is the Workbench-facing composition boundary, not the proof-pack authority.
+
+Business outcome:
+
+1. portfolio managers can see proof-pack readiness and review evidence without leaving the DPM
+   command center,
+2. compliance, operations, and audit can inspect proof-pack hashes, section states, lineage, and
+   generated handoff refs,
+3. sales/pre-sales can demonstrate proof-backed discretionary management without implying Gateway
+   or Workbench recomputes proof-pack evidence.
+
+Gateway responsibility:
+
+1. consume `lotus-manage` `POST /api/v1/rebalance/proof-packs`,
+   `GET /api/v1/rebalance/proof-packs/{proof_pack_id}`,
+   `GET /api/v1/rebalance/proof-packs/{proof_pack_id}/summary.md`,
+   `GET /api/v1/rebalance/proof-packs/{proof_pack_id}/report-input`, and
+   `GET /api/v1/rebalance/proof-packs/{proof_pack_id}/ai-evidence-input`,
+2. preserve manage `proof_pack_id`, `content_hash`, `source_hashes`, section states, reason codes,
+   lineage refs, report-input refs, and AI-evidence refs,
+3. expose Workbench-ready proof-pack summary, readiness, Markdown, and evidence-drawer contracts,
+4. compose report materialization posture from `lotus-report` separately from proof-pack authority,
+5. compose optional AI memo/task posture from `lotus-ai` separately from manage AI-evidence input,
+6. return degraded or unavailable module state when manage proof-pack APIs are unavailable.
+
+Gateway must not:
+
+1. rebuild proof-pack sections from raw source services,
+2. recalculate proof-pack hashes,
+3. generate report-input or AI-evidence payloads locally,
+4. treat `lotus-report` as the proof-pack authority,
+5. expose Workbench action eligibility for proof-pack generation unless manage source readiness and
+   entitlement posture support it.
+
 ### 8.1 Endpoint Family
 
 Gateway must expose one strategic route family:
@@ -316,7 +360,7 @@ routes, remove them before promoting the feature because the surface is pre-live
 | `model_portfolio_id` | string | no | book route | Optional model portfolio filter. | `MODEL_PB_SG_GLOBAL_BAL_DPM` |
 | `mandate_state` | enum | no | book route | Filter by `ready`, `attention_required`, `blocked`, `stale`, `degraded`, `not_supported`. | `attention_required` |
 | `severity` | enum | no | book route | Filter by `critical`, `high`, `medium`, `low`. | `high` |
-| `include` | CSV enum | no | all read routes | Optional modules: `core`, `manage`, `risk`, `performance`, `reporting`, `archive`, `ai`, `evidence`. | `core,manage,risk,performance` |
+| `include` | CSV enum | no | all read routes | Optional modules: `core`, `manage`, `risk`, `performance`, `proof_pack`, `reporting`, `archive`, `ai`, `evidence`. | `core,manage,risk,performance,proof_pack` |
 
 ### 8.3 Command-Center Module Taxonomy
 
@@ -326,9 +370,10 @@ All responses must use these module identifiers consistently:
 2. `mandate_operating_state`
 3. `risk_posture`
 4. `performance_posture`
-5. `proof_and_reporting`
-6. `evidence_archive`
-7. `narrative_support`
+5. `proof_pack_evidence`
+6. `reporting`
+7. `evidence_archive`
+8. `narrative_support`
 
 Module state values:
 
@@ -389,7 +434,8 @@ Module state values:
         "mandate_operating_state": "attention_required",
         "risk_posture": "ready",
         "performance_posture": "attention_required",
-        "proof_and_reporting": "ready"
+        "proof_pack_evidence": "ready",
+        "reporting": "ready"
       },
       "recommended_actions": [
         {
@@ -411,6 +457,7 @@ Module state values:
     "domain_products": [
       "DpmSourceReadiness:v1",
       "DpmMandateHealth:v1",
+      "DpmPreTradeProofPack:v1",
       "RiskConcentration:v1",
       "PerformanceAttribution:v1"
     ]
@@ -428,7 +475,8 @@ Module state values:
 | `mandate_operating_state` | digital twin state, drift dimensions, constraints, restrictions, cash posture, rebalance readiness, workflow gates, active run refs |
 | `risk_posture` | concentration state, drawdown state, liquidity/stress state where available, active risk, risk attribution, calculation supportability |
 | `performance_posture` | return path state, contribution, attribution, benchmark-relative state, horizon trend, calculation supportability |
-| `proof_and_reporting` | proof-pack readiness, report batch state, latest generated report refs, blocked/degraded report reasons |
+| `proof_pack_evidence` | proof-pack readiness, proof-pack id, section states, content hash, source hashes, Markdown ref, report-input ref, AI-evidence ref, blocked/degraded proof reasons |
+| `reporting` | report batch state, materialization state, latest generated report refs, blocked/degraded report reasons |
 | `evidence_archive` | archive refs, document metadata refs, controlled download refs, retention/access posture |
 | `narrative_support` | optional AI summary, task-flow posture, handoff refs, bounded supportability |
 | `recommended_actions` | review, simulate, generate proof pack, investigate source, investigate risk, investigate performance, defer, escalate |

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -2,87 +2,154 @@
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | PROPOSED |
+| **Status** | PROPOSED - IMPLEMENTATION READY |
 | **Created** | 2026-05-03 |
-| **Owner** | lotus-gateway |
-| **Primary Consumers** | lotus-workbench, future client demo and operations surfaces |
-| **Depends On** | lotus-manage RFC-0037, lotus-manage RFC-0038, lotus-core RFC-0087, Gateway RFC-0082, Gateway RFC-0108, Workbench RFC-0098 |
+| **Last Tightened** | 2026-05-03 |
+| **Owner** | `lotus-gateway` |
+| **Primary Consumer** | `lotus-workbench` DPM mandate command center |
+| **Business Sponsor Persona** | DPM head, portfolio manager, CIO desk, investment control, operations, sales/pre-sales |
+| **Depends On** | `lotus-manage` RFC-0037, `lotus-manage` RFC-0038, `lotus-core` RFC-0087, Gateway RFC-0082, Gateway RFC-0108, Workbench RFC-0098 |
 | **Doc Location** | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
+| **Implementation Branch** | TBD when implementation begins |
 
 ---
 
 ## 0. Executive Summary
 
 `lotus-manage` RFC-0038 delivered the backend foundation for mandate digital twin, mandate health,
-and DPM command-center readiness. The full business outcome is not realized until the front-office
-experience can see the full mandate picture: source readiness from `lotus-core`, DPM operating
-state from `lotus-manage`, risk posture from `lotus-risk`, performance posture from
-`lotus-performance`, report/proof-pack posture from `lotus-report`, archived evidence from
-`lotus-archive`, and governed narrative support from `lotus-ai`.
+source-data-aware stateful management, and DPM operating posture. That does not by itself realize
+the business outcome of a DPM command center. A portfolio manager needs one front-office contract
+that brings together:
 
-This RFC defines the Gateway composition contract that makes that outcome possible without turning
-`lotus-manage` into a mega-orchestrator and without making `lotus-workbench` call every domain
-service directly. Gateway owns the product-facing experience API. Domain apps remain authoritative
-for their own data products.
+1. source-of-record mandate and portfolio readiness from `lotus-core`,
+2. mandate health, drift, constraints, action posture, and rebalance readiness from `lotus-manage`,
+3. risk posture from `lotus-risk`,
+4. performance posture from `lotus-performance`,
+5. proof-pack and reporting posture from `lotus-report`,
+6. archived evidence metadata and controlled document access from `lotus-archive`,
+7. governed narrative and task-flow posture from `lotus-ai` where AI support is enabled.
 
-The target is a private-banking-grade DPM command-center contract that a portfolio manager, CIO
-desk, investment control team, operations team, and client-demo team can trust.
+This RFC makes `lotus-gateway` the certified composition boundary for that business view.
+`lotus-manage` must not become a mega-orchestrator for risk and performance, and
+`lotus-workbench` must not stitch raw domain services in the browser. Gateway composes
+domain-authoritative products into one stable, supportability-aware, Workbench-facing command-center
+contract.
+
+The result should be an enterprise-grade private-banking DPM command-center API that supports daily
+portfolio-manager book control, operations triage, CIO oversight, client-demo storytelling, and
+future automation.
 
 ---
 
-## 1. Business Outcomes
+## 1. Gold-Standard Tightening Review
 
-The RFC must deliver these business outcomes:
+This section records the critical review performed before implementation. It is intentionally kept
+inside the RFC so future implementers understand why the final shape is stricter than the first
+draft.
 
-1. **Single command-center contract for discretionary mandates**
-   Workbench receives one governed Gateway payload for the DPM command center instead of stitching
-   multiple raw service contracts in the browser.
-2. **Daily book-control readiness**
-   Portfolio managers can see which mandates are ready, which are drifting, which are blocked by
-   data or policy, and which require PM, CIO, compliance, or operations action.
-3. **Faster diagnosis of mandate issues**
-   The contract explains whether the issue comes from source data, mandate drift, risk, performance,
-   liquidity, tax, restrictions, workflow, or proof-pack readiness.
-4. **Clear accountability by domain**
-   Each figure and state carries source ownership so business users and operations know which
-   service is authoritative and where remediation belongs.
+| Area | First-draft weakness | Tightened requirement |
+| --- | --- | --- |
+| Business outcome | Correct direction but not measurable enough. | Added explicit PM, CIO, operations, and demo outcomes plus definition of done. |
+| Scope | Endpoint list was useful but not sequenced against upstream readiness. | Added minimum viable contract, upstream readiness matrix, and missing-field escalation rules. |
+| Architecture | Correctly kept Gateway as composition boundary. | Added anti-corruption rules, fan-out discipline, no domain recomputation rule, and no direct Workbench raw-service calls. |
+| API contract | Example response was helpful but not enough for implementation. | Added canonical endpoint family, module taxonomy, action contract, supportability taxonomy, and attribute-level certification expectations. |
+| Slices | Missing the full delivery-standard slices requested for RFC execution. | Added platform/scaffolding, cleanup, implementation proof, hardening, and closure slices. |
+| Evidence | Live proof was mentioned but not concrete. | Added canonical proof package with request/response evidence, source matrix, degraded-state evidence, and Workbench handoff proof boundary. |
+| Data mesh | Mentioned lineage but not certification gates. | Added domain-product provenance, trust posture, low-cardinality observability, audit restrictions, and mesh certification expectations. |
+| Documentation | Wiki update was present but not audience-specific. | Added business/sales/ops/dev documentation outputs and demo narrative requirements. |
+
+Implementation must not begin until this RFC and Workbench RFC-0098 agree on the same Gateway
+contract family, route names, supportability states, and proof expectations.
+
+---
+
+## 2. Business Outcomes
+
+The RFC must deliver the following business outcomes.
+
+1. **Daily DPM book control**
+   A portfolio manager can open one command-center view and know which discretionary mandates are
+   ready, drifting, blocked, stale, degraded, or action-ready.
+2. **Faster exception triage**
+   The API explains whether a mandate problem is caused by source data, model drift, risk,
+   performance, liquidity, tax, restrictions, workflow state, or proof-pack readiness.
+3. **Clear domain accountability**
+   Every module identifies the authoritative app and the remediation owner. Gateway never hides
+   whether the problem belongs to core, manage, risk, performance, reporting, archive, AI, or
+   entitlement.
+4. **Safer portfolio actions**
+   Workbench can only enable management actions that Gateway marks eligible based on manage
+   readiness, source readiness, entitlement, and supportability.
 5. **Client-demo-grade story**
-   The same contract supports demo and pre-sales material showing how Lotus turns source data,
-   analytics, risk, and DPM workflow into a coherent discretionary management cockpit.
-6. **Enterprise data mesh posture**
-   Every domain input keeps provenance, freshness, supportability, degradation reason, and bounded
-   observability metadata.
+   Sales and pre-sales can explain how Lotus connects source data, risk, performance, mandate
+   controls, and workflow into one discretionary management cockpit.
+6. **Operations-grade supportability**
+   Operations can inspect support reference, degraded source, blocked source, freshness, and
+   remediation route without reading raw payloads or logs.
+7. **Enterprise data mesh posture**
+   Gateway preserves product identity, lineage, calculation supportability, freshness, and trust
+   posture without becoming the domain product authority.
 
 ---
 
-## 2. Problem Statement
+## 3. Problem Statement
 
-RFC-0038 made `lotus-manage` capable of exposing DPM mandate health and command-center primitives.
-However, a business-grade DPM command center needs more than manage-side health:
+`lotus-manage` RFC-0038 created DPM mandate health and command-center primitives, but a business
+command center requires the full front-office context:
 
-1. `lotus-core` owns source-of-record portfolio, holdings, model binding, tax lots, eligibility,
-   market data readiness, and source lineage.
-2. `lotus-manage` owns DPM operating posture, mandate digital twin, rebalance readiness, drift,
-   constraints, action recommendations, and workflow state.
-3. `lotus-risk` owns risk analytics such as concentration, drawdown, active risk, stress, and
-   risk attribution.
-4. `lotus-performance` owns performance analytics such as return path, contribution, attribution,
-   benchmark-relative underperformance, and horizon trends.
-5. `lotus-report` owns proof-pack and report-batch materialization.
-6. `lotus-archive` owns immutable generated-document metadata and controlled downloads.
-7. `lotus-ai` owns governed narrative generation and task-flow posture when AI support is used.
-8. `lotus-workbench` owns the user experience, not domain authority.
+1. `lotus-core` owns source-of-record portfolio identity, holdings, model binding, market data,
+   tax-lot, eligibility, source readiness, and source lineage.
+2. `lotus-manage` owns DPM mandate interpretation, digital twin, health, drift, constraints,
+   action posture, simulation readiness, and workflow state.
+3. `lotus-risk` owns concentration, drawdown, active risk, liquidity risk, stress, and risk
+   attribution.
+4. `lotus-performance` owns returns, contribution, attribution, benchmark-relative posture, and
+   performance methodology supportability.
+5. `lotus-report` owns proof-pack and reporting batch lifecycle.
+6. `lotus-archive` owns generated-document metadata, controlled download, retention, legal-hold,
+   and access audit.
+7. `lotus-ai` owns optional governed narrative generation and task-flow posture.
+8. `lotus-workbench` owns the product experience and must render Gateway truth.
 
-If Workbench calls each service directly, the product surface becomes brittle, inconsistent, and
-hard to certify. If `lotus-manage` calls every analytics service directly, manage becomes
-over-coupled and starts owning analytics it should not own. Gateway is the correct composition
-boundary.
+If Workbench stitches every service directly, the product becomes brittle and uncertifiable. If
+`lotus-manage` calls risk/performance/report/archive/AI directly for the command-center screen,
+manage becomes over-coupled and starts to own analytics and evidence domains it should not own.
+Gateway is the correct experience API and composition boundary.
 
 ---
 
-## 3. Architecture Direction
+## 4. Goals and Non-Goals
 
-### 3.1 Target Architecture
+### 4.1 Goals
+
+1. Define one strategic Gateway DPM command-center API family.
+2. Compose core, manage, risk, performance, report, archive, and optional AI posture into a
+   product-facing contract.
+3. Preserve upstream domain authority and calculation supportability.
+4. Provide Workbench with stable book-level, mandate-detail, evidence, and action-handoff
+   contracts.
+5. Make degradation explicit and action-blocking where needed.
+6. Certify OpenAPI, examples, vocabulary, error handling, observability, and test coverage.
+7. Support canonical live proof for `PB_SG_GLOBAL_BAL_001`.
+8. Produce business-grade README/wiki/demo documentation after implementation.
+
+### 4.2 Non-Goals
+
+1. Gateway does not calculate mandate health. That belongs to `lotus-manage`.
+2. Gateway does not calculate risk. That belongs to `lotus-risk`.
+3. Gateway does not calculate performance. That belongs to `lotus-performance`.
+4. Gateway does not own source portfolio data. That belongs to `lotus-core`.
+5. Gateway does not generate proof packs. That belongs to `lotus-report`.
+6. Gateway does not own archived documents. That belongs to `lotus-archive`.
+7. Gateway does not generate investment narratives. That belongs to `lotus-ai`.
+8. Gateway does not implement the UI. That belongs to `lotus-workbench`.
+9. Gateway does not create compatibility aliases for pre-live DPM command-center contracts.
+
+---
+
+## 5. Architecture Direction
+
+### 5.1 Target Architecture
 
 ```mermaid
 flowchart LR
@@ -96,81 +163,147 @@ flowchart LR
     Gateway --> Workbench[lotus-workbench<br/>DPM command center]
 ```
 
-### 3.2 Ownership Principles
+### 5.2 Composition Rules
 
-1. Gateway composes and shapes product-facing contracts.
-2. Gateway does not compute domain analytics that belong to upstream apps.
-3. Gateway does not hide upstream degradation. It normalizes it into product-safe supportability.
-4. Gateway preserves source lineage and calculation supportability where upstream provides it.
-5. Gateway keeps bounded audit, metrics, and diagnostic posture under RFC-0108 rules.
-6. Gateway should replace pre-live endpoint clutter with one strategic DPM command-center family.
+1. Gateway composes product state and preserves domain truth.
+2. Gateway may rank or group product states for the user journey, but must not recompute
+   upstream domain figures.
+3. Gateway must surface partial readiness. It must not flatten all upstream problems into a single
+   generic error.
+4. Gateway must keep each module independently supportable so Workbench can render ready, degraded,
+   stale, blocked, or not-supported states per module.
+5. Gateway must use explicit upstream clients and typed models, not ad hoc JSON pass-through.
+6. Gateway must keep fan-out bounded, timeout-governed, observable, and testable.
+7. Gateway must use strategic route names and avoid duplicate aliases.
 
-### 3.3 Runtime Boundary
+### 5.3 Anti-Corruption Boundary
 
-Workbench should consume Gateway only for this command center. Workbench must not call raw
-`lotus-core`, `lotus-manage`, `lotus-risk`, `lotus-performance`, `lotus-report`, `lotus-archive`,
-or `lotus-ai` APIs for this workflow.
+Gateway must normalize upstream service language into product-facing language without changing
+meaning.
 
----
-
-## 4. App-by-App Responsibilities
-
-| App | Responsibility in command center | Must provide | Must not do |
-| --- | --- | --- | --- |
-| `lotus-core` | Source-of-record portfolio data product owner | portfolio snapshot, holdings, model binding, tax lots, market data coverage, eligibility, source readiness, lineage | DPM health scoring or UI composition |
-| `lotus-manage` | DPM mandate operating layer | mandate digital twin, health score, drift, constraints, execution readiness, action queue, rebalance/run posture | risk/performance calculation ownership |
-| `lotus-risk` | Certified risk analytics owner | concentration, drawdown, stress, liquidity risk, active risk, risk attribution, supportability | DPM action recommendation ownership |
-| `lotus-performance` | Certified performance analytics owner | return path, contribution, attribution, benchmark-relative performance, horizon trend, calculation supportability | risk or DPM workflow ownership |
-| `lotus-report` | Proof-pack and report-batch owner | latest proof-pack readiness, batch status, report generation posture, materialization history | command-center composition |
-| `lotus-archive` | Evidence archive owner | immutable document metadata, controlled download refs, retention posture | analytics or workflow decisioning |
-| `lotus-ai` | Governed narrative and task-flow owner | optional PM narrative, explanation draft, task-flow posture, handoff refs | source-of-truth analytics |
-| `lotus-gateway` | Product-facing composition boundary | stable DPM command-center API, degraded-state normalization, source attribution, bounded observability | domain calculation ownership |
-| `lotus-workbench` | User experience owner | command-center UI, workflow affordances, drill-down, evidence trail, demo screens | raw service stitching or fake data |
-
----
-
-## 5. Strategic API Contract
-
-### 5.1 Endpoint Family
-
-Gateway should expose one strategic DPM command-center family:
-
-| Endpoint | Purpose |
+| Upstream concern | Gateway product language |
 | --- | --- |
-| `GET /api/v1/dpm/command-center` | PM book-level command-center summary across mandates. |
-| `GET /api/v1/dpm/command-center/mandates/{portfolio_id}` | Single mandate command-center detail for Workbench route entry. |
-| `GET /api/v1/dpm/command-center/mandates/{portfolio_id}/evidence` | Evidence/provenance bundle for support drawer and proof-pack handoff. |
-| `POST /api/v1/dpm/command-center/mandates/{portfolio_id}/actions/simulate` | Gateway-shaped handoff into `lotus-manage` rebalance simulation when user acts from the command center. |
+| Core source readiness | Source Data Readiness |
+| Manage health/action state | Mandate Operating State |
+| Risk calculations | Risk Posture |
+| Performance calculations | Performance Posture |
+| Report batches/proof packs | Proof and Reporting |
+| Archive records | Evidence Archive |
+| AI workflow/task flow | Narrative Support |
 
-No duplicate legacy DPM command-center endpoints should be added. Any old downstream consumer should
-move to this family because Lotus is still pre-live for this app surface.
+Gateway must retain source ownership in evidence and operations sections.
 
-### 5.2 Query Parameters
+---
 
-All read endpoints should support:
+## 6. App-by-App Responsibility Map
 
-| Parameter | Type | Required | Description | Example |
+| App | Responsibility in command center | Required contribution | Gateway handling | Must not do |
 | --- | --- | --- | --- | --- |
-| `as_of_date` | date | no | Business date for source and analytics posture. Defaults to canonical date in demo proof or latest supported business date in runtime. | `2026-04-10` |
-| `region` | string | no | Front-office region or booking center context. | `SG` |
-| `relationship_manager_id` | string | no | Optional filter for book ownership. | `RM-PRIVATEBANK-01` |
-| `mandate_state` | string | no | Filter by `ready`, `attention_required`, `blocked`, `stale`, `degraded`. | `attention_required` |
-| `include` | array | no | Optional modules: `core`, `manage`, `risk`, `performance`, `reporting`, `ai`, `evidence`. | `core,manage,risk,performance` |
+| `lotus-core` | Source-of-record portfolio data products | portfolio snapshot, mandate binding, model target, eligibility, tax lots, market data coverage, DPM source readiness, lineage | source readiness, mandate identity, source evidence | DPM health scoring or UI composition |
+| `lotus-manage` | DPM mandate operating layer | digital twin, health score, health dimensions, exceptions, action eligibility, rebalance readiness, simulation handoff refs | DPM operating state and action affordances | risk/performance calculation ownership |
+| `lotus-risk` | Certified risk analytics | concentration, drawdown, liquidity/stress where available, active risk, risk attribution, calculation supportability | risk posture and degraded risk state | DPM workflow ownership |
+| `lotus-performance` | Certified performance analytics | return path, contribution, attribution, benchmark-relative performance, horizon trend, calculation supportability | performance posture and degraded performance state | DPM workflow ownership |
+| `lotus-report` | Proof pack and report lifecycle | latest proof pack, report batch status, materialization status, recovery state | proof/reporting module | command-center composition |
+| `lotus-archive` | Generated-document archive | document metadata, controlled download links, retention/access posture | evidence archive refs only | analytics or workflow decisioning |
+| `lotus-ai` | Governed narrative support | optional PM narrative, task-flow posture, handoff refs | optional narrative support module | source-of-truth analytics or action authority |
+| `lotus-gateway` | Experience API | stable DPM command-center contract, supportability normalization, audit, metrics, diagnostics | owns product contract | domain calculation ownership |
+| `lotus-workbench` | Product UI | command-center rendering, workflow affordances, drilldown, evidence trail | consumes Gateway only | raw service stitching |
 
-### 5.3 Book-Level Response Shape
+---
 
-The book-level response should be product-facing, not a raw merge of upstream payloads.
+## 7. Upstream Readiness Matrix
+
+Implementation must validate the exact source route family before writing Gateway code. The initial
+implementation should use existing certified endpoints where available and create upstream issues
+for missing fields rather than inventing local synthetic truth.
+
+| Domain | Required data | Expected source | Required for MVP | Missing-data behavior |
+| --- | --- | --- | --- | --- |
+| Portfolio identity | portfolio id, name, book, region, base/reference currency, benchmark | `lotus-core` | yes | mandate detail blocked if identity unavailable |
+| Mandate binding | mandate id, model id, policy version, review cadence | `lotus-core` + `lotus-manage` twin | yes | DPM operating module blocked |
+| Holdings/source readiness | holdings state, price/FX freshness, tax-lot readiness, eligibility | `lotus-core` RFC-0087 endpoints | yes | source readiness degraded or blocked by dependency |
+| DPM health | health score, dimensions, exceptions, recommended action | `lotus-manage` RFC-0038 | yes | command center blocked for DPM action, but source panel may render |
+| Rebalance readiness | simulation eligibility, blocked reasons, active run refs | `lotus-manage` | yes | simulate action disabled |
+| Risk posture | concentration, drawdown, liquidity/stress if available, risk attribution | `lotus-risk` | no for first route availability, yes for gold business proof | risk module degraded/not-supported |
+| Performance posture | return path, contribution, attribution, benchmark-relative signals | `lotus-performance` | no for first route availability, yes for gold business proof | performance module degraded/not-supported |
+| Proof/reporting | proof pack readiness, report batch status, latest report refs | `lotus-report` | no for first route availability, yes before demo claim | proof module degraded/not-supported |
+| Archive evidence | generated document metadata, controlled download refs | `lotus-archive` | no for first route availability, yes when proof refs exist | archive refs omitted with reason |
+| Narrative support | bounded PM summary, AI task-flow posture | `lotus-ai` | no | narrative module omitted unless requested and available |
+
+---
+
+## 8. Strategic API Contract
+
+### 8.1 Endpoint Family
+
+Gateway must expose one strategic route family:
+
+| Endpoint | Purpose | Workbench use |
+| --- | --- | --- |
+| `GET /api/v1/dpm/command-center` | Book-level command-center summary across mandates. | `/dpm` book view |
+| `GET /api/v1/dpm/command-center/mandates/{portfolio_id}` | Single mandate command-center detail. | `/dpm/mandates/[portfolioId]` |
+| `GET /api/v1/dpm/command-center/mandates/{portfolio_id}/evidence` | Evidence/provenance bundle for support drawer and proof-pack handoff. | evidence drawer/deep link |
+| `POST /api/v1/dpm/command-center/mandates/{portfolio_id}/actions/simulate` | Gateway-shaped action handoff into `lotus-manage` stateful rebalance simulation. | action rail |
+
+No route aliases should be added. If implementation discovers duplicate legacy DPM command-center
+routes, remove them before promoting the feature because the surface is pre-live.
+
+### 8.2 Query Parameters
+
+| Parameter | Type | Required | Applies to | Description | Example |
+| --- | --- | --- | --- | --- | --- |
+| `as_of_date` | date | no | read routes | Business date for source and analytics posture. Defaults to latest supported date or canonical proof date. | `2026-04-10` |
+| `region` | string | no | book route | Front-office region or booking center. | `SG` |
+| `book_id` | string | no | book route | DPM portfolio book identifier. | `DPM-SG-GLOBAL-BALANCED` |
+| `relationship_manager_id` | string | no | book route | Optional relationship manager/book owner filter. | `RM-PRIVATEBANK-01` |
+| `model_portfolio_id` | string | no | book route | Optional model portfolio filter. | `MODEL_PB_SG_GLOBAL_BAL_DPM` |
+| `mandate_state` | enum | no | book route | Filter by `ready`, `attention_required`, `blocked`, `stale`, `degraded`, `not_supported`. | `attention_required` |
+| `severity` | enum | no | book route | Filter by `critical`, `high`, `medium`, `low`. | `high` |
+| `include` | CSV enum | no | all read routes | Optional modules: `core`, `manage`, `risk`, `performance`, `reporting`, `archive`, `ai`, `evidence`. | `core,manage,risk,performance` |
+
+### 8.3 Command-Center Module Taxonomy
+
+All responses must use these module identifiers consistently:
+
+1. `source_data_readiness`
+2. `mandate_operating_state`
+3. `risk_posture`
+4. `performance_posture`
+5. `proof_and_reporting`
+6. `evidence_archive`
+7. `narrative_support`
+
+Module state values:
+
+1. `ready`
+2. `attention_required`
+3. `degraded`
+4. `blocked`
+5. `stale`
+6. `not_supported`
+7. `not_requested`
+8. `unavailable`
+
+### 8.4 Book-Level Response Shape
 
 ```json
 {
+  "contract": {
+    "name": "DpmCommandCenter",
+    "version": "v1",
+    "as_of_date": "2026-04-10",
+    "generated_at": "2026-05-03T08:00:00Z"
+  },
   "portfolio_book": {
     "book_id": "DPM-SG-GLOBAL-BALANCED",
-    "as_of_date": "2026-04-10",
+    "region": "SG",
     "currency": "USD",
     "mandate_count": 126,
     "ready_count": 91,
     "attention_required_count": 27,
-    "blocked_count": 8
+    "blocked_count": 8,
+    "stale_count": 0,
+    "degraded_count": 4
   },
   "summary": {
     "overall_state": "attention_required",
@@ -181,319 +314,501 @@ The book-level response should be product-facing, not a raw merge of upstream pa
   "mandates": [
     {
       "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-      "client_segment": "Private Banking",
+      "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
       "mandate_name": "Singapore Global Balanced DPM",
+      "model_portfolio_id": "MODEL_PB_SG_GLOBAL_BAL_DPM",
+      "portfolio_manager_id": "PM-SG-DPM-01",
       "mandate_state": "attention_required",
       "health_score": 82.4,
       "health_band": "watch",
-      "primary_exception": "equity_overweight_drift",
+      "primary_exception": {
+        "code": "equity_overweight_drift",
+        "severity": "high",
+        "business_summary": "Equity allocation is outside the tactical tolerance band."
+      },
       "rebalance_readiness": "ready_for_simulation",
-      "risk_state": "within_limits",
-      "performance_state": "underperforming_benchmark",
-      "source_readiness": "ready",
-      "latest_action": "simulate_rebalance"
+      "module_states": {
+        "source_data_readiness": "ready",
+        "mandate_operating_state": "attention_required",
+        "risk_posture": "ready",
+        "performance_posture": "attention_required",
+        "proof_and_reporting": "ready"
+      },
+      "recommended_actions": [
+        {
+          "action": "simulate_rebalance",
+          "eligible": true,
+          "reason": "Source data and mandate policy are ready."
+        }
+      ]
     }
   ],
   "supportability": {
     "state": "ready",
     "degraded_sources": [],
     "blocked_sources": [],
-    "freshness": {
-      "core": "ready",
-      "manage": "ready",
-      "risk": "ready",
-      "performance": "ready",
-      "report": "ready"
-    }
+    "support_reference": "dpm-command-center-20260410-001"
   },
   "lineage": {
-    "contract": "DpmCommandCenter:v1",
     "source_systems": ["lotus-core", "lotus-manage", "lotus-risk", "lotus-performance", "lotus-report"],
-    "correlation_id": "dpm-command-center-20260410-001"
+    "domain_products": [
+      "DpmSourceReadiness:v1",
+      "DpmMandateHealth:v1",
+      "RiskConcentration:v1",
+      "PerformanceAttribution:v1"
+    ]
   }
 }
 ```
 
-### 5.4 Single-Mandate Detail Shape
+### 8.5 Single-Mandate Detail Required Sections
 
-The single mandate response should contain these sections:
+| Section | Required fields |
+| --- | --- |
+| `mandate_identity` | portfolio id, mandate id, book id, model id, benchmark id, region, currency, PM owner, policy version, review cadence |
+| `command_summary` | overall state, health score, health band, primary reason, top exception, recommended next action |
+| `source_data_readiness` | holdings readiness, market data coverage, tax lot readiness, eligibility readiness, source freshness, lineage bundle |
+| `mandate_operating_state` | digital twin state, drift dimensions, constraints, restrictions, cash posture, rebalance readiness, workflow gates, active run refs |
+| `risk_posture` | concentration state, drawdown state, liquidity/stress state where available, active risk, risk attribution, calculation supportability |
+| `performance_posture` | return path state, contribution, attribution, benchmark-relative state, horizon trend, calculation supportability |
+| `proof_and_reporting` | proof-pack readiness, report batch state, latest generated report refs, blocked/degraded report reasons |
+| `evidence_archive` | archive refs, document metadata refs, controlled download refs, retention/access posture |
+| `narrative_support` | optional AI summary, task-flow posture, handoff refs, bounded supportability |
+| `recommended_actions` | review, simulate, generate proof pack, investigate source, investigate risk, investigate performance, defer, escalate |
+| `observability` | support reference, upstream source states, low-cardinality reason codes, correlation scope |
 
-1. `mandate_identity`
-   portfolio id, mandate id, model portfolio id, policy version, review cadence, PM ownership,
-   booking center, currency, benchmark, client segment.
-2. `command_summary`
-   overall state, business explanation, health score, priority action, severity, due date.
-3. `core_source_state`
-   holdings readiness, market data coverage, eligibility, tax lots, model binding, freshness.
-4. `dpm_operating_state`
-   digital twin status, drift, constraints, cash needs, restrictions, rebalance readiness, workflow
-   gates, active run refs.
-5. `risk_posture`
-   risk state, concentration, drawdown, liquidity, stress, active-risk signal, unavailable/degraded
-   reasons.
-6. `performance_posture`
-   return path, contribution, attribution, benchmark-relative signal, horizon trend,
-   unavailable/degraded reasons.
-7. `proof_and_reporting`
-   latest proof pack, report batch state, archive refs.
-8. `recommended_actions`
-   review, simulate, approve, defer, investigate source data, investigate risk, investigate
-   performance, generate proof pack.
-9. `evidence_refs`
-   source system refs, data product ids, calculation supportability, generated document refs.
-10. `observability`
-   bounded support reference, route, panel, upstream status class, degraded source labels.
+### 8.6 Action Handoff Contract
+
+`POST /api/v1/dpm/command-center/mandates/{portfolio_id}/actions/simulate` must:
+
+1. verify the requested action is eligible from the latest command-center state,
+2. verify source readiness and manage rebalance readiness,
+3. route to `lotus-manage` stateful simulation,
+4. preserve idempotency/replay posture where manage exposes it,
+5. return product-safe run refs and next action,
+6. not call risk or performance synchronously as part of the simulate action unless future manage
+   or Gateway contract explicitly requires it.
+
+Blocked action response example:
+
+```json
+{
+  "action": "simulate_rebalance",
+  "eligible": false,
+  "state": "blocked",
+  "blocked_reason": "source_data_readiness_blocked",
+  "business_message": "Simulation is blocked because market data coverage is stale for required holdings.",
+  "remediation_owner": "lotus-core",
+  "support_reference": "dpm-command-center-action-20260410-001"
+}
+```
 
 ---
 
-## 6. Supportability and Degradation Model
+## 9. Supportability and Degradation
 
-Gateway must return a useful payload even when some upstreams are degraded. It should use a common
-state taxonomy:
+Gateway must use this common taxonomy.
 
-| State | Meaning | Workbench behavior |
+| State | Meaning | Action behavior |
 | --- | --- | --- |
-| `ready` | Required data and calculations are available. | Render the module as actionable. |
-| `attention_required` | Data is available but business posture requires PM review. | Promote the exception and next action. |
-| `degraded` | Optional or secondary input is unavailable, but the core command-center view is usable. | Render the module with explanation and no fake values. |
-| `blocked` | Required input is missing or invalid. | Block dependent actions and show remediation owner. |
-| `stale` | Input is outside freshness tolerance. | Mark stale and prevent time-sensitive actions. |
-| `not_supported` | Capability is intentionally unavailable for the mandate or region. | Render a truthful unavailable state. |
+| `ready` | Required data and calculations are available. | Dependent action may be enabled if entitlement allows. |
+| `attention_required` | Data is available but business posture requires review. | Action may be enabled or gated by severity. |
+| `degraded` | Optional or secondary input is unavailable; core command-center view remains usable. | Dependent action disabled only if the degraded source is required for that action. |
+| `blocked` | Required input is missing, invalid, unauthorized, or failed. | Dependent action disabled. |
+| `stale` | Input is outside freshness tolerance. | Time-sensitive action disabled unless policy allows stale read-only display. |
+| `not_supported` | Capability is intentionally unavailable for mandate, product, or region. | Do not show as failure; hide or render unavailable module. |
+| `not_requested` | Optional module was not requested. | Do not count as degraded. |
+| `unavailable` | Upstream could not be contacted or returned unusable data. | Render with support reference and retry/remediation path. |
 
-Supportability must identify:
+Every degraded or blocked module must include:
 
-1. affected module,
+1. module id,
 2. upstream owner,
 3. reason code,
 4. business impact,
-5. blocked action, if any,
-6. remediation route.
+5. blocked actions,
+6. remediation owner,
+7. support reference,
+8. freshness or last-known-good timestamp when available.
 
 ---
 
-## 7. Data Mesh and Enterprise Requirements
+## 10. Security, Entitlement, and Sensitive-Data Rules
 
-Every composed response must carry:
+Gateway must enforce front-office entitlement before returning command-center payloads.
 
-1. domain product identity where available,
-2. source system,
-3. as-of date,
-4. freshness timestamp,
-5. calculation supportability,
-6. source lineage,
-7. contract version,
-8. support reference,
-9. bounded audit event,
-10. metrics labels limited to approved low-cardinality values.
+Required controls:
 
-Forbidden in logs, metrics, or diagnostics:
+1. portfolio/book access check,
+2. action entitlement check,
+3. protected diagnostics entitlement check,
+4. archive/download entitlement pass-through,
+5. AI narrative entitlement where AI module is requested,
+6. product-safe error handling for unauthorized or forbidden reads.
+
+Forbidden in logs, metrics, diagnostics, and audit records:
 
 1. client name,
 2. raw holdings list,
-3. transaction details,
-4. prompt text,
-5. model output,
-6. raw entitlement state,
-7. request or response body,
-8. trace ids exposed to unauthorized users.
+3. raw tax lots,
+4. transaction details,
+5. request body,
+6. response body,
+7. raw prompt,
+8. model output,
+9. raw entitlement details,
+10. high-cardinality portfolio/client/holding identifiers in metric labels.
+
+Portfolio id may appear in API response and test evidence where it is the requested resource, but
+must not appear as an unbounded metric label.
 
 ---
 
-## 8. OpenAPI and Certification Requirements
+## 11. Observability and Data Mesh Requirements
 
-All new Gateway endpoints must be certified before they can be called by Workbench:
+Every route must produce RFC-0108-aligned observability:
 
-1. grouped under `DPM Command Center`,
-2. endpoint description explains what, when, why, and how to use it,
-3. request parameters include type, description, allowed values, and examples,
-4. every response attribute has description, type, and example,
-5. full ready, degraded, blocked, and stale examples,
-6. error examples for upstream timeout, authorization failure, missing portfolio, and unsupported
-   mandate,
-7. response schemas avoid `Any` and untyped dictionaries,
-8. endpoint tests prove examples remain valid,
-9. no duplicate aliases or compatibility routes,
-10. vocabulary aligns with Lotus API vocabulary governance.
+1. bounded fan-out metrics by `operation`, `upstream_service`, `status_class`, and degraded
+   `reason`,
+2. structured logs with support reference and low-cardinality route/operation state,
+3. audit events for allowed reads, denied reads, protected diagnostics lookup, and action handoff,
+4. diagnostics lookup that returns product-safe source state and never raw payloads,
+5. trace correlation internally without leaking trace ids to unauthorized users.
+
+Every successful response must carry:
+
+1. contract name and version,
+2. as-of date,
+3. generated timestamp,
+4. source systems,
+5. domain products where available,
+6. lineage refs,
+7. freshness refs,
+8. supportability summary,
+9. calculation supportability for risk/performance modules where upstream provides it,
+10. source support references.
+
+Mesh certification must validate that Gateway is a consumer/composer and not a new authority for
+upstream domain products.
 
 ---
 
-## 9. Implementation Slices
+## 12. OpenAPI and API Certification Requirements
 
-### Slice 0: RFC and Contract Alignment
+All endpoints in this RFC must be certified before Workbench implementation begins.
 
-1. Finalize this RFC with Workbench RFC-0098.
-2. Confirm exact upstream endpoints and supported modules.
-3. Validate that `lotus-manage` RFC-0038 outputs are sufficient for manage-side health.
-4. Identify missing risk/performance/report fields as upstream issues, not local Gateway hacks.
+Swagger requirements:
+
+1. group under `DPM Command Center`,
+2. explain what the endpoint is for,
+3. explain when to use it,
+4. explain how Workbench and operators should interpret degraded states,
+5. include request parameter type, description, allowed values, and examples,
+6. include every response attribute with description, type, and example,
+7. include full examples for ready, attention-required, degraded, blocked, stale, and
+   not-supported cases,
+8. include error examples for missing portfolio, unauthorized, forbidden, upstream timeout,
+   upstream malformed response, and unsupported mandate,
+9. use typed schemas only; no `Any`-style response contracts,
+10. avoid endpoint aliases and duplicate compatibility paths,
+11. pass API vocabulary and no-alias governance,
+12. include example validation tests that fail if Swagger examples drift from executable schemas.
+
+---
+
+## 13. Implementation Slices
+
+### Slice 0: RFC, Contract, and Branch Readiness
+
+Scope:
+
+1. finalize this RFC and Workbench RFC-0098 together,
+2. verify implementation branch and branch hygiene,
+3. confirm no PR is opened until RFC readiness is accepted,
+4. record upstream endpoint inventory and gaps,
+5. create issues for upstream missing fields if required.
 
 Acceptance:
 
-1. RFC has app-by-app responsibility map.
-2. Workbench RFC references this RFC as its only command-center data source.
-3. Missing upstream fields are listed with owner and required reason.
+1. Gateway and Workbench RFCs agree on endpoint family, module ids, states, and proof expectations.
+2. Upstream matrix has owner, endpoint, required/optional status, and fallback behavior.
+3. No implementation begins with unresolved route naming ambiguity.
 
-### Slice 1: Composition Models and Client Boundaries
+### Slice 1: Platform Automation and Scaffolding Improvement Slice
 
-1. Add typed Gateway models for command-center summary, mandate detail, evidence refs, and
-   supportability.
-2. Add dedicated upstream client methods for only the required service endpoints.
-3. Keep fan-out bounded and timeout-governed.
-4. Preserve upstream supportability without recomputation.
+Scope:
 
-Acceptance:
-
-1. Unit tests prove model parsing and degraded states.
-2. Contract tests prove no raw upstream payload leak.
-3. Typecheck and lint pass.
-
-### Slice 2: Book-Level Command Center Endpoint
-
-1. Implement `GET /api/v1/dpm/command-center`.
-2. Compose book-level mandate posture from manage plus source supportability from core.
-3. Add optional risk/performance/report modules when requested.
-4. Return partial-ready payloads with source-level degradation.
+1. identify Gateway or platform scaffolding gaps that would affect this RFC,
+2. check whether OpenAPI certification, Swagger examples, observability, health, structured
+   logging, error handling, test scaffolding, CI defaults, wiki scaffolding, and governance hooks
+   are already scaffolded for a new Gateway endpoint family,
+3. improve platform automation when the gap is cross-cutting,
+4. improve Gateway-local reusable endpoint scaffolding only when the gap is Gateway-specific.
 
 Acceptance:
 
-1. Ready, degraded, blocked, and stale cases tested.
-2. Empty book and unauthorized book cases tested.
+1. Cross-cutting gaps are fixed in `lotus-platform`, not locally duplicated, when applicable.
+2. Gateway endpoint scaffolding supports typed schemas, example validation, supportability,
+   observability, and contract tests.
+3. Any no-change decision is explicit and evidence-backed.
+
+### Slice 2: Cleanup and Structure Slice
+
+Scope:
+
+1. remove stale DPM command-center drafts or duplicate route ideas if found,
+2. align RFC index, repo context, README, and wiki roadmap,
+3. keep long-lived business/product material in wiki source where appropriate,
+4. avoid duplicating full RFC detail in wiki,
+5. keep Gateway domain boundary documentation aligned with RFC-0082.
+
+Acceptance:
+
+1. Documentation truth is not split across stale docs.
+2. Wiki source has business-readable roadmap summary.
+3. `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` passes before merge.
+
+### Slice 3: Composition Models and Upstream Clients
+
+Scope:
+
+1. add typed command-center models,
+2. add explicit upstream client methods,
+3. implement bounded fan-out coordinator,
+4. implement supportability normalization,
+5. preserve upstream calculation supportability without recomputation.
+
+Acceptance:
+
+1. Unit tests cover ready, attention, degraded, blocked, stale, not-supported, unavailable, and
+   not-requested states.
+2. Client tests cover timeout, malformed response, 401/403, 404, and partial-readiness behavior.
+3. Contract tests prove raw upstream payloads do not leak.
+
+### Slice 4: Book-Level Command Center Endpoint
+
+Scope:
+
+1. implement `GET /api/v1/dpm/command-center`,
+2. support filters and include modules,
+3. return mandate queue and book-level counts,
+4. preserve module states and supportability,
+5. do not require optional risk/performance/report modules for base source/manage rendering.
+
+Acceptance:
+
+1. Book route returns canonical `PB_SG_GLOBAL_BAL_001` in local proof when seeded.
+2. Empty book, unauthorized book, and degraded upstream cases are tested.
 3. OpenAPI examples validate.
 
-### Slice 3: Single-Mandate Detail Endpoint
+### Slice 5: Single-Mandate Detail Endpoint
 
-1. Implement `GET /api/v1/dpm/command-center/mandates/{portfolio_id}`.
-2. Compose mandate identity, manage state, risk, performance, reporting, and evidence refs.
-3. Preserve domain ownership labels per section.
-4. Add action affordances based on manage readiness and supportability.
+Scope:
 
-Acceptance:
-
-1. Canonical portfolio `PB_SG_GLOBAL_BAL_001` returns a complete detail contract in live proof.
-2. Missing optional analytics degrade cleanly.
-3. Blocked source readiness prevents simulate action.
-
-### Slice 4: Evidence Endpoint and Proof-Pack Handoff
-
-1. Implement `GET /api/v1/dpm/command-center/mandates/{portfolio_id}/evidence`.
-2. Include source refs, calculation supportability, generated report refs, archive refs, and
-   support references.
-3. Do not expose raw holdings, raw report content, raw prompts, or model outputs.
+1. implement `GET /api/v1/dpm/command-center/mandates/{portfolio_id}`,
+2. compose all required sections,
+3. expose action eligibility from Gateway-shaped manage readiness,
+4. preserve domain ownership labels and evidence refs.
 
 Acceptance:
 
-1. Evidence contract supports Workbench drawer and sales/demo explanation.
-2. Archive links are controlled Gateway links.
-3. Audit tests prove protected fields are absent.
+1. Canonical portfolio returns complete detail when upstreams are ready.
+2. Optional modules degrade truthfully.
+3. Blocked source readiness disables simulation.
+4. Workbench contract test fixture is created from the schema, not hand-waved.
 
-### Slice 5: Simulate Action Handoff
+### Slice 6: Evidence Endpoint and Protected Diagnostics
 
-1. Implement `POST /api/v1/dpm/command-center/mandates/{portfolio_id}/actions/simulate`.
-2. Route to `lotus-manage` stateful rebalance simulation.
-3. Require Gateway to verify source readiness and mandate action eligibility before handoff.
-4. Return a product-friendly action result with run refs and next action.
+Scope:
 
-Acceptance:
-
-1. Ready state calls manage and returns run refs.
-2. Blocked state does not call manage.
-3. Idempotency and replay posture are tested where manage supports it.
-
-### Slice 6: Observability, Security, and Governance
-
-1. Add RFC-0108-aligned fan-out logs and metrics.
-2. Add bounded audit events for allowed reads, denied reads, protected diagnostics, and action
-   handoff.
-3. Add security and entitlement checks consistent with existing Gateway contracts.
-4. Add diagnostics lookup without leaking raw payloads.
+1. implement `GET /api/v1/dpm/command-center/mandates/{portfolio_id}/evidence`,
+2. include source refs, lineage, calculation supportability, proof/report refs, archive refs, and
+   support references,
+3. implement protected diagnostics lookup if not already covered by RFC-0108 diagnostics,
+4. exclude sensitive/raw fields.
 
 Acceptance:
 
-1. Metrics labels are low-cardinality.
-2. Audit records exclude forbidden fields.
-3. Unauthorized users receive product-safe errors.
+1. Evidence supports Workbench drawer and operations triage.
+2. Audit tests prove forbidden fields are absent.
+3. Archive links are Gateway-controlled links, not raw service links.
 
-### Slice 7: Canonical Proof and Test Pyramid
+### Slice 7: Simulate Action Handoff
 
-1. Add unit tests for model mapping and supportability.
-2. Add integration tests for composed Gateway behavior.
-3. Add contract tests for Workbench-facing payload stability.
-4. Add live canonical validation for `PB_SG_GLOBAL_BAL_001`.
-5. Capture request/response evidence in non-git tracked output.
+Scope:
+
+1. implement `POST /api/v1/dpm/command-center/mandates/{portfolio_id}/actions/simulate`,
+2. validate latest action eligibility,
+3. call `lotus-manage` stateful simulation,
+4. preserve idempotency/replay posture where available,
+5. return product-safe run refs and next actions.
+
+Acceptance:
+
+1. Eligible state calls manage and returns run refs.
+2. Ineligible state does not call manage.
+3. Timeout, denied, malformed response, and manage-degraded cases are tested.
+4. Audit event records action handoff without forbidden fields.
+
+### Slice 8: Implementation Proof Slice
+
+Scope:
+
+1. prove all Gateway endpoints against mocked and live upstream behavior,
+2. bring up canonical front-office stack,
+3. validate core/manage integration and optional risk/performance/report/archive modules,
+4. capture request/response evidence in non-git tracked output,
+5. critically review evidence for gaps and iterate.
 
 Acceptance:
 
 1. Feature lane and PR merge gate pass.
-2. Canonical live stack proves core, manage, risk, performance, report, and archive composition or
-   truthful degradation.
-3. No unsupported Workbench panel claim is made from backend-only proof.
+2. Live canonical proof passes for `PB_SG_GLOBAL_BAL_001`.
+3. Evidence includes at least one ready path and one degraded or blocked path.
+4. Backend proof does not claim Workbench UI completion until Workbench RFC-0098 is implemented.
 
-### Slice 8: Documentation, Wiki, and Closure
+### Slice 9: Second-Last Hardening and Review Slice
 
-1. Update README, repository context, RFC index, and wiki.
-2. Add business-facing documentation with diagrams.
-3. Add operator runbook for troubleshooting degraded command-center sources.
-4. Record supported features only after implementation proof.
+Scope:
+
+1. perform full code review of the implementation,
+2. verify API certification pattern compliance,
+3. verify platform governance and enterprise data mesh standards,
+4. verify Swagger quality,
+5. verify error handling and tests,
+6. remove dead code and duplicate endpoints,
+7. review latency and fan-out behavior.
 
 Acceptance:
 
-1. Wiki is useful to business, engineering, sales, marketing, and operations.
-2. `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` passes before merge.
-3. Post-merge wiki publish is completed.
+1. No duplicate DPM command-center endpoints remain.
+2. All Swagger attributes have description, type, and example.
+3. Error handling is complete and tested.
+4. Fan-out latency and timeout behavior are measured or bounded.
+
+### Slice 10: Final Closure Slice
+
+Scope:
+
+1. update README, repo context, RFC index, wiki, and supported-features material,
+2. publish wiki after merge,
+3. update agent context or skills if this creates reusable guidance,
+4. verify branch hygiene,
+5. record final gold-pass assessment in this RFC.
+
+Acceptance:
+
+1. Documentation is useful to business, engineering, sales, marketing, operations, and client-demo
+   audiences.
+2. Supported features are implementation-backed, not aspirational.
+3. Wiki check-only passes before merge and publish succeeds after merge.
+4. Final section records what was completed, debt removed, proof captured, and remaining work.
 
 ---
 
-## 10. Testing Strategy
+## 14. Test Pyramid
 
-| Layer | Coverage |
+| Layer | Required proof |
 | --- | --- |
-| Unit | model normalization, supportability mapping, action affordance logic, upstream error mapping |
-| Contract | response schema stability, OpenAPI examples, forbidden-field checks, vocabulary checks |
-| Integration | composed route behavior with mocked upstreams, partial readiness, blocked action flows |
-| E2E/live | canonical core/manage/risk/performance/report/archive composition for `PB_SG_GLOBAL_BAL_001` |
-| Observability | audit events, metrics labels, diagnostics lookup, denied-read posture |
+| Unit | model normalization, state mapping, action eligibility, supportability, forbidden-field filtering |
+| Client/unit | upstream success, timeout, 401/403, 404, malformed response, stale data, optional module omitted |
+| Contract | Workbench-facing schema stability, OpenAPI examples, vocabulary/no-alias checks |
+| Integration | composed route behavior with mocked upstreams and partial readiness |
+| E2E/live | canonical core/manage/risk/performance/report/archive composition or truthful degradation |
+| Observability | audit events, bounded metrics, diagnostics lookup, denied-read posture |
+| Performance | bounded fan-out latency, timeout behavior, no serial calls where safe parallel calls are possible |
 
-Tests must validate figures and states, not only status codes.
+Tests must validate business states and returned figures where figures are present. Status-code-only
+tests are not enough.
 
 ---
 
-## 11. Risks and Controls
+## 15. Canonical Evidence Package
+
+Implementation proof must produce a non-git-tracked evidence folder, for example:
+
+`output/live-demo/<timestamp>/dpm-command-center-gateway/`
+
+Required artifacts:
+
+1. book route request and response,
+2. single mandate request and response for `PB_SG_GLOBAL_BAL_001`,
+3. evidence route request and response,
+4. simulate action eligible request/response,
+5. simulate action blocked request/response,
+6. OpenAPI excerpt or validation result,
+7. supportability summary,
+8. source matrix showing core/manage/risk/performance/report/archive/AI state,
+9. latency/fan-out summary,
+10. critical review notes explaining any degraded or deferred module.
+
+---
+
+## 16. Risks and Controls
 
 | Risk | Control |
 | --- | --- |
-| Gateway becomes a domain calculation layer | Preserve upstream ownership and only compose product state. |
+| Gateway becomes a domain calculation layer | Preserve upstream ownership and do only product composition. |
 | Workbench bypasses Gateway | Workbench RFC-0098 requires Gateway-only consumption. |
-| Partial upstream outages create misleading UI | Use explicit degraded, blocked, stale, and not-supported states. |
-| Sensitive data leaks into diagnostics | Apply RFC-0108 audit and metrics restrictions. |
-| API sprawl | Create one strategic endpoint family and remove/avoid duplicates. |
-| Demo claims exceed implementation truth | Promote supported features only after live evidence. |
+| Optional upstream degradation blocks the whole command center | Module-level supportability and include semantics. |
+| Sensitive data leaks into diagnostics | RFC-0108 forbidden-field tests and protected diagnostics. |
+| API sprawl | One strategic endpoint family, no aliases. |
+| Demo claims exceed implementation | Supported-features promotion only after live evidence. |
+| Latency grows due cross-service fan-out | Bounded fan-out, timeouts, parallel upstream calls where safe, latency evidence. |
+| Upstream fields missing | Create upstream issues with owner and field-level requirement; do not fabricate local truth. |
 
 ---
 
-## 12. Definition of Done
+## 17. Definition of Done
 
 This RFC is complete only when:
 
-1. all strategic Gateway DPM command-center endpoints are implemented and certified,
-2. OpenAPI is complete with examples and attribute descriptions,
-3. Workbench consumes this Gateway contract without direct raw service calls,
-4. canonical live proof passes for `PB_SG_GLOBAL_BAL_001`,
-5. source degradation is truthful and action-blocking where required,
-6. audit, metrics, diagnostics, and entitlement checks meet Gateway standards,
-7. README, wiki, RFC index, and supported-features material are updated,
-8. all CI lanes pass,
-9. post-merge wiki publication is complete,
-10. no duplicate command-center endpoints remain.
+1. all strategic DPM command-center endpoints are implemented,
+2. all endpoints are API-certified,
+3. OpenAPI has grouped endpoints, full examples, and attribute-level descriptions,
+4. Gateway composes core, manage, risk, performance, report, archive, and optional AI posture or
+   truthfully reports unavailable/degraded modules,
+5. action eligibility prevents unsafe simulate handoff,
+6. Workbench RFC-0098 has a stable contract to consume,
+7. canonical live proof passes for `PB_SG_GLOBAL_BAL_001`,
+8. request/response evidence is captured and critically reviewed,
+9. audit, metrics, diagnostics, entitlement, and security tests pass,
+10. latency/fan-out behavior is bounded and documented,
+11. README, repo context, RFC index, wiki, and supported-features material are updated,
+12. CI is green,
+13. wiki is published after merge,
+14. branch and remote hygiene are clean.
 
 ---
 
-## 13. Relationship to Workbench RFC-0098
+## 18. Gold-Pass Assessment Template
 
-This RFC defines the backend composition contract. Workbench RFC-0098 defines the user experience.
-The two RFCs must be implemented as a coordinated delivery program:
+To be completed during the final closure slice:
 
-1. Gateway owns the certified payload.
-2. Workbench owns layout, workflow, interaction, and evidence presentation.
-3. Domain apps own their respective source products.
-4. Platform canonical automation owns repeatable proof and demo seed posture.
+| Assessment Area | Final Result |
+| --- | --- |
+| What was truly completed | TBD |
+| Quality improvements made | TBD |
+| Debt removed | TBD |
+| Tests and live evidence captured | TBD |
+| API certification result | TBD |
+| Data mesh and observability result | TBD |
+| Documentation/wiki result | TBD |
+| Remaining governed follow-up | TBD |
+| Gold-standard conclusion | TBD |
 
-The business outcome is not complete until both RFCs are implemented and validated together.
+---
+
+## 19. Relationship to Workbench RFC-0098
+
+Gateway RFC-0098 is the backend composition contract. Workbench RFC-0098 is the product experience
+that renders this contract into a DPM mandate command center.
+
+The business outcome is not complete until both RFCs are implemented and validated:
+
+1. Gateway composes certified domain products.
+2. Workbench renders the PM workflow.
+3. Domain apps remain authoritative.
+4. Platform canonical automation proves the integrated stack.
+5. README/wiki/demo material explains the feature for business, engineering, operations,
+   sales/pre-sales, marketing, and clients.

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -234,6 +234,63 @@ for missing fields rather than inventing local synthetic truth.
 
 ## 8. Strategic API Contract
 
+### 8.0 Construction Alternatives Module Addendum
+
+RFC-0098 must also realize `lotus-manage` RFC-0039 construction alternatives after the manage
+contract is hardened and live-proven. This is intentionally included in the command-center
+composition RFC so Gateway does not create a second, disconnected DPM construction API family.
+
+Business outcome:
+
+1. portfolio managers compare disciplined construction choices before action,
+2. CIO and investment-control users see trade-off evidence before approval,
+3. tax specialists and operations can inspect turnover, tax, source-readiness, and supportability,
+4. sales/pre-sales can demonstrate that Lotus does not emit one black-box trade list.
+
+Gateway responsibility:
+
+1. expose a Workbench-facing construction-alternatives module within the DPM command-center
+   experience contract,
+2. consume `lotus-manage` `POST /api/v1/construction/alternative-sets/generate`,
+   `GET /api/v1/construction/alternative-sets/{alternative_set_id}`, and
+   `POST /api/v1/construction/alternative-sets/{alternative_set_id}/selections`,
+3. preserve manage method identifiers, method statuses, objective traces, constraint traces,
+   comparison metrics, source supportability, selected alternative, actor, reason code, comment,
+   and correlation id,
+4. add entitlement, tenant, channel, and Workbench action posture without recomputing alternatives,
+5. keep risk and performance figures domain-authoritative; if `lotus-risk` or
+   `lotus-performance` enrichment is unavailable, Gateway surfaces degraded or not-supported state
+   rather than fabricating values.
+
+The initial construction module must support the manage first-wave methods:
+
+| Method | Gateway product treatment |
+| --- | --- |
+| `DO_NOTHING_BASELINE` | Always visible as the governed comparator for accepting current drift. |
+| `HEURISTIC_EXPLAINABLE` | Primary explainable rebalance comparator. |
+| `MIN_TURNOVER` | Low-turnover comparator; may be `PENDING_REVIEW` when turnover budget suppresses intents. |
+| `TAX_AWARE` | Tax-aware posture; must preserve degraded reason codes when authoritative tax/cost/risk/performance enrichment is partial. |
+
+Gateway must not flatten manage statuses into generic success/failure.
+
+| Manage status | Gateway handling |
+| --- | --- |
+| `READY` | Enable Workbench selection if entitlement and downstream preconditions pass. |
+| `PENDING_REVIEW` | Display as review-required; downstream automation remains gated unless explicitly approved by later workflow contract. |
+| `DEGRADED` | Display with supportability and reason codes. |
+| `BLOCKED` | Disable action and show remediation owner. |
+| `INFEASIBLE` | Keep as a rejected alternative with constraint evidence, not as a transport failure. |
+
+Gateway proof must use the manage evidence package from RFC-0039:
+
+1. `output/rfc0039-proof/20260503-172059/04-comparison-matrix.json`,
+2. `output/rfc0039-proof/20260503-173624-canonical-postgres/summary.json`,
+3. validator probe `construction_alternatives_first_wave`.
+
+Gateway implementation must not begin until it validates the current manage OpenAPI for the
+construction endpoint family and confirms whether additional downstream action fields are required
+for Workbench. Missing fields should be raised against `lotus-manage`; Gateway must not infer them.
+
 ### 8.1 Endpoint Family
 
 Gateway must expose one strategic route family:

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_rfc0098_proof_pack_ownership_matches_manage_rfc0040() -> None:
+    rfc = (
+        ROOT / "docs" / "rfcs" / "RFC-0098-dpm-command-center-composition-contract.md"
+    ).read_text(encoding="utf-8")
+    index = (ROOT / "docs" / "rfcs" / "README.md").read_text(encoding="utf-8")
+    api_surface = (ROOT / "wiki" / "API-Surface.md").read_text(encoding="utf-8")
+    integrations = (ROOT / "wiki" / "Integrations.md").read_text(encoding="utf-8")
+
+    assert "RFC-0040 PROOF-PACK OWNERSHIP ALIGNED" in rfc
+    assert "RFC-0040 PROOF-PACK OWNERSHIP ALIGNED" in index
+    assert "`lotus-manage` RFC-0040" in rfc
+    assert "Gateway must not" in rfc
+    assert "treat `lotus-report` as the proof-pack authority" in rfc
+    assert "proof_pack_evidence" in rfc
+    assert "DpmPreTradeProofPack:v1" in rfc
+    assert "proof-pack authority APIs" in integrations
+    assert "not proof-pack authority" in api_surface
+    assert "Gateway does not generate proof packs. That belongs to `lotus-report`." not in rfc

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -49,6 +49,9 @@
   `supportability.feature_key=report.observability.evidence_surface_supportability` from
   `lotus-report` integration capabilities so Workbench can record report evidence-surface
   freshness and supportability without direct service coupling
+- RFC-0098 proof-pack composition must consume `lotus-manage` RFC-0040 proof-pack APIs for
+  proof-pack JSON, section states, hashes, Markdown, report-input payloads, and AI-evidence
+  payloads; `lotus-report` remains report materialization authority, not proof-pack authority
 - report batch schedule list and run-due actions are gateway-first under
   `/api/v1/report-batch-schedules`; schedules remain config-backed in `lotus-report`, and gateway
   does not expose schedule CRUD or scheduler registry management

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -17,11 +17,10 @@
   proposal simulation, proposal persistence, workflow events, approvals, and lineage through
   `/advisory/proposals/*`
 - `lotus-manage`
-  discretionary management run lookup, supportability summary, and capabilities only:
-  `GET /api/v1/rebalance/runs`, `GET /api/v1/rebalance/supportability/summary`, and
-  `GET /api/v1/platform/capabilities`; RFC-0098 proposes the next strategic Gateway DPM
-  command-center family that composes manage mandate health with core, risk, performance,
-  reporting, archive, and optional AI posture
+  discretionary management run lookup, supportability summary, capabilities, and RFC-0040
+  proof-pack authority APIs. RFC-0098 proposes the next strategic Gateway DPM command-center
+  family that composes manage mandate health and proof-pack evidence with core, risk, performance,
+  report materialization, archive, and optional AI posture
 - `lotus-report`
   reporting snapshot, summary, and review payloads
 - `lotus-archive`
@@ -68,5 +67,6 @@
 8. Workbench and other product clients consume `lotus-gateway`; they do not call `lotus-advise` or
    `lotus-manage` directly for proposal or management workflow data
 9. RFC-0098 keeps Gateway as the DPM command-center composition boundary. `lotus-manage` remains
-   the DPM operating-state authority, while `lotus-risk` and `lotus-performance` remain analytics
-   authorities and Workbench remains a renderer of Gateway truth.
+   the DPM operating-state and proof-pack authority, `lotus-report` remains report materialization
+   authority, `lotus-risk` and `lotus-performance` remain analytics authorities, and Workbench
+   remains a renderer of Gateway truth.

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -19,7 +19,9 @@
 - `lotus-manage`
   discretionary management run lookup, supportability summary, and capabilities only:
   `GET /api/v1/rebalance/runs`, `GET /api/v1/rebalance/supportability/summary`, and
-  `GET /api/v1/platform/capabilities`
+  `GET /api/v1/platform/capabilities`; RFC-0098 proposes the next strategic Gateway DPM
+  command-center family that composes manage mandate health with core, risk, performance,
+  reporting, archive, and optional AI posture
 - `lotus-report`
   reporting snapshot, summary, and review payloads
 - `lotus-archive`
@@ -65,3 +67,6 @@
    does not call `lotus-archive` directly
 8. Workbench and other product clients consume `lotus-gateway`; they do not call `lotus-advise` or
    `lotus-manage` directly for proposal or management workflow data
+9. RFC-0098 keeps Gateway as the DPM command-center composition boundary. `lotus-manage` remains
+   the DPM operating-state authority, while `lotus-risk` and `lotus-performance` remain analytics
+   authorities and Workbench remains a renderer of Gateway truth.

--- a/wiki/RFC-Index.md
+++ b/wiki/RFC-Index.md
@@ -16,6 +16,9 @@
   context and agent guidance system
 - RFC-0082
   upstream contract-family classification and boundary hardening
+- RFC-0098
+  proposed DPM command-center composition contract over core, manage, risk, performance, report,
+  archive, and AI domain products
 
 ## Local references
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -14,5 +14,7 @@
 ## Next priorities
 
 1. keep replacing thin pass-through surfaces with clearer product contracts
-2. preserve RFC-0082 boundary discipline as integrations evolve
-3. keep request-convention and runtime guidance explicit for operators and future agents
+2. implement RFC-0098 as the strategic DPM command-center composition contract for Workbench,
+   preserving domain ownership across core, manage, risk, performance, report, archive, and AI
+3. preserve RFC-0082 boundary discipline as integrations evolve
+4. keep request-convention and runtime guidance explicit for operators and future agents


### PR DESCRIPTION
## Summary
- Aligns Gateway RFC-0098 with RFC-0040 proof-pack ownership boundaries.
- Keeps lotus-manage as the proof-pack authority and records Gateway composition as downstream realization work, not a manage-local substitute.

## Proof
- Bounded Gateway documentation commit: `6099ffe docs: align rfc0098 proof pack ownership`.
- No runtime Gateway behavior is claimed as implemented by this PR.

## Post-merge
- Publish Gateway wiki source after merge if repository wiki drift is present.