### PR TITLE
feat: add outcome narrative gateway handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ Always:
 7. keep commits small, meaningful, and truthful,
 8. remove dead code, duplicate logic, and stale non-standard handling when encountered,
 9. ensure every UI feature is genuinely backed by supported backend functionality,
-10. ensure RFC/docs/wiki/context/contract closure truth is present on `main`, not stranded on an
+10. treat "merged to `main` and validated" as the definition of done; ensure
+    RFC/docs/wiki/context/contract closure truth is present on `main`, not stranded on an
     unmerged side branch.
 
 For RFC, documentation, wiki, context, contract, supported-features, API-governance, migration, or

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -35,8 +35,8 @@ Current repository posture:
    with proposal simulation/lifecycle/workflow/approval/lineage routed to `lotus-advise`
    `/advisory/proposals/*`; `lotus-manage` consumption is through versioned `/api/v1` APIs for
    run lookup, supportability summary, capability posture, and RFC-0042 outcome-review
-   preview/create/search/detail/source-refresh/supportability/report-input/AI-evidence route
-   families,
+   preview/create/search/detail/source-refresh/supportability/report-input/AI-evidence and
+   AI-narrative handoff route families,
 4. report job initiation/search/status/event-history/cancellation routes are active for
    gateway-first portfolio review report job workflows under `/api/v1/reports/portfolio-reviews`,
    `/api/v1/report-jobs`, and `/api/v1/report-jobs/*`,
@@ -51,8 +51,12 @@ Current repository posture:
    active under `/api/v1/domain-products`,
 8. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
 9. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
