### PR TITLE
fix: map manage supportability into Workbench rebalance snapshot

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -201,9 +201,10 @@ Most relevant current governance:
     choose alternatives locally.
 12. The Workbench overview and portfolio-360 `rebalance_snapshot` now carry bounded
     portfolio-level DPM operations posture for RFC36-WTBD-003: latest rebalance status, last run,
-    manage action-register supportability, and up to five recent manage runs with bounded status,
-    timestamp, workflow posture, and error code. Gateway remains the product-facing composition
-    boundary and does not calculate supportability, workflow state, or error semantics locally.
+    manage action-register supportability from `/api/v1/rebalance/supportability/summary`, and up
+    to five recent manage runs from `/api/v1/rebalance/runs` with bounded status, timestamp,
+    workflow posture, and error code. Gateway remains the product-facing composition boundary and
+    does not calculate supportability, workflow state, or error semantics locally.
 
 ## Context Maintenance Rule
 

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-05-06T09:01:21Z",
+  "generated_at": "2026-05-06T09:37:53Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -988,73 +988,73 @@
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:609:weight_pct = float(",
+      "finding": "src/app/services/workbench_service.py:620:weight_pct = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:629:def _parse_position_market_value(self, item: dict[str, Any]) -> float | None:",
+      "finding": "src/app/services/workbench_service.py:640:def _parse_position_market_value(self, item: dict[str, Any]) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:637:return float(quantize_money(value))",
+      "finding": "src/app/services/workbench_service.py:648:return float(quantize_money(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:652:return float(quantize_money(value))",
+      "finding": "src/app/services/workbench_service.py:663:return float(quantize_money(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:755:float(quantize_money(total_market_value_value))",
+      "finding": "src/app/services/workbench_service.py:766:float(quantize_money(total_market_value_value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:760:float(row.get(\"market_value_base\", 0.0))",
+      "finding": "src/app/services/workbench_service.py:771:float(row.get(\"market_value_base\", 0.0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:770:float(row.get(\"market_value_base\", 0.0))",
+      "finding": "src/app/services/workbench_service.py:781:float(row.get(\"market_value_base\", 0.0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:778:cash_weight = float(",
+      "finding": "src/app/services/workbench_service.py:789:cash_weight = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:899:def _optional_money(self, value: Any) -> float | None:",
+      "finding": "src/app/services/workbench_service.py:910:def _optional_money(self, value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:903:return float(quantize_money(value))",
+      "finding": "src/app/services/workbench_service.py:914:return float(quantize_money(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:907:def _ratio_to_pct(self, value: Any) -> float | None:",
+      "finding": "src/app/services/workbench_service.py:918:def _ratio_to_pct(self, value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/workbench_service.py:911:return float(quantize_performance(float(value) * 100.0))",
+      "finding": "src/app/services/workbench_service.py:922:return float(quantize_performance(float(value) * 100.0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-02"

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -473,15 +473,25 @@ class WorkbenchService:
             else:
                 performance_task = self._empty_async_result()
 
-            dpm_task = (
-                self._dpm_client.list_runs(
+            dpm_runs_task: Awaitable[tuple[int, dict[str, Any]]]
+            dpm_supportability_task: Awaitable[tuple[int, dict[str, Any]]]
+            if include_rebalance_snapshot:
+                dpm_runs_task = self._dpm_client.list_runs(
                     params={"portfolio_id": portfolio_id, "limit": 5},
                     correlation_id=correlation_id,
                 )
-                if include_rebalance_snapshot
-                else self._empty_async_result()
+                dpm_supportability_task = self._dpm_client.get_supportability_summary(
+                    correlation_id=correlation_id,
+                )
+            else:
+                dpm_runs_task = self._empty_async_result()
+                dpm_supportability_task = self._empty_async_result()
+            gathered = await asyncio.gather(
+                performance_task,
+                dpm_runs_task,
+                dpm_supportability_task,
+                return_exceptions=True,
             )
-            gathered = await asyncio.gather(performance_task, dpm_task, return_exceptions=True)
             if include_performance_snapshot:
                 performance_snapshot = self._parse_performance_snapshot(
                     result=cast(object, gathered[0]),
@@ -491,6 +501,7 @@ class WorkbenchService:
             if include_rebalance_snapshot:
                 rebalance_snapshot = self._parse_dpm_snapshot(
                     result=cast(object, gathered[1]),
+                    supportability_result=cast(object, gathered[2]),
                     partial_failures=partial_failures,
                     warnings=warnings,
                 )
@@ -917,6 +928,7 @@ class WorkbenchService:
         result: object,
         partial_failures: list[WorkbenchPartialFailure],
         warnings: list[str],
+        supportability_result: object | None = None,
     ) -> WorkbenchRebalanceSnapshot | None:
         if isinstance(result, Exception):
             partial_failures.append(
@@ -979,7 +991,12 @@ class WorkbenchService:
             last_run_at_utc = created_at.astimezone(UTC).isoformat()
 
         recent_runs = self._parse_recent_dpm_runs(items)
-        supportability = self._parse_rebalance_supportability(dpm_payload)
+        supportability = self._parse_rebalance_supportability(
+            dpm_payload,
+            supportability_result=supportability_result,
+            partial_failures=partial_failures,
+            warnings=warnings,
+        )
 
         return WorkbenchRebalanceSnapshot(
             status=str(latest.get("status", "UNKNOWN")),
@@ -1015,8 +1032,17 @@ class WorkbenchService:
     def _parse_rebalance_supportability(
         self,
         dpm_payload: dict[str, Any],
+        *,
+        supportability_result: object | None = None,
+        partial_failures: list[WorkbenchPartialFailure] | None = None,
+        warnings: list[str] | None = None,
     ) -> PortfolioRebalanceSupportabilitySummary | None:
-        supportability_payload = dpm_payload.get("supportability")
+        supportability_payload = self._extract_rebalance_supportability_payload(
+            dpm_payload=dpm_payload,
+            supportability_result=supportability_result,
+            partial_failures=partial_failures,
+            warnings=warnings,
+        )
         if not isinstance(supportability_payload, dict):
             return None
         return PortfolioRebalanceSupportabilitySummary(
@@ -1033,6 +1059,83 @@ class WorkbenchService:
                 supportability_payload.get("workflow_decision_count")
             ),
         )
+
+    def _extract_rebalance_supportability_payload(
+        self,
+        *,
+        dpm_payload: dict[str, Any],
+        supportability_result: object | None,
+        partial_failures: list[WorkbenchPartialFailure] | None,
+        warnings: list[str] | None,
+    ) -> dict[str, Any] | None:
+        supportability_payload = dpm_payload.get("supportability")
+        if isinstance(supportability_payload, dict):
+            return supportability_payload
+        if supportability_result is None:
+            return None
+        if isinstance(supportability_result, BaseException):
+            if partial_failures is not None:
+                partial_failures.append(
+                    WorkbenchPartialFailure(
+                        source_service="lotus-manage",
+                        error_code="SUPPORTABILITY_SUMMARY_UNAVAILABLE",
+                        detail=str(supportability_result),
+                    )
+                )
+            if warnings is not None:
+                warnings.append("MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
+            return None
+        if not isinstance(supportability_result, tuple) or len(supportability_result) != 2:
+            if partial_failures is not None:
+                partial_failures.append(
+                    WorkbenchPartialFailure(
+                        source_service="lotus-manage",
+                        error_code="INVALID_SUPPORTABILITY_SUMMARY_RESULT",
+                        detail=f"unexpected supportability result: {type(supportability_result)}",
+                    )
+                )
+            if warnings is not None:
+                warnings.append("MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
+            return None
+        supportability_status, supportability_summary = supportability_result
+        if not isinstance(supportability_status, int) or not isinstance(
+            supportability_summary,
+            dict,
+        ):
+            if partial_failures is not None:
+                partial_failures.append(
+                    WorkbenchPartialFailure(
+                        source_service="lotus-manage",
+                        error_code="INVALID_SUPPORTABILITY_SUMMARY_PAYLOAD",
+                        detail=(
+                            "supportability summary result must include integer status "
+                            "and object payload"
+                        ),
+                    )
+                )
+            if warnings is not None:
+                warnings.append("MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
+            return None
+        if supportability_status >= status.HTTP_400_BAD_REQUEST:
+            if partial_failures is not None:
+                partial_failures.append(
+                    WorkbenchPartialFailure(
+                        source_service="lotus-manage",
+                        error_code=f"SUPPORTABILITY_HTTP_{supportability_status}",
+                        detail=str(supportability_summary.get("detail", supportability_summary)),
+                    )
+                )
+            if warnings is not None:
+                warnings.append("MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
+            return None
+        supportability_payload = supportability_summary.get("supportability")
+        if isinstance(supportability_payload, dict):
+            merged_payload = dict(supportability_payload)
+            for summary_key in ("run_count", "operation_count", "workflow_decision_count"):
+                if summary_key not in merged_payload and summary_key in supportability_summary:
+                    merged_payload[summary_key] = supportability_summary[summary_key]
+            return merged_payload
+        return None
 
     def _extract_dpm_run_error_code(self, item: dict[str, Any]) -> str | None:
         for key in ("error_code", "failure_code", "reason_code"):

--- a/tests/unit/test_workbench_service.py
+++ b/tests/unit/test_workbench_service.py
@@ -159,14 +159,27 @@ class _StubLotusAnalyticsClient:
 
 
 class _StubDpmClient:
-    def __init__(self, status_code: int, payload: dict):
+    def __init__(
+        self,
+        status_code: int,
+        payload: dict,
+        supportability_status_code: int = 200,
+        supportability_payload: dict | None = None,
+    ):
         self.status_code = status_code
         self.payload = payload
+        self.supportability_status_code = supportability_status_code
+        self.supportability_payload = supportability_payload or {}
         self.list_runs_calls = 0
+        self.supportability_summary_calls = 0
 
     async def list_runs(self, params: dict, correlation_id: str):
         self.list_runs_calls += 1
         return self.status_code, self.payload
+
+    async def get_supportability_summary(self, correlation_id: str):
+        self.supportability_summary_calls += 1
+        return self.supportability_status_code, self.supportability_payload
 
     async def simulate_proposal(
         self,
@@ -260,6 +273,12 @@ async def test_workbench_overview_success():
                         "error_code": "SOURCE_READINESS_BLOCKED",
                     },
                 ],
+            },
+            supportability_payload={
+                "store_backend": "POSTGRES",
+                "run_count": 2,
+                "operation_count": 4,
+                "workflow_decision_count": 1,
                 "supportability": {
                     "feature_key": "manage.observability.action_register_supportability",
                     "state": "healthy",
@@ -304,6 +323,7 @@ async def test_workbench_overview_success():
     assert response.rebalance_snapshot.supportability.run_count == 2
     assert response.rebalance_snapshot.supportability.operation_count == 4
     assert response.rebalance_snapshot.supportability.workflow_decision_count == 1
+    assert service._dpm_client.supportability_summary_calls == 1
     assert len(response.rebalance_snapshot.recent_runs) == 2
     assert response.rebalance_snapshot.recent_runs[0].rebalance_run_id == "rr_1"
     assert response.rebalance_snapshot.recent_runs[0].workflow_state == "PM_REVIEW_REQUIRED"

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -123,11 +123,16 @@ class _StubDpmClient:
     def __init__(self):
         self.list_runs_status = 200
         self.list_runs_payload: dict = {"items": []}
+        self.supportability_status = 200
+        self.supportability_payload: dict = {}
         self.simulate_status = 200
         self.simulate_payload: dict = {"status": "AVAILABLE"}
 
     async def list_runs(self, params: dict, correlation_id: str):
         return self.list_runs_status, self.list_runs_payload
+
+    async def get_supportability_summary(self, correlation_id: str):
+        return self.supportability_status, self.supportability_payload
 
     async def simulate_proposal(self, body: dict, idempotency_key: str, correlation_id: str):
         return self.simulate_status, self.simulate_payload
@@ -306,6 +311,48 @@ def test_parse_dpm_snapshot_with_datetime_created_at_converts_to_utc():
     assert parsed.last_rebalance_run_id == "rr-1"
     assert parsed.last_run_at_utc is not None
     assert parsed.last_run_at_utc.endswith("+00:00")
+
+
+def test_parse_dpm_snapshot_uses_live_shape_supportability_summary():
+    service, _, _, _ = _build_service()
+    parsed = service._parse_dpm_snapshot(
+        (
+            200,
+            {
+                "items": [
+                    {
+                        "status": "PENDING_REVIEW",
+                        "created_at": "2026-05-06T15:37:05.939203+08:00",
+                        "rebalance_run_id": "rr_c09f73d0",
+                    }
+                ]
+            },
+        ),
+        [],
+        [],
+        supportability_result=(
+            200,
+            {
+                "store_backend": "POSTGRES",
+                "run_count": 82,
+                "operation_count": 0,
+                "workflow_decision_count": 0,
+                "supportability": {
+                    "state": "ready",
+                    "reason": "supportability_summary_ready",
+                    "freshness_bucket": "current",
+                    "run_count": 82,
+                    "operation_count": 0,
+                    "workflow_decision_count": 0,
+                },
+            },
+        ),
+    )
+    assert parsed is not None
+    assert parsed.supportability is not None
+    assert parsed.supportability.state == "ready"
+    assert parsed.supportability.freshness_bucket == "current"
+    assert parsed.supportability.run_count == 82
 
 
 @pytest.mark.parametrize(

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -70,7 +70,8 @@
   let Workbench bypass Gateway.
 - RFC36-WTBD-003 portfolio-level DPM operations posture is exposed on Workbench overview and
   portfolio-360 `rebalance_snapshot`. Gateway reads manage rebalance runs through
-  `/api/v1/rebalance/runs`, preserves manage action-register supportability when returned, and
+  `/api/v1/rebalance/runs`, reads manage supportability summary through
+  `/api/v1/rebalance/supportability/summary`, preserves manage action-register supportability, and
   includes a bounded recent-run list with run id, status, timestamp, workflow posture, and error
   code for Workbench operations dashboards. Gateway must not calculate supportability, workflow
   posture, or error semantics locally.

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -91,5 +91,7 @@
     order execution.
 12. RFC36-WTBD-003 portfolio-level DPM operations dashboards consume Gateway Workbench
     `rebalance_snapshot` only. Gateway reads manage rebalance runs, preserves manage
-    supportability and bounded recent-run posture, and keeps Workbench from calling
-    `lotus-manage` directly or inventing workflow/error semantics.
+    supportability summary and bounded recent-run posture, and keeps Workbench from calling
+    `lotus-manage` directly or inventing workflow/error semantics. Supportability comes from
+    manage `/api/v1/rebalance/supportability/summary`; run posture comes from
+    `/api/v1/rebalance/runs`.

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -71,8 +71,8 @@ Supported routes:
 Authority and integrations:
 
 1. `lotus-manage` remains the rebalance run and action-register supportability authority.
-2. Gateway reads manage `/api/v1/rebalance/runs` and preserves manage-provided supportability when
-   present.
+2. Gateway reads manage `/api/v1/rebalance/runs` for bounded recent run posture and
+   `/api/v1/rebalance/supportability/summary` for manage-owned action-register supportability.
 3. Gateway exposes up to five bounded recent run summaries with run id, status, timestamp,
    workflow posture, and error code.
 4. Gateway does not compute supportability, workflow status, source readiness, execution outcomes,


### PR DESCRIPTION
## Summary
- fetch manage `/api/v1/rebalance/supportability/summary` alongside bounded rebalance runs for Workbench overview enrichment
- map the live manage supportability-summary payload into `rebalance_snapshot.supportability` without calculating supportability in Gateway
- update Gateway wiki/context wording for the two-call RFC36-WTBD-003 integration

## Validation
- `python -m pytest tests/unit/test_workbench_service.py::test_workbench_overview_success tests/unit/test_workbench_service_additional.py::test_parse_dpm_snapshot_uses_live_shape_supportability_summary -q` -> 2 passed
- `python -m pytest tests/unit/test_workbench_service.py tests/unit/test_workbench_service_additional.py tests/integration/test_workbench_router.py::test_workbench_router_success tests/contract/test_workbench_contract.py::test_workbench_openapi_contract_registered -q` -> 54 passed
- `make check` -> ruff, format, monetary-float guard, mypy, Workbench contract smoke, and 424 unit/contract tests passed
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` -> expected pre-merge drift in API-Surface.md, Integrations.md, Supported-Features.md

## Notes
- `docs/standards/monetary-float-allowlist.json` changed only because formatting shifted existing Workbench float finding line numbers; no new monetary float usage was added.