### PR TITLE
feat: expose RFC42 outcome review report jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ It depends on:
   discretionary management run lookup, supportability summary, platform capability posture, and
   RFC-0042 post-trade outcome-review authority through the DPM command-center BFF routes
 - `lotus-report`
-  reporting snapshot, summary, review payloads, durable report job lifecycle/search, and
-  RFC-0104 batch materialization/status/control/operator-run APIs
+  reporting snapshot, summary, review payloads, portfolio-review and outcome-review durable report
+  job initiation/lifecycle/search, and RFC-0104 batch materialization/status/control/operator-run APIs
 - `lotus-archive`
   archived generated-document metadata and controlled binary retrieval
 - `lotus-ai`

--- a/src/app/clients/reporting_client.py
+++ b/src/app/clients/reporting_client.py
@@ -106,6 +106,26 @@ class ReportingClient:
             headers=headers,
         )
 
+    async def submit_outcome_review_report_job(
+        self,
+        *,
+        payload: dict[str, Any],
+        idempotency_key: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/reports/outcome-reviews"
+        headers = propagation_headers(correlation_id)
+        headers["Idempotency-Key"] = idempotency_key
+        headers.update(caller_headers)
+        return await self._request(
+            operation="report.outcome-review-jobs.submit",
+            method="POST",
+            url=url,
+            json_body=payload,
+            headers=headers,
+        )
+
     async def get_report_job(
         self,
         *,

--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -413,6 +413,50 @@ class PortfolioReviewJobRequest(BaseModel):
     )
 
 
+class OutcomeReviewReportJobRequest(BaseModel):
+    outcome_report_input: dict[str, Any] = Field(
+        ...,
+        description=(
+            "Manage-owned DpmOutcomeReportInput payload forwarded to lotus-report for governed "
+            "post-trade outcome-review report artifact generation."
+        ),
+        examples=[
+            {
+                "contract_version": "1.0",
+                "outcome_review_id": "dor_001",
+                "outcome_review_content_hash": "sha256:outcome-review",
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "proof_pack_id": "dpp_001",
+                "review_window": {"start_date": "2026-04-22", "end_date": "2026-04-23"},
+                "report_title": "Post-Trade Outcome Review - PB_SG_GLOBAL_BAL_001",
+                "state": "READY",
+                "overall_outcome": "Execution outcome aligned with pre-trade proof.",
+                "dimensions": [],
+                "source_lineage": [],
+                "source_hashes": {"realized": "sha256:realized"},
+                "section_hashes": {"proof_pack": "sha256:proof-pack"},
+                "redaction_policy": "NO_RAW_PAYLOADS",
+                "content_hash": "sha256:report-input",
+            }
+        ],
+    )
+    requested_output_formats: list[str] = Field(
+        default_factory=lambda: ["pdf"],
+        description="Requested output formats for the outcome-review report job.",
+        examples=[["pdf"]],
+    )
+    reporting_currency: str | None = Field(
+        default=None,
+        description="Optional reporting currency forwarded to lotus-report.",
+        examples=["USD"],
+    )
+    options: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Output-affecting options such as retention policy or template controls.",
+        examples=[{"retention_policy_id": "generated-report-standard"}],
+    )
+
+
 class ReportJobErrorDetail(BaseModel):
     code: str = Field(
         ...,

--- a/src/app/routers/reporting.py
+++ b/src/app/routers/reporting.py
@@ -30,6 +30,7 @@ from app.contracts.reporting import (
     BatchStatusResponse,
     BatchWorkerRunRequest,
     BatchWorkerRunResponse,
+    OutcomeReviewReportJobRequest,
     PortfolioReviewJobRequest,
     ReportingPortfolioRequest,
     ReportingReviewResponse,
@@ -104,6 +105,37 @@ PORTFOLIO_REVIEW_JOB_REQUEST_EXAMPLES = {
                 "sections": ["OVERVIEW", "PERFORMANCE", "RISK_ANALYTICS"],
                 "benchmark_code": "BMK_PB_GLOBAL_BALANCED_60_40",
             },
+        },
+    }
+}
+
+OUTCOME_REVIEW_REPORT_JOB_REQUEST_EXAMPLES = {
+    "outcomeReviewReportJob": {
+        "summary": "Outcome-review report job request",
+        "description": (
+            "Create a durable report job from manage-owned DpmOutcomeReportInput evidence."
+        ),
+        "value": {
+            "outcome_report_input": {
+                "contract_version": "1.0",
+                "outcome_review_id": "dor_001",
+                "outcome_review_content_hash": "sha256:outcome-review",
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "proof_pack_id": "dpp_001",
+                "review_window": {"start_date": "2026-04-22", "end_date": "2026-04-23"},
+                "report_title": "Post-Trade Outcome Review - PB_SG_GLOBAL_BAL_001",
+                "state": "READY",
+                "overall_outcome": "Execution outcome aligned with pre-trade proof.",
+                "dimensions": [],
+                "source_lineage": [],
+                "source_hashes": {"realized": "sha256:realized"},
+                "section_hashes": {"proof_pack": "sha256:proof-pack"},
+                "redaction_policy": "NO_RAW_PAYLOADS",
+                "content_hash": "sha256:report-input",
+            },
+            "requested_output_formats": ["pdf"],
+            "reporting_currency": "USD",
+            "options": {"retention_policy_id": "generated-report-standard"},
         },
     }
 }