-10. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
-11. RFC-0108 analytics UI observability is active for selected Workbench performance summary,
+10. RFC-0042 outcome-review AI narrative handoff now reads manage-owned
+    `DpmOutcomeAiEvidenceInput` and executes `lotus-ai` `outcome_review_narrative.pack@v1` as
+    `lotus-gateway`; manage remains outcome evidence and workflow authority, and Gateway does not
+    generate narrative locally,
+11. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
+12. RFC-0108 analytics UI observability is active for selected Workbench performance summary,
     risk summary, advisor-brief read, and advisor-brief review-action paths, and has expanded
     fan-out coverage for central `lotus-advise`, `lotus-manage`,
     `lotus-report`, `lotus-archive`, `lotus-ai`, direct `lotus-core` query/control-plane, and

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -1138,6 +1138,7 @@ outcome-review route family so Workbench can later consume Gateway/BFF instead o
 | Item | Status | Evidence |
 | --- | --- | --- |
 | RFC42-WTBD-001 Gateway outcome-review composition and BFF contract | Implemented in Gateway feature branch; local CI passed; pending PR/merge/live proof closure | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/contract/test_dpm_command_center_contract.py`, `make ci` |
+| RFC42-WTBD-005 Gateway AI narrative handoff | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | Gateway reads manage-owned `DpmOutcomeAiEvidenceInput`, executes `lotus-ai` `outcome_review_narrative.pack@v1` as `lotus-gateway`, preserves manage workflow authority, and exposes `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative` |
 | RFC-0042 manage authority preservation | Implemented for BFF envelope; Gateway forwards payloads and preserves manage supportability | Service tests prove payload preservation and upstream error forwarding; contract tests prove OpenAPI route family registration and What/When/How guidance |
 | Broader RFC-0098 command-center book, mandate detail, evidence, action handoff, wave composition, proof-pack composition, report/archive/AI modules | Not implemented in this slice | Remains governed by this RFC and the work-to-be-done ledger; no supported-feature claim is made |
 
@@ -1151,12 +1152,14 @@ Implementation boundaries:
    `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/supportability`,
    `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/report-input`,
    `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-evidence-input`,
+   `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`,
    `GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`, and
    `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`.
 2. Gateway does not calculate expected values, realized values, variance, tolerance, hashes,
    lineage, source freshness, supportability, or review state.
-3. Gateway does not generate reports, render artifacts, archive documents, generate AI narrative,
-   score PM quality, or claim Workbench UI support in this slice.
+3. Gateway does not generate reports, render artifacts, archive documents, generate AI narrative
+   locally, score PM quality, approve trades, contact clients, or claim Workbench UI support in
+   this slice. The AI narrative endpoint is a governed handoff to `lotus-ai` over manage evidence.
 4. Workbench product realization remains a separate owning-repository implementation item.
 
 Validation performed on 2026-05-05:

--- a/src/app/contracts/dpm_command_center.py
+++ b/src/app/contracts/dpm_command_center.py
@@ -30,6 +30,28 @@ class DpmOutcomeReviewRefreshRequest(BaseModel):
     )
 
 
+class DpmOutcomeReviewNarrativeRequest(BaseModel):
+    requested_outputs: list[str] = Field(
+        default_factory=lambda: [
+            "pm_summary",
+            "cio_summary",
+            "control_summary",
+            "evidence_gaps",
+        ],
+        description=(
+            "Support-only narrative sections requested from lotus-ai. Gateway forwards these "
+            "requests to the governed outcome-review narrative workflow pack and does not allow "
+            "trade approval, client messaging, PM scoring, or execution instructions."
+        ),
+        examples=[["pm_summary", "cio_summary", "control_summary", "evidence_gaps"]],
+    )
+    audience: list[str] = Field(
+        default_factory=lambda: ["portfolio_manager", "cio_office", "investment_control"],
+        description="Intended internal audience labels for the generated support-only narrative.",
+        examples=[["portfolio_manager", "cio_office", "investment_control"]],
+    )
+
+
 class DpmOutcomeReviewSupportability(BaseModel):
     source_service: str = Field(
         default="lotus-manage",
@@ -112,6 +134,60 @@ class DpmOutcomeReviewGatewayResponse(BaseModel):
                 ],
             }
         ],
+    )
+
+
+class DpmOutcomeReviewNarrativeGatewayResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated across Gateway, lotus-manage, and lotus-ai.",
+        examples=["corr-rfc42-outcome-review-narrative-1"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway BFF contract version for outcome-review AI narrative handoff.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        default="lotus-ai",
+        description="Service that executed the governed narrative workflow pack.",
+        examples=["lotus-ai"],
+    )
+    evidence_source_service: str = Field(
+        default="lotus-manage",
+        description="Service that supplied the bounded DPM outcome-review AI evidence input.",
+        examples=["lotus-manage"],
+    )
+    manage_upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage for the AI evidence input read.",
+        examples=[200],
+    )
+    ai_upstream_status: int = Field(
+        description="HTTP status returned by lotus-ai for workflow-pack execution.",
+        examples=[200],
+    )
+    supportability: DpmOutcomeReviewSupportability = Field(
+        description="Manage-derived supportability summary for the source AI evidence handoff.",
+    )
+    ai_evidence_input: dict[str, object] = Field(
+        description=(
+            "Manage-owned DpmOutcomeAiEvidenceInput used as the sole source for narrative "
+            "generation. Gateway preserves it without adding facts or removing guardrails."
+        ),
+    )
+    narrative_request: dict[str, object] = Field(
+        description="Bounded narrative request forwarded to lotus-ai with support-only outputs.",
+        examples=[
+            {
+                "requested_outputs": ["pm_summary", "cio_summary", "control_summary"],
+                "audience": ["portfolio_manager", "cio_office"],
+            }
+        ],
+    )
+    data: dict[str, object] = Field(
+        description=(
+            "Authoritative lotus-ai workflow-pack execution response, including execution audit, "
+            "workflow-pack run posture, review state, and guardrail-supported structured output."
+        ),
     )
 
 

--- a/src/app/routers/dpm_command_center.py
+++ b/src/app/routers/dpm_command_center.py
@@ -1,10 +1,13 @@
 from fastapi import APIRouter, Path, Query
 
 from app.clients.dpm_client import DpmClient
+from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_command_center import (
     DpmOutcomeReviewForwardRequest,
     DpmOutcomeReviewGatewayResponse,
+    DpmOutcomeReviewNarrativeGatewayResponse,
+    DpmOutcomeReviewNarrativeRequest,
     DpmOutcomeReviewRefreshRequest,
 )
 from app.middleware.correlation import correlation_id_var
@@ -20,7 +23,13 @@ def _dpm_command_center_service() -> DpmCommandCenterService:
             timeout_seconds=settings.upstream_timeout_seconds,
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
-        )
+        ),
+        lotus_ai_client=LotusAiClient(
+            base_url=settings.ai_service_base_url,
+            timeout_seconds=settings.ai_service_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
     )
 
 
@@ -242,6 +251,34 @@ async def get_outcome_review_ai_evidence_input(
 ) -> DpmOutcomeReviewGatewayResponse:
     return await _dpm_command_center_service().get_outcome_review_ai_evidence_input(
         outcome_review_id=outcome_review_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/outcome-reviews/{outcome_review_id}/ai-narrative",
+    response_model=DpmOutcomeReviewNarrativeGatewayResponse,
+    summary="Request outcome review AI narrative",
+    description=(
+        "What: requests a governed lotus-ai outcome-review narrative workflow-pack run from "
+        "manage-owned DPM outcome AI evidence. When: call this only after manage supportability "
+        "shows AI evidence is available and the user needs review-gated PM/CIO/control support "
+        "copy. How: Gateway first reads manage's DpmOutcomeAiEvidenceInput, then executes "
+        "lotus-ai outcome_review_narrative.pack@v1 as lotus-gateway; Gateway does not generate "
+        "narrative, score PMs, approve trades, contact clients, or invent evidence."
+    ),
+)
+async def request_outcome_review_ai_narrative(
+    request: DpmOutcomeReviewNarrativeRequest,
+    outcome_review_id: str = Path(
+        ...,
+        description="Manage-owned outcome-review identifier for the bounded AI evidence handoff.",
+        examples=["or_20260415_001"],
+    ),
+) -> DpmOutcomeReviewNarrativeGatewayResponse:
+    return await _dpm_command_center_service().request_outcome_review_ai_narrative(
+        outcome_review_id=outcome_review_id,
+        request=request,
         correlation_id=correlation_id_var.get(),
     )
 

--- a/src/app/services/dpm_command_center_service.py
+++ b/src/app/services/dpm_command_center_service.py
@@ -3,17 +3,21 @@ from typing import Any
 from fastapi import HTTPException, status
 
 from app.clients.dpm_client import DpmClient
+from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_command_center import (
     DpmOutcomeReviewErrorDetail,
     DpmOutcomeReviewGatewayResponse,
+    DpmOutcomeReviewNarrativeGatewayResponse,
+    DpmOutcomeReviewNarrativeRequest,
     DpmOutcomeReviewSupportability,
 )
 
 
 class DpmCommandCenterService:
-    def __init__(self, dpm_client: DpmClient):
+    def __init__(self, dpm_client: DpmClient, lotus_ai_client: LotusAiClient | None = None):
         self._dpm_client = dpm_client
+        self._lotus_ai_client = lotus_ai_client
 
     async def preview_outcome_review(
         self,
@@ -111,6 +115,100 @@ class DpmCommandCenterService:
         )
         return self._compose_response(upstream_status, upstream_payload, correlation_id)
 
+    async def request_outcome_review_ai_narrative(
+        self,
+        outcome_review_id: str,
+        request: DpmOutcomeReviewNarrativeRequest,
+        correlation_id: str,
+    ) -> DpmOutcomeReviewNarrativeGatewayResponse:
+        if self._lotus_ai_client is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="lotus-ai workflow-pack execution is not configured for Gateway.",
+            )
+
+        manage_status, manage_payload = await self._dpm_client.get_outcome_review_ai_evidence_input(
+            outcome_review_id=outcome_review_id,
+            correlation_id=correlation_id,
+        )
+        if manage_status >= status.HTTP_400_BAD_REQUEST:
+            raise HTTPException(
+                status_code=manage_status,
+                detail=DpmOutcomeReviewErrorDetail(
+                    upstream_status=manage_status,
+                    error_code="MANAGE_OUTCOME_REVIEW_AI_EVIDENCE_UPSTREAM_ERROR",
+                    detail=_safe_upstream_detail(manage_payload),
+                ).model_dump(),
+            )
+
+        supportability = _supportability_from(manage_payload)
+        narrative_request: dict[str, object] = {
+            "requested_outputs": request.requested_outputs,
+            "audience": request.audience,
+        }
+        task_payload = {
+            "ai_evidence_input": manage_payload,
+            "narrative_request": narrative_request,
+            "supportability": {
+                "source_state": supportability.state,
+                "reason_codes": supportability.reason_codes,
+                "blocked_actions": supportability.blocked_actions,
+                "requires_human_review": True,
+                "unsupported_claims": [
+                    "client_contact",
+                    "trade_approval",
+                    "portfolio_manager_scoring",
+                ],
+            },
+        }
+        source_refs = _outcome_ai_source_refs(manage_payload, outcome_review_id)
+        ai_status, ai_payload = await self._lotus_ai_client.execute_workflow_pack(
+            pack_id="outcome_review_narrative.pack",
+            version="v1",
+            environment="DEVELOPMENT",
+            caller_identity_class="INTERNAL_SERVICE",
+            workflow_surface="dpm-outcome-review-ai-evidence",
+            task_request={
+                "task_id": "explain.v1",
+                "input_mode": "STRUCTURED_CONTEXT",
+                "caller": {
+                    "caller_app": "lotus-gateway",
+                    "correlation_id": correlation_id,
+                },
+                "context": {
+                    "summary": (
+                        "Generate review-gated outcome-review narrative from bounded "
+                        f"AI evidence for {outcome_review_id}."
+                    ),
+                    "payload": task_payload,
+                    "source_refs": source_refs,
+                },
+                "expected_output_label": "EXPLANATION_ONLY",
+            },
+            correlation_id=correlation_id,
+        )
+        if ai_status >= status.HTTP_400_BAD_REQUEST:
+            raise HTTPException(
+                status_code=ai_status,
+                detail={
+                    "source_service": "lotus-ai",
+                    "upstream_status": ai_status,
+                    "error_code": "AI_OUTCOME_REVIEW_NARRATIVE_UPSTREAM_ERROR",
+                    "detail": _safe_upstream_detail(ai_payload),
+                },
+            )
+
+        return DpmOutcomeReviewNarrativeGatewayResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            manage_upstream_status=manage_status,
+            ai_upstream_status=ai_status,
+            supportability=supportability,
+            ai_evidence_input=manage_payload,
+            narrative_request=narrative_request,
+            data=ai_payload,
+        )
+
     async def get_run_outcome_review(
         self,
         rebalance_run_id: str,
@@ -194,6 +292,18 @@ def _list_of_strings(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
     return [str(item) for item in value]
+
+
+def _outcome_ai_source_refs(payload: dict[str, Any], outcome_review_id: str) -> list[str]:
+    source_refs: list[str] = [f"lotus-manage:outcome-review:{outcome_review_id}"]
+    evidence_ref = payload.get("evidence_ref")
+    if isinstance(evidence_ref, dict):
+        source_id = evidence_ref.get("source_id")
+        if source_id is not None:
+            source_refs.append(f"lotus-manage:outcome-ai-evidence:{source_id}")
+    if len(source_refs) == 1:
+        source_refs.append(f"lotus-manage:outcome-ai-evidence:{outcome_review_id}")
+    return source_refs
 
 
 def _safe_upstream_detail(payload: dict[str, Any]) -> str:

--- a/tests/contract/test_dpm_command_center_contract.py
+++ b/tests/contract/test_dpm_command_center_contract.py
@@ -1,6 +1,9 @@
 from fastapi.testclient import TestClient
 
-from app.contracts.dpm_command_center import DpmOutcomeReviewGatewayResponse
+from app.contracts.dpm_command_center import (
+    DpmOutcomeReviewGatewayResponse,
+    DpmOutcomeReviewNarrativeGatewayResponse,
+)
 from app.main import app
 
 
@@ -26,6 +29,29 @@ def test_dpm_outcome_review_gateway_response_contract_shape() -> None:
     assert response.data["outcome_review_id"] == "or_1"
 
 
+def test_dpm_outcome_review_narrative_gateway_response_contract_shape() -> None:
+    response = DpmOutcomeReviewNarrativeGatewayResponse(
+        correlation_id="corr-1",
+        manage_upstream_status=200,
+        ai_upstream_status=200,
+        supportability={"state": "SUPPORTED"},
+        ai_evidence_input={
+            "outcome_review_id": "or_1",
+            "content_hash": "sha256:ai-evidence",
+        },
+        narrative_request={"requested_outputs": ["pm_summary"], "audience": ["pm"]},
+        data={
+            "execution": {"status": "COMPLETED"},
+            "workflow_pack_run": {"workflow_authority_owner": "lotus-manage"},
+        },
+    )
+
+    assert response.source_service == "lotus-ai"
+    assert response.evidence_source_service == "lotus-manage"
+    assert response.supportability.authority == "lotus-manage:RFC-0042"
+    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+
+
 def test_dpm_command_center_openapi_contract_registered() -> None:
     client = TestClient(app)
     spec = client.get("/openapi.json").json()
@@ -38,6 +64,7 @@ def test_dpm_command_center_openapi_contract_registered() -> None:
         ("/api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/supportability", "get"),
         ("/api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/report-input", "get"),
         ("/api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-evidence-input", "get"),
+        ("/api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative", "post"),
         ("/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review", "get"),
         ("/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews", "get"),
     ]
@@ -57,6 +84,7 @@ def test_dpm_command_center_openapi_models_are_described() -> None:
     spec = client.get("/openapi.json").json()
     schemas = spec["components"]["schemas"]
     response_schema = schemas["DpmOutcomeReviewGatewayResponse"]
+    narrative_response_schema = schemas["DpmOutcomeReviewNarrativeGatewayResponse"]
     supportability_schema = schemas["DpmOutcomeReviewSupportability"]
 
     for property_schema in response_schema["properties"].values():
@@ -65,5 +93,9 @@ def test_dpm_command_center_openapi_models_are_described() -> None:
     for property_schema in supportability_schema["properties"].values():
         assert property_schema.get("description")
 
+    for property_schema in narrative_response_schema["properties"].values():
+        assert property_schema.get("description")
+
     assert response_schema["properties"]["data"]["description"]
+    assert narrative_response_schema["properties"]["data"]["description"]
     assert supportability_schema["properties"]["state"]["examples"]

--- a/tests/integration/test_dpm_command_center_router.py
+++ b/tests/integration/test_dpm_command_center_router.py
@@ -104,3 +104,98 @@ def test_dpm_command_center_outcome_review_error_is_not_marked_supported(monkeyp
     assert response.status_code == 404
     assert response.json()["detail"]["error_code"] == "MANAGE_OUTCOME_REVIEW_UPSTREAM_ERROR"
     assert response.json()["detail"]["detail"] == "outcome review not found"
+
+
+def test_dpm_command_center_outcome_review_ai_narrative_executes_lotus_ai(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_get_outcome_review_ai_evidence_input(
+        self,
+        outcome_review_id,
+        correlation_id,
+    ):  # noqa: ANN001
+        _ = self
+        captured["manage"] = {
+            "outcome_review_id": outcome_review_id,
+            "correlation_id": correlation_id,
+        }
+        return 200, _outcome_ai_evidence(outcome_review_id)
+
+    async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN003
+        _ = self
+        captured["ai"] = kwargs
+        return 200, {
+            "execution": {
+                "status": "COMPLETED",
+                "audit": {"workflow_pack_run_id": "packrun_or_1"},
+                "result": {
+                    "structured_output": {
+                        "outcome_review_narrative_status": "REVIEW_REQUIRED",
+                        "evidence_content_hash": "sha256:or_1-ai-evidence",
+                    }
+                },
+            },
+            "workflow_pack_run": {
+                "run_id": "packrun_or_1",
+                "workflow_authority_owner": "lotus-manage",
+            },
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_outcome_review_ai_evidence_input",
+        _fake_get_outcome_review_ai_evidence_input,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_ai_client.LotusAiClient.execute_workflow_pack",
+        _fake_execute_workflow_pack,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/outcome-reviews/or_1/ai-narrative",
+        json={"requested_outputs": ["pm_summary", "evidence_gaps"], "audience": ["pm"]},
+        headers={"X-Correlation-Id": "corr-ai-router-1"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert captured["manage"] == {
+        "outcome_review_id": "or_1",
+        "correlation_id": "corr-ai-router-1",
+    }
+    ai_call = captured["ai"]
+    assert ai_call["pack_id"] == "outcome_review_narrative.pack"
+    assert ai_call["correlation_id"] == "corr-ai-router-1"
+    assert ai_call["task_request"]["caller"]["caller_app"] == "lotus-gateway"
+    assert payload["source_service"] == "lotus-ai"
+    assert payload["evidence_source_service"] == "lotus-manage"
+    assert payload["ai_evidence_input"]["content_hash"] == "sha256:or_1-ai-evidence"
+    assert payload["data"]["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+
+
+def _outcome_ai_evidence(outcome_review_id: str) -> dict[str, object]:
+    return {
+        "contract_version": "1.0",
+        "outcome_review_id": outcome_review_id,
+        "outcome_review_content_hash": "sha256:outcome-review",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "proof_pack_id": "pp_1",
+        "permitted_use": "Draft support-only PM, CIO, compliance, and operations narratives.",
+        "forbidden_actions": [
+            "place_orders",
+            "approve_rebalance",
+            "override_controls",
+            "invent_missing_evidence",
+            "score_portfolio_manager",
+            "contact_client",
+        ],
+        "forbidden_fields_removed": [],
+        "overall_outcome": "Implemented rebalance stayed inside expected bands.",
+        "dimensions": [{"dimension": "cash", "state": "MATCHED"}],
+        "source_refs": [],
+        "evidence_ref": {
+            "source_id": f"{outcome_review_id}:dpm_outcome_ai_evidence_input",
+            "content_hash": f"sha256:{outcome_review_id}-ai-evidence",
+        },
+        "content_hash": f"sha256:{outcome_review_id}-ai-evidence",
+    }

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -1,6 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
+from app.contracts.dpm_command_center import DpmOutcomeReviewNarrativeRequest
 from app.services.dpm_command_center_service import DpmCommandCenterService
 
 
@@ -21,6 +22,26 @@ class _FakeDpmClient:
                 "correlation_id": correlation_id,
             }
         )
+        return self.result
+
+    async def get_outcome_review_ai_evidence_input(self, outcome_review_id, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "ai_evidence",
+                "outcome_review_id": outcome_review_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+
+class _FakeLotusAiClient:
+    def __init__(self, result: tuple[int, dict]):
+        self.result = result
+        self.calls: list[dict[str, object]] = []
+
+    async def execute_workflow_pack(self, **kwargs):  # noqa: ANN003
+        self.calls.append(kwargs)
         return self.result
 
 
@@ -130,4 +151,140 @@ async def test_dpm_command_center_forwards_manage_errors_as_product_safe_detail(
         "upstream_status": 409,
         "error_code": "MANAGE_OUTCOME_REVIEW_UPSTREAM_ERROR",
         "detail": "execution evidence incomplete",
+    }
+
+
+@pytest.mark.asyncio
+async def test_dpm_command_center_requests_ai_narrative_from_manage_evidence_only() -> None:
+    ai_evidence = _outcome_ai_evidence()
+    dpm_client = _FakeDpmClient((200, ai_evidence))
+    ai_client = _FakeLotusAiClient(
+        (
+            200,
+            {
+                "execution": {
+                    "status": "COMPLETED",
+                    "audit": {"workflow_pack_run_id": "packrun_outcome_1"},
+                    "result": {
+                        "structured_output": {
+                            "outcome_review_narrative_status": "REVIEW_REQUIRED",
+                            "evidence_content_hash": "sha256:outcome-ai-evidence-001",
+                        }
+                    },
+                },
+                "workflow_pack_run": {
+                    "run_id": "packrun_outcome_1",
+                    "workflow_authority_owner": "lotus-manage",
+                },
+            },
+        )
+    )
+    service = DpmCommandCenterService(  # type: ignore[arg-type]
+        dpm_client=dpm_client,
+        lotus_ai_client=ai_client,
+    )
+
+    response = await service.request_outcome_review_ai_narrative(
+        outcome_review_id="or_1",
+        request=DpmOutcomeReviewNarrativeRequest(
+            requested_outputs=["pm_summary", "evidence_gaps"],
+            audience=["pm"],
+        ),
+        correlation_id="corr-ai-narrative-1",
+    )
+
+    assert response.source_service == "lotus-ai"
+    assert response.evidence_source_service == "lotus-manage"
+    assert response.manage_upstream_status == 200
+    assert response.ai_upstream_status == 200
+    assert response.ai_evidence_input == ai_evidence
+    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    assert dpm_client.calls == [
+        {
+            "method": "ai_evidence",
+            "outcome_review_id": "or_1",
+            "correlation_id": "corr-ai-narrative-1",
+        }
+    ]
+    [ai_call] = ai_client.calls
+    assert ai_call["pack_id"] == "outcome_review_narrative.pack"
+    assert ai_call["workflow_surface"] == "dpm-outcome-review-ai-evidence"
+    assert ai_call["correlation_id"] == "corr-ai-narrative-1"
+    task_request = ai_call["task_request"]
+    assert task_request["caller"]["caller_app"] == "lotus-gateway"
+    assert task_request["context"]["payload"]["ai_evidence_input"] == ai_evidence
+    assert task_request["context"]["payload"]["narrative_request"] == {
+        "requested_outputs": ["pm_summary", "evidence_gaps"],
+        "audience": ["pm"],
+    }
+    assert "lotus-manage:outcome-review:or_1" in task_request["context"]["source_refs"]
+
+
+@pytest.mark.asyncio
+async def test_dpm_command_center_ai_narrative_preserves_ai_guardrail_failure() -> None:
+    service = DpmCommandCenterService(  # type: ignore[arg-type]
+        dpm_client=_FakeDpmClient((200, _outcome_ai_evidence())),
+        lotus_ai_client=_FakeLotusAiClient(
+            (
+                422,
+                {
+                    "detail": (
+                        "OUTCOME_REVIEW_NARRATIVE_GUARDRAIL_BLOCKED: "
+                        "Forbidden narrative outputs requested: pm_score."
+                    )
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.request_outcome_review_ai_narrative(
+            outcome_review_id="or_1",
+            request=DpmOutcomeReviewNarrativeRequest(
+                requested_outputs=["pm_score"],
+                audience=["pm"],
+            ),
+            correlation_id="corr-ai-narrative-blocked",
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail["source_service"] == "lotus-ai"
+    assert exc_info.value.detail["error_code"] == "AI_OUTCOME_REVIEW_NARRATIVE_UPSTREAM_ERROR"
+    assert "OUTCOME_REVIEW_NARRATIVE_GUARDRAIL_BLOCKED" in exc_info.value.detail["detail"]
+
+
+def _outcome_ai_evidence() -> dict[str, object]:
+    return {
+        "contract_version": "1.0",
+        "outcome_review_id": "or_1",
+        "outcome_review_content_hash": "sha256:outcome-review-001",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "proof_pack_id": "pp_1",
+        "permitted_use": "Draft support-only PM, CIO, compliance, and operations narratives.",
+        "forbidden_actions": [
+            "place_orders",
+            "approve_rebalance",
+            "override_controls",
+            "invent_missing_evidence",
+            "score_portfolio_manager",
+            "contact_client",
+        ],
+        "forbidden_fields_removed": [],
+        "overall_outcome": "Implemented rebalance stayed inside expected bands.",
+        "dimensions": [{"dimension": "cash", "state": "MATCHED"}],
+        "source_refs": [
+            {
+                "source_system": "lotus-manage",
+                "source_type": "DPM_OUTCOME_AI_EVIDENCE_INPUT",
+                "source_id": "or_1:dpm_outcome_ai_evidence_input",
+                "content_hash": "sha256:outcome-ai-evidence-001",
+            }
+        ],
+        "evidence_ref": {
+            "source_system": "lotus-manage",
+            "source_type": "DPM_OUTCOME_AI_EVIDENCE_INPUT",
+            "source_id": "or_1:dpm_outcome_ai_evidence_input",
+            "content_hash": "sha256:outcome-ai-evidence-001",
+        },
+        "content_hash": "sha256:outcome-ai-evidence-001",
     }

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -16,6 +16,7 @@
 - `GET` and `POST /api/v1/dpm/command-center/outcome-reviews*`
 - `GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`
 - `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
