### PR TITLE
fix: harden platform capabilities live proof

### DIFF
--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -183,7 +183,9 @@ class DpmClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         manage_consumer_system = (
-            consumer_system if consumer_system in _MANAGE_CAPABILITIES_CONSUMERS else "lotus-gateway"
+            consumer_system
+            if consumer_system in _MANAGE_CAPABILITIES_CONSUMERS
+            else "lotus-gateway"
         )
         return await self._get(
             "/api/v1/integration/capabilities",

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -6,6 +6,14 @@ from app.middleware.correlation import propagation_headers
 
 logger = logging.getLogger("analytics_ui.gateway")
 
+_MANAGE_CAPABILITIES_CONSUMERS = {
+    "lotus-gateway",
+    "lotus-performance",
+    "lotus-manage",
+    "UI",
+    "UNKNOWN",
+}
+
 
 class DpmClient:
     def __init__(
@@ -174,11 +182,14 @@ class DpmClient:
         tenant_id: str,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
+        manage_consumer_system = (
+            consumer_system if consumer_system in _MANAGE_CAPABILITIES_CONSUMERS else "lotus-gateway"
+        )
         return await self._get(
-            "/api/v1/platform/capabilities",
-            params={"consumerSystem": consumer_system, "tenantId": tenant_id},
+            "/api/v1/integration/capabilities",
+            params={"consumer_system": manage_consumer_system, "tenant_id": tenant_id},
             headers=self._headers(correlation_id),
-            operation="manage.platform.capabilities",
+            operation="manage.integration.capabilities",
         )
 
     def _headers(

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -45,6 +45,7 @@ class Settings(BaseSettings):
     archive_service_base_url: str = Field(default="http://archive.dev.lotus")
     management_service_base_url: str = Field(default="http://manage.dev.lotus")
     upstream_timeout_seconds: float = Field(default=3.0)
+    platform_capabilities_source_timeout_seconds: float = Field(default=5.0)
     performance_analytics_timeout_seconds: float = Field(default=15.0)
     ai_service_timeout_seconds: float = Field(default=45.0)
     upstream_max_retries: int = Field(default=2)

--- a/src/app/routers/platform.py
+++ b/src/app/routers/platform.py
@@ -53,6 +53,7 @@ def _platform_capabilities_service() -> PlatformCapabilitiesService:
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
         contract_version=settings.contract_version,
+        source_timeout_seconds=settings.platform_capabilities_source_timeout_seconds,
     )
 
 

--- a/src/app/services/platform_capabilities_service.py
+++ b/src/app/services/platform_capabilities_service.py
@@ -142,7 +142,7 @@ class PlatformCapabilitiesService:
                     CapabilitySourceError(
                         service=service_name,
                         status_code=500,
-                        detail=f"upstream_exception: {result}",
+                        detail=self._exception_detail(result),
                     )
                 )
                 continue
@@ -167,7 +167,7 @@ class PlatformCapabilitiesService:
                 CapabilitySourceError(
                     service="lotus_core_policy",
                     status_code=500,
-                    detail=f"upstream_exception: {lotus_core_policy_result}",
+                    detail=self._exception_detail(lotus_core_policy_result),
                 )
             )
         else:
@@ -726,7 +726,7 @@ class PlatformCapabilitiesService:
                 CapabilitySourceError(
                     service=gateway_source_name,
                     status_code=500,
-                    detail=f"upstream_exception: {result}",
+                    detail=self._exception_detail(result),
                 )
             )
             return
@@ -741,3 +741,10 @@ class PlatformCapabilitiesService:
             )
             return
         sources[gateway_source_name] = payload
+
+    def _exception_detail(self, exc: BaseException) -> str:
+        message = str(exc)
+        exception_type = type(exc).__name__
+        if message:
+            return f"upstream_exception:{exception_type}: {message}"
+        return f"upstream_exception:{exception_type}"

--- a/tests/unit/test_platform_capabilities_service.py
+++ b/tests/unit/test_platform_capabilities_service.py
@@ -723,6 +723,7 @@ async def test_platform_capabilities_timeout_budget_preserves_partial_response()
     assert response.data.normalized.navigation["performance_workspace"] is False
     assert response.data.normalized.module_health["lotus_performance"] == "unavailable"
     assert {error.service for error in response.data.errors} == {"lotus_performance"}
+    assert response.data.errors[0].detail == "upstream_exception:TimeoutError"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_router_upstream_selection.py
+++ b/tests/unit/test_router_upstream_selection.py
@@ -48,3 +48,11 @@ def test_platform_capabilities_keeps_manage_and_advise_clients_separate(monkeypa
     service = _platform_capabilities_service()
     assert service._advise_client._base_url == "http://advise:8000"
     assert service._manage_client._base_url == "http://manage:8000"
+
+
+def test_platform_capabilities_uses_configured_source_timeout(monkeypatch):
+    monkeypatch.setattr(
+        "app.routers.platform.settings.platform_capabilities_source_timeout_seconds", 7.5
+    )
+    service = _platform_capabilities_service()
+    assert service._source_timeout_seconds == 7.5

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1596,7 +1596,7 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
                 "tenant_id": "default",
                 "correlation_id": "corr-5",
             },
-            "http://dpm/api/v1/platform/capabilities",
+            "http://dpm/api/v1/integration/capabilities",
         ),
         (
             "list_outcome_reviews",
@@ -1644,6 +1644,31 @@ async def test_dpm_client_manage_routes(method_name, kwargs, expected_url):
     assert status_code == 200
     assert payload["ok"] is True
     assert _FakeAsyncClient.calls[0]["url"] == expected_url
+    if method_name == "get_capabilities":
+        assert _FakeAsyncClient.calls[0]["params"] == {
+            "consumer_system": "lotus-gateway",
+            "tenant_id": "default",
+        }
+
+
+@pytest.mark.asyncio
+async def test_dpm_client_capabilities_uses_gateway_consumer_for_manage_contract():
+    client = DpmClient(base_url="http://dpm", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"ok": True})
+
+    status_code, payload = await client.get_capabilities(
+        consumer_system="lotus-workbench",
+        tenant_id="tenant-sg",
+        correlation_id="corr-workbench",
+    )
+
+    assert status_code == 200
+    assert payload["ok"] is True
+    assert _FakeAsyncClient.calls[0]["url"] == "http://dpm/api/v1/integration/capabilities"
+    assert _FakeAsyncClient.calls[0]["params"] == {
+        "consumer_system": "lotus-gateway",
+        "tenant_id": "tenant-sg",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- route lotus-manage capability fanout to the implemented `/api/v1/integration/capabilities` contract
- normalize Workbench-facing manage capability reads to the gateway consumer accepted by lotus-manage
- make platform-capabilities source timeout configurable and surface explicit exception types

## Evidence
- `python -m pytest tests/unit/test_upstream_clients.py -k "dpm_client_manage_routes or dpm_client_capabilities_uses_gateway_consumer or dpm_client_non_json"`
- `python -m pytest tests/unit/test_router_upstream_selection.py tests/unit/test_platform_capabilities_service.py -k "platform_capabilities_uses_configured_source_timeout or timeout_budget_preserves_partial_response"`
- Live probe: Gateway platform capabilities returned all sources available with `partialFailure=false`.

## RFC / Ledger
Supports lotus-manage RFC42 work-to-be-done item for Workbench outcome-review proof by removing Gateway platform-capabilities false degradation.
