### PR TITLE
feat: expose DPM operations posture in Workbench contract

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -199,6 +199,11 @@ Most relevant current governance:
     method status, diagnostics, comparison metrics, selected-alternative state, and supportability,
     and must not optimize portfolios, recompute construction metrics, infer source readiness, or
     choose alternatives locally.
+12. The Workbench overview and portfolio-360 `rebalance_snapshot` now carry bounded
+    portfolio-level DPM operations posture for RFC36-WTBD-003: latest rebalance status, last run,
+    manage action-register supportability, and up to five recent manage runs with bounded status,
+    timestamp, workflow posture, and error code. Gateway remains the product-facing composition
+    boundary and does not calculate supportability, workflow state, or error semantics locally.
 
 ## Context Maintenance Rule
 

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-05-01T14:58:49Z",
+  "generated_at": "2026-05-06T09:01:21Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -598,82 +598,82 @@
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/workbench.py:178:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/workbench.py:239:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/contracts/workbench.py:183:weight_pct: float | None = Field(",
+      "finding": "src/app/contracts/workbench.py:244:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/contracts/workbench.py:26:market_value_base: float = Field(",
+      "finding": "src/app/contracts/workbench.py:28:market_value_base: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/contracts/workbench.py:30:cash_weight_pct: float = Field(",
+      "finding": "src/app/contracts/workbench.py:32:cash_weight_pct: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/contracts/workbench.py:387:price: float | None = Field(",
+      "finding": "src/app/contracts/workbench.py:466:price: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/contracts/workbench.py:392:amount: float | None = Field(",
+      "finding": "src/app/contracts/workbench.py:471:amount: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/contracts/workbench.py:45:return_pct: float | None = Field(",
+      "finding": "src/app/contracts/workbench.py:47:return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/contracts/workbench.py:50:benchmark_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/workbench.py:52:benchmark_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/contracts/workbench.py:578:current_weight_pct: float = Field(",
+      "finding": "src/app/contracts/workbench.py:657:current_weight_pct: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/contracts/workbench.py:582:proposed_weight_pct: float = Field(",
+      "finding": "src/app/contracts/workbench.py:661:proposed_weight_pct: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/contracts/workbench.py:638:portfolio_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/workbench.py:717:portfolio_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/contracts/workbench.py:643:benchmark_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/workbench.py:722:benchmark_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/contracts/workbench.py:648:active_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/workbench.py:727:active_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-02"
     },
     {
       "finding": "src/app/services/foundation_service.py:245:market_value_base = float(",
@@ -958,106 +958,106 @@
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/workbench_service.py:321:current_weight_pct=float(",
+      "finding": "src/app/services/workbench_service.py:323:current_weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:324:proposed_weight_pct=float(",
+      "finding": "src/app/services/workbench_service.py:326:proposed_weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:376:float(quantize_performance(portfolio_return))",
+      "finding": "src/app/services/workbench_service.py:378:float(quantize_performance(portfolio_return))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:381:float(quantize_performance(benchmark_return))",
+      "finding": "src/app/services/workbench_service.py:383:float(quantize_performance(benchmark_return))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:386:float(quantize_performance(active_return)) if active_return is not None else None",
+      "finding": "src/app/services/workbench_service.py:388:float(quantize_performance(active_return)) if active_return is not None else None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:607:weight_pct = float(",
+      "finding": "src/app/services/workbench_service.py:609:weight_pct = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:627:def _parse_position_market_value(self, item: dict[str, Any]) -> float | None:",
+      "finding": "src/app/services/workbench_service.py:629:def _parse_position_market_value(self, item: dict[str, Any]) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:635:return float(quantize_money(value))",
+      "finding": "src/app/services/workbench_service.py:637:return float(quantize_money(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:650:return float(quantize_money(value))",
+      "finding": "src/app/services/workbench_service.py:652:return float(quantize_money(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:753:float(quantize_money(total_market_value_value))",
+      "finding": "src/app/services/workbench_service.py:755:float(quantize_money(total_market_value_value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:758:float(row.get(\"market_value_base\", 0.0))",
+      "finding": "src/app/services/workbench_service.py:760:float(row.get(\"market_value_base\", 0.0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:768:float(row.get(\"market_value_base\", 0.0))",
+      "finding": "src/app/services/workbench_service.py:770:float(row.get(\"market_value_base\", 0.0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:776:cash_weight = float(",
+      "finding": "src/app/services/workbench_service.py:778:cash_weight = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:897:def _optional_money(self, value: Any) -> float | None:",
+      "finding": "src/app/services/workbench_service.py:899:def _optional_money(self, value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:901:return float(quantize_money(value))",
+      "finding": "src/app/services/workbench_service.py:903:return float(quantize_money(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:905:def _ratio_to_pct(self, value: Any) -> float | None:",
+      "finding": "src/app/services/workbench_service.py:907:def _ratio_to_pct(self, value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:909:return float(quantize_performance(float(value) * 100.0))",
+      "finding": "src/app/services/workbench_service.py:911:return float(quantize_performance(float(value) * 100.0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-28"
+      "review_by": "2026-11-02"
     }
   ]
 }

