### PR TITLE
feat: expose DPM construction alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ It depends on:
   proposal simulation, persisted proposal lifecycle, workflow, approval, and lineage capability
 - `lotus-manage`
   discretionary management run lookup, supportability summary, platform capability posture, and
-  RFC-0042 post-trade outcome-review authority through the DPM command-center BFF routes
+  RFC-0039 construction alternative-set authority and RFC-0042 post-trade outcome-review authority
+  through the DPM command-center BFF routes
 - `lotus-report`
   reporting snapshot, summary, review payloads, portfolio-review and outcome-review durable report
   job initiation/lifecycle/search, and RFC-0104 batch materialization/status/control/operator-run APIs
@@ -90,6 +91,9 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
 - `portfolio`
   `/api/v1/portfolio/*`
 - `dpm-command-center`
+  `/api/v1/dpm/command-center/construction/alternative-sets/generate`,
+  `/api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}`,
+  `/api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}/selections`,
   `/api/v1/dpm/command-center/outcome-reviews*`,
   `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`,
   `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
@@ -249,6 +253,12 @@ Important current parameter conventions:
    `/api/v1/dpm/command-center/outcome-reviews*` consume `lotus-manage` RFC-0042 APIs and preserve
    manage-owned `outcome_review_id`, state, supportability, lineage, hashes, report-input payloads,
    and AI-evidence payloads without recomputing expected-versus-realized outcome truth
+14. DPM command-center construction routes under
+   `/api/v1/dpm/command-center/construction/alternative-sets*` consume `lotus-manage` RFC-0039
+   construction authority APIs and preserve manage-owned alternative-set ids, method ids, method
+   statuses, objective traces, constraint traces, comparison metrics, diagnostics, supportability,
+   selected-alternative state, and lineage without optimizing, recomputing, or selecting
+   alternatives locally
 
 Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 
@@ -262,8 +272,9 @@ Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 - downstream ownership rule:
   proposal routes call `lotus-advise` `/advisory/proposals/*`; `lotus-manage` calls are limited to
   certified `/api/v1` discretionary management APIs, including run lookup, supportability summary,
-  platform capabilities, and RFC-0042 outcome-review preview/create/search/detail/source-refresh,
-  supportability, report-input, AI-evidence, run lookup, and wave lookup
+  platform capabilities, RFC-0039 construction alternative-set generate/get/select APIs, and
+  RFC-0042 outcome-review preview/create/search/detail/source-refresh, supportability,
+  report-input, AI-evidence, run lookup, and wave lookup
 - contract rule:
   gateway may reshape, aggregate, and annotate upstream data for product use, but must not assume
   upstream business authority

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -193,6 +193,12 @@ Most relevant current governance:
     and supportability summary over manage truth, but it must not recompute outcome dimensions,
     generate reports, generate AI narrative, infer PM quality, or let Workbench call manage
     directly.
+11. RFC-0039 construction-alternative Gateway routes are active under
+    `/api/v1/dpm/command-center/construction/alternative-sets*`. Gateway forwards generation,
+    retrieval, and selection requests to `lotus-manage`, preserves manage-owned alternatives,
+    method status, diagnostics, comparison metrics, selected-alternative state, and supportability,
+    and must not optimize portfolios, recompute construction metrics, infer source readiness, or
+    choose alternatives locally.
 
 ## Context Maintenance Rule
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -21,5 +21,5 @@ Governance boundary:
 | RFC-0013 | Workbench Position Valuation Fields | IMPLEMENTED | `docs/rfcs/RFC-0013-workbench-position-valuation-fields.md` |
 | RFC-0014 | Experience API Foundation and Pre-Live Replacement Strategy | PROPOSED | `docs/rfcs/RFC-0014-experience-api-foundation-and-prelive-replacement-strategy.md` |
 | RFC-0015 | Foundation Workspace Experience Contract | IMPLEMENTED | `docs/rfcs/RFC-0015-foundation-workspace-experience-contract.md` |
-| RFC-0098 | DPM Command Center Composition Contract | PARTIAL IMPLEMENTATION - RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER COMMAND CENTER PENDING | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
+| RFC-0098 | DPM Command Center Composition Contract | PARTIAL IMPLEMENTATION - RFC-0039 CONSTRUCTION AND RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER COMMAND CENTER PENDING | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
 

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -1131,20 +1131,29 @@ To be completed during the final closure slice:
 
 ## 19. Implementation Progress Ledger
 
-This RFC is not fully implemented. The first ledger-driven slice delivered the RFC-0042
-outcome-review route family so Workbench can later consume Gateway/BFF instead of calling
-`lotus-manage` directly.
+This RFC is not fully implemented. Ledger-driven slices have delivered the RFC-0039 construction
+alternative-set route family and the RFC-0042 outcome-review route family so Workbench can consume
+Gateway/BFF instead of calling `lotus-manage` directly.
 
 | Item | Status | Evidence |
 | --- | --- | --- |
-| RFC42-WTBD-001 Gateway outcome-review composition and BFF contract | Implemented in Gateway feature branch; local CI passed; pending PR/merge/live proof closure | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/contract/test_dpm_command_center_contract.py`, `make ci` |
-| RFC42-WTBD-005 Gateway AI narrative handoff | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | Gateway reads manage-owned `DpmOutcomeAiEvidenceInput`, executes `lotus-ai` `outcome_review_narrative.pack@v1` as `lotus-gateway`, preserves manage workflow authority, and exposes `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative` |
+| RFC39-WTBD-001 Gateway construction-alternatives composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_construction.py`, `src/app/services/dpm_construction_service.py`, `src/app/contracts/dpm_construction.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_construction_service.py`, `tests/integration/test_dpm_construction_router.py`, `tests/contract/test_dpm_construction_contract.py` |
+| RFC42-WTBD-001 Gateway outcome-review composition and BFF contract | Implemented and merged before this slice | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/contract/test_dpm_command_center_contract.py`, `make ci` |
+| RFC42-WTBD-005 Gateway AI narrative handoff | Implemented and merged before this slice | Gateway reads manage-owned `DpmOutcomeAiEvidenceInput`, executes `lotus-ai` `outcome_review_narrative.pack@v1` as `lotus-gateway`, preserves manage workflow authority, and exposes `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative` |
 | RFC-0042 manage authority preservation | Implemented for BFF envelope; Gateway forwards payloads and preserves manage supportability | Service tests prove payload preservation and upstream error forwarding; contract tests prove OpenAPI route family registration and What/When/How guidance |
 | Broader RFC-0098 command-center book, mandate detail, evidence, action handoff, wave composition, proof-pack composition, report/archive/AI modules | Not implemented in this slice | Remains governed by this RFC and the work-to-be-done ledger; no supported-feature claim is made |
 
 Implementation boundaries:
 
-1. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,
+1. Gateway now exposes `POST /api/v1/dpm/command-center/construction/alternative-sets/generate`,
+   `GET /api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}`, and
+   `POST /api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}/selections`.
+2. Construction routes preserve manage-owned alternative-set ids, method identifiers, method
+   statuses, objective traces, constraint traces, comparison metrics, diagnostics, supportability,
+   selected-alternative state, and lineage.
+3. Gateway does not optimize portfolios, recompute construction metrics, infer source readiness,
+   select alternatives, execute orders, or fabricate degraded-source values.
+4. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,
    `POST /api/v1/dpm/command-center/outcome-reviews`,
    `GET /api/v1/dpm/command-center/outcome-reviews`,
    `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}`,
@@ -1155,12 +1164,12 @@ Implementation boundaries:
    `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`,
    `GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`, and
    `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`.
-2. Gateway does not calculate expected values, realized values, variance, tolerance, hashes,
+5. Gateway does not calculate expected values, realized values, variance, tolerance, hashes,
    lineage, source freshness, supportability, or review state.
-3. Gateway does not generate reports, render artifacts, archive documents, generate AI narrative
+6. Gateway does not generate reports, render artifacts, archive documents, generate AI narrative
    locally, score PM quality, approve trades, contact clients, or claim Workbench UI support in
    this slice. The AI narrative endpoint is a governed handoff to `lotus-ai` over manage evidence.
-4. Workbench product realization remains a separate owning-repository implementation item.
+7. Workbench product realization remains a separate owning-repository implementation item.
 
 Validation performed on 2026-05-05:
 

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -176,6 +176,44 @@ class DpmClient:
             operation="manage.rebalance.waves.outcome_reviews",
         )
 
+    async def generate_construction_alternative_set(
+        self,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/api/v1/construction/alternative-sets/generate",
+            body=body,
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="manage.construction.alternative_sets.generate",
+        )
+
+    async def get_construction_alternative_set(
+        self,
+        alternative_set_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/construction/alternative-sets/{alternative_set_id}",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.construction.alternative_sets.get",
+        )
+
+    async def select_construction_alternative(
+        self,
+        alternative_set_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/api/v1/construction/alternative-sets/{alternative_set_id}/selections",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.construction.alternative_sets.select",
+        )
+
     async def get_capabilities(
         self,
         consumer_system: str,

--- a/src/app/contracts/dpm_construction.py
+++ b/src/app/contracts/dpm_construction.py
@@ -1,0 +1,136 @@
+from pydantic import BaseModel, Field
+
+
+class DpmConstructionGenerateRequest(BaseModel):
+    idempotency_key: str = Field(
+        description=(
+            "Required manage idempotency token for construction alternative-set generation. "
+            "Gateway forwards it as the `Idempotency-Key` header and does not derive replay keys."
+        ),
+        examples=["construction-idem-001"],
+    )
+    body: dict[str, object] = Field(
+        description=(
+            "Request payload forwarded unchanged to lotus-manage RFC-0039 construction authority. "
+            "Gateway does not optimize, recompute alternatives, infer source readiness, or choose "
+            "methods."
+        ),
+        examples=[
+            {
+                "input_mode": "stateless",
+                "methods": ["DO_NOTHING_BASELINE", "HEURISTIC_EXPLAINABLE", "MIN_TURNOVER"],
+                "stateless_input": {
+                    "portfolio_snapshot": {"portfolio_id": "PB_SG_GLOBAL_BAL_001"},
+                },
+            }
+        ],
+    )
+
+
+class DpmConstructionSelectionRequest(BaseModel):
+    body: dict[str, object] = Field(
+        description=(
+            "Selection payload forwarded unchanged to lotus-manage. Gateway records no independent "
+            "selection truth and does not execute orders."
+        ),
+        examples=[
+            {
+                "alternative_id": "alt_heuristic_explainable",
+                "actor_id": "pm_sg_1",
+                "reason_code": "PM_SELECTED_EXPLAINABLE_BASELINE",
+                "comment": "Selected for lower operational complexity.",
+            }
+        ],
+    )
+
+
+class DpmConstructionSupportability(BaseModel):
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Authoritative service that owns construction alternative supportability.",
+        examples=["lotus-manage"],
+    )
+    authority: str = Field(
+        default="lotus-manage:RFC-0039",
+        description="Business authority and RFC provenance for construction alternatives.",
+        examples=["lotus-manage:RFC-0039"],
+    )
+    state: str = Field(
+        description="Manage-published aggregate construction state preserved by Gateway.",
+        examples=["READY", "PENDING_REVIEW", "DEGRADED", "BLOCKED", "UNKNOWN"],
+    )
+    reason_codes: list[str] = Field(
+        default_factory=list,
+        description="Manage-published bounded reason codes collected for product supportability.",
+        examples=[["REGIME_SCENARIO_PACK_READY", "CASHFLOW_PROJECTION_READY"]],
+    )
+    selected_alternative_id: str | None = Field(
+        default=None,
+        description="Manage-owned selected alternative id when returned by a selection route.",
+        examples=["alt_heuristic_explainable"],
+    )
+
+
+class DpmConstructionGatewayResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated across Gateway and lotus-manage.",
+        examples=["corr-rfc39-construction-1"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway BFF contract version for construction alternative responses.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Upstream service that supplied the authoritative construction payload.",
+        examples=["lotus-manage"],
+    )
+    upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage before Gateway envelope composition.",
+        examples=[200],
+    )
+    supportability: DpmConstructionSupportability = Field(
+        description=(
+            "Gateway-normalized supportability summary derived from manage-published fields."
+        )
+    )
+    data: dict[str, object] = Field(
+        description=(
+            "Authoritative manage construction payload preserved for Workbench composition. "
+            "Gateway does not alter alternative ids, method statuses, objective traces, "
+            "constraint traces, comparison metrics, diagnostics, selected state, or lineage."
+        ),
+        examples=[
+            {
+                "alternative_set_id": "cas_001",
+                "status": "READY",
+                "alternatives": [
+                    {
+                        "alternative_id": "alt_heuristic_explainable",
+                        "method": "HEURISTIC_EXPLAINABLE",
+                        "method_status": "READY",
+                    }
+                ],
+            }
+        ],
+    )
+
+
+class DpmConstructionErrorDetail(BaseModel):
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Upstream service that rejected or failed the construction request.",
+        examples=["lotus-manage"],
+    )
+    upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage.", examples=[409]
+    )
+    error_code: str = Field(
+        description="Gateway error classification for the failed construction request.",
+        examples=["MANAGE_CONSTRUCTION_UPSTREAM_ERROR"],
+    )
+    detail: str = Field(
+        description="Product-safe summary of the manage error payload.",
+        examples=["CONSTRUCTION_IDEMPOTENCY_KEY_CONFLICT"],
+    )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -14,6 +14,7 @@ from app.routers.analytics_diagnostics import router as analytics_diagnostics_ro
 from app.routers.archive_documents import router as archive_documents_router
 from app.routers.domain_products import router as domain_products_router
 from app.routers.dpm_command_center import router as dpm_command_center_router
+from app.routers.dpm_construction import router as dpm_construction_router
 from app.routers.foundation import router as foundation_router
 from app.routers.intake import router as intake_router
 from app.routers.platform import router as platform_router
@@ -89,6 +90,7 @@ app.include_router(intake_router)
 app.include_router(foundation_router)
 app.include_router(portfolio_router)
 app.include_router(dpm_command_center_router)
+app.include_router(dpm_construction_router)
 app.include_router(workbench_router)
 app.include_router(reporting_router)
 app.include_router(reporting_jobs_router)

--- a/src/app/routers/dpm_construction.py
+++ b/src/app/routers/dpm_construction.py
@@ -1,0 +1,121 @@
+from typing import Any
+
+from fastapi import APIRouter, Path
+
+from app.clients.dpm_client import DpmClient
+from app.config import settings
+from app.contracts.dpm_construction import (
+    DpmConstructionErrorDetail,
+    DpmConstructionGatewayResponse,
+    DpmConstructionGenerateRequest,
+    DpmConstructionSelectionRequest,
+)
+from app.middleware.correlation import correlation_id_var
+from app.services.dpm_construction_service import DpmConstructionService
+
+router = APIRouter(
+    prefix="/api/v1/dpm/command-center/construction",
+    tags=["DPM Command Center"],
+)
+_UPSTREAM_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
+    409: {
+        "model": DpmConstructionErrorDetail,
+        "description": "lotus-manage rejected the construction request.",
+    },
+    422: {
+        "model": DpmConstructionErrorDetail,
+        "description": "lotus-manage rejected the construction payload as invalid.",
+    },
+    503: {
+        "model": DpmConstructionErrorDetail,
+        "description": "lotus-manage construction authority is unavailable or degraded.",
+    },
+}
+
+
+def _dpm_construction_service() -> DpmConstructionService:
+    return DpmConstructionService(
+        dpm_client=DpmClient(
+            base_url=settings.management_service_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+    )
+
+
+@router.post(
+    "/alternative-sets/generate",
+    response_model=DpmConstructionGatewayResponse,
+    summary="Generate construction alternatives",
+    description=(
+        "What: asks lotus-manage to generate an RFC-0039 construction alternative set for "
+        "Workbench comparison. When: call this after source readiness and mandate context are "
+        "available and a PM needs construction choices before approval. How: Gateway forwards "
+        "the payload and idempotency key to manage, then preserves the manage alternative set "
+        "without optimizing, recomputing metrics, or selecting an alternative."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def generate_construction_alternative_set(
+    request: DpmConstructionGenerateRequest,
+) -> DpmConstructionGatewayResponse:
+    return await _dpm_construction_service().generate_alternative_set(
+        body=request.body,
+        idempotency_key=request.idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/alternative-sets/{alternative_set_id}",
+    response_model=DpmConstructionGatewayResponse,
+    summary="Get construction alternative set",
+    description=(
+        "What: returns one manage-owned RFC-0039 construction alternative set. When: call this "
+        "to reopen comparison, audit selected posture, or populate Workbench detail views. "
+        "How: Gateway retrieves the manage payload by id and preserves alternative ids, method "
+        "statuses, objective traces, constraint traces, comparison metrics, diagnostics, and "
+        "lineage without recalculation."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def get_construction_alternative_set(
+    alternative_set_id: str = Path(
+        ...,
+        description="Manage-owned construction alternative-set identifier.",
+        examples=["cas_001"],
+    ),
+) -> DpmConstructionGatewayResponse:
+    return await _dpm_construction_service().get_alternative_set(
+        alternative_set_id=alternative_set_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/alternative-sets/{alternative_set_id}/selections",
+    response_model=DpmConstructionGatewayResponse,
+    summary="Select construction alternative",
+    description=(
+        "What: records a PM or workflow selection against a manage-owned construction "
+        "alternative set. When: call this only after the user chooses a visible alternative and "
+        "supportability allows selection. How: Gateway forwards the selection payload to manage "
+        "and preserves the returned audit decision; it does not execute trades or choose for the "
+        "user."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def select_construction_alternative(
+    request: DpmConstructionSelectionRequest,
+    alternative_set_id: str = Path(
+        ...,
+        description="Manage-owned construction alternative-set identifier.",
+        examples=["cas_001"],
+    ),
+) -> DpmConstructionGatewayResponse:
+    return await _dpm_construction_service().select_alternative(
+        alternative_set_id=alternative_set_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )

--- a/src/app/services/dpm_construction_service.py
+++ b/src/app/services/dpm_construction_service.py
@@ -1,0 +1,137 @@
+from typing import Any
+
+from fastapi import HTTPException, status
+
+from app.clients.dpm_client import DpmClient
+from app.config import settings
+from app.contracts.dpm_construction import (
+    DpmConstructionErrorDetail,
+    DpmConstructionGatewayResponse,
+    DpmConstructionSupportability,
+)
+
+
+class DpmConstructionService:
+    def __init__(self, dpm_client: DpmClient):
+        self._dpm_client = dpm_client
+
+    async def generate_alternative_set(
+        self,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> DpmConstructionGatewayResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._dpm_client.generate_construction_alternative_set(
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_alternative_set(
+        self,
+        alternative_set_id: str,
+        correlation_id: str,
+    ) -> DpmConstructionGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_construction_alternative_set(
+            alternative_set_id=alternative_set_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def select_alternative(
+        self,
+        alternative_set_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmConstructionGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.select_construction_alternative(
+            alternative_set_id=alternative_set_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    def _compose_response(
+        self,
+        upstream_status: int,
+        upstream_payload: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmConstructionGatewayResponse:
+        if upstream_status >= status.HTTP_400_BAD_REQUEST:
+            raise HTTPException(
+                status_code=upstream_status,
+                detail=DpmConstructionErrorDetail(
+                    upstream_status=upstream_status,
+                    error_code="MANAGE_CONSTRUCTION_UPSTREAM_ERROR",
+                    detail=_safe_upstream_detail(upstream_payload),
+                ).model_dump(),
+            )
+
+        return DpmConstructionGatewayResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            upstream_status=upstream_status,
+            supportability=_supportability_from(upstream_payload),
+            data=upstream_payload,
+        )
+
+
+def _supportability_from(payload: dict[str, Any]) -> DpmConstructionSupportability:
+    reason_codes = _reason_codes_from_payload(payload)
+    state = payload.get("status") or payload.get("state") or "UNKNOWN"
+    selected_alternative_id = payload.get("alternative_id")
+    return DpmConstructionSupportability(
+        state=str(state),
+        reason_codes=sorted(set(reason_codes)),
+        selected_alternative_id=(
+            str(selected_alternative_id) if selected_alternative_id is not None else None
+        ),
+    )
+
+
+def _reason_codes_from_payload(payload: dict[str, Any]) -> list[str]:
+    reason_codes = _list_of_strings(payload.get("reason_codes") or payload.get("reasonCodes") or [])
+    alternatives = payload.get("alternatives")
+    if isinstance(alternatives, list):
+        for alternative in alternatives:
+            if not isinstance(alternative, dict):
+                continue
+            diagnostics = alternative.get("diagnostics")
+            if not isinstance(diagnostics, dict):
+                continue
+            enrichment_summary = diagnostics.get("enrichment_summary")
+            if isinstance(enrichment_summary, dict):
+                reason_codes.extend(
+                    _list_of_strings(
+                        enrichment_summary.get("reason_codes")
+                        or enrichment_summary.get("reasonCodes")
+                        or []
+                    )
+                )
+            method_plan = diagnostics.get("method_plan")
+            if isinstance(method_plan, dict):
+                reason_codes.extend(
+                    _list_of_strings(
+                        method_plan.get("reason_codes") or method_plan.get("reasonCodes") or []
+                    )
+                )
+    return reason_codes
+
+
+def _list_of_strings(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _safe_upstream_detail(payload: dict[str, Any]) -> str:
+    detail = payload.get("detail") or payload.get("message") or payload.get("error")
+    if isinstance(detail, str):
+        return detail
+    if detail is not None:
+        return str(detail)
+    return "lotus-manage construction request failed"

--- a/tests/contract/test_dpm_construction_contract.py
+++ b/tests/contract/test_dpm_construction_contract.py
@@ -1,0 +1,80 @@
+from fastapi.testclient import TestClient
+
+from app.contracts.dpm_construction import DpmConstructionGatewayResponse
+from app.main import app
+
+
+def test_dpm_construction_gateway_response_contract_shape() -> None:
+    response = DpmConstructionGatewayResponse(
+        correlation_id="corr-1",
+        upstream_status=200,
+        supportability={
+            "state": "READY",
+            "reason_codes": ["REGIME_SCENARIO_PACK_READY"],
+            "selected_alternative_id": "alt_regime_stress_aware",
+        },
+        data={
+            "alternative_set_id": "cas_1",
+            "status": "READY",
+            "alternatives": [
+                {
+                    "alternative_id": "alt_regime_stress_aware",
+                    "method": "REGIME_STRESS_AWARE",
+                    "method_status": "READY",
+                }
+            ],
+        },
+    )
+
+    assert response.source_service == "lotus-manage"
+    assert response.supportability.authority == "lotus-manage:RFC-0039"
+    assert response.data["alternative_set_id"] == "cas_1"
+
+
+def test_dpm_construction_openapi_contract_registered() -> None:
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+    expected_paths = [
+        (
+            "/api/v1/dpm/command-center/construction/alternative-sets/generate",
+            "post",
+        ),
+        (
+            "/api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}",
+            "get",
+        ),
+        (
+            "/api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}/selections",
+            "post",
+        ),
+    ]
+
+    for path, method in expected_paths:
+        assert path in spec["paths"]
+        operation = spec["paths"][path][method]
+        assert operation["tags"] == ["DPM Command Center"]
+        assert operation["summary"]
+        assert "What:" in operation["description"]
+        assert "When:" in operation["description"]
+        assert "How:" in operation["description"]
+
+
+def test_dpm_construction_openapi_models_are_described() -> None:
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+    schemas = spec["components"]["schemas"]
+
+    for schema_name in [
+        "DpmConstructionGenerateRequest",
+        "DpmConstructionSelectionRequest",
+        "DpmConstructionGatewayResponse",
+        "DpmConstructionSupportability",
+        "DpmConstructionErrorDetail",
+    ]:
+        schema = schemas[schema_name]
+        for property_schema in schema["properties"].values():
+            assert property_schema.get("description")
+
+    assert schemas["DpmConstructionGenerateRequest"]["properties"]["body"]["examples"]
+    assert schemas["DpmConstructionGatewayResponse"]["properties"]["data"]["description"]
+    assert schemas["DpmConstructionSupportability"]["properties"]["state"]["examples"]

--- a/tests/integration/test_dpm_construction_router.py
+++ b/tests/integration/test_dpm_construction_router.py
@@ -1,0 +1,162 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_dpm_construction_generate_preserves_manage_truth(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_generate_construction_alternative_set(
+        self,
+        body,
+        idempotency_key,
+        correlation_id,
+    ):  # noqa: ANN001
+        _ = self
+        captured["body"] = body
+        captured["idempotency_key"] = idempotency_key
+        captured["correlation_id"] = correlation_id
+        return 200, _construction_alternative_set()
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.generate_construction_alternative_set",
+        _fake_generate_construction_alternative_set,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/construction/alternative-sets/generate",
+        json={
+            "idempotency_key": "idem-construction-router-1",
+            "body": {"input_mode": "stateless", "methods": ["REGIME_STRESS_AWARE"]},
+        },
+        headers={"X-Correlation-Id": "corr-construction-router-1"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert captured == {
+        "body": {"input_mode": "stateless", "methods": ["REGIME_STRESS_AWARE"]},
+        "idempotency_key": "idem-construction-router-1",
+        "correlation_id": "corr-construction-router-1",
+    }
+    assert payload["correlation_id"] == "corr-construction-router-1"
+    assert payload["source_service"] == "lotus-manage"
+    assert payload["supportability"]["state"] == "READY"
+    assert payload["supportability"]["reason_codes"] == [
+        "REGIME_SCENARIO_PACK_READY",
+        "TARGET_METHOD_COMPARISON_AVAILABLE",
+    ]
+    assert payload["data"] == _construction_alternative_set()
+
+
+def test_dpm_construction_get_uses_manage_identifier(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_get_construction_alternative_set(
+        self,
+        alternative_set_id,
+        correlation_id,
+    ):  # noqa: ANN001
+        _ = self
+        captured["alternative_set_id"] = alternative_set_id
+        captured["correlation_id"] = correlation_id
+        return 200, _construction_alternative_set()
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_construction_alternative_set",
+        _fake_get_construction_alternative_set,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/dpm/command-center/construction/alternative-sets/cas_1",
+        headers={"X-Correlation-Id": "corr-construction-get-1"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "alternative_set_id": "cas_1",
+        "correlation_id": "corr-construction-get-1",
+    }
+    assert response.json()["data"]["alternative_set_id"] == "cas_1"
+
+
+def test_dpm_construction_selection_preserves_manage_decision(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_select_construction_alternative(
+        self,
+        alternative_set_id,
+        body,
+        correlation_id,
+    ):  # noqa: ANN001
+        _ = self
+        captured["alternative_set_id"] = alternative_set_id
+        captured["body"] = body
+        captured["correlation_id"] = correlation_id
+        return 200, {
+            "selection_id": "casel_1",
+            "alternative_set_id": alternative_set_id,
+            "alternative_id": body["alternative_id"],
+            "actor_id": body["actor_id"],
+            "reason_code": body["reason_code"],
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.select_construction_alternative",
+        _fake_select_construction_alternative,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/construction/alternative-sets/cas_1/selections",
+        json={
+            "body": {
+                "alternative_id": "alt_regime_stress_aware",
+                "actor_id": "pm_sg_1",
+                "reason_code": "PM_SELECTED_REGIME_AWARE",
+            }
+        },
+        headers={"X-Correlation-Id": "corr-construction-select-1"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "alternative_set_id": "cas_1",
+        "body": {
+            "alternative_id": "alt_regime_stress_aware",
+            "actor_id": "pm_sg_1",
+            "reason_code": "PM_SELECTED_REGIME_AWARE",
+        },
+        "correlation_id": "corr-construction-select-1",
+    }
+    payload = response.json()
+    assert payload["supportability"]["selected_alternative_id"] == "alt_regime_stress_aware"
+    assert payload["data"]["selection_id"] == "casel_1"
+
+
+def _construction_alternative_set() -> dict[str, object]:
+    return {
+        "alternative_set_id": "cas_1",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "status": "READY",
+        "alternatives": [
+            {
+                "alternative_id": "alt_regime_stress_aware",
+                "method": "REGIME_STRESS_AWARE",
+                "method_status": "READY",
+                "objective_trace": [],
+                "constraint_trace": [],
+                "comparison_metrics": {"turnover_weight": "0.05"},
+                "diagnostics": {
+                    "method_plan": {
+                        "reason_codes": ["TARGET_METHOD_COMPARISON_AVAILABLE"],
+                    },
+                    "enrichment_summary": {
+                        "reason_codes": ["REGIME_SCENARIO_PACK_READY"],
+                    },
+                },
+            }
+        ],
+    }

--- a/tests/unit/test_dpm_construction_service.py
+++ b/tests/unit/test_dpm_construction_service.py
@@ -1,0 +1,196 @@
+import pytest
+from fastapi import HTTPException
+
+from app.services.dpm_construction_service import DpmConstructionService
+
+
+class _FakeDpmClient:
+    def __init__(self, result: tuple[int, dict]):
+        self.result = result
+        self.calls: list[dict[str, object]] = []
+
+    async def generate_construction_alternative_set(
+        self,
+        body,
+        idempotency_key,
+        correlation_id,
+    ):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "construction_generate",
+                "body": body,
+                "idempotency_key": idempotency_key,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+    async def get_construction_alternative_set(self, alternative_set_id, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "construction_get",
+                "alternative_set_id": alternative_set_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+    async def select_construction_alternative(
+        self,
+        alternative_set_id,
+        body,
+        correlation_id,
+    ):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "construction_select",
+                "alternative_set_id": alternative_set_id,
+                "body": body,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_dpm_construction_preserves_manage_alternative_set_payload() -> None:
+    manage_payload = _construction_alternative_set()
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmConstructionService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.generate_alternative_set(
+        body={"input_mode": "stateless", "methods": ["REGIME_STRESS_AWARE"]},
+        idempotency_key="idem-construction-1",
+        correlation_id="corr-construction-1",
+    )
+
+    assert response.correlation_id == "corr-construction-1"
+    assert response.source_service == "lotus-manage"
+    assert response.upstream_status == 200
+    assert response.supportability.authority == "lotus-manage:RFC-0039"
+    assert response.supportability.state == "READY"
+    assert response.supportability.reason_codes == [
+        "REGIME_SCENARIO_PACK_READY",
+        "TARGET_METHOD_COMPARISON_AVAILABLE",
+    ]
+    assert response.data == manage_payload
+    assert client.calls == [
+        {
+            "method": "construction_generate",
+            "body": {"input_mode": "stateless", "methods": ["REGIME_STRESS_AWARE"]},
+            "idempotency_key": "idem-construction-1",
+            "correlation_id": "corr-construction-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_construction_retrieves_manage_alternative_set_without_mutation() -> None:
+    manage_payload = _construction_alternative_set()
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmConstructionService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.get_alternative_set(
+        alternative_set_id="cas_1",
+        correlation_id="corr-get-1",
+    )
+
+    assert response.data == manage_payload
+    assert response.supportability.state == "READY"
+    assert client.calls == [
+        {
+            "method": "construction_get",
+            "alternative_set_id": "cas_1",
+            "correlation_id": "corr-get-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_construction_selection_preserves_manage_decision() -> None:
+    client = _FakeDpmClient(
+        (
+            200,
+            {
+                "selection_id": "casel_1",
+                "alternative_set_id": "cas_1",
+                "alternative_id": "alt_regime_stress_aware",
+                "actor_id": "pm_sg_1",
+                "reason_code": "PM_SELECTED_REGIME_AWARE",
+            },
+        )
+    )
+    service = DpmConstructionService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.select_alternative(
+        alternative_set_id="cas_1",
+        body={
+            "alternative_id": "alt_regime_stress_aware",
+            "actor_id": "pm_sg_1",
+            "reason_code": "PM_SELECTED_REGIME_AWARE",
+        },
+        correlation_id="corr-select-1",
+    )
+
+    assert response.supportability.state == "UNKNOWN"
+    assert response.supportability.selected_alternative_id == "alt_regime_stress_aware"
+    assert response.data["selection_id"] == "casel_1"
+    assert client.calls == [
+        {
+            "method": "construction_select",
+            "alternative_set_id": "cas_1",
+            "body": {
+                "alternative_id": "alt_regime_stress_aware",
+                "actor_id": "pm_sg_1",
+                "reason_code": "PM_SELECTED_REGIME_AWARE",
+            },
+            "correlation_id": "corr-select-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_construction_forwards_manage_errors_as_product_safe_detail() -> None:
+    client = _FakeDpmClient((409, {"detail": "CONSTRUCTION_IDEMPOTENCY_KEY_CONFLICT"}))
+    service = DpmConstructionService(dpm_client=client)  # type: ignore[arg-type]
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.generate_alternative_set(
+            body={"input_mode": "stateless"},
+            idempotency_key="idem-conflict",
+            correlation_id="corr-conflict",
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == {
+        "source_service": "lotus-manage",
+        "upstream_status": 409,
+        "error_code": "MANAGE_CONSTRUCTION_UPSTREAM_ERROR",
+        "detail": "CONSTRUCTION_IDEMPOTENCY_KEY_CONFLICT",
+    }
+
+
+def _construction_alternative_set() -> dict[str, object]:
+    return {
+        "alternative_set_id": "cas_1",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "status": "READY",
+        "alternatives": [
+            {
+                "alternative_id": "alt_regime_stress_aware",
+                "method": "REGIME_STRESS_AWARE",
+                "method_status": "READY",
+                "objective_trace": [],
+                "constraint_trace": [],
+                "comparison_metrics": {"turnover_weight": "0.05"},
+                "diagnostics": {
+                    "method_plan": {
+                        "reason_codes": ["TARGET_METHOD_COMPARISON_AVAILABLE"],
+                    },
+                    "enrichment_summary": {
+                        "reason_codes": ["REGIME_SCENARIO_PACK_READY"],
+                    },
+                },
+            }
+        ],
+    }

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1629,6 +1629,11 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
             "http://dpm/api/v1/rebalance/runs/rr_1/outcome-review",
         ),
         (
+            "get_construction_alternative_set",
+            {"alternative_set_id": "cas_1", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/construction/alternative-sets/cas_1",
+        ),
+        (
             "list_wave_outcome_reviews",
             {"wave_id": "wave_1", "params": {"state": None}, "correlation_id": "corr-5"},
             "http://dpm/api/v1/rebalance/waves/wave_1/outcome-reviews",
@@ -1694,6 +1699,15 @@ async def test_dpm_client_capabilities_uses_gateway_consumer_for_manage_contract
             },
             "http://dpm/api/v1/rebalance/outcome-reviews/or_1/refresh-sources",
         ),
+        (
+            "select_construction_alternative",
+            {
+                "alternative_set_id": "cas_1",
+                "body": {"alternative_id": "alt_1", "actor_id": "pm_sg_1"},
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/construction/alternative-sets/cas_1/selections",
+        ),
     ],
 )
 async def test_dpm_client_outcome_review_command_routes(method_name, kwargs, expected_url):
@@ -1707,6 +1721,29 @@ async def test_dpm_client_outcome_review_command_routes(method_name, kwargs, exp
     assert _FakeAsyncClient.calls[0]["method"] == "POST"
     assert _FakeAsyncClient.calls[0]["url"] == expected_url
     assert _FakeAsyncClient.calls[0]["json"] == kwargs["body"]
+
+
+@pytest.mark.asyncio
+async def test_dpm_client_construction_generate_route_forwards_idempotency_key():
+    client = DpmClient(base_url="http://dpm", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"alternative_set_id": "cas_1"})
+
+    status_code, payload = await client.generate_construction_alternative_set(
+        body={"input_mode": "stateless"},
+        idempotency_key="idem-construction-1",
+        correlation_id="corr-construction-1",
+    )
+
+    assert status_code == 200
+    assert payload["alternative_set_id"] == "cas_1"
+    assert _FakeAsyncClient.calls[0]["method"] == "POST"
+    assert (
+        _FakeAsyncClient.calls[0]["url"]
+        == "http://dpm/api/v1/construction/alternative-sets/generate"
+    )
+    assert _FakeAsyncClient.calls[0]["json"] == {"input_mode": "stateless"}
+    assert _FakeAsyncClient.calls[0]["headers"]["Idempotency-Key"] == "idem-construction-1"
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Correlation-Id"] == "corr-construction-1"
 
 
 @pytest.mark.asyncio

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -17,6 +17,7 @@
 - `GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`
 - `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
 - `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`
+- `GET` and `POST /api/v1/dpm/command-center/construction/alternative-sets*`
 - `GET` and `POST /api/v1/workbench/*`
 - `GET` and `POST /api/v1/reports/*`
 - `POST /api/v1/reports/outcome-reviews`
@@ -60,6 +61,13 @@
 - RFC-0098 proof-pack composition must consume `lotus-manage` RFC-0040 proof-pack APIs for
   proof-pack JSON, section states, hashes, Markdown, report-input payloads, and AI-evidence
   payloads; `lotus-report` remains report materialization authority, not proof-pack authority
+- RFC-0098 construction-alternative composition consumes `lotus-manage` RFC-0039 construction
+  APIs through `/api/v1/dpm/command-center/construction/alternative-sets*`. Gateway exposes
+  generate, get, and select routes for Workbench, preserving manage alternative-set ids, method
+  identifiers, method statuses, objective traces, constraint traces, comparison metrics,
+  diagnostics, supportability, selected-alternative state, and lineage. Gateway must not optimize,
+  recompute construction metrics, infer source readiness, select alternatives, execute orders, or
+  let Workbench bypass Gateway.
 - RFC-0098 wave composition must consume `lotus-manage` RFC-0041 wave APIs for preview, create,
   source-check, simulation, selection, approval, staging, handoff, and supportability. Target
   Gateway routes belong under `/api/v1/dpm/command-center/waves*`, preserve manage `wave_id`,
@@ -107,8 +115,8 @@
 - proposal simulation, create, list, detail, version, workflow-event, approval, and lineage routes
   call `lotus-advise` `/advisory/proposals/*`; they do not call `lotus-manage`
 - gateway calls `lotus-manage` only through versioned `/api/v1/*` paths for discretionary
-  management run lookup, supportability summary, capability posture, and RFC-0042
-  outcome-review authority APIs
+  management run lookup, supportability summary, capability posture, RFC-0039 construction
+  alternative-set authority APIs, and RFC-0042 outcome-review authority APIs
 - `/metrics` includes RFC-0108 gateway analytics fan-out metrics for selected Workbench analytics
   operations plus the central `lotus-advise`, `lotus-manage`, `lotus-report`, `lotus-archive`,
   `lotus-ai`, direct `lotus-core` query/control-plane, and `lotus-core` ingestion client seams:

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -32,6 +32,9 @@
   config-backed scheduler inspection and bounded run-due boundary over `lotus-report`
 - `archived documents`
   generated-document metadata and controlled download boundary over `lotus-archive`
+- `dpm-command-center construction`
+  Workbench-facing construction alternative generation, retrieval, and selection over
+  `lotus-manage` RFC-0039 authority
 
 ## Boundary notes
 
@@ -43,3 +46,5 @@
    purge, legal-hold mutation, and access-event ownership stay in `lotus-archive`
 6. report batch lifecycle, scheduler configuration, and execution truth stay in `lotus-report`;
    gateway exposes the governed operator boundary and rewrites only gateway-relative status URLs
+7. construction alternatives stay in `lotus-manage`; gateway exposes the Workbench contract and
+   preserves manage-owned alternatives, statuses, diagnostics, supportability, and selections

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -17,13 +17,14 @@
   proposal simulation, proposal persistence, workflow events, approvals, and lineage through
   `/advisory/proposals/*`
 - `lotus-manage`
-  discretionary management run lookup, supportability summary, capabilities, RFC-0040
+  discretionary management run lookup, supportability summary, capabilities, RFC-0039
+  construction alternative-set authority APIs, RFC-0040
   proof-pack authority APIs, RFC-0041 rebalance-wave orchestration authority APIs, and RFC-0042
   post-trade outcome-review authority APIs. RFC-0098 remains the strategic Gateway DPM
-  command-center contract; the RFC-0042 outcome-review BFF route family is now
-  implementation-backed, while broader mandate health, RFC-0041 wave composition, proof-pack
-  modules, report materialization, archive, and optional AI posture remain governed follow-on
-  slices until implemented and proven
+  command-center contract; the RFC-0039 construction alternative-set BFF route family and
+  RFC-0042 outcome-review BFF route family are now implementation-backed, while broader mandate
+  health, RFC-0041 wave composition, proof-pack modules, report materialization, archive, and
+  optional AI posture remain governed follow-on slices until implemented and proven
 - `lotus-report`
   reporting snapshot, summary, and review payloads
 - `lotus-archive`
@@ -80,3 +81,11 @@
     route family is `/api/v1/dpm/command-center/outcome-reviews*`,
     `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`, and
     `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`.
+11. RFC-0039 construction alternatives remain `lotus-manage` truth. Gateway construction
+    realization exposes `/api/v1/dpm/command-center/construction/alternative-sets/generate`,
+    `/api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}`, and
+    `/api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}/selections`
+    for Workbench. Gateway forwards request bodies and idempotency/correlation context to manage,
+    then preserves alternatives, method status, diagnostics, comparison metrics, supportability,
+    and selection decisions without performing optimization, recomputation, readiness inference, or
+    order execution.

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -23,6 +23,9 @@
    realization; the first implementation-backed outcome-review BFF route family is active under
    `/api/v1/dpm/command-center/outcome-reviews*`, run lookup, and wave lookup routes, preserving
    manage source-lineage, supportability, report-input, and AI-evidence truth without recomputing
-   expected-versus-realized outcomes.
+   expected-versus-realized outcomes. RFC-0039 construction alternative-set composition is also
+   implementation-backed under `/api/v1/dpm/command-center/construction/alternative-sets*`,
+   preserving manage-owned alternatives, diagnostics, supportability, and selection decisions
+   without Gateway optimization or recomputation.
 3. preserve RFC-0082 boundary discipline as integrations evolve
 4. keep request-convention and runtime guidance explicit for operators and future agents

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -1,0 +1,60 @@
+# Supported Features
+
+This page lists implementation-backed `lotus-gateway` feature coverage. It is product material for
+developers, business users, operations, sales/pre-sales, and client demos; it must not describe
+future capability as supported until the owning service, Gateway contract, tests, and validation
+evidence exist.
+
+## DPM Command Center Construction Alternatives
+
+Status: implementation-backed in Gateway for RFC39-WTBD-001.
+
+Business outcome:
+
+1. portfolio managers can request and compare disciplined rebalance construction alternatives,
+2. CIO and investment-control users can inspect method status, diagnostics, supportability, and
+   comparison evidence before approval,
+3. Workbench can use Gateway as the product-facing contract instead of calling `lotus-manage`
+   directly.
+
+Supported routes:
+
+1. `POST /api/v1/dpm/command-center/construction/alternative-sets/generate`
+2. `GET /api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}`
+3. `POST /api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}/selections`
+
+Authority and integrations:
+
+1. `lotus-manage` remains the RFC-0039 construction authority.
+2. Gateway forwards request bodies, idempotency keys, and correlation context to manage.
+3. Gateway preserves manage-owned alternative-set ids, method ids, method statuses, objective
+   traces, constraint traces, comparison metrics, diagnostics, supportability, selected alternative
+   state, and lineage.
+4. Gateway does not optimize portfolios, recompute construction metrics, infer source readiness,
+   select alternatives, execute orders, or fabricate degraded-source values.
+
+```mermaid
+flowchart LR
+    Workbench[lotus-workbench] --> Gateway[lotus-gateway DPM command-center construction routes]
+    Gateway --> Manage[lotus-manage RFC-0039 construction authority]
+    Manage --> Risk[lotus-risk regime scenario source product]
+    Manage --> Perf[lotus-performance method evidence when available]
+    Manage --> Gateway
+    Gateway --> Workbench
+```
+
+Operational behavior:
+
+1. degraded or rejected manage states are surfaced as product supportability, not hidden as generic
+   success,
+2. manage upstream errors are returned using product-safe Gateway error detail,
+3. OpenAPI documents What/When/How guidance and request/response examples for each route.
+
+## DPM Command Center Outcome Reviews
+
+Status: implementation-backed in Gateway for RFC42-WTBD-001 and RFC42-WTBD-005.
+
+Gateway exposes outcome-review preview/create/search/detail/source-refresh/supportability,
+report-input, AI-evidence, run lookup, wave lookup, and governed AI narrative handoff routes under
+`/api/v1/dpm/command-center/outcome-reviews*`. `lotus-manage` remains outcome-review authority and
+`lotus-ai` remains AI workflow execution authority.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -4,6 +4,7 @@
 - [Overview](Overview)
 - [Architecture](Architecture)
 - [API Surface](API-Surface)
+- [Supported Features](Supported-Features)
 - [Getting Started](Getting-Started)
 
 ### Delivery


### PR DESCRIPTION
## Summary
- add DPM command-center construction alternative generate/get/select routes over lotus-manage RFC-0039 authority
- preserve manage-owned alternatives, diagnostics, supportability, and selected-alternative state without Gateway recomputation
- add dedicated service, router, client, integration, contract, OpenAPI, README, RFC, and wiki supported-feature documentation

## Validation
- python -m pytest tests\\unit\\test_dpm_construction_service.py tests\\unit\\test_dpm_command_center_service.py tests\\unit\\test_upstream_clients.py::test_dpm_client_manage_routes tests\\unit\\test_upstream_clients.py::test_dpm_client_outcome_review_command_routes tests\\unit\\test_upstream_clients.py::test_dpm_client_construction_generate_route_forwards_idempotency_key tests\\integration\\test_dpm_construction_router.py tests\\integration\\test_dpm_command_center_router.py tests\\contract\\test_dpm_construction_contract.py tests\\contract\\test_dpm_command_center_contract.py -q
- make check
- powershell -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-AgentOperatingContract.ps1 -AllRepoRoots -IncludeDeployedTarget -CheckOnly
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py

## Wiki
- repo-local wiki source updated; Sync-RepoWikis.ps1 -CheckOnly currently reports expected drift for this branch and must be published after merge