+- `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`
 - `GET` and `POST /api/v1/workbench/*`
 - `GET` and `POST /api/v1/reports/*`
 - `POST /api/v1/reports/outcome-reviews`
@@ -73,8 +74,12 @@
   `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`. These routes preserve manage
   `outcome_review_id`, state, dimension outcomes, expected values, realized values, variance,
   tolerances, source refs, source hashes, freshness, report-input posture, AI-evidence posture,
-  remediation routes, and supportability. They do not recompute outcome truth, generate reports,
-  generate AI narrative, infer PM quality, or let Workbench bypass Gateway.
+  remediation routes, and supportability. Gateway also exposes a governed AI narrative handoff
+  action that reads manage-owned `DpmOutcomeAiEvidenceInput` and calls `lotus-ai`
+  `outcome_review_narrative.pack@v1` as `lotus-gateway`; Gateway must not recompute outcome
+  truth, generate reports, generate AI narrative locally, infer PM quality, approve trades, contact
+  clients, or let Workbench bypass Gateway.
+  In short: Gateway must not recompute outcome truth.
 - report batch schedule list and run-due actions are gateway-first under
   `/api/v1/report-batch-schedules`; schedules remain config-backed in `lotus-report`, and gateway
   does not expose schedule CRUD or scheduler registry management