--- a/src/app/contracts/workbench.py
+++ b/src/app/contracts/workbench.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, Field
 
+from app.contracts.portfolio import PortfolioRebalanceSupportabilitySummary
+
 
 class WorkbenchPortfolioSummary(BaseModel):
     portfolio_id: str = Field(
@@ -68,6 +70,47 @@ class WorkbenchRebalanceSnapshot(BaseModel):
         default=None,
         description="UTC timestamp when the latest rebalance run was created.",
         examples=["2026-02-23T01:00:00Z"],
+    )
+    supportability: PortfolioRebalanceSupportabilitySummary | None = Field(
+        default=None,
+        description=(
+            "Manage-owned action-register supportability posture for the portfolio-level DPM "
+            "operation dashboard."
+        ),
+    )
+    recent_runs: list["WorkbenchRebalanceRunSummary"] = Field(
+        default_factory=list,
+        description=(
+            "Bounded recent manage rebalance runs used by operations and PM users to assess "
+            "portfolio-level execution posture without calling lotus-manage directly."
+        ),
+    )
+
+
+class WorkbenchRebalanceRunSummary(BaseModel):
+    rebalance_run_id: str | None = Field(
+        default=None,
+        description="Manage rebalance run identifier for the recent execution row.",
+        examples=["rr_100"],
+    )
+    status: str = Field(
+        description="Manage-owned status for the recent rebalance run.",
+        examples=["PENDING_REVIEW"],
+    )
+    created_at_utc: str | None = Field(
+        default=None,
+        description="UTC timestamp when manage created the rebalance run.",
+        examples=["2026-02-23T01:00:00Z"],
+    )
+    error_code: str | None = Field(
+        default=None,
+        description="Bounded manage-provided error code when the run ended in an error state.",
+        examples=["SOURCE_READINESS_BLOCKED"],
+    )
+    workflow_state: str | None = Field(
+        default=None,
+        description="Optional bounded workflow posture for the run when manage provides it.",
+        examples=["PM_REVIEW_REQUIRED"],
     )
 
 
@@ -149,6 +192,24 @@ class WorkbenchOverviewResponse(BaseModel):
                     "status": "PENDING_REVIEW",
                     "last_rebalance_run_id": "rr_100",
                     "last_run_at_utc": "2026-02-23T01:00:00Z",
+                    "supportability": {
+                        "feature_key": "manage.observability.action_register_supportability",
+                        "state": "healthy",
+                        "reason": "action_register_current",
+                        "freshness_bucket": "fresh",
+                        "run_count": 4,
+                        "operation_count": 12,
+                        "workflow_decision_count": 3,
+                    },
+                    "recent_runs": [
+                        {
+                            "rebalance_run_id": "rr_100",
+                            "status": "PENDING_REVIEW",
+                            "created_at_utc": "2026-02-23T01:00:00Z",
+                            "error_code": None,
+                            "workflow_state": "PM_REVIEW_REQUIRED",
+                        }
+                    ],
                 },
                 "warnings": [],
                 "partial_failures": [],
@@ -312,6 +373,24 @@ class WorkbenchPortfolio360Response(BaseModel):
                     "status": "PENDING_REVIEW",
                     "last_rebalance_run_id": "rr_100",
                     "last_run_at_utc": "2026-02-23T01:00:00Z",
