### PR TITLE
test: guard manage canonical API consumption

### DIFF
--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -41,7 +41,7 @@ outputs.
 | `lotus-performance` | performance summary, TWR, MWR, contribution, attribution, workspace summary, benchmark exposure context, execution polling, lineage artifact inventory | performance workspace, first-paint modules, and gateway-owned evidence posture | performance calculations, execution state, and lineage provenance remain in `lotus-performance`; gateway may reshape them for UI-safe evidence review but must not invent or replace source truth |
 | `lotus-risk` | calculate risk, concentration, drawdown, rolling metrics, historical attribution | risk workspace modules and risk panels | risk methodology, concentration, drawdown, and attribution semantics remain in `lotus-risk` |
 | `lotus-advise` | proposal lifecycle and advisory workflow surfaces | proposal workflow composition | advisory decision workflow remains in `lotus-advise` |
-| `lotus-manage` | management workflow surfaces where split routing still applies | management workflow composition | discretionary management operations remain in `lotus-manage` |
+| `lotus-manage` | versioned `/api/v1` rebalance run lookup, supportability summary, capability posture, construction alternatives, outcome reviews, report input, and AI evidence input | management workflow composition | discretionary management operations remain in `lotus-manage`; gateway must not reintroduce retired unversioned aliases or monolithic `dpm-execution-context` assumptions |
 | `lotus-report` | report snapshot rows, summary/review payloads, report job status/search/event/cancellation APIs, report batch materialization/status/control/operator-run APIs | report-ready experience payloads, durable report-job support posture, and RFC-0104 batch operator boundary | report generation, request semantics, job lifecycle truth, batch lifecycle truth, and batch execution truth remain in `lotus-report` |
 | `lotus-archive` | archived document metadata, current-document resolution, and binary download APIs | gateway-controlled generated-document retrieval for product clients | archive metadata, retention, legal-hold, purge, lifecycle, checksum, storage, and access-audit truth remain in `lotus-archive`; gateway exposes metadata and controlled download only |
 | `lotus-ai` | advisor-brief, workflow-pack run-ledger, and RFC-0097 task-flow posture surfaces | evidence-grounded narrative support plus bounded run/task-flow posture for Workbench | gateway must not invent unsupported evidence, model outputs, review states, replacement lineage, or task-flow authority |
@@ -67,6 +67,9 @@ outputs.
 Existing tests that cover this posture include:
 
 1. `tests/unit/test_upstream_clients.py`
+   Includes `test_dpm_client_uses_only_canonical_manage_api_v1_contracts`, which exercises every
+   manage-facing DPM client method and rejects retired unversioned route families and monolithic
+   execution-context assumptions.
 2. `tests/unit/test_workbench_service.py`
 3. `tests/unit/test_workbench_service_additional.py`
 4. `tests/unit/test_performance_workspace_service.py`

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1677,6 +1677,120 @@ async def test_dpm_client_capabilities_uses_gateway_consumer_for_manage_contract
 
 
 @pytest.mark.asyncio
+async def test_dpm_client_uses_only_canonical_manage_api_v1_contracts():
+    client = DpmClient(base_url="http://dpm", timeout_seconds=2.0)
+    calls = [
+        (
+            client.list_runs,
+            {"params": {"portfolio_id": "P1"}, "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.get_supportability_summary,
+            {"correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.get_capabilities,
+            {
+                "consumer_system": "lotus-workbench",
+                "tenant_id": "default",
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.preview_outcome_review,
+            {"body": {"portfolio_id": "P1"}, "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.create_outcome_review,
+            {"body": {"rebalance_run_id": "rr_1"}, "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.list_outcome_reviews,
+            {"params": {"portfolio_id": "P1"}, "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.get_outcome_review,
+            {"outcome_review_id": "or_1", "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.refresh_outcome_review_sources,
+            {
+                "outcome_review_id": "or_1",
+                "body": {"refresh_reason": "late fill"},
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.get_outcome_review_supportability,
+            {"outcome_review_id": "or_1", "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.get_outcome_review_report_input,
+            {"outcome_review_id": "or_1", "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.get_outcome_review_ai_evidence_input,
+            {"outcome_review_id": "or_1", "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.get_run_outcome_review,
+            {"rebalance_run_id": "rr_1", "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.list_wave_outcome_reviews,
+            {
+                "wave_id": "wave_1",
+                "params": {"state": "READY"},
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.generate_construction_alternative_set,
+            {
+                "body": {"portfolio_id": "P1"},
+                "idempotency_key": "idem-rfc36-canonical",
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.get_construction_alternative_set,
+            {
+                "alternative_set_id": "cas_1",
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.select_construction_alternative,
+            {
+                "alternative_set_id": "cas_1",
+                "body": {"alternative_id": "alt_1", "actor_id": "pm_1"},
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+    ]
+    for _method, _kwargs in calls:
+        _FakeAsyncClient.queue_json(200, {"ok": True})
+
+    for method, kwargs in calls:
+        await method(**kwargs)
+
+    forbidden_fragments = (
+        "/dpm-execution-context",
+        "/integration/capabilities",
+        "/rebalance/runs",
+        "/rebalance/supportability",
+        "/construction/alternative-sets",
+        "/dpm/",
+    )
+    manage_urls = [call["url"] for call in _FakeAsyncClient.calls]
+    assert manage_urls
+    assert all(url.startswith("http://dpm/api/v1/") for url in manage_urls)
+    for url in manage_urls:
+        path = url.removeprefix("http://dpm")
+        assert not any(path.startswith(fragment) for fragment in forbidden_fragments)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("method_name", "kwargs", "expected_url"),
     [


### PR DESCRIPTION
## Summary
- Adds a focused regression test proving every manage-facing `DpmClient` method consumes canonical `/api/v1` manage APIs only.
- Guards against retired unversioned rebalance/supportability/construction aliases and monolithic `dpm-execution-context` assumptions.
- Tightens the RFC-0082 upstream contract family map for `lotus-manage` consumption.

## RFC / WTBD
- Closes the Gateway proof gap for `lotus-manage` ledger item `RFC36-WTBD-001` once merged and validated.

## Local proof
- `python -m pytest tests/unit/test_upstream_clients.py -k "dpm_client_uses_only_canonical_manage_api_v1_contracts or dpm_client_manage_routes or dpm_client_outcome_review_command_routes or dpm_client_construction_generate_route"` -> 17 passed
- `make check` -> ruff, format, monetary-float guard, mypy, contract smoke, and 423 unit/contract tests passed

## Wiki
- No repo-local wiki change required. This change tightens developer standards documentation and executable regression coverage; published product/operator behavior is unchanged.