### PR TITLE
feat: add RFC42 outcome-review gateway BFF routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ It depends on:
 - `lotus-advise`
   proposal simulation, persisted proposal lifecycle, workflow, approval, and lineage capability
 - `lotus-manage`
-  discretionary management run lookup, supportability summary, and platform capability posture
+  discretionary management run lookup, supportability summary, platform capability posture, and
+  RFC-0042 post-trade outcome-review authority through the DPM command-center BFF routes
 - `lotus-report`
   reporting snapshot, summary, review payloads, durable report job lifecycle/search, and
   RFC-0104 batch materialization/status/control/operator-run APIs
@@ -88,6 +89,10 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/intake/*`, `/api/v1/lookups/*`
 - `portfolio`
   `/api/v1/portfolio/*`
+- `dpm-command-center`
+  `/api/v1/dpm/command-center/outcome-reviews*`,
+  `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`,
+  `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
 - `workbench`
   `/api/v1/workbench/*`
 - `reporting`
@@ -240,6 +245,10 @@ Important current parameter conventions:
    `panel=advisor-brief` and `operation=advisor_brief.summary`; upstream `401` and `403` outcomes
    are recorded as permission-blocked denials without portfolio, client, prompt, response-body,
    trace, or raw entitlement fields
+13. DPM command-center outcome-review routes under
+   `/api/v1/dpm/command-center/outcome-reviews*` consume `lotus-manage` RFC-0042 APIs and preserve
+   manage-owned `outcome_review_id`, state, supportability, lineage, hashes, report-input payloads,
+   and AI-evidence payloads without recomputing expected-versus-realized outcome truth
 
 Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 
@@ -252,8 +261,9 @@ Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
   `lotus-archive`, `lotus-ai`
 - downstream ownership rule:
   proposal routes call `lotus-advise` `/advisory/proposals/*`; `lotus-manage` calls are limited to
-  `GET /api/v1/rebalance/runs`, `GET /api/v1/rebalance/supportability/summary`, and
-  `GET /api/v1/platform/capabilities`
+  certified `/api/v1` discretionary management APIs, including run lookup, supportability summary,
+  platform capabilities, and RFC-0042 outcome-review preview/create/search/detail/source-refresh,
+  supportability, report-input, AI-evidence, run lookup, and wave lookup
 - contract rule:
   gateway may reshape, aggregate, and annotate upstream data for product use, but must not assume
   upstream business authority

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -33,8 +33,10 @@ Current repository posture:
 2. the repository is moving from thin pass-through behavior to a cleaner experience-API posture,
 3. performance, proposal, foundation, reporting, and capability aggregation routes are active,
    with proposal simulation/lifecycle/workflow/approval/lineage routed to `lotus-advise`
-   `/advisory/proposals/*` and `lotus-manage` limited to versioned run lookup,
-   supportability summary, and capability posture endpoints,
+   `/advisory/proposals/*`; `lotus-manage` consumption is through versioned `/api/v1` APIs for
+   run lookup, supportability summary, capability posture, and RFC-0042 outcome-review
+   preview/create/search/detail/source-refresh/supportability/report-input/AI-evidence route
+   families,
 4. report job initiation/search/status/event-history/cancellation routes are active for
    gateway-first portfolio review report job workflows under `/api/v1/reports/portfolio-reviews`,
    `/api/v1/report-jobs`, and `/api/v1/report-jobs/*`,
@@ -180,6 +182,13 @@ Most relevant current governance:
 9. report batch gateway routes are an RFC-0104 API/operator boundary only; Workbench batch UI,
    RFC-0105 replay/dashboard operations, and RFC-0106 entitlement certification remain separate
    implementation scopes until explicitly delivered and proven.
+10. RFC-0042 outcome-review Gateway routes are active under
+    `/api/v1/dpm/command-center/outcome-reviews*`,
+    `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`, and
+    `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`. Gateway composes a BFF envelope
+    and supportability summary over manage truth, but it must not recompute outcome dimensions,
+    generate reports, generate AI narrative, infer PM quality, or let Workbench call manage
+    directly.
 
 ## Context Maintenance Rule
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -21,5 +21,5 @@ Governance boundary:
 | RFC-0013 | Workbench Position Valuation Fields | IMPLEMENTED | `docs/rfcs/RFC-0013-workbench-position-valuation-fields.md` |
 | RFC-0014 | Experience API Foundation and Pre-Live Replacement Strategy | PROPOSED | `docs/rfcs/RFC-0014-experience-api-foundation-and-prelive-replacement-strategy.md` |
 | RFC-0015 | Foundation Workspace Experience Contract | IMPLEMENTED | `docs/rfcs/RFC-0015-foundation-workspace-experience-contract.md` |
-| RFC-0098 | DPM Command Center Composition Contract | PROPOSED - RFC-0041/0042 WAVE AND OUTCOME REALIZATION ALIGNED | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
+| RFC-0098 | DPM Command Center Composition Contract | PARTIAL IMPLEMENTATION - RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER COMMAND CENTER PENDING | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
 

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -2,7 +2,7 @@
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | PROPOSED - RFC-0041/0042 WAVE AND OUTCOME REALIZATION ALIGNED |
+| **Status** | PARTIAL IMPLEMENTATION - RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER COMMAND CENTER PENDING |
 | **Created** | 2026-05-03 |
 | **Last Tightened** | 2026-05-05 |
 | **Owner** | `lotus-gateway` |
@@ -10,7 +10,7 @@
 | **Business Sponsor Persona** | DPM head, portfolio manager, CIO desk, investment control, operations, sales/pre-sales |
 | **Depends On** | `lotus-manage` RFC-0037, `lotus-manage` RFC-0038, `lotus-manage` RFC-0040, `lotus-manage` RFC-0041, `lotus-manage` RFC-0042, `lotus-core` RFC-0087, Gateway RFC-0082, Gateway RFC-0108, Workbench RFC-0098 |
 | **Doc Location** | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
-| **Implementation Branch** | `feat/rfc0042-outcome-realization` for RFC-0042 realization alignment |
+| **Implementation Branch** | `feat/rfc42-outcome-review-gateway` for RFC-0042 outcome-review BFF realization |
 
 ---
 
@@ -1126,6 +1126,51 @@ To be completed during the final closure slice:
 | Documentation/wiki result | TBD |
 | Remaining governed follow-up | TBD |
 | Gold-standard conclusion | TBD |
+
+---
+
+## 19. Implementation Progress Ledger
+
+This RFC is not fully implemented. The first ledger-driven slice delivered the RFC-0042
+outcome-review route family so Workbench can later consume Gateway/BFF instead of calling
+`lotus-manage` directly.
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| RFC42-WTBD-001 Gateway outcome-review composition and BFF contract | Implemented in Gateway feature branch; local CI passed; pending PR/merge/live proof closure | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/contract/test_dpm_command_center_contract.py`, `make ci` |
+| RFC-0042 manage authority preservation | Implemented for BFF envelope; Gateway forwards payloads and preserves manage supportability | Service tests prove payload preservation and upstream error forwarding; contract tests prove OpenAPI route family registration and What/When/How guidance |
+| Broader RFC-0098 command-center book, mandate detail, evidence, action handoff, wave composition, proof-pack composition, report/archive/AI modules | Not implemented in this slice | Remains governed by this RFC and the work-to-be-done ledger; no supported-feature claim is made |
+
+Implementation boundaries:
+
+1. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,
+   `POST /api/v1/dpm/command-center/outcome-reviews`,
+   `GET /api/v1/dpm/command-center/outcome-reviews`,
+   `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}`,
+   `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/refresh-sources`,
+   `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/supportability`,
+   `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/report-input`,
+   `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-evidence-input`,
+   `GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`, and
+   `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`.
+2. Gateway does not calculate expected values, realized values, variance, tolerance, hashes,
+   lineage, source freshness, supportability, or review state.
+3. Gateway does not generate reports, render artifacts, archive documents, generate AI narrative,
+   score PM quality, or claim Workbench UI support in this slice.
+4. Workbench product realization remains a separate owning-repository implementation item.
+
+Validation performed on 2026-05-05:
+
+1. Focused changed-surface tests passed: DPM client route tests, DPM command-center service tests,
+   router integration tests, and OpenAPI contract tests.
+2. `make check` passed: lint, format, monetary-float guard, mypy, OpenAPI gate, and 402
+   unit/contract tests.
+3. `make test-integration` passed: 151 integration tests.
+4. `make ci` passed: migration smoke, integration tests, full unit/contract/integration coverage
+   with 88.44 percent total coverage, and `pip-audit` with no known vulnerabilities.
+5. `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reported drift for
+   `API-Surface.md`, `Integrations.md`, and `Roadmap.md` because this branch intentionally updates
+   repo-authored wiki source; wiki publication remains a post-merge closure action.
 
 ---
 

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -44,6 +44,130 @@ class DpmClient:
             operation="manage.rebalance.supportability.summary",
         )
 
+    async def preview_outcome_review(
+        self,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/api/v1/rebalance/outcome-reviews/preview",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.outcome_reviews.preview",
+        )
+
+    async def create_outcome_review(
+        self,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/api/v1/rebalance/outcome-reviews",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.outcome_reviews.create",
+        )
+
+    async def list_outcome_reviews(
+        self,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        cleaned_params = {key: value for key, value in params.items() if value is not None}
+        return await self._get(
+            "/api/v1/rebalance/outcome-reviews",
+            params=cleaned_params,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.outcome_reviews.list",
+        )
+
+    async def get_outcome_review(
+        self,
+        outcome_review_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/outcome-reviews/{outcome_review_id}",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.outcome_reviews.get",
+        )
+
+    async def refresh_outcome_review_sources(
+        self,
+        outcome_review_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/api/v1/rebalance/outcome-reviews/{outcome_review_id}/refresh-sources",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.outcome_reviews.refresh_sources",
+        )
+
+    async def get_outcome_review_supportability(
+        self,
+        outcome_review_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/outcome-reviews/{outcome_review_id}/supportability",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.outcome_reviews.supportability",
+        )
+
+    async def get_outcome_review_report_input(
+        self,
+        outcome_review_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/outcome-reviews/{outcome_review_id}/report-input",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.outcome_reviews.report_input",
+        )
+
+    async def get_outcome_review_ai_evidence_input(
+        self,
+        outcome_review_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/outcome-reviews/{outcome_review_id}/ai-evidence-input",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.outcome_reviews.ai_evidence_input",
+        )
+
+    async def get_run_outcome_review(
+        self,
+        rebalance_run_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/runs/{rebalance_run_id}/outcome-review",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.runs.outcome_review",
+        )
+
+    async def list_wave_outcome_reviews(
+        self,
+        wave_id: str,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        cleaned_params = {key: value for key, value in params.items() if value is not None}
+        return await self._get(
+            f"/api/v1/rebalance/waves/{wave_id}/outcome-reviews",
+            params=cleaned_params,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.outcome_reviews",
+        )
+
     async def get_capabilities(
         self,
         consumer_system: str,
@@ -86,4 +210,25 @@ class DpmClient:
             backoff_seconds=self._retry_backoff_seconds,
             params=params,
             headers=headers,
+        )
+
+    async def _post(
+        self,
+        path: str,
+        body: dict[str, Any],
+        headers: dict[str, str],
+        operation: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}{path}"
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-manage",
+            operation=operation,
+            method="POST",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=headers,
+            json_body=body,
         )

--- a/src/app/contracts/dpm_command_center.py
+++ b/src/app/contracts/dpm_command_center.py
@@ -1,0 +1,135 @@
+from pydantic import BaseModel, Field
+
+
+class DpmOutcomeReviewForwardRequest(BaseModel):
+    body: dict[str, object] = Field(
+        description=(
+            "Request payload forwarded unchanged to the lotus-manage RFC-0042 outcome-review "
+            "authority. Gateway does not calculate expected values, realized values, variance, "
+            "tolerance, hashes, lineage, or review state."
+        ),
+        examples=[
+            {
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "rebalance_run_id": "rr_20260415_001",
+                "proof_pack_id": "ppack_20260415_001",
+                "requested_by": "dpm_sg_1",
+            }
+        ],
+    )
+
+
+class DpmOutcomeReviewRefreshRequest(BaseModel):
+    body: dict[str, object] = Field(
+        default_factory=dict,
+        description=(
+            "Optional refresh controls forwarded unchanged to lotus-manage for RFC-0042 "
+            "source refresh. Empty payload asks manage to use its default source-refresh policy."
+        ),
+        examples=[{"refresh_reason": "late execution fill received", "requested_by": "ops_sg_1"}],
+    )
+
+
+class DpmOutcomeReviewSupportability(BaseModel):
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Authoritative service that owns the outcome-review supportability state.",
+        examples=["lotus-manage"],
+    )
+    authority: str = Field(
+        default="lotus-manage:RFC-0042",
+        description="Business authority and RFC provenance for the returned outcome-review data.",
+        examples=["lotus-manage:RFC-0042"],
+    )
+    state: str = Field(
+        description=(
+            "Manage-published supportability state. Gateway preserves this value and only "
+            "defaults to UNKNOWN when the upstream payload omits explicit supportability."
+        ),
+        examples=["SUPPORTED", "DEGRADED", "BLOCKED", "UNKNOWN"],
+    )
+    reason_codes: list[str] = Field(
+        default_factory=list,
+        description="Manage-published reason codes explaining degraded, blocked, or notable state.",
+        examples=[["POST_TRADE_SOURCE_STALE", "EXECUTION_EVIDENCE_PENDING"]],
+    )
+    blocked_actions: list[str] = Field(
+        default_factory=list,
+        description="Manage-published action identifiers that callers should disable.",
+        examples=[["CREATE_REPORT_INPUT", "REQUEST_AI_NARRATIVE"]],
+    )
+    remediation_owner: str | None = Field(
+        default=None,
+        description=(
+            "Manage-published remediation owner when source or supportability action is needed."
+        ),
+        examples=["Portfolio Operations"],
+    )
+
+
+class DpmOutcomeReviewGatewayResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated across Gateway and lotus-manage.",
+        examples=["corr-rfc42-outcome-review-1"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway BFF contract version for DPM command-center outcome-review responses.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Upstream service that supplied the authoritative payload.",
+        examples=["lotus-manage"],
+    )
+    upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage before Gateway envelope composition.",
+        examples=[200],
+    )
+    supportability: DpmOutcomeReviewSupportability = Field(
+        description=(
+            "Gateway-normalized supportability summary derived from manage-published fields."
+        ),
+    )
+    data: dict[str, object] = Field(
+        description=(
+            "Authoritative manage outcome-review payload preserved for Workbench composition. "
+            "Gateway does not alter manage-owned calculations, hashes, lineage, state, or evidence."
+        ),
+        examples=[
+            {
+                "outcome_review_id": "or_20260415_001",
+                "state": "READY",
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "dimension_results": [
+                    {
+                        "dimension": "cash_weight",
+                        "expected": {"value": "0.0340", "unit": "ratio"},
+                        "realized": {"value": "0.0342", "unit": "ratio"},
+                        "variance": {"value": "0.0002", "unit": "ratio"},
+                        "state": "WITHIN_TOLERANCE",
+                    }
+                ],
+            }
+        ],
+    )
+
+
+class DpmOutcomeReviewErrorDetail(BaseModel):
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Upstream service that rejected or failed the outcome-review request.",
+        examples=["lotus-manage"],
+    )
+    upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage.",
+        examples=[409],
+    )
+    error_code: str = Field(
+        description="Gateway error classification for the failed manage outcome-review request.",
+        examples=["MANAGE_OUTCOME_REVIEW_UPSTREAM_ERROR"],
+    )
+    detail: str = Field(
+        description="Product-safe summary of the manage error payload.",
+        examples=["Outcome review cannot be created until execution evidence is complete."],
+    )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -13,6 +13,7 @@ from app.middleware.correlation import correlation_id_var, correlation_middlewar
 from app.routers.analytics_diagnostics import router as analytics_diagnostics_router
 from app.routers.archive_documents import router as archive_documents_router
 from app.routers.domain_products import router as domain_products_router
+from app.routers.dpm_command_center import router as dpm_command_center_router
 from app.routers.foundation import router as foundation_router
 from app.routers.intake import router as intake_router
 from app.routers.platform import router as platform_router
@@ -67,6 +68,13 @@ app = FastAPI(
                 "Protected operator analytics UI diagnostics lookup with bounded audit posture."
             ),
         },
+        {
+            "name": "DPM Command Center",
+            "description": (
+                "Gateway BFF composition APIs for DPM rebalance-wave and post-trade "
+                "outcome-review workflows backed by lotus-manage authority."
+            ),
+        },
     ],
 )
 setup_logging()
@@ -80,6 +88,7 @@ app.include_router(domain_products_router)
 app.include_router(intake_router)
 app.include_router(foundation_router)
 app.include_router(portfolio_router)
+app.include_router(dpm_command_center_router)
 app.include_router(workbench_router)
 app.include_router(reporting_router)
 app.include_router(reporting_jobs_router)

--- a/src/app/routers/dpm_command_center.py
+++ b/src/app/routers/dpm_command_center.py
@@ -1,0 +1,311 @@
+from fastapi import APIRouter, Path, Query
+
+from app.clients.dpm_client import DpmClient
+from app.config import settings
+from app.contracts.dpm_command_center import (
+    DpmOutcomeReviewForwardRequest,
+    DpmOutcomeReviewGatewayResponse,
+    DpmOutcomeReviewRefreshRequest,
+)
+from app.middleware.correlation import correlation_id_var
+from app.services.dpm_command_center_service import DpmCommandCenterService
+
+router = APIRouter(prefix="/api/v1/dpm/command-center", tags=["DPM Command Center"])
+
+
+def _dpm_command_center_service() -> DpmCommandCenterService:
+    return DpmCommandCenterService(
+        dpm_client=DpmClient(
+            base_url=settings.management_service_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        )
+    )
+
+
+@router.post(
+    "/outcome-reviews/preview",
+    response_model=DpmOutcomeReviewGatewayResponse,
+    summary="Preview outcome review",
+    description=(
+        "What: previews a post-trade expected-versus-realized outcome review through the "
+        "lotus-manage RFC-0042 authority. When: call this before creating a persisted review "
+        "to confirm source readiness, supportability, lineage, and expected review contents. "
+        "How: Gateway forwards the request unchanged to manage and returns a BFF envelope with "
+        "manage-published supportability; Gateway does not calculate outcome dimensions."
+    ),
+)
+async def preview_outcome_review(
+    request: DpmOutcomeReviewForwardRequest,
+) -> DpmOutcomeReviewGatewayResponse:
+    return await _dpm_command_center_service().preview_outcome_review(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/outcome-reviews",
+    response_model=DpmOutcomeReviewGatewayResponse,
+    summary="Create outcome review",
+    description=(
+        "What: creates a persisted post-trade outcome review in lotus-manage. When: call this "
+        "after execution evidence is available and a DPM or operations workflow needs an "
+        "immutable review object. How: Gateway forwards the create payload unchanged and "
+        "preserves manage-owned identifiers, state, hashes, lineage, and supportability."
+    ),
+)
+async def create_outcome_review(
+    request: DpmOutcomeReviewForwardRequest,
+) -> DpmOutcomeReviewGatewayResponse:
+    return await _dpm_command_center_service().create_outcome_review(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/outcome-reviews",
+    response_model=DpmOutcomeReviewGatewayResponse,
+    summary="List outcome reviews",
+    description=(
+        "What: lists manage-owned RFC-0042 outcome reviews for command-center triage. When: "
+        "call this to populate DPM review queues by portfolio, run, wave, state, and source "
+        "freshness posture. How: Gateway passes filters to manage and returns the authoritative "
+        "list payload with a normalized supportability summary."
+    ),
+)
+async def list_outcome_reviews(
+    portfolio_id: str | None = Query(
+        default=None,
+        description="Optional portfolio identifier filter for the outcome-review queue.",
+        examples=["PB_SG_GLOBAL_BAL_001"],
+    ),
+    rebalance_run_id: str | None = Query(
+        default=None,
+        description="Optional rebalance-run identifier filter.",
+        examples=["rr_20260415_001"],
+    ),
+    wave_id: str | None = Query(
+        default=None,
+        description="Optional rebalance-wave identifier filter.",
+        examples=["wave_20260415_sg_balanced"],
+    ),
+    state: str | None = Query(
+        default=None,
+        description="Optional manage-published outcome-review state filter.",
+        examples=["READY"],
+    ),
+    limit: int = Query(
+        default=25,
+        ge=1,
+        le=200,
+        description="Maximum number of outcome-review records to return.",
+        examples=[25],
+    ),
+    cursor: str | None = Query(
+        default=None,
+        description="Opaque pagination cursor returned by manage.",
+        examples=["or_cursor_0025"],
+    ),
+) -> DpmOutcomeReviewGatewayResponse:
+    filters = {
+        "portfolio_id": portfolio_id,
+        "rebalance_run_id": rebalance_run_id,
+        "wave_id": wave_id,
+        "state": state,
+        "limit": limit,
+        "cursor": cursor,
+    }
+    return await _dpm_command_center_service().list_outcome_reviews(
+        filters=filters,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/outcome-reviews/{outcome_review_id}",
+    response_model=DpmOutcomeReviewGatewayResponse,
+    summary="Get outcome review",
+    description=(
+        "What: returns one authoritative manage outcome review. When: call this for DPM "
+        "detail, evidence inspection, and downstream report or AI handoff readiness checks. "
+        "How: Gateway retrieves the manage review by id and preserves the manage payload "
+        "without recalculating expected or realized outcomes."
+    ),
+)
+async def get_outcome_review(
+    outcome_review_id: str = Path(
+        ...,
+        description="Manage-owned outcome-review identifier.",
+        examples=["or_20260415_001"],
+    ),
+) -> DpmOutcomeReviewGatewayResponse:
+    return await _dpm_command_center_service().get_outcome_review(
+        outcome_review_id=outcome_review_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/outcome-reviews/{outcome_review_id}/refresh-sources",
+    response_model=DpmOutcomeReviewGatewayResponse,
+    summary="Refresh outcome review sources",
+    description=(
+        "What: asks manage to refresh source evidence for one outcome review. When: call this "
+        "after late fills, corrected valuations, or stale source diagnostics require a managed "
+        "refresh. How: Gateway forwards refresh controls unchanged and returns manage's updated "
+        "supportability and outcome-review state."
+    ),
+)
+async def refresh_outcome_review_sources(
+    request: DpmOutcomeReviewRefreshRequest,
+    outcome_review_id: str = Path(
+        ...,
+        description="Manage-owned outcome-review identifier to refresh.",
+        examples=["or_20260415_001"],
+    ),
+) -> DpmOutcomeReviewGatewayResponse:
+    return await _dpm_command_center_service().refresh_outcome_review_sources(
+        outcome_review_id=outcome_review_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/outcome-reviews/{outcome_review_id}/supportability",
+    response_model=DpmOutcomeReviewGatewayResponse,
+    summary="Get outcome review supportability",
+    description=(
+        "What: returns manage-published supportability for one outcome review. When: call this "
+        "to decide whether Workbench should enable report generation, AI evidence handoff, or "
+        "source-refresh actions. How: Gateway surfaces manage's state, reason codes, blocked "
+        "actions, and remediation owner without replacing manage policy."
+    ),
+)
+async def get_outcome_review_supportability(
+    outcome_review_id: str = Path(
+        ...,
+        description="Manage-owned outcome-review identifier.",
+        examples=["or_20260415_001"],
+    ),
+) -> DpmOutcomeReviewGatewayResponse:
+    return await _dpm_command_center_service().get_outcome_review_supportability(
+        outcome_review_id=outcome_review_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/outcome-reviews/{outcome_review_id}/report-input",
+    response_model=DpmOutcomeReviewGatewayResponse,
+    summary="Get outcome review report input",
+    description=(
+        "What: returns manage-certified report input for an outcome review. When: call this "
+        "only after supportability shows report input is available. How: Gateway passes through "
+        "the manage report-input contract for downstream report composition without rendering "
+        "or reshaping report content."
+    ),
+)
+async def get_outcome_review_report_input(
+    outcome_review_id: str = Path(
+        ...,
+        description="Manage-owned outcome-review identifier.",
+        examples=["or_20260415_001"],
+    ),
+) -> DpmOutcomeReviewGatewayResponse:
+    return await _dpm_command_center_service().get_outcome_review_report_input(
+        outcome_review_id=outcome_review_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/outcome-reviews/{outcome_review_id}/ai-evidence-input",
+    response_model=DpmOutcomeReviewGatewayResponse,
+    summary="Get outcome review AI evidence input",
+    description=(
+        "What: returns manage-certified evidence input for governed AI narrative workflows. "
+        "When: call this after supportability shows AI evidence is available and the caller "
+        "needs traceable evidence for lotus-ai. How: Gateway preserves manage evidence and "
+        "does not generate narrative or infer missing evidence."
+    ),
+)
+async def get_outcome_review_ai_evidence_input(
+    outcome_review_id: str = Path(
+        ...,
+        description="Manage-owned outcome-review identifier.",
+        examples=["or_20260415_001"],
+    ),
+) -> DpmOutcomeReviewGatewayResponse:
+    return await _dpm_command_center_service().get_outcome_review_ai_evidence_input(
+        outcome_review_id=outcome_review_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/runs/{rebalance_run_id}/outcome-review",
+    response_model=DpmOutcomeReviewGatewayResponse,
+    summary="Get run outcome review",
+    description=(
+        "What: resolves the outcome review linked to one manage rebalance run. When: call this "
+        "from run-centric command-center views that need post-trade outcome state. How: Gateway "
+        "delegates run lookup to manage and returns the linked RFC-0042 review payload."
+    ),
+)
+async def get_run_outcome_review(
+    rebalance_run_id: str = Path(
+        ...,
+        description="Manage-owned rebalance-run identifier.",
+        examples=["rr_20260415_001"],
+    ),
+) -> DpmOutcomeReviewGatewayResponse:
+    return await _dpm_command_center_service().get_run_outcome_review(
+        rebalance_run_id=rebalance_run_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/waves/{wave_id}/outcome-reviews",
+    response_model=DpmOutcomeReviewGatewayResponse,
+    summary="List wave outcome reviews",
+    description=(
+        "What: lists outcome reviews linked to one manage rebalance wave. When: call this from "
+        "wave-centric DPM command-center views to compare post-trade completion across accounts. "
+        "How: Gateway delegates wave lookup to manage and preserves each manage-owned review."
+    ),
+)
+async def list_wave_outcome_reviews(
+    wave_id: str = Path(
+        ...,
+        description="Manage-owned rebalance-wave identifier.",
+        examples=["wave_20260415_sg_balanced"],
+    ),
+    state: str | None = Query(
+        default=None,
+        description="Optional manage-published outcome-review state filter.",
+        examples=["READY"],
+    ),
+    limit: int = Query(
+        default=100,
+        ge=1,
+        le=500,
+        description="Maximum number of wave-linked outcome reviews to return.",
+        examples=[100],
+    ),
+    cursor: str | None = Query(
+        default=None,
+        description="Opaque pagination cursor returned by manage.",
+        examples=["wave_or_cursor_0100"],
+    ),
+) -> DpmOutcomeReviewGatewayResponse:
+    filters = {"state": state, "limit": limit, "cursor": cursor}
+    return await _dpm_command_center_service().list_wave_outcome_reviews(
+        wave_id=wave_id,
+        filters=filters,
+        correlation_id=correlation_id_var.get(),
+    )

--- a/src/app/services/dpm_command_center_service.py
+++ b/src/app/services/dpm_command_center_service.py
@@ -1,0 +1,205 @@
+from typing import Any
+
+from fastapi import HTTPException, status
+
+from app.clients.dpm_client import DpmClient
+from app.config import settings
+from app.contracts.dpm_command_center import (
+    DpmOutcomeReviewErrorDetail,
+    DpmOutcomeReviewGatewayResponse,
+    DpmOutcomeReviewSupportability,
+)
+
+
+class DpmCommandCenterService:
+    def __init__(self, dpm_client: DpmClient):
+        self._dpm_client = dpm_client
+
+    async def preview_outcome_review(
+        self,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmOutcomeReviewGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.preview_outcome_review(
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def create_outcome_review(
+        self,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmOutcomeReviewGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.create_outcome_review(
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def list_outcome_reviews(
+        self,
+        filters: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmOutcomeReviewGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.list_outcome_reviews(
+            params=filters,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_outcome_review(
+        self,
+        outcome_review_id: str,
+        correlation_id: str,
+    ) -> DpmOutcomeReviewGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_outcome_review(
+            outcome_review_id=outcome_review_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def refresh_outcome_review_sources(
+        self,
+        outcome_review_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmOutcomeReviewGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.refresh_outcome_review_sources(
+            outcome_review_id=outcome_review_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_outcome_review_supportability(
+        self,
+        outcome_review_id: str,
+        correlation_id: str,
+    ) -> DpmOutcomeReviewGatewayResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._dpm_client.get_outcome_review_supportability(
+            outcome_review_id=outcome_review_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_outcome_review_report_input(
+        self,
+        outcome_review_id: str,
+        correlation_id: str,
+    ) -> DpmOutcomeReviewGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_outcome_review_report_input(
+            outcome_review_id=outcome_review_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_outcome_review_ai_evidence_input(
+        self,
+        outcome_review_id: str,
+        correlation_id: str,
+    ) -> DpmOutcomeReviewGatewayResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._dpm_client.get_outcome_review_ai_evidence_input(
+            outcome_review_id=outcome_review_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_run_outcome_review(
+        self,
+        rebalance_run_id: str,
+        correlation_id: str,
+    ) -> DpmOutcomeReviewGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_run_outcome_review(
+            rebalance_run_id=rebalance_run_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def list_wave_outcome_reviews(
+        self,
+        wave_id: str,
+        filters: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmOutcomeReviewGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.list_wave_outcome_reviews(
+            wave_id=wave_id,
+            params=filters,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    def _compose_response(
+        self,
+        upstream_status: int,
+        upstream_payload: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmOutcomeReviewGatewayResponse:
+        if upstream_status >= status.HTTP_400_BAD_REQUEST:
+            raise HTTPException(
+                status_code=upstream_status,
+                detail=DpmOutcomeReviewErrorDetail(
+                    upstream_status=upstream_status,
+                    error_code="MANAGE_OUTCOME_REVIEW_UPSTREAM_ERROR",
+                    detail=_safe_upstream_detail(upstream_payload),
+                ).model_dump(),
+            )
+
+        return DpmOutcomeReviewGatewayResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            upstream_status=upstream_status,
+            supportability=_supportability_from(upstream_payload),
+            data=upstream_payload,
+        )
+
+
+def _supportability_from(payload: dict[str, Any]) -> DpmOutcomeReviewSupportability:
+    raw = payload.get("supportability")
+    supportability = raw if isinstance(raw, dict) else payload
+    reason_codes = _list_of_strings(
+        supportability.get("reason_codes")
+        or supportability.get("reasonCodes")
+        or supportability.get("reasons")
+        or []
+    )
+    blocked_actions = _list_of_strings(
+        supportability.get("blocked_actions") or supportability.get("blockedActions") or []
+    )
+    state = (
+        supportability.get("state")
+        or supportability.get("supportability_state")
+        or supportability.get("supportabilityState")
+        or "UNKNOWN"
+    )
+    remediation_owner = supportability.get("remediation_owner") or supportability.get(
+        "remediationOwner"
+    )
+
+    return DpmOutcomeReviewSupportability(
+        state=str(state),
+        reason_codes=reason_codes,
+        blocked_actions=blocked_actions,
+        remediation_owner=str(remediation_owner) if remediation_owner is not None else None,
+    )
+
+
+def _list_of_strings(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _safe_upstream_detail(payload: dict[str, Any]) -> str:
+    detail = payload.get("detail") or payload.get("message") or payload.get("error")
+    if isinstance(detail, str):
+        return detail
+    if detail is not None:
+        return str(detail)
+    return "lotus-manage outcome-review request failed"

--- a/tests/contract/test_dpm_command_center_contract.py
+++ b/tests/contract/test_dpm_command_center_contract.py
@@ -1,0 +1,69 @@
+from fastapi.testclient import TestClient
+
+from app.contracts.dpm_command_center import DpmOutcomeReviewGatewayResponse
+from app.main import app
+
+
+def test_dpm_outcome_review_gateway_response_contract_shape() -> None:
+    response = DpmOutcomeReviewGatewayResponse(
+        correlation_id="corr-1",
+        upstream_status=200,
+        supportability={
+            "state": "SUPPORTED",
+            "reason_codes": ["READY_FOR_REPORT_INPUT"],
+            "blocked_actions": [],
+        },
+        data={
+            "outcome_review_id": "or_1",
+            "state": "READY",
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "expected_snapshot_hash": "sha256:expected",
+        },
+    )
+
+    assert response.source_service == "lotus-manage"
+    assert response.supportability.authority == "lotus-manage:RFC-0042"
+    assert response.data["outcome_review_id"] == "or_1"
+
+
+def test_dpm_command_center_openapi_contract_registered() -> None:
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+    expected_paths = [
+        ("/api/v1/dpm/command-center/outcome-reviews/preview", "post"),
+        ("/api/v1/dpm/command-center/outcome-reviews", "get"),
+        ("/api/v1/dpm/command-center/outcome-reviews", "post"),
+        ("/api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}", "get"),
+        ("/api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/refresh-sources", "post"),
+        ("/api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/supportability", "get"),
+        ("/api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/report-input", "get"),
+        ("/api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-evidence-input", "get"),
+        ("/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review", "get"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews", "get"),
+    ]
+
+    for path, method in expected_paths:
+        assert path in spec["paths"]
+        operation = spec["paths"][path][method]
+        assert operation["tags"] == ["DPM Command Center"]
+        assert operation["summary"]
+        assert "What:" in operation["description"]
+        assert "When:" in operation["description"]
+        assert "How:" in operation["description"]
+
+
+def test_dpm_command_center_openapi_models_are_described() -> None:
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+    schemas = spec["components"]["schemas"]
+    response_schema = schemas["DpmOutcomeReviewGatewayResponse"]
+    supportability_schema = schemas["DpmOutcomeReviewSupportability"]
+
+    for property_schema in response_schema["properties"].values():
+        assert property_schema.get("description")
+
+    for property_schema in supportability_schema["properties"].values():
+        assert property_schema.get("description")
+
+    assert response_schema["properties"]["data"]["description"]
+    assert supportability_schema["properties"]["state"]["examples"]

--- a/tests/integration/test_dpm_command_center_router.py
+++ b/tests/integration/test_dpm_command_center_router.py
@@ -1,0 +1,106 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_dpm_command_center_outcome_review_create_preserves_manage_truth(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_create_outcome_review(self, body, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["body"] = body
+        captured["correlation_id"] = correlation_id
+        return 200, {
+            "outcome_review_id": "or_1",
+            "state": "READY",
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "expected_snapshot_hash": "sha256:expected",
+            "realized_snapshot_hash": "sha256:realized",
+            "supportability": {
+                "state": "SUPPORTED",
+                "reason_codes": ["READY_FOR_REPORT_INPUT"],
+                "blocked_actions": [],
+            },
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.create_outcome_review",
+        _fake_create_outcome_review,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/outcome-reviews",
+        json={"body": {"rebalance_run_id": "rr_1", "proof_pack_id": "ppack_1"}},
+        headers={"X-Correlation-Id": "corr-router-1"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert captured == {
+        "body": {"rebalance_run_id": "rr_1", "proof_pack_id": "ppack_1"},
+        "correlation_id": "corr-router-1",
+    }
+    assert payload["correlation_id"] == "corr-router-1"
+    assert payload["source_service"] == "lotus-manage"
+    assert payload["supportability"]["state"] == "SUPPORTED"
+    assert payload["data"]["expected_snapshot_hash"] == "sha256:expected"
+    assert payload["data"]["realized_snapshot_hash"] == "sha256:realized"
+
+
+def test_dpm_command_center_outcome_review_list_passes_filters(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_list_outcome_reviews(self, params, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["params"] = params
+        captured["correlation_id"] = correlation_id
+        return 200, {
+            "items": [{"outcome_review_id": "or_1", "state": "READY"}],
+            "next_cursor": None,
+            "supportability": {"state": "SUPPORTED"},
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.list_outcome_reviews",
+        _fake_list_outcome_reviews,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/dpm/command-center/outcome-reviews"
+        "?portfolio_id=PB_SG_GLOBAL_BAL_001&state=READY&limit=10",
+        headers={"X-Correlation-Id": "corr-router-2"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "params": {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "rebalance_run_id": None,
+            "wave_id": None,
+            "state": "READY",
+            "limit": 10,
+            "cursor": None,
+        },
+        "correlation_id": "corr-router-2",
+    }
+    assert response.json()["data"]["items"][0]["outcome_review_id"] == "or_1"
+
+
+def test_dpm_command_center_outcome_review_error_is_not_marked_supported(monkeypatch) -> None:
+    async def _fake_get_outcome_review(self, outcome_review_id, correlation_id):  # noqa: ANN001
+        _ = self, outcome_review_id, correlation_id
+        return 404, {"detail": "outcome review not found"}
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_outcome_review",
+        _fake_get_outcome_review,
+    )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/dpm/command-center/outcome-reviews/or_missing")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["error_code"] == "MANAGE_OUTCOME_REVIEW_UPSTREAM_ERROR"
+    assert response.json()["detail"]["detail"] == "outcome review not found"

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -1,0 +1,133 @@
+import pytest
+from fastapi import HTTPException
+
+from app.services.dpm_command_center_service import DpmCommandCenterService
+
+
+class _FakeDpmClient:
+    def __init__(self, result: tuple[int, dict]):
+        self.result = result
+        self.calls: list[dict[str, object]] = []
+
+    async def create_outcome_review(self, body, correlation_id):  # noqa: ANN001
+        self.calls.append({"method": "create", "body": body, "correlation_id": correlation_id})
+        return self.result
+
+    async def get_outcome_review_supportability(self, outcome_review_id, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "supportability",
+                "outcome_review_id": outcome_review_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_dpm_command_center_preserves_manage_payload_and_supportability() -> None:
+    manage_payload = {
+        "outcome_review_id": "or_1",
+        "state": "READY",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "expected_snapshot_hash": "sha256:expected",
+        "supportability": {
+            "state": "SUPPORTED",
+            "reason_codes": ["READY_FOR_REPORT_INPUT"],
+            "blocked_actions": [],
+            "remediation_owner": "Portfolio Operations",
+        },
+    }
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmCommandCenterService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.create_outcome_review(
+        body={"rebalance_run_id": "rr_1"},
+        correlation_id="corr-1",
+    )
+
+    assert response.correlation_id == "corr-1"
+    assert response.source_service == "lotus-manage"
+    assert response.upstream_status == 200
+    assert response.supportability.state == "SUPPORTED"
+    assert response.supportability.reason_codes == ["READY_FOR_REPORT_INPUT"]
+    assert response.data == manage_payload
+    assert client.calls == [
+        {
+            "method": "create",
+            "body": {"rebalance_run_id": "rr_1"},
+            "correlation_id": "corr-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_command_center_supportability_endpoint_handles_flat_payload() -> None:
+    client = _FakeDpmClient(
+        (
+            200,
+            {
+                "state": "DEGRADED",
+                "reasonCodes": ["SOURCE_STALE"],
+                "blockedActions": ["CREATE_REPORT_INPUT"],
+            },
+        )
+    )
+    service = DpmCommandCenterService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.get_outcome_review_supportability(
+        outcome_review_id="or_1",
+        correlation_id="corr-2",
+    )
+
+    assert response.supportability.state == "DEGRADED"
+    assert response.supportability.reason_codes == ["SOURCE_STALE"]
+    assert response.supportability.blocked_actions == ["CREATE_REPORT_INPUT"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["DEGRADED", "BLOCKED", "UNSUPPORTED", "UNAVAILABLE"])
+async def test_dpm_command_center_preserves_manage_supportability_states(state: str) -> None:
+    client = _FakeDpmClient(
+        (
+            200,
+            {
+                "outcome_review_id": "or_1",
+                "supportability": {
+                    "state": state,
+                    "reason_codes": [f"{state}_REASON"],
+                    "blocked_actions": ["CREATE_REPORT_INPUT"] if state == "BLOCKED" else [],
+                },
+            },
+        )
+    )
+    service = DpmCommandCenterService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.create_outcome_review(
+        body={"rebalance_run_id": "rr_1"},
+        correlation_id=f"corr-{state.lower()}",
+    )
+
+    assert response.supportability.state == state
+    assert response.supportability.reason_codes == [f"{state}_REASON"]
+    if state == "BLOCKED":
+        assert response.supportability.blocked_actions == ["CREATE_REPORT_INPUT"]
+
+
+@pytest.mark.asyncio
+async def test_dpm_command_center_forwards_manage_errors_as_product_safe_detail() -> None:
+    client = _FakeDpmClient((409, {"detail": "execution evidence incomplete"}))
+    service = DpmCommandCenterService(dpm_client=client)  # type: ignore[arg-type]
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.create_outcome_review(
+            body={"rebalance_run_id": "rr_1"}, correlation_id="corr-3"
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == {
+        "source_service": "lotus-manage",
+        "upstream_status": 409,
+        "error_code": "MANAGE_OUTCOME_REVIEW_UPSTREAM_ERROR",
+        "detail": "execution evidence incomplete",
+    }

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -11,8 +11,8 @@ def test_rfc0098_ownership_matches_manage_rfc0040_rfc0041_and_rfc0042() -> None:
     api_surface = (ROOT / "wiki" / "API-Surface.md").read_text(encoding="utf-8")
     integrations = (ROOT / "wiki" / "Integrations.md").read_text(encoding="utf-8")
 
-    assert "RFC-0041/0042 WAVE AND OUTCOME REALIZATION ALIGNED" in rfc
-    assert "RFC-0041/0042 WAVE AND OUTCOME REALIZATION ALIGNED" in index
+    assert "RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED" in rfc
+    assert "RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED" in index
     assert "`lotus-manage` RFC-0040" in rfc
     assert "`lotus-manage` RFC-0041" in rfc
     assert "`lotus-manage` RFC-0042" in rfc
@@ -25,6 +25,8 @@ def test_rfc0098_ownership_matches_manage_rfc0040_rfc0041_and_rfc0042() -> None:
     assert "DpmPreTradeProofPack:v1" in rfc
     assert "RFC-0042 Post-Trade Outcome Review Addendum" in rfc
     assert "`GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}`" in rfc
+    assert "`GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`" in rfc
+    assert "`GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`" in rfc
     assert "outcome_review_summary" in rfc
     assert "dimension_outcomes" in rfc
     assert "not recompute outcome truth" in api_surface

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1598,6 +1598,41 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
             },
             "http://dpm/api/v1/platform/capabilities",
         ),
+        (
+            "list_outcome_reviews",
+            {"params": {"portfolio_id": "P1", "state": None}, "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/outcome-reviews",
+        ),
+        (
+            "get_outcome_review",
+            {"outcome_review_id": "or_1", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/outcome-reviews/or_1",
+        ),
+        (
+            "get_outcome_review_supportability",
+            {"outcome_review_id": "or_1", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/outcome-reviews/or_1/supportability",
+        ),
+        (
+            "get_outcome_review_report_input",
+            {"outcome_review_id": "or_1", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/outcome-reviews/or_1/report-input",
+        ),
+        (
+            "get_outcome_review_ai_evidence_input",
+            {"outcome_review_id": "or_1", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/outcome-reviews/or_1/ai-evidence-input",
+        ),
+        (
+            "get_run_outcome_review",
+            {"rebalance_run_id": "rr_1", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/runs/rr_1/outcome-review",
+        ),
+        (
+            "list_wave_outcome_reviews",
+            {"wave_id": "wave_1", "params": {"state": None}, "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/waves/wave_1/outcome-reviews",
+        ),
     ],
 )
 async def test_dpm_client_manage_routes(method_name, kwargs, expected_url):
@@ -1609,6 +1644,44 @@ async def test_dpm_client_manage_routes(method_name, kwargs, expected_url):
     assert status_code == 200
     assert payload["ok"] is True
     assert _FakeAsyncClient.calls[0]["url"] == expected_url
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "kwargs", "expected_url"),
+    [
+        (
+            "preview_outcome_review",
+            {"body": {"portfolio_id": "P1"}, "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/outcome-reviews/preview",
+        ),
+        (
+            "create_outcome_review",
+            {"body": {"rebalance_run_id": "rr_1"}, "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/outcome-reviews",
+        ),
+        (
+            "refresh_outcome_review_sources",
+            {
+                "outcome_review_id": "or_1",
+                "body": {"refresh_reason": "late fill"},
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/outcome-reviews/or_1/refresh-sources",
+        ),
+    ],
+)
+async def test_dpm_client_outcome_review_command_routes(method_name, kwargs, expected_url):
+    client = DpmClient(base_url="http://dpm", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"ok": True})
+
+    method = getattr(client, method_name)
+    status_code, payload = await method(**kwargs)
+    assert status_code == 200
+    assert payload["ok"] is True
+    assert _FakeAsyncClient.calls[0]["method"] == "POST"
+    assert _FakeAsyncClient.calls[0]["url"] == expected_url
+    assert _FakeAsyncClient.calls[0]["json"] == kwargs["body"]
 
 
 @pytest.mark.asyncio

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -13,6 +13,9 @@
 - `POST /api/v1/intake/*`
 - `GET /api/v1/lookups/*`
 - `GET /api/v1/portfolio/*`
+- `GET` and `POST /api/v1/dpm/command-center/outcome-reviews*`
+- `GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`
+- `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
 - `GET` and `POST /api/v1/workbench/*`
 - `GET` and `POST /api/v1/reports/*`
 - `GET /api/v1/report-jobs` and `GET`/`POST /api/v1/report-jobs/*`
@@ -60,11 +63,14 @@
   proof-pack state, or external execution posture.
 - RFC-0098 outcome-review composition must consume `lotus-manage` RFC-0042 outcome-review APIs
   for preview, durable create, search, detail, source refresh, supportability, report input, AI
-  evidence input, run lookup, and wave lookup. Target Gateway routes belong under
-  `/api/v1/dpm/command-center/outcome-reviews*`, preserve manage `outcome_review_id`, state,
-  dimension outcomes, expected values, realized values, variance, tolerances, source refs, source
-  hashes, freshness, report-input posture, AI-evidence posture, and remediation routes, and must
-  not recompute outcome truth, generate reports, generate AI narrative, or infer PM quality.
+  evidence input, run lookup, and wave lookup. Gateway now exposes the first implementation-backed
+  outcome-review BFF route family under `/api/v1/dpm/command-center/outcome-reviews*`,
+  `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`, and
+  `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`. These routes preserve manage
+  `outcome_review_id`, state, dimension outcomes, expected values, realized values, variance,
+  tolerances, source refs, source hashes, freshness, report-input posture, AI-evidence posture,
+  remediation routes, and supportability. They do not recompute outcome truth, generate reports,
+  generate AI narrative, infer PM quality, or let Workbench bypass Gateway.
 - report batch schedule list and run-due actions are gateway-first under
   `/api/v1/report-batch-schedules`; schedules remain config-backed in `lotus-report`, and gateway
   does not expose schedule CRUD or scheduler registry management
@@ -91,8 +97,9 @@
 - proposal writes require `Idempotency-Key`
 - proposal simulation, create, list, detail, version, workflow-event, approval, and lineage routes
   call `lotus-advise` `/advisory/proposals/*`; they do not call `lotus-manage`
-- gateway calls `lotus-manage` only for discretionary management run lookup, supportability
-  summary, and capability posture through versioned `/api/v1/*` paths
+- gateway calls `lotus-manage` only through versioned `/api/v1/*` paths for discretionary
+  management run lookup, supportability summary, capability posture, and RFC-0042
+  outcome-review authority APIs
 - `/metrics` includes RFC-0108 gateway analytics fan-out metrics for selected Workbench analytics
   operations plus the central `lotus-advise`, `lotus-manage`, `lotus-report`, `lotus-archive`,
   `lotus-ai`, direct `lotus-core` query/control-plane, and `lotus-core` ingestion client seams:
@@ -225,6 +232,22 @@ curl -X POST "http://127.0.0.1:8111/api/v1/reports/portfolio-reviews" \
   -H "X-Booking-Center-Code: SG" \
   -H "X-Role: advisor" \
   -d "{\"portfolio_scope\":{\"portfolio_ids\":[\"PB_SG_GLOBAL_BAL_001\"]},\"as_of_date\":\"2026-04-22\",\"requested_output_formats\":[\"json\"],\"reporting_currency\":\"USD\",\"options\":{\"sections\":[\"OVERVIEW\",\"PERFORMANCE\",\"RISK_ANALYTICS\"],\"benchmark_code\":\"BMK_PB_GLOBAL_BALANCED_60_40\"}}"
+```
+
+DPM outcome-review create:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/dpm/command-center/outcome-reviews" \
+  -H "Content-Type: application/json" \
+  -H "X-Correlation-Id: corr-rfc42-outcome-review-1" \
+  -d "{\"body\":{\"portfolio_id\":\"PB_SG_GLOBAL_BAL_001\",\"rebalance_run_id\":\"rr_20260415_001\",\"proof_pack_id\":\"ppack_20260415_001\",\"requested_by\":\"dpm_sg_1\"}}"
+```
+
+DPM outcome-review supportability:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/dpm/command-center/outcome-reviews/or_20260415_001/supportability" \
+  -H "X-Correlation-Id: corr-rfc42-supportability-1"
 ```
 
 Report job status:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -17,11 +17,13 @@
   proposal simulation, proposal persistence, workflow events, approvals, and lineage through
   `/advisory/proposals/*`
 - `lotus-manage`
-  discretionary management run lookup, supportability summary, capabilities, and RFC-0040
-  proof-pack authority APIs. RFC-0098 proposes the next strategic Gateway DPM command-center
-  family that composes manage mandate health, RFC-0041 rebalance-wave orchestration, and
-  proof-pack evidence with core, risk, performance, report materialization, archive, and optional
-  AI posture
+  discretionary management run lookup, supportability summary, capabilities, RFC-0040
+  proof-pack authority APIs, RFC-0041 rebalance-wave orchestration authority APIs, and RFC-0042
+  post-trade outcome-review authority APIs. RFC-0098 remains the strategic Gateway DPM
+  command-center contract; the RFC-0042 outcome-review BFF route family is now
+  implementation-backed, while broader mandate health, RFC-0041 wave composition, proof-pack
+  modules, report materialization, archive, and optional AI posture remain governed follow-on
+  slices until implemented and proven
 - `lotus-report`
   reporting snapshot, summary, and review payloads
 - `lotus-archive`
@@ -74,4 +76,7 @@
 10. RFC-0042 outcome reviews remain `lotus-manage` truth. Gateway outcome-review realization must
     compose expected-versus-realized review summaries, dimension outcomes, source lineage,
     supportability, report-input posture, and AI-evidence posture without recomputing outcome
-    values or calling source-owner apps behind manage's review authority.
+    values or calling source-owner apps behind manage's review authority. The implemented Gateway
+    route family is `/api/v1/dpm/command-center/outcome-reviews*`,
+    `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`, and
+    `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`.

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -14,13 +14,15 @@
 ## Next priorities
 
 1. keep replacing thin pass-through surfaces with clearer product contracts
-2. implement RFC-0098 as the strategic DPM command-center composition contract for Workbench,
+2. continue implementing RFC-0098 as the strategic DPM command-center composition contract for
+   Workbench,
    preserving domain ownership across core, manage, risk, performance, report, archive, and AI.
    The RFC now includes RFC-0041 rebalance-wave realization so Gateway can plan wave preview,
    source-check, simulation, selection, approval, staging, handoff, and supportability composition
    without becoming the wave authority. It also includes RFC-0042 post-trade outcome-review
-   realization so Gateway can plan expected-versus-realized review composition, source-lineage
-   preservation, supportability, report-input, and AI-evidence input routes without recomputing
-   manage outcome truth.
+   realization; the first implementation-backed outcome-review BFF route family is active under
+   `/api/v1/dpm/command-center/outcome-reviews*`, run lookup, and wave lookup routes, preserving
+   manage source-lineage, supportability, report-input, and AI-evidence truth without recomputing
+   expected-versus-realized outcomes.
 3. preserve RFC-0082 boundary discipline as integrations evolve
 4. keep request-convention and runtime guidance explicit for operators and future agents


### PR DESCRIPTION
## Summary
- Add RFC-0042 outcome-review Gateway/BFF route family under `/api/v1/dpm/command-center/outcome-reviews*`, run lookup, and wave lookup routes.
- Preserve `lotus-manage` as the outcome-review authority; Gateway does not recompute expected/realized outcomes, hashes, lineage, supportability, report input, or AI evidence.
- Update README, RFC-0098, repo context, wiki source, and tests with implementation-backed truth.

## Validation
- `make check` passed: lint, format, monetary-float guard, mypy, OpenAPI gate, and 402 unit/contract tests.
- `make test-integration` passed: 151 integration tests.
- `make ci` passed: migration smoke, integration tests, coverage at 88.44%, and `pip-audit` with no known vulnerabilities.

## Notes
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reports drift for API-Surface.md, Integrations.md, and Roadmap.md because this PR intentionally updates repo-authored wiki source. Publish after merge.