+                    "supportability": {
+                        "feature_key": "manage.observability.action_register_supportability",
+                        "state": "healthy",
+                        "reason": "action_register_current",
+                        "freshness_bucket": "fresh",
+                        "run_count": 4,
+                        "operation_count": 12,
+                        "workflow_decision_count": 3,
+                    },
+                    "recent_runs": [
+                        {
+                            "rebalance_run_id": "rr_100",
+                            "status": "PENDING_REVIEW",
+                            "created_at_utc": "2026-02-23T01:00:00Z",
+                            "error_code": None,
+                            "workflow_state": "PM_REVIEW_REQUIRED",
+                        }
+                    ],
                 },
                 "current_positions": [
                     {

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -11,6 +11,7 @@ from app.clients.dpm_client import DpmClient
 from app.clients.lotus_analytics_client import LotusAnalyticsClient
 from app.clients.lotus_core_query_client import LotusCoreQueryClient
 from app.config import settings
+from app.contracts.portfolio import PortfolioRebalanceSupportabilitySummary
 from app.contracts.workbench import (
     WorkbenchAnalyticsBucket,
     WorkbenchAnalyticsResponse,
@@ -24,6 +25,7 @@ from app.contracts.workbench import (
     WorkbenchPositionView,
     WorkbenchProjectedPositionView,
     WorkbenchProjectedSummary,
+    WorkbenchRebalanceRunSummary,
     WorkbenchRebalanceSnapshot,
     WorkbenchSandboxStateResponse,
     WorkbenchTopChange,
@@ -473,7 +475,7 @@ class WorkbenchService:
 
             dpm_task = (
                 self._dpm_client.list_runs(
-                    params={"portfolio_id": portfolio_id, "limit": 1},
+                    params={"portfolio_id": portfolio_id, "limit": 5},
                     correlation_id=correlation_id,
                 )
                 if include_rebalance_snapshot
@@ -976,15 +978,92 @@ class WorkbenchService:
         elif isinstance(created_at, datetime):
             last_run_at_utc = created_at.astimezone(UTC).isoformat()
 
+        recent_runs = self._parse_recent_dpm_runs(items)
+        supportability = self._parse_rebalance_supportability(dpm_payload)
+
         return WorkbenchRebalanceSnapshot(
             status=str(latest.get("status", "UNKNOWN")),
-            last_rebalance_run_id=(
-                str(latest["rebalance_run_id"])
-                if latest.get("rebalance_run_id") is not None
-                else None
-            ),
+            last_rebalance_run_id=self._optional_str(latest.get("rebalance_run_id")),
             last_run_at_utc=last_run_at_utc,
+            supportability=supportability,
+            recent_runs=recent_runs,
         )
+
+    def _parse_recent_dpm_runs(
+        self,
+        items: list[Any],
+    ) -> list[WorkbenchRebalanceRunSummary]:
+        recent_runs: list[WorkbenchRebalanceRunSummary] = []
+        for item in items[:5]:
+            if not isinstance(item, dict):
+                continue
+            recent_runs.append(
+                WorkbenchRebalanceRunSummary(
+                    rebalance_run_id=self._optional_str(item.get("rebalance_run_id")),
+                    status=str(item.get("status", "UNKNOWN")),
+                    created_at_utc=self._optional_datetime_str(item.get("created_at")),
+                    error_code=self._extract_dpm_run_error_code(item),
+                    workflow_state=self._optional_str(
+                        item.get("workflow_state")
+                        or item.get("workflow_decision_state")
+                        or item.get("review_state")
+                    ),
+                )
+            )
+        return recent_runs
+
+    def _parse_rebalance_supportability(
+        self,
+        dpm_payload: dict[str, Any],
+    ) -> PortfolioRebalanceSupportabilitySummary | None:
+        supportability_payload = dpm_payload.get("supportability")
+        if not isinstance(supportability_payload, dict):
+            return None
+        return PortfolioRebalanceSupportabilitySummary(
+            feature_key=(
+                self._optional_str(supportability_payload.get("feature_key"))
+                or "manage.observability.action_register_supportability"
+            ),
+            state=str(supportability_payload.get("state") or "unknown"),
+            reason=self._optional_str(supportability_payload.get("reason")),
+            freshness_bucket=self._optional_str(supportability_payload.get("freshness_bucket")),
+            run_count=self._optional_int(supportability_payload.get("run_count")),
+            operation_count=self._optional_int(supportability_payload.get("operation_count")),
+            workflow_decision_count=self._optional_int(
+                supportability_payload.get("workflow_decision_count")
+            ),
+        )
+
+    def _extract_dpm_run_error_code(self, item: dict[str, Any]) -> str | None:
+        for key in ("error_code", "failure_code", "reason_code"):
+            value = self._optional_str(item.get(key))
+            if value:
+                return value
+        error_payload = item.get("error")
+        if isinstance(error_payload, dict):
+            return self._optional_str(error_payload.get("code"))
+        return None
+
+    def _optional_datetime_str(self, value: Any) -> str | None:
+        if isinstance(value, str):
+            return value
+        if isinstance(value, datetime):
+            return value.astimezone(UTC).isoformat()
+        return None
+
+    def _optional_str(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    def _optional_int(self, value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
 
 @dataclass(slots=True)

--- a/tests/contract/test_workbench_contract.py
+++ b/tests/contract/test_workbench_contract.py
@@ -377,6 +377,14 @@ def test_workbench_openapi_contract_registered() -> None:
     assert overview_schema["properties"]["overview"]["description"]
     assert overview_schema["properties"]["performance_snapshot"]["description"]
     assert overview_schema["properties"]["rebalance_snapshot"]["description"]
+    assert (
+        overview_schema["example"]["rebalance_snapshot"]["supportability"]["feature_key"]
+        == "manage.observability.action_register_supportability"
+    )
+    assert (
+        overview_schema["example"]["rebalance_snapshot"]["recent_runs"][0]["workflow_state"]
+        == "PM_REVIEW_REQUIRED"
+    )
     assert overview_schema["properties"]["warnings"]["description"]
     assert overview_schema["properties"]["partial_failures"]["description"]
     assert portfolio_summary_schema["properties"]["portfolio_id"]["description"]
@@ -392,6 +400,14 @@ def test_workbench_openapi_contract_registered() -> None:
     assert rebalance_snapshot_schema["properties"]["status"]["description"]
     assert rebalance_snapshot_schema["properties"]["last_rebalance_run_id"]["description"]
     assert rebalance_snapshot_schema["properties"]["last_run_at_utc"]["description"]
+    assert rebalance_snapshot_schema["properties"]["supportability"]["description"]
+    assert rebalance_snapshot_schema["properties"]["recent_runs"]["description"]
+    rebalance_run_schema = spec["components"]["schemas"]["WorkbenchRebalanceRunSummary"]
+    assert rebalance_run_schema["properties"]["rebalance_run_id"]["description"]
+    assert rebalance_run_schema["properties"]["status"]["description"]
+    assert rebalance_run_schema["properties"]["created_at_utc"]["description"]
+    assert rebalance_run_schema["properties"]["error_code"]["description"]
+    assert rebalance_run_schema["properties"]["workflow_state"]["description"]
     assert partial_failure_schema["properties"]["source_service"]["description"]
     assert partial_failure_schema["properties"]["error_code"]["description"]
     assert partial_failure_schema["properties"]["detail"]["description"]

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -102,14 +102,31 @@ def test_workbench_router_success(monkeypatch):
         }
 
     async def _dpm(*args, **kwargs):
+        assert kwargs["params"]["limit"] == 5
         return 200, {
             "items": [
                 {
                     "rebalance_run_id": "rr_100",
                     "status": "PENDING_REVIEW",
                     "created_at": "2026-02-23T01:00:00Z",
-                }
-            ]
+                    "workflow_state": "PM_REVIEW_REQUIRED",
+                },
+                {
+                    "rebalance_run_id": "rr_099",
+                    "status": "FAILED",
+                    "created_at": "2026-02-22T01:00:00Z",
+                    "error": {"code": "SOURCE_READINESS_BLOCKED"},
+                },
+            ],
+            "supportability": {
+                "feature_key": "manage.observability.action_register_supportability",
+                "state": "healthy",
+                "reason": "action_register_current",
+                "freshness_bucket": "fresh",
+                "run_count": 2,
+                "operation_count": 5,
+                "workflow_decision_count": 1,
+            },
         }
 
     monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio", _get_portfolio)
@@ -137,6 +154,31 @@ def test_workbench_router_success(monkeypatch):
     assert body["rebalance_snapshot"]["status"] == "PENDING_REVIEW"
     assert body["rebalance_snapshot"]["last_rebalance_run_id"] == "rr_100"
     assert body["rebalance_snapshot"]["last_run_at_utc"] == "2026-02-23T01:00:00Z"
+    assert body["rebalance_snapshot"]["supportability"] == {
+        "feature_key": "manage.observability.action_register_supportability",
+        "state": "healthy",
+        "reason": "action_register_current",
+        "freshness_bucket": "fresh",
+        "run_count": 2,
+        "operation_count": 5,
+        "workflow_decision_count": 1,
+    }
+    assert body["rebalance_snapshot"]["recent_runs"] == [
+        {
+            "rebalance_run_id": "rr_100",
+            "status": "PENDING_REVIEW",
+            "created_at_utc": "2026-02-23T01:00:00Z",
+            "error_code": None,
+            "workflow_state": "PM_REVIEW_REQUIRED",
+        },
+        {
+            "rebalance_run_id": "rr_099",
+            "status": "FAILED",
+            "created_at_utc": "2026-02-22T01:00:00Z",
+            "error_code": "SOURCE_READINESS_BLOCKED",
+            "workflow_state": None,
+        },
+    ]
     assert body["warnings"] == []
     assert body["partial_failures"] == []
 

--- a/tests/unit/test_workbench_service.py
+++ b/tests/unit/test_workbench_service.py
@@ -251,8 +251,24 @@ async def test_workbench_overview_success():
                         "rebalance_run_id": "rr_1",
                         "status": "READY",
                         "created_at": "2026-02-23T00:00:00Z",
-                    }
-                ]
+                        "workflow_state": "PM_REVIEW_REQUIRED",
+                    },
+                    {
+                        "rebalance_run_id": "rr_0",
+                        "status": "FAILED",
+                        "created_at": "2026-02-22T00:00:00Z",
+                        "error_code": "SOURCE_READINESS_BLOCKED",
+                    },
+                ],
+                "supportability": {
+                    "feature_key": "manage.observability.action_register_supportability",
+                    "state": "healthy",
+                    "reason": "action_register_current",
+                    "freshness_bucket": "fresh",
+                    "run_count": 2,
+                    "operation_count": 4,
+                    "workflow_decision_count": 1,
+                },
             },
         ),
     )