@@ -265,6 +270,15 @@ DPM outcome-review supportability:
 ```bash
 curl "http://127.0.0.1:8111/api/v1/dpm/command-center/outcome-reviews/or_20260415_001/supportability" \
   -H "X-Correlation-Id: corr-rfc42-supportability-1"
+```
+
+DPM outcome-review AI narrative handoff:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/dpm/command-center/outcome-reviews/or_20260415_001/ai-narrative" \
+  -H "Content-Type: application/json" \
+  -H "X-Correlation-Id: corr-rfc42-outcome-review-ai-narrative" \
+  -d "{\"requested_outputs\":[\"pm_summary\",\"cio_summary\",\"control_summary\",\"evidence_gaps\"],\"audience\":[\"portfolio_manager\",\"cio_office\",\"investment_control\"]}"
 ```
 
 Report job status:


### PR DESCRIPTION
## Summary
- Adds Gateway BFF action POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative.
- Composes manage-owned DpmOutcomeAiEvidenceInput with lotus-ai outcome_review_narrative.pack@v1 execution as lotus-gateway.
- Preserves manage evidence and workflow authority; Gateway does not generate narrative locally, score PMs, approve trades, contact clients, or invent evidence.
- Updates RFC-0098, repo context, wiki API surface, OpenAPI contract tests, router integration tests, and service tests.
- Includes synchronized AGENTS.md copy from the merged platform operating-contract update.

## Validation
- python -m pytest tests/unit/test_dpm_command_center_service.py tests/integration/test_dpm_command_center_router.py tests/contract/test_dpm_command_center_contract.py tests/unit/test_rfc0098_documentation.py -q
- python -m ruff check src/app/contracts/dpm_command_center.py src/app/services/dpm_command_center_service.py src/app/routers/dpm_command_center.py tests/unit/test_dpm_command_center_service.py tests/integration/test_dpm_command_center_router.py tests/contract/test_dpm_command_center_contract.py tests/unit/test_rfc0098_documentation.py
- git diff --check
- make check
- make ci

## Cross-repo dependency
- Requires lotus-ai PR #60, merged to main as d1df451, so outcome_review_narrative.pack@v1 supports lotus-gateway as an approved caller while keeping lotus-manage as workflow/evidence authority.

## Wiki
- Repo-local wiki/API-Surface.md changed. Run Sync-RepoWikis.ps1 -CheckOnly before merge and publish lotus-gateway wiki after merge.