@@ -656,6 +688,85 @@ async def submit_portfolio_review_report_job(
         )
 
     status_code, payload = await _reporting_client().submit_portfolio_review_job(
+        payload=request.model_dump(exclude_none=True, mode="json"),
+        idempotency_key=idempotency_key,
+        caller_headers=caller_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+        correlation_id=correlation_id,
+    )
+    _raise_report_job_error(status_code, payload)
+    response = ReportJobHandleResponse.model_validate(payload)
+    return response.model_copy(update={"status_url": _gateway_status_url(response.report_job_id)})
+
+
+@router.post(
+    "/outcome-reviews",
+    response_model=ReportJobHandleResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Submit outcome-review report job",
+    description=(
+        "Create a durable post-trade outcome-review report job through the governed gateway "
+        "boundary. Use this endpoint when Workbench or another product client needs a rendered "
+        "outcome-review artifact from manage-owned report input without calling lotus-report "
+        "directly or recomputing outcome facts."
+    ),
+    responses={
+        **_job_error_response(
+            400,
+            example_key="missing_idempotency_key",
+            description="Returned when idempotency or required caller context is missing.",
+        ),
+        **_job_error_response(
+            409,
+            example_key="idempotency_conflict",
+            description="Returned when the idempotency key conflicts with a different request.",
+        ),
+        **_job_error_response(
+            502,
+            example_key="report_job_upstream_unavailable",
+            description="Returned when lotus-report is unavailable or returns an unsafe failure.",
+        ),
+    },
+)
+async def submit_outcome_review_report_job(
+    request: Annotated[
+        OutcomeReviewReportJobRequest,
+        Body(
+            description="Outcome-review report job request.",
+            openapi_examples=OUTCOME_REVIEW_REPORT_JOB_REQUEST_EXAMPLES,
+        ),
+    ],
+    idempotency_key: Annotated[
+        str | None,
+        Header(
+            alias="Idempotency-Key",
+            description="Required caller idempotency key for job creation.",
+        ),
+    ] = None,
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> ReportJobHandleResponse:
+    correlation_id = correlation_id_var.get()
+    if not idempotency_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "missing_idempotency_key",
+                "message": "Idempotency-Key is required.",
+            },
+        )
+
+    status_code, payload = await _reporting_client().submit_outcome_review_report_job(
         payload=request.model_dump(exclude_none=True, mode="json"),
         idempotency_key=idempotency_key,
         caller_headers=caller_context_headers(

--- a/tests/contract/test_reporting_contract.py
+++ b/tests/contract/test_reporting_contract.py
@@ -220,6 +220,7 @@ def test_reporting_openapi_contract_registered() -> None:
     assert "/api/v1/reports/{portfolio_id}/summary" in spec["paths"]
     assert "/api/v1/reports/{portfolio_id}/review" in spec["paths"]
     assert "/api/v1/reports/portfolio-reviews" in spec["paths"]
+    assert "/api/v1/reports/outcome-reviews" in spec["paths"]
     assert "/api/v1/report-jobs" in spec["paths"]
     assert "/api/v1/report-jobs/{job_id}" in spec["paths"]
     assert "/api/v1/report-jobs/{job_id}/events" in spec["paths"]
@@ -242,6 +243,7 @@ def test_reporting_openapi_contract_registered() -> None:
     summary_path = spec["paths"]["/api/v1/reports/{portfolio_id}/summary"]["post"]
     review_path = spec["paths"]["/api/v1/reports/{portfolio_id}/review"]["post"]
     job_submit_path = spec["paths"]["/api/v1/reports/portfolio-reviews"]["post"]
+    outcome_job_submit_path = spec["paths"]["/api/v1/reports/outcome-reviews"]["post"]
     job_list_path = spec["paths"]["/api/v1/report-jobs"]["get"]
     job_status_path = spec["paths"]["/api/v1/report-jobs/{job_id}"]["get"]
     job_events_path = spec["paths"]["/api/v1/report-jobs/{job_id}/events"]["get"]
@@ -263,6 +265,7 @@ def test_reporting_openapi_contract_registered() -> None:
     assert summary_path["description"]
     assert review_path["description"]
     assert job_submit_path["summary"] == "Submit portfolio review report job"
+    assert outcome_job_submit_path["summary"] == "Submit outcome-review report job"
     assert job_list_path["summary"] == "Search report jobs for operations and support"
     assert job_status_path["summary"] == "Get report job status"
     assert job_events_path["summary"] == "Get report job event history"
@@ -276,12 +279,14 @@ def test_reporting_openapi_contract_registered() -> None:
     assert schedule_list_path["summary"] == "List governed report batch schedules"
     assert schedule_run_path["summary"] == "Run one bounded report batch scheduler pass"
     assert "RFC-" not in str(job_submit_path)
+    assert "RFC-" not in str(outcome_job_submit_path)
     assert "RFC-" not in str(job_list_path)
     assert "RFC-" not in str(job_status_path)
     assert "RFC-" not in str(job_events_path)
     assert "RFC-" not in str(job_cancel_path)
     for schema_name in [
         "ReportJobHandleResponse",
+        "OutcomeReviewReportJobRequest",
         "ReportJobListResponse",
         "ReportJobListItem",
         "ReportJobListFilters",

--- a/tests/integration/test_reporting_router.py
+++ b/tests/integration/test_reporting_router.py
@@ -347,6 +347,31 @@ def _job_payload():
     }
 
 
+def _outcome_report_job_payload():
+    return {
+        "outcome_report_input": {
+            "contract_version": "1.0",
+            "outcome_review_id": "dor_001",
+            "outcome_review_content_hash": "sha256:outcome-review",
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "proof_pack_id": "dpp_001",
+            "review_window": {"start_date": "2026-04-22", "end_date": "2026-04-23"},
+            "report_title": "Post-Trade Outcome Review - PB_SG_GLOBAL_BAL_001",
+            "state": "READY",
+            "overall_outcome": "Execution outcome aligned with pre-trade proof.",
+            "dimensions": [],
+            "source_lineage": [],
+            "source_hashes": {"realized": "sha256:realized"},
+            "section_hashes": {"proof_pack": "sha256:proof-pack"},
+            "redaction_policy": "NO_RAW_PAYLOADS",
+            "content_hash": "sha256:report-input",
+        },
+        "requested_output_formats": ["pdf"],
+        "reporting_currency": "USD",
+        "options": {"retention_policy_id": "generated-report-standard"},
+    }
+
+
 def test_portfolio_review_job_gateway_route_forwards_context(monkeypatch):
     captured: dict[str, object] = {}
 
@@ -406,6 +431,60 @@ def test_portfolio_review_job_gateway_route_forwards_context(monkeypatch):
         "X-Role": "advisor",
     }
     assert captured["correlation_id"] == "corr-gateway-job"
+
+
+def test_outcome_review_report_job_gateway_route_forwards_context(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _mock_submit_job(
+        self,
+        *,
+        payload,
+        idempotency_key,
+        caller_headers,
+        correlation_id,
+    ):
+        captured["payload"] = payload
+        captured["idempotency_key"] = idempotency_key
+        captured["caller_headers"] = caller_headers
+        captured["correlation_id"] = correlation_id
+        return 202, {
+            "report_request_id": "rrq_outcome_1",
+            "report_job_id": "rjob_outcome_1",
+            "status": "accepted",
+            "status_url": "/reports/jobs/rjob_outcome_1",
+            "idempotency_key": idempotency_key,
+        }
+
+    monkeypatch.setattr(
+        "app.clients.reporting_client.ReportingClient.submit_outcome_review_report_job",
+        _mock_submit_job,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/reports/outcome-reviews",
+        json=_outcome_report_job_payload(),
+        headers={
+            "Idempotency-Key": "outcome-review-dor_001-pdf",
+            "X-Actor-Id": "advisor-123",
+            "X-Caller-Application": "lotus-workbench",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+            "X-Booking-Center-Code": "SG",
+            "X-Role": "advisor",
+            "X-Correlation-Id": "corr-outcome-report",
+        },
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["report_job_id"] == "rjob_outcome_1"
+    assert body["status_url"] == "/api/v1/report-jobs/rjob_outcome_1"
+    assert captured["payload"] == _outcome_report_job_payload()
+    assert captured["idempotency_key"] == "outcome-review-dor_001-pdf"
+    assert captured["caller_headers"]["X-Caller-Application"] == "lotus-workbench"
+    assert captured["correlation_id"] == "corr-outcome-report"
 
 
 def test_portfolio_review_job_gateway_requires_idempotency_key():

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -2035,9 +2035,7 @@ async def test_reporting_client_outcome_review_report_job_route_forwards_governe
     assert _FakeAsyncClient.calls[0]["json"] == {
         "outcome_report_input": {"outcome_review_id": "dor_001"}
     }
-    assert _FakeAsyncClient.calls[0]["headers"]["Idempotency-Key"] == (
-        "outcome-review-dor_001-pdf"
-    )
+    assert _FakeAsyncClient.calls[0]["headers"]["Idempotency-Key"] == ("outcome-review-dor_001-pdf")
     assert _FakeAsyncClient.calls[0]["headers"]["X-Actor-Id"] == "advisor-123"
     assert _FakeAsyncClient.calls[0]["headers"]["X-Correlation-Id"] == "corr-outcome-report"
 

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -2007,6 +2007,42 @@ async def test_reporting_client_report_job_routes_forward_governed_headers():
 
 
 @pytest.mark.asyncio
+async def test_reporting_client_outcome_review_report_job_route_forwards_governed_headers():
+    client = ReportingClient(base_url="http://ras", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(
+        202,
+        {
+            "report_request_id": "rrq_outcome_1",
+            "report_job_id": "rjob_outcome_1",
+            "status": "accepted",
+        },
+    )
+
+    status_code, payload = await client.submit_outcome_review_report_job(
+        payload={"outcome_report_input": {"outcome_review_id": "dor_001"}},
+        idempotency_key="outcome-review-dor_001-pdf",
+        caller_headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+        },
+        correlation_id="corr-outcome-report",
+    )
+
+    assert status_code == 202
+    assert payload["report_job_id"] == "rjob_outcome_1"
+    assert _FakeAsyncClient.calls[0]["url"] == "http://ras/reports/outcome-reviews"
+    assert _FakeAsyncClient.calls[0]["json"] == {
+        "outcome_report_input": {"outcome_review_id": "dor_001"}
+    }
+    assert _FakeAsyncClient.calls[0]["headers"]["Idempotency-Key"] == (
+        "outcome-review-dor_001-pdf"
+    )
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Actor-Id"] == "advisor-123"
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Correlation-Id"] == "corr-outcome-report"
+
+
+@pytest.mark.asyncio
 async def test_reporting_client_report_batch_routes_forward_governed_headers():
     client = ReportingClient(base_url="http://ras", timeout_seconds=2.0)
     caller_headers = {

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -18,6 +18,7 @@
 - `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
 - `GET` and `POST /api/v1/workbench/*`
 - `GET` and `POST /api/v1/reports/*`
+- `POST /api/v1/reports/outcome-reviews`
 - `GET /api/v1/report-jobs` and `GET`/`POST /api/v1/report-jobs/*`
 - `POST /api/v1/report-batches`, `GET /api/v1/report-batches/{batch_id}`, and
   `POST /api/v1/report-batches/{batch_id}:*`
@@ -43,6 +44,9 @@
   `advisor_sections`
 - portfolio review report job initiation uses canonical snake_case body fields and requires
   `Idempotency-Key`
+- outcome-review report job initiation uses manage-owned `DpmOutcomeReportInput` through
+  `/api/v1/reports/outcome-reviews`; Gateway forwards the payload to `lotus-report` and does not
+  recompute outcome truth, render artifacts, or archive documents
 - report job search, status, append-only event history, and cancellation are gateway-first under
   `/api/v1/report-jobs` and `/api/v1/report-jobs/*`
 - report batch materialization, status, pause, resume, cancel, retry-failed,
@@ -232,6 +236,19 @@ curl -X POST "http://127.0.0.1:8111/api/v1/reports/portfolio-reviews" \
   -H "X-Booking-Center-Code: SG" \
   -H "X-Role: advisor" \
   -d "{\"portfolio_scope\":{\"portfolio_ids\":[\"PB_SG_GLOBAL_BAL_001\"]},\"as_of_date\":\"2026-04-22\",\"requested_output_formats\":[\"json\"],\"reporting_currency\":\"USD\",\"options\":{\"sections\":[\"OVERVIEW\",\"PERFORMANCE\",\"RISK_ANALYTICS\"],\"benchmark_code\":\"BMK_PB_GLOBAL_BALANCED_60_40\"}}"
+```
+
+Outcome-review report job:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/reports/outcome-reviews" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: outcome-review-dor_001-pdf" \
+  -H "X-Actor-Id: advisor-123" \
+  -H "X-Caller-Application: lotus-workbench" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -d "{\"outcome_report_input\":{\"outcome_review_id\":\"dor_001\",\"portfolio_id\":\"PB_SG_GLOBAL_BAL_001\",\"review_window\":{\"end_date\":\"2026-04-23\"},\"content_hash\":\"sha256:report-input\"},\"requested_output_formats\":[\"pdf\"]}"
 ```
 
 DPM outcome-review create:


### PR DESCRIPTION
## Summary
- add Gateway client and route for POST /api/v1/reports/outcome-reviews
- add OpenAPI contract, tests, README/wiki posture
- keep report/render/archive ownership behind Gateway boundary

## Validation
- python -m ruff check src/app/clients/reporting_client.py src/app/contracts/reporting.py src/app/routers/reporting.py tests/integration/test_reporting_router.py tests/unit/test_upstream_clients.py tests/contract/test_reporting_contract.py
- python -m pytest tests/integration/test_reporting_router.py::test_outcome_review_report_job_gateway_route_forwards_context tests/unit/test_upstream_clients.py::test_reporting_client_outcome_review_report_job_route_forwards_governed_headers tests/contract/test_reporting_contract.py::test_reporting_openapi_contract_registered -q
- git diff --check