@@ -282,6 +298,17 @@ async def test_workbench_overview_success():
     assert response.rebalance_snapshot.status == "READY"
     assert response.rebalance_snapshot.last_rebalance_run_id == "rr_1"
     assert response.rebalance_snapshot.last_run_at_utc == "2026-02-23T00:00:00Z"
+    assert response.rebalance_snapshot.supportability is not None
+    assert response.rebalance_snapshot.supportability.state == "healthy"
+    assert response.rebalance_snapshot.supportability.freshness_bucket == "fresh"
+    assert response.rebalance_snapshot.supportability.run_count == 2
+    assert response.rebalance_snapshot.supportability.operation_count == 4
+    assert response.rebalance_snapshot.supportability.workflow_decision_count == 1
+    assert len(response.rebalance_snapshot.recent_runs) == 2
+    assert response.rebalance_snapshot.recent_runs[0].rebalance_run_id == "rr_1"
+    assert response.rebalance_snapshot.recent_runs[0].workflow_state == "PM_REVIEW_REQUIRED"
+    assert response.rebalance_snapshot.recent_runs[1].status == "FAILED"
+    assert response.rebalance_snapshot.recent_runs[1].error_code == "SOURCE_READINESS_BLOCKED"
     assert response.partial_failures == []
 
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -68,6 +68,12 @@
   diagnostics, supportability, selected-alternative state, and lineage. Gateway must not optimize,
   recompute construction metrics, infer source readiness, select alternatives, execute orders, or
   let Workbench bypass Gateway.
+- RFC36-WTBD-003 portfolio-level DPM operations posture is exposed on Workbench overview and
+  portfolio-360 `rebalance_snapshot`. Gateway reads manage rebalance runs through
+  `/api/v1/rebalance/runs`, preserves manage action-register supportability when returned, and
+  includes a bounded recent-run list with run id, status, timestamp, workflow posture, and error
+  code for Workbench operations dashboards. Gateway must not calculate supportability, workflow
+  posture, or error semantics locally.
 - RFC-0098 wave composition must consume `lotus-manage` RFC-0041 wave APIs for preview, create,
   source-check, simulation, selection, approval, staging, handoff, and supportability. Target
   Gateway routes belong under `/api/v1/dpm/command-center/waves*`, preserve manage `wave_id`,

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -89,3 +89,7 @@
     then preserves alternatives, method status, diagnostics, comparison metrics, supportability,
     and selection decisions without performing optimization, recomputation, readiness inference, or
     order execution.
+12. RFC36-WTBD-003 portfolio-level DPM operations dashboards consume Gateway Workbench
+    `rebalance_snapshot` only. Gateway reads manage rebalance runs, preserves manage
+    supportability and bounded recent-run posture, and keeps Workbench from calling
+    `lotus-manage` directly or inventing workflow/error semantics.

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -50,6 +50,48 @@ Operational behavior:
 2. manage upstream errors are returned using product-safe Gateway error detail,
 3. OpenAPI documents What/When/How guidance and request/response examples for each route.
 
+## Portfolio-Level DPM Operations Posture
+
+Status: implementation-backed in Gateway for RFC36-WTBD-003.
+
+Business outcome:
+
+1. portfolio managers and operations users can see recent stateful DPM execution posture from the
+   Workbench overview without direct `lotus-manage` access,
+2. Workbench can render supportability, last-run identity, recent run status, workflow posture, and
+   bounded run issue codes from a governed Gateway envelope,
+3. missing supportability or absent recent runs stay explicit instead of becoming fabricated zero
+   activity.
+
+Supported routes:
+
+1. `GET /api/v1/workbench/{portfolio_id}/overview`
+2. `GET /api/v1/workbench/{portfolio_id}/portfolio-360`
+
+Authority and integrations:
+
+1. `lotus-manage` remains the rebalance run and action-register supportability authority.
+2. Gateway reads manage `/api/v1/rebalance/runs` and preserves manage-provided supportability when
+   present.
+3. Gateway exposes up to five bounded recent run summaries with run id, status, timestamp,
+   workflow posture, and error code.
+4. Gateway does not compute supportability, workflow status, source readiness, execution outcomes,
+   or error semantics locally.
+
+```mermaid
+flowchart LR
+    Workbench[lotus-workbench operations dashboard] --> Gateway[Workbench overview and portfolio-360]
+    Gateway --> Manage[lotus-manage rebalance runs and supportability]
+    Manage --> Gateway
+    Gateway --> Workbench
+```
+
+Operational behavior:
+
+1. Gateway returns partial failures and warnings if manage is unavailable,
+2. recent run detail is bounded to keep the Workbench contract product-safe,
+3. Workbench remains Gateway-first and must not call `lotus-manage` directly.
+
 ## DPM Command Center Outcome Reviews
 
 Status: implementation-backed in Gateway for RFC42-WTBD-001 and RFC42-WTBD-005.


### PR DESCRIPTION
## Summary

Implements RFC36-WTBD-003 Gateway slice for portfolio-level DPM operations posture.

- Extends Workbench overview and portfolio-360 `rebalance_snapshot` with manage action-register supportability and a bounded recent-run list.
- Preserves manage-owned run status, workflow posture, error code, and timestamp without computing DPM semantics in Gateway.
- Updates OpenAPI examples, contract assertions, repository context, and wiki source.
- Refreshes the monetary-float allowlist because formatting shifted pre-existing Workbench float findings; no new float usage was introduced.

## Evidence

- `python -m pytest tests/unit/test_workbench_service.py::test_workbench_overview_success tests/integration/test_workbench_router.py::test_workbench_router_success tests/contract/test_workbench_contract.py::test_workbench_openapi_contract_registered -q` -> 3 passed
- `make check` -> ruff, format, monetary-float guard, mypy, Workbench contract smoke, 423 unit/contract tests passed
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` -> expected pre-merge drift in authored wiki files: API-Surface.md, Integrations.md, Supported-Features.md. Publish after merge.

## Boundary

Gateway remains the product-facing composition boundary. `lotus-manage` remains run/supportability authority. Gateway does not compute supportability, workflow posture, source readiness, execution outcomes, or error semantics locally.