### PR TITLE
feat: expose DPM mandate command center

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -34,7 +34,8 @@ Current repository posture:
 3. performance, proposal, foundation, reporting, and capability aggregation routes are active,
    with proposal simulation/lifecycle/workflow/approval/lineage routed to `lotus-advise`
    `/advisory/proposals/*`; `lotus-manage` consumption is through versioned `/api/v1` APIs for
-   run lookup, supportability summary, capability posture, and RFC-0042 outcome-review
+   run lookup, supportability summary, capability posture, RFC-0038 mandate command-center
+   summary/monitoring/exception/mandate drill-down route families, and RFC-0042 outcome-review
    preview/create/search/detail/source-refresh/supportability/report-input/AI-evidence and
    AI-narrative handoff route families,
 4. report job initiation/search/status/event-history/cancellation routes are active for
@@ -193,13 +194,20 @@ Most relevant current governance:
     and supportability summary over manage truth, but it must not recompute outcome dimensions,
     generate reports, generate AI narrative, infer PM quality, or let Workbench call manage
     directly.
-11. RFC-0039 construction-alternative Gateway routes are active under
+11. RFC-0038 mandate command-center Gateway routes are active under
+    `/api/v1/dpm/command-center`, `/api/v1/dpm/command-center/monitoring/*`,
+    `/api/v1/dpm/command-center/exceptions*`, and
+    `/api/v1/dpm/command-center/mandates*`. Gateway composes a BFF envelope and supportability
+    summary over manage truth, but it must not discover PM books, calculate health scores,
+    reconstruct health dimensions, infer source readiness, merge exceptions across monitoring
+    runs, or close exceptions locally.
+12. RFC-0039 construction-alternative Gateway routes are active under
     `/api/v1/dpm/command-center/construction/alternative-sets*`. Gateway forwards generation,
     retrieval, and selection requests to `lotus-manage`, preserves manage-owned alternatives,
     method status, diagnostics, comparison metrics, selected-alternative state, and supportability,
     and must not optimize portfolios, recompute construction metrics, infer source readiness, or
     choose alternatives locally.
-12. The Workbench overview and portfolio-360 `rebalance_snapshot` now carry bounded
+13. The Workbench overview and portfolio-360 `rebalance_snapshot` now carry bounded
     portfolio-level DPM operations posture for RFC36-WTBD-003: latest rebalance status, last run,
     manage action-register supportability from `/api/v1/rebalance/supportability/summary`, and up
     to five recent manage runs from `/api/v1/rebalance/runs` with bounded status, timestamp,

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -2,7 +2,7 @@
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | PARTIAL IMPLEMENTATION - RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER COMMAND CENTER PENDING |
+| **Status** | PARTIAL IMPLEMENTATION - RFC-0038 MANDATE COMMAND-CENTER, RFC-0039 CONSTRUCTION, AND RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER WAVE/PROOF/REPORT/ARCHIVE MODULES PENDING |
 | **Created** | 2026-05-03 |
 | **Last Tightened** | 2026-05-05 |
 | **Owner** | `lotus-gateway` |
@@ -1131,29 +1131,47 @@ To be completed during the final closure slice:
 
 ## 19. Implementation Progress Ledger
 
-This RFC is not fully implemented. Ledger-driven slices have delivered the RFC-0039 construction
-alternative-set route family and the RFC-0042 outcome-review route family so Workbench can consume
-Gateway/BFF instead of calling `lotus-manage` directly.
+This RFC is not fully implemented. Ledger-driven slices have delivered the RFC-0038 mandate
+command-center route family, the RFC-0039 construction alternative-set route family, and the
+RFC-0042 outcome-review route family so Workbench can consume Gateway/BFF instead of calling
+`lotus-manage` directly.
 
 | Item | Status | Evidence |
 | --- | --- | --- |
+| RFC38-WTBD-001 Gateway DPM command-center composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/unit/test_upstream_clients.py` |
 | RFC39-WTBD-001 Gateway construction-alternatives composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_construction.py`, `src/app/services/dpm_construction_service.py`, `src/app/contracts/dpm_construction.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_construction_service.py`, `tests/integration/test_dpm_construction_router.py`, `tests/contract/test_dpm_construction_contract.py` |
 | RFC42-WTBD-001 Gateway outcome-review composition and BFF contract | Implemented and merged before this slice | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/contract/test_dpm_command_center_contract.py`, `make ci` |
 | RFC42-WTBD-005 Gateway AI narrative handoff | Implemented and merged before this slice | Gateway reads manage-owned `DpmOutcomeAiEvidenceInput`, executes `lotus-ai` `outcome_review_narrative.pack@v1` as `lotus-gateway`, preserves manage workflow authority, and exposes `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative` |
 | RFC-0042 manage authority preservation | Implemented for BFF envelope; Gateway forwards payloads and preserves manage supportability | Service tests prove payload preservation and upstream error forwarding; contract tests prove OpenAPI route family registration and What/When/How guidance |
-| Broader RFC-0098 command-center book, mandate detail, evidence, action handoff, wave composition, proof-pack composition, report/archive/AI modules | Not implemented in this slice | Remains governed by this RFC and the work-to-be-done ledger; no supported-feature claim is made |
+| Broader RFC-0098 wave composition, proof-pack composition, report/archive modules, and Workbench cockpit | Not implemented in this slice | Remains governed by this RFC and the work-to-be-done ledger; no supported-feature claim is made |
 
 Implementation boundaries:
 
-1. Gateway now exposes `POST /api/v1/dpm/command-center/construction/alternative-sets/generate`,
+1. Gateway now exposes `GET /api/v1/dpm/command-center`,
+   `POST /api/v1/dpm/command-center/monitoring/run-once`,
+   `GET /api/v1/dpm/command-center/monitoring/runs`,
+   `GET /api/v1/dpm/command-center/monitoring/runs/{monitoring_run_id}`,
+   `GET /api/v1/dpm/command-center/exceptions`,
+   `POST /api/v1/dpm/command-center/exceptions/{exception_id}/resolve`,
+   `GET /api/v1/dpm/command-center/mandates/by-portfolio/{portfolio_id}`,
+   `GET /api/v1/dpm/command-center/mandates/{mandate_id}`,
+   `GET /api/v1/dpm/command-center/mandates/{mandate_id}/health`, and
+   `GET /api/v1/dpm/command-center/mandates/{mandate_id}/diff`.
+2. Mandate command-center routes preserve manage-owned health distribution, health dimensions,
+   source readiness, supportability, latest monitoring run identity, monitoring-run state,
+   active exceptions, reason codes, recommended actions, mandate source lineage, and version diffs.
+3. Gateway does not discover PM-book membership, calculate mandate health, reconstruct health
+   dimensions, infer source readiness, merge exceptions across monitoring runs, or resolve
+   exceptions locally.
+4. Gateway now exposes `POST /api/v1/dpm/command-center/construction/alternative-sets/generate`,
    `GET /api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}`, and
    `POST /api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}/selections`.
-2. Construction routes preserve manage-owned alternative-set ids, method identifiers, method
+5. Construction routes preserve manage-owned alternative-set ids, method identifiers, method
    statuses, objective traces, constraint traces, comparison metrics, diagnostics, supportability,
    selected-alternative state, and lineage.
-3. Gateway does not optimize portfolios, recompute construction metrics, infer source readiness,
+6. Gateway does not optimize portfolios, recompute construction metrics, infer source readiness,
    select alternatives, execute orders, or fabricate degraded-source values.
-4. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,
+7. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,
    `POST /api/v1/dpm/command-center/outcome-reviews`,
    `GET /api/v1/dpm/command-center/outcome-reviews`,
    `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}`,
@@ -1164,12 +1182,12 @@ Implementation boundaries:
    `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`,
    `GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`, and
    `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`.
-5. Gateway does not calculate expected values, realized values, variance, tolerance, hashes,
+8. Gateway does not calculate expected values, realized values, variance, tolerance, hashes,
    lineage, source freshness, supportability, or review state.
-6. Gateway does not generate reports, render artifacts, archive documents, generate AI narrative
+9. Gateway does not generate reports, render artifacts, archive documents, generate AI narrative
    locally, score PM quality, approve trades, contact clients, or claim Workbench UI support in
    this slice. The AI narrative endpoint is a governed handoff to `lotus-ai` over manage evidence.
-7. Workbench product realization remains a separate owning-repository implementation item.
+10. Workbench product realization remains a separate owning-repository implementation item.
 
 Validation performed on 2026-05-05:
 

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -52,6 +52,132 @@ class DpmClient:
             operation="manage.rebalance.supportability.summary",
         )
 
+    async def get_command_center(
+        self,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        cleaned_params = {key: value for key, value in params.items() if value is not None}
+        return await self._get(
+            "/api/v1/dpm/command-center",
+            params=cleaned_params,
+            headers=self._headers(correlation_id),
+            operation="manage.dpm.command_center.get",
+        )
+
+    async def run_monitoring_once(
+        self,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/api/v1/dpm/monitoring/run-once",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.dpm.monitoring.run_once",
+        )
+
+    async def list_monitoring_runs(
+        self,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        cleaned_params = {key: value for key, value in params.items() if value is not None}
+        return await self._get(
+            "/api/v1/dpm/monitoring/runs",
+            params=cleaned_params,
+            headers=self._headers(correlation_id),
+            operation="manage.dpm.monitoring.runs.list",
+        )
+
+    async def get_monitoring_run(
+        self,
+        monitoring_run_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/dpm/monitoring/runs/{monitoring_run_id}",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.dpm.monitoring.runs.get",
+        )
+
+    async def list_monitoring_exceptions(
+        self,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        cleaned_params = {key: value for key, value in params.items() if value is not None}
+        return await self._get(
+            "/api/v1/dpm/exceptions",
+            params=cleaned_params,
+            headers=self._headers(correlation_id),
+            operation="manage.dpm.exceptions.list",
+        )
+
+    async def resolve_monitoring_exception(
+        self,
+        exception_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/api/v1/dpm/exceptions/{exception_id}/resolve",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.dpm.exceptions.resolve",
+        )
+
+    async def get_mandate_by_portfolio(
+        self,
+        portfolio_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/mandates/by-portfolio/{portfolio_id}",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.mandates.by_portfolio.get",
+        )
+
+    async def get_mandate(
+        self,
+        mandate_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/mandates/{mandate_id}",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.mandates.get",
+        )
+
+    async def get_mandate_health(
+        self,
+        mandate_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/mandates/{mandate_id}/health",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.mandates.health.get",
+        )
+
+    async def get_mandate_diff(
+        self,
+        mandate_id: str,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        cleaned_params = {key: value for key, value in params.items() if value is not None}
+        return await self._get(
+            f"/api/v1/mandates/{mandate_id}/diff",
+            params=cleaned_params,
+            headers=self._headers(correlation_id),
+            operation="manage.mandates.diff.get",
+        )
+
     async def preview_outcome_review(
         self,
         body: dict[str, Any],

--- a/src/app/contracts/dpm_command_center.py
+++ b/src/app/contracts/dpm_command_center.py
@@ -1,6 +1,121 @@
 from pydantic import BaseModel, Field
 
 
+class DpmCommandCenterForwardRequest(BaseModel):
+    body: dict[str, object] = Field(
+        description=(
+            "Request payload forwarded unchanged to the lotus-manage RFC-0038 mandate "
+            "monitoring authority. Gateway does not discover books, calculate health, infer "
+            "exceptions, or change source-readiness posture."
+        ),
+        examples=[
+            {
+                "mandate_ids": ["MANDATE_PB_SG_GLOBAL_BAL_001"],
+                "as_of_date": "2026-05-03",
+                "tenant_id": "default",
+                "portfolio_manager_id": "PM_SG_DPM_001",
+                "requested_by": "workbench.pm.sg.001",
+            }
+        ],
+    )
+
+
+class DpmCommandCenterResolveExceptionRequest(BaseModel):
+    resolution_reason: str = Field(
+        description=(
+            "Bounded resolution reason forwarded to lotus-manage for the selected monitoring "
+            "exception. Gateway preserves the reason and does not close exceptions locally."
+        ),
+        examples=["SOURCE_DATA_REPAIRED_AND_RECALCULATED"],
+    )
+
+
+class DpmCommandCenterSupportability(BaseModel):
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Authoritative service that owns the DPM command-center supportability state.",
+        examples=["lotus-manage"],
+    )
+    authority: str = Field(
+        default="lotus-manage:RFC-0038",
+        description="Business authority and RFC provenance for mandate health and monitoring.",
+        examples=["lotus-manage:RFC-0038"],
+    )
+    state: str = Field(
+        description=(
+            "Manage-published command-center supportability state. Gateway preserves this value "
+            "and defaults to UNKNOWN only when the upstream payload omits explicit state."
+        ),
+        examples=["COMPLETE", "PARTIAL", "EMPTY", "UNKNOWN"],
+    )
+    data_completeness_state: str | None = Field(
+        default=None,
+        description=(
+            "Manage-published data completeness state, preserved for Workbench readiness displays."
+        ),
+        examples=["PARTIAL"],
+    )
+    partial_readiness_reasons: list[str] = Field(
+        default_factory=list,
+        description="Manage-published reason codes explaining partial or degraded readiness.",
+        examples=[["PM_BOOK_DISCOVERY_NOT_AVAILABLE"]],
+    )
+    source_run_id: str | None = Field(
+        default=None,
+        description="Manage-published source or monitoring run id backing the command-center view.",
+        examples=["dmr_20260503_083000"],
+    )
+    remediation_owner: str | None = Field(
+        default=None,
+        description="Manage-published owner for source repair or supportability remediation.",
+        examples=["Portfolio Operations"],
+    )
+
+
+class DpmCommandCenterGatewayResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated across Gateway and lotus-manage.",
+        examples=["corr-rfc38-command-center-1"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway BFF contract version for DPM command-center authority responses.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Upstream service that supplied the authoritative payload.",
+        examples=["lotus-manage"],
+    )
+    upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage before Gateway envelope composition.",
+        examples=[200],
+    )
+    supportability: DpmCommandCenterSupportability = Field(
+        description=(
+            "Gateway-normalized supportability summary derived only from manage-published fields."
+        ),
+    )
+    data: dict[str, object] = Field(
+        description=(
+            "Authoritative manage command-center payload preserved for Workbench composition. "
+            "Gateway does not alter health scores, dimensions, exceptions, reason codes, "
+            "lineage, recommended actions, or monitoring-run state."
+        ),
+        examples=[
+            {
+                "health_distribution": {"READY": 3, "PENDING_REVIEW": 1, "BLOCKED": 1},
+                "evaluated_mandates": 5,
+                "active_exception_count": 2,
+                "supportability": {
+                    "data_completeness_state": "PARTIAL",
+                    "partial_readiness_reasons": ["PM_BOOK_DISCOVERY_NOT_AVAILABLE"],
+                },
+            }
+        ],
+    )
+
+
 class DpmOutcomeReviewForwardRequest(BaseModel):
     body: dict[str, object] = Field(
         description=(

--- a/src/app/routers/dpm_command_center.py
+++ b/src/app/routers/dpm_command_center.py
@@ -4,6 +4,9 @@ from app.clients.dpm_client import DpmClient
 from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_command_center import (
+    DpmCommandCenterForwardRequest,
+    DpmCommandCenterGatewayResponse,
+    DpmCommandCenterResolveExceptionRequest,
     DpmOutcomeReviewForwardRequest,
     DpmOutcomeReviewGatewayResponse,
     DpmOutcomeReviewNarrativeGatewayResponse,
@@ -30,6 +33,293 @@ def _dpm_command_center_service() -> DpmCommandCenterService:
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
+    )
+
+
+@router.get(
+    "",
+    response_model=DpmCommandCenterGatewayResponse,
+    summary="Get DPM command-center summary",
+    description=(
+        "What: returns the manage-owned RFC-0038 DPM command-center summary for a PM book, "
+        "tenant, date, or health-state focus. When: use this for Workbench command-center "
+        "cockpit first paint. How: Gateway forwards filters to lotus-manage and preserves "
+        "health distribution, source readiness, attention buckets, recommended actions, "
+        "latest-run identity, and supportability without recalculating them."
+    ),
+)
+async def get_command_center(
+    portfolio_manager_id: str | None = Query(
+        default=None,
+        description="Optional portfolio-manager id captured on manage monitoring runs.",
+        examples=["PM_SG_DPM_001"],
+    ),
+    tenant_id: str | None = Query(
+        default=None,
+        description="Optional tenant filter captured on manage monitoring runs.",
+        examples=["default"],
+    ),
+    as_of_date: str | None = Query(
+        default=None,
+        description="Optional business date represented by the command-center view.",
+        examples=["2026-05-03"],
+    ),
+    book_id: str | None = Query(
+        default=None,
+        description="Optional PM book identifier captured on manage monitoring runs.",
+        examples=["BOOK_SG_BALANCED_DPM"],
+    ),
+    health_state: str | None = Query(
+        default=None,
+        description="Optional manage-published health-state focus.",
+        examples=["PENDING_REVIEW"],
+    ),
+    limit: int = Query(
+        default=50,
+        ge=1,
+        le=200,
+        description="Maximum active exceptions to consider for attention buckets.",
+    ),
+) -> DpmCommandCenterGatewayResponse:
+    return await _dpm_command_center_service().get_command_center(
+        filters={
+            "portfolio_manager_id": portfolio_manager_id,
+            "tenant_id": tenant_id,
+            "as_of_date": as_of_date,
+            "book_id": book_id,
+            "health_state": health_state,
+            "limit": limit,
+        },
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/monitoring/run-once",
+    response_model=DpmCommandCenterGatewayResponse,
+    summary="Run DPM mandate monitoring once",
+    description=(
+        "What: asks lotus-manage to evaluate a bounded set of refreshed mandate digital twins. "
+        "When: call this from an entitled Workbench command-center action or operator workflow. "
+        "How: Gateway forwards the request unchanged and returns manage's monitoring run state, "
+        "health results, exceptions, and lineage without discovering books or calculating health."
+    ),
+)
+async def run_monitoring_once(
+    request: DpmCommandCenterForwardRequest,
+) -> DpmCommandCenterGatewayResponse:
+    return await _dpm_command_center_service().run_monitoring_once(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/monitoring/runs",
+    response_model=DpmCommandCenterGatewayResponse,
+    summary="List DPM monitoring runs",
+    description=(
+        "What: lists manage-owned mandate monitoring runs newest first. When: use this for "
+        "command-center audit and operations drill-down. How: Gateway forwards search filters "
+        "to manage and preserves run status, source lineage, and supportability."
+    ),
+)
+async def list_monitoring_runs(
+    status_filter: str | None = Query(
+        default=None,
+        description="Optional terminal monitoring-run status filter.",
+        examples=["SUCCEEDED"],
+    ),
+    limit: int = Query(default=50, ge=1, le=200, description="Maximum runs to return."),
+    cursor: str | None = Query(default=None, description="Cursor from a previous page."),
+) -> DpmCommandCenterGatewayResponse:
+    return await _dpm_command_center_service().list_monitoring_runs(
+        filters={"status_filter": status_filter, "limit": limit, "cursor": cursor},
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/monitoring/runs/{monitoring_run_id}",
+    response_model=DpmCommandCenterGatewayResponse,
+    summary="Get DPM monitoring run",
+    description=(
+        "What: returns one manage-owned mandate monitoring run. When: use this for audit "
+        "drill-down from command-center latest-run or exception evidence. How: Gateway returns "
+        "the manage payload in a product envelope without changing health or exception truth."
+    ),
+)
+async def get_monitoring_run(
+    monitoring_run_id: str = Path(
+        ...,
+        description="Manage-owned mandate monitoring-run identifier.",
+        examples=["dmr_20260503_083000"],
+    ),
+) -> DpmCommandCenterGatewayResponse:
+    return await _dpm_command_center_service().get_monitoring_run(
+        monitoring_run_id=monitoring_run_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/exceptions",
+    response_model=DpmCommandCenterGatewayResponse,
+    summary="List DPM monitoring exceptions",
+    description=(
+        "What: lists manage-owned mandate monitoring exceptions. When: use this for Workbench "
+        "attention queues and operations triage by mandate, portfolio, or state. How: Gateway "
+        "preserves manage exception ids, severity, reason codes, state, and recommended action."
+    ),
+)
+async def list_monitoring_exceptions(
+    mandate_id: str | None = Query(default=None, description="Optional mandate id filter."),
+    portfolio_id: str | None = Query(default=None, description="Optional portfolio id filter."),
+    state: str | None = Query(
+        default=None,
+        description="Optional manage-published exception state filter.",
+        examples=["ACTIVE"],
+    ),
+    limit: int = Query(default=50, ge=1, le=200, description="Maximum exceptions to return."),
+    cursor: str | None = Query(default=None, description="Cursor from a previous page."),
+) -> DpmCommandCenterGatewayResponse:
+    return await _dpm_command_center_service().list_monitoring_exceptions(
+        filters={
+            "mandate_id": mandate_id,
+            "portfolio_id": portfolio_id,
+            "state": state,
+            "limit": limit,
+            "cursor": cursor,
+        },
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/exceptions/{exception_id}/resolve",
+    response_model=DpmCommandCenterGatewayResponse,
+    summary="Resolve DPM monitoring exception",
+    description=(
+        "What: forwards an exception resolution reason to lotus-manage. When: use this after a "
+        "PM, supervisor, or operator has reviewed the exception. How: Gateway does not close "
+        "exceptions locally; it returns the manage-owned resolved exception payload."
+    ),
+)
+async def resolve_monitoring_exception(
+    request: DpmCommandCenterResolveExceptionRequest,
+    exception_id: str = Path(
+        ...,
+        description="Manage-owned monitoring exception identifier.",
+        examples=["me_source_readiness_001"],
+    ),
+) -> DpmCommandCenterGatewayResponse:
+    return await _dpm_command_center_service().resolve_monitoring_exception(
+        exception_id=exception_id,
+        body={"resolution_reason": request.resolution_reason},
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/mandates/by-portfolio/{portfolio_id}",
+    response_model=DpmCommandCenterGatewayResponse,
+    summary="Get DPM mandate by portfolio",
+    description=(
+        "What: resolves the latest manage-owned mandate digital twin for a portfolio. When: use "
+        "this for Workbench navigation from existing portfolio pages into DPM command-center "
+        "detail. How: Gateway preserves mandate source lineage and field gap codes."
+    ),
+)
+async def get_mandate_by_portfolio(
+    portfolio_id: str = Path(
+        ...,
+        description="Core-governed portfolio identifier.",
+        examples=["PB_SG_GLOBAL_BAL_001"],
+    ),
+) -> DpmCommandCenterGatewayResponse:
+    return await _dpm_command_center_service().get_mandate_by_portfolio(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/mandates/{mandate_id}",
+    response_model=DpmCommandCenterGatewayResponse,
+    summary="Get DPM mandate",
+    description=(
+        "What: returns one manage-owned mandate digital twin. When: use this for mandate "
+        "drill-down from the command center. How: Gateway does not infer mandate fields or "
+        "source gaps; it preserves manage truth."
+    ),
+)
+async def get_mandate(
+    mandate_id: str = Path(
+        ...,
+        description="Manage-owned discretionary mandate identifier.",
+        examples=["MANDATE_PB_SG_GLOBAL_BAL_001"],
+    ),
+) -> DpmCommandCenterGatewayResponse:
+    return await _dpm_command_center_service().get_mandate(
+        mandate_id=mandate_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/mandates/{mandate_id}/health",
+    response_model=DpmCommandCenterGatewayResponse,
+    summary="Get DPM mandate health",
+    description=(
+        "What: returns the latest manage-owned mandate health snapshot. When: use this for "
+        "dimension drill-down from the command center. How: Gateway preserves health score, "
+        "dimension evidence, source readiness, and recommended action without recalculation."
+    ),
+)
+async def get_mandate_health(
+    mandate_id: str = Path(
+        ...,
+        description="Manage-owned discretionary mandate identifier.",
+        examples=["MANDATE_PB_SG_GLOBAL_BAL_001"],
+    ),
+) -> DpmCommandCenterGatewayResponse:
+    return await _dpm_command_center_service().get_mandate_health(
+        mandate_id=mandate_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/mandates/{mandate_id}/diff",
+    response_model=DpmCommandCenterGatewayResponse,
+    summary="Get DPM mandate version diff",
+    description=(
+        "What: returns manage-owned mandate version differences. When: use this to explain "
+        "material mandate changes during PM or operations review. How: Gateway forwards optional "
+        "version selectors and preserves the deterministic manage diff."
+    ),
+)
+async def get_mandate_diff(
+    mandate_id: str = Path(
+        ...,
+        description="Manage-owned discretionary mandate identifier.",
+        examples=["MANDATE_PB_SG_GLOBAL_BAL_001"],
+    ),
+    from_version: str | None = Query(
+        default=None,
+        description="Optional older version to compare.",
+        examples=["2"],
+    ),
+    to_version: str | None = Query(
+        default=None,
+        description="Optional newer version to compare.",
+        examples=["3"],
+    ),
+) -> DpmCommandCenterGatewayResponse:
+    return await _dpm_command_center_service().get_mandate_diff(
+        mandate_id=mandate_id,
+        filters={"from_version": from_version, "to_version": to_version},
+        correlation_id=correlation_id_var.get(),
     )
 
 

--- a/src/app/services/dpm_command_center_service.py
+++ b/src/app/services/dpm_command_center_service.py
@@ -6,6 +6,8 @@ from app.clients.dpm_client import DpmClient
 from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_command_center import (
+    DpmCommandCenterGatewayResponse,
+    DpmCommandCenterSupportability,
     DpmOutcomeReviewErrorDetail,
     DpmOutcomeReviewGatewayResponse,
     DpmOutcomeReviewNarrativeGatewayResponse,
@@ -18,6 +20,160 @@ class DpmCommandCenterService:
     def __init__(self, dpm_client: DpmClient, lotus_ai_client: LotusAiClient | None = None):
         self._dpm_client = dpm_client
         self._lotus_ai_client = lotus_ai_client
+
+    async def get_command_center(
+        self,
+        filters: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmCommandCenterGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_command_center(
+            params=filters,
+            correlation_id=correlation_id,
+        )
+        return self._compose_command_center_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
+    async def run_monitoring_once(
+        self,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmCommandCenterGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.run_monitoring_once(
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_command_center_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
+    async def list_monitoring_runs(
+        self,
+        filters: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmCommandCenterGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.list_monitoring_runs(
+            params=filters,
+            correlation_id=correlation_id,
+        )
+        return self._compose_command_center_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
+    async def get_monitoring_run(
+        self,
+        monitoring_run_id: str,
+        correlation_id: str,
+    ) -> DpmCommandCenterGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_monitoring_run(
+            monitoring_run_id=monitoring_run_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_command_center_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
+    async def list_monitoring_exceptions(
+        self,
+        filters: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmCommandCenterGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.list_monitoring_exceptions(
+            params=filters,
+            correlation_id=correlation_id,
+        )
+        return self._compose_command_center_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
+    async def resolve_monitoring_exception(
+        self,
+        exception_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmCommandCenterGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.resolve_monitoring_exception(
+            exception_id=exception_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_command_center_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
+    async def get_mandate_by_portfolio(
+        self,
+        portfolio_id: str,
+        correlation_id: str,
+    ) -> DpmCommandCenterGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_mandate_by_portfolio(
+            portfolio_id=portfolio_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_command_center_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
+    async def get_mandate(
+        self,
+        mandate_id: str,
+        correlation_id: str,
+    ) -> DpmCommandCenterGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_mandate(
+            mandate_id=mandate_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_command_center_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
+    async def get_mandate_health(
+        self,
+        mandate_id: str,
+        correlation_id: str,
+    ) -> DpmCommandCenterGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_mandate_health(
+            mandate_id=mandate_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_command_center_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
+    async def get_mandate_diff(
+        self,
+        mandate_id: str,
+        filters: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmCommandCenterGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_mandate_diff(
+            mandate_id=mandate_id,
+            params=filters,
+            correlation_id=correlation_id,
+        )
+        return self._compose_command_center_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
 
     async def preview_outcome_review(
         self,
@@ -257,6 +413,30 @@ class DpmCommandCenterService:
             data=upstream_payload,
         )
 
+    def _compose_command_center_response(
+        self,
+        upstream_status: int,
+        upstream_payload: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmCommandCenterGatewayResponse:
+        if upstream_status >= status.HTTP_400_BAD_REQUEST:
+            raise HTTPException(
+                status_code=upstream_status,
+                detail=DpmOutcomeReviewErrorDetail(
+                    upstream_status=upstream_status,
+                    error_code="MANAGE_COMMAND_CENTER_UPSTREAM_ERROR",
+                    detail=_safe_upstream_detail(upstream_payload),
+                ).model_dump(),
+            )
+
+        return DpmCommandCenterGatewayResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            upstream_status=upstream_status,
+            supportability=_command_center_supportability_from(upstream_payload),
+            data=upstream_payload,
+        )
+
 
 def _supportability_from(payload: dict[str, Any]) -> DpmOutcomeReviewSupportability:
     raw = payload.get("supportability")
@@ -284,6 +464,48 @@ def _supportability_from(payload: dict[str, Any]) -> DpmOutcomeReviewSupportabil
         state=str(state),
         reason_codes=reason_codes,
         blocked_actions=blocked_actions,
+        remediation_owner=str(remediation_owner) if remediation_owner is not None else None,
+    )
+
+
+def _command_center_supportability_from(payload: dict[str, Any]) -> DpmCommandCenterSupportability:
+    raw = payload.get("supportability")
+    supportability = raw if isinstance(raw, dict) else {}
+    data_completeness_state = supportability.get("data_completeness_state") or supportability.get(
+        "dataCompletenessState"
+    )
+    state = (
+        supportability.get("state")
+        or supportability.get("supportability_state")
+        or supportability.get("supportabilityState")
+        or data_completeness_state
+        or payload.get("command_center_state")
+        or payload.get("state")
+        or "UNKNOWN"
+    )
+    source_run_id = (
+        supportability.get("source_run_id")
+        or supportability.get("sourceRunId")
+        or payload.get("monitoring_run_id")
+    )
+    remediation_owner = supportability.get("remediation_owner") or supportability.get(
+        "remediationOwner"
+    )
+    partial_reasons = _list_of_strings(
+        supportability.get("partial_readiness_reasons")
+        or supportability.get("partialReadinessReasons")
+        or supportability.get("reason_codes")
+        or supportability.get("reasonCodes")
+        or []
+    )
+
+    return DpmCommandCenterSupportability(
+        state=str(state),
+        data_completeness_state=(
+            str(data_completeness_state) if data_completeness_state is not None else None
+        ),
+        partial_readiness_reasons=partial_reasons,
+        source_run_id=str(source_run_id) if source_run_id is not None else None,
         remediation_owner=str(remediation_owner) if remediation_owner is not None else None,
     )
 

--- a/tests/contract/test_dpm_command_center_contract.py
+++ b/tests/contract/test_dpm_command_center_contract.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 
 from app.contracts.dpm_command_center import (
+    DpmCommandCenterGatewayResponse,
     DpmOutcomeReviewGatewayResponse,
     DpmOutcomeReviewNarrativeGatewayResponse,
 )
@@ -27,6 +28,28 @@ def test_dpm_outcome_review_gateway_response_contract_shape() -> None:
     assert response.source_service == "lotus-manage"
     assert response.supportability.authority == "lotus-manage:RFC-0042"
     assert response.data["outcome_review_id"] == "or_1"
+
+
+def test_dpm_command_center_gateway_response_contract_shape() -> None:
+    response = DpmCommandCenterGatewayResponse(
+        correlation_id="corr-rfc38-1",
+        upstream_status=200,
+        supportability={
+            "state": "PARTIAL",
+            "data_completeness_state": "PARTIAL",
+            "partial_readiness_reasons": ["PM_BOOK_DISCOVERY_NOT_AVAILABLE"],
+            "source_run_id": "dmr_1",
+        },
+        data={
+            "health_distribution": {"READY": 3, "PENDING_REVIEW": 1},
+            "active_exception_count": 1,
+        },
+    )
+
+    assert response.source_service == "lotus-manage"
+    assert response.supportability.authority == "lotus-manage:RFC-0038"
+    assert response.supportability.partial_readiness_reasons == ["PM_BOOK_DISCOVERY_NOT_AVAILABLE"]
+    assert response.data["health_distribution"] == {"READY": 3, "PENDING_REVIEW": 1}
 
 
 def test_dpm_outcome_review_narrative_gateway_response_contract_shape() -> None:
@@ -56,6 +79,16 @@ def test_dpm_command_center_openapi_contract_registered() -> None:
     client = TestClient(app)
     spec = client.get("/openapi.json").json()
     expected_paths = [
+        ("/api/v1/dpm/command-center", "get"),
+        ("/api/v1/dpm/command-center/monitoring/run-once", "post"),
+        ("/api/v1/dpm/command-center/monitoring/runs", "get"),
+        ("/api/v1/dpm/command-center/monitoring/runs/{monitoring_run_id}", "get"),
+        ("/api/v1/dpm/command-center/exceptions", "get"),
+        ("/api/v1/dpm/command-center/exceptions/{exception_id}/resolve", "post"),
+        ("/api/v1/dpm/command-center/mandates/by-portfolio/{portfolio_id}", "get"),
+        ("/api/v1/dpm/command-center/mandates/{mandate_id}", "get"),
+        ("/api/v1/dpm/command-center/mandates/{mandate_id}/health", "get"),
+        ("/api/v1/dpm/command-center/mandates/{mandate_id}/diff", "get"),
         ("/api/v1/dpm/command-center/outcome-reviews/preview", "post"),
         ("/api/v1/dpm/command-center/outcome-reviews", "get"),
         ("/api/v1/dpm/command-center/outcome-reviews", "post"),
@@ -83,9 +116,17 @@ def test_dpm_command_center_openapi_models_are_described() -> None:
     client = TestClient(app)
     spec = client.get("/openapi.json").json()
     schemas = spec["components"]["schemas"]
+    command_center_response_schema = schemas["DpmCommandCenterGatewayResponse"]
+    command_center_supportability_schema = schemas["DpmCommandCenterSupportability"]
     response_schema = schemas["DpmOutcomeReviewGatewayResponse"]
     narrative_response_schema = schemas["DpmOutcomeReviewNarrativeGatewayResponse"]
     supportability_schema = schemas["DpmOutcomeReviewSupportability"]
+
+    for property_schema in command_center_response_schema["properties"].values():
+        assert property_schema.get("description")
+
+    for property_schema in command_center_supportability_schema["properties"].values():
+        assert property_schema.get("description")
 
     for property_schema in response_schema["properties"].values():
         assert property_schema.get("description")
@@ -96,6 +137,8 @@ def test_dpm_command_center_openapi_models_are_described() -> None:
     for property_schema in narrative_response_schema["properties"].values():
         assert property_schema.get("description")
 
+    assert command_center_response_schema["properties"]["data"]["description"]
+    assert command_center_supportability_schema["properties"]["state"]["examples"]
     assert response_schema["properties"]["data"]["description"]
     assert narrative_response_schema["properties"]["data"]["description"]
     assert supportability_schema["properties"]["state"]["examples"]

--- a/tests/integration/test_dpm_command_center_router.py
+++ b/tests/integration/test_dpm_command_center_router.py
@@ -3,6 +3,175 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
+def test_dpm_command_center_summary_passes_filters_and_preserves_manage_truth(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_get_command_center(self, params, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["params"] = params
+        captured["correlation_id"] = correlation_id
+        return 200, {
+            "health_distribution": {"READY": 3, "PENDING_REVIEW": 1},
+            "evaluated_mandates": 4,
+            "active_exception_count": 1,
+            "supportability": {
+                "data_completeness_state": "PARTIAL",
+                "partial_readiness_reasons": ["PM_BOOK_DISCOVERY_NOT_AVAILABLE"],
+                "source_run_id": "dmr_1",
+            },
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_command_center",
+        _fake_get_command_center,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/dpm/command-center"
+        "?tenant_id=default&portfolio_manager_id=PM_SG_DPM_001"
+        "&book_id=BOOK_SG_BALANCED_DPM&health_state=PENDING_REVIEW&limit=25",
+        headers={"X-Correlation-Id": "corr-command-router-1"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "params": {
+            "portfolio_manager_id": "PM_SG_DPM_001",
+            "tenant_id": "default",
+            "as_of_date": None,
+            "book_id": "BOOK_SG_BALANCED_DPM",
+            "health_state": "PENDING_REVIEW",
+            "limit": 25,
+        },
+        "correlation_id": "corr-command-router-1",
+    }
+    payload = response.json()
+    assert payload["supportability"]["state"] == "PARTIAL"
+    assert payload["supportability"]["source_run_id"] == "dmr_1"
+    assert payload["data"]["health_distribution"] == {"READY": 3, "PENDING_REVIEW": 1}
+
+
+def test_dpm_command_center_monitoring_run_action_forwards_body(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_run_monitoring_once(self, body, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["body"] = body
+        captured["correlation_id"] = correlation_id
+        return 200, {
+            "monitoring_run_id": "dmr_1",
+            "status": "SUCCEEDED",
+            "mandate_results": [{"mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001"}],
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.run_monitoring_once",
+        _fake_run_monitoring_once,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/monitoring/run-once",
+        json={
+            "body": {
+                "mandate_ids": ["MANDATE_PB_SG_GLOBAL_BAL_001"],
+                "as_of_date": "2026-05-03",
+                "tenant_id": "default",
+                "portfolio_manager_id": "PM_SG_DPM_001",
+            }
+        },
+        headers={"X-Correlation-Id": "corr-command-router-run"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "body": {
+            "mandate_ids": ["MANDATE_PB_SG_GLOBAL_BAL_001"],
+            "as_of_date": "2026-05-03",
+            "tenant_id": "default",
+            "portfolio_manager_id": "PM_SG_DPM_001",
+        },
+        "correlation_id": "corr-command-router-run",
+    }
+    assert response.json()["data"]["monitoring_run_id"] == "dmr_1"
+
+
+def test_dpm_command_center_exception_resolution_forwards_reason(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_resolve_monitoring_exception(
+        self,
+        exception_id,
+        body,
+        correlation_id,
+    ):  # noqa: ANN001
+        _ = self
+        captured["exception_id"] = exception_id
+        captured["body"] = body
+        captured["correlation_id"] = correlation_id
+        return 200, {
+            "exception_id": exception_id,
+            "state": "RESOLVED",
+            "resolution_reason": body["resolution_reason"],
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.resolve_monitoring_exception",
+        _fake_resolve_monitoring_exception,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/exceptions/me_source_1/resolve",
+        json={"resolution_reason": "SOURCE_DATA_REPAIRED_AND_RECALCULATED"},
+        headers={"X-Correlation-Id": "corr-command-router-resolve"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "exception_id": "me_source_1",
+        "body": {"resolution_reason": "SOURCE_DATA_REPAIRED_AND_RECALCULATED"},
+        "correlation_id": "corr-command-router-resolve",
+    }
+    assert response.json()["data"]["state"] == "RESOLVED"
+
+
+def test_dpm_command_center_mandate_health_drilldown_preserves_dimensions(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_get_mandate_health(self, mandate_id, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["mandate_id"] = mandate_id
+        captured["correlation_id"] = correlation_id
+        return 200, {
+            "health_snapshot_id": "mh_1",
+            "mandate_id": mandate_id,
+            "health_score": 97,
+            "dimension_scores": [{"dimension": "SOURCE_READINESS", "state": "READY"}],
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_mandate_health",
+        _fake_get_mandate_health,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/dpm/command-center/mandates/MANDATE_PB_SG_GLOBAL_BAL_001/health",
+        headers={"X-Correlation-Id": "corr-command-router-health"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+        "correlation_id": "corr-command-router-health",
+    }
+    assert response.json()["data"]["dimension_scores"] == [
+        {"dimension": "SOURCE_READINESS", "state": "READY"}
+    ]
+
+
 def test_dpm_command_center_outcome_review_create_preserves_manage_truth(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -14,6 +14,28 @@ class _FakeDpmClient:
         self.calls.append({"method": "create", "body": body, "correlation_id": correlation_id})
         return self.result
 
+    async def get_command_center(self, params, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {"method": "command_center", "params": params, "correlation_id": correlation_id}
+        )
+        return self.result
+
+    async def run_monitoring_once(self, body, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {"method": "run_monitoring_once", "body": body, "correlation_id": correlation_id}
+        )
+        return self.result
+
+    async def get_mandate_health(self, mandate_id, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "mandate_health",
+                "mandate_id": mandate_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
     async def get_outcome_review_supportability(self, outcome_review_id, correlation_id):  # noqa: ANN001
         self.calls.append(
             {
@@ -43,6 +65,147 @@ class _FakeLotusAiClient:
     async def execute_workflow_pack(self, **kwargs):  # noqa: ANN003
         self.calls.append(kwargs)
         return self.result
+
+
+@pytest.mark.asyncio
+async def test_dpm_command_center_summary_preserves_manage_health_and_supportability() -> None:
+    manage_payload = {
+        "health_distribution": {"READY": 3, "PENDING_REVIEW": 1, "BLOCKED": 1},
+        "evaluated_mandates": 5,
+        "active_exception_count": 2,
+        "latest_monitoring_run": {"monitoring_run_id": "dmr_1", "status": "SUCCEEDED"},
+        "supportability": {
+            "data_completeness_state": "PARTIAL",
+            "partial_readiness_reasons": ["PM_BOOK_DISCOVERY_NOT_AVAILABLE"],
+            "source_run_id": "dmr_1",
+            "remediation_owner": "Portfolio Operations",
+        },
+    }
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmCommandCenterService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.get_command_center(
+        filters={
+            "tenant_id": "default",
+            "portfolio_manager_id": "PM_SG_DPM_001",
+            "health_state": "PENDING_REVIEW",
+            "limit": 25,
+        },
+        correlation_id="corr-command-center-1",
+    )
+
+    assert response.correlation_id == "corr-command-center-1"
+    assert response.source_service == "lotus-manage"
+    assert response.upstream_status == 200
+    assert response.supportability.state == "PARTIAL"
+    assert response.supportability.data_completeness_state == "PARTIAL"
+    assert response.supportability.partial_readiness_reasons == ["PM_BOOK_DISCOVERY_NOT_AVAILABLE"]
+    assert response.supportability.source_run_id == "dmr_1"
+    assert response.data == manage_payload
+    assert client.calls == [
+        {
+            "method": "command_center",
+            "params": {
+                "tenant_id": "default",
+                "portfolio_manager_id": "PM_SG_DPM_001",
+                "health_state": "PENDING_REVIEW",
+                "limit": 25,
+            },
+            "correlation_id": "corr-command-center-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_command_center_monitoring_run_forwards_body_without_book_discovery() -> None:
+    manage_payload = {
+        "monitoring_run_id": "dmr_1",
+        "status": "SUCCEEDED",
+        "mandate_results": [{"mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001"}],
+    }
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmCommandCenterService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.run_monitoring_once(
+        body={
+            "mandate_ids": ["MANDATE_PB_SG_GLOBAL_BAL_001"],
+            "as_of_date": "2026-05-03",
+            "tenant_id": "default",
+        },
+        correlation_id="corr-command-center-run",
+    )
+
+    assert response.supportability.state == "UNKNOWN"
+    assert response.data == manage_payload
+    assert client.calls == [
+        {
+            "method": "run_monitoring_once",
+            "body": {
+                "mandate_ids": ["MANDATE_PB_SG_GLOBAL_BAL_001"],
+                "as_of_date": "2026-05-03",
+                "tenant_id": "default",
+            },
+            "correlation_id": "corr-command-center-run",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_command_center_mandate_health_preserves_manage_dimensions() -> None:
+    manage_payload = {
+        "health_snapshot_id": "mh_1",
+        "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+        "health_score": 97,
+        "health_state": "PENDING_REVIEW",
+        "dimension_scores": [
+            {
+                "dimension": "SOURCE_READINESS",
+                "score": 90,
+                "state": "PENDING_REVIEW",
+                "reason_codes": ["TAX_LOT_SOURCE_PARTIAL"],
+            }
+        ],
+        "source_readiness_state": "READY",
+        "recommended_action": "SIMULATE_REBALANCE",
+    }
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmCommandCenterService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.get_mandate_health(
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        correlation_id="corr-mandate-health",
+    )
+
+    assert response.supportability.state == "UNKNOWN"
+    assert response.data["health_score"] == 97
+    assert response.data["dimension_scores"] == manage_payload["dimension_scores"]
+    assert client.calls == [
+        {
+            "method": "mandate_health",
+            "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+            "correlation_id": "corr-mandate-health",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_command_center_manage_errors_are_product_safe() -> None:
+    client = _FakeDpmClient((422, {"detail": "invalid health_state"}))
+    service = DpmCommandCenterService(dpm_client=client)  # type: ignore[arg-type]
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.get_command_center(
+            filters={"health_state": "NOT_REAL"},
+            correlation_id="corr-command-center-error",
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == {
+        "source_service": "lotus-manage",
+        "upstream_status": 422,
+        "error_code": "MANAGE_COMMAND_CENTER_UPSTREAM_ERROR",
+        "detail": "invalid health_state",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1862,6 +1862,119 @@ async def test_dpm_client_construction_generate_route_forwards_idempotency_key()
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("method_name", "kwargs", "expected_url", "expected_method"),
+    [
+        (
+            "get_command_center",
+            {
+                "params": {
+                    "tenant_id": "default",
+                    "portfolio_manager_id": "PM_SG_DPM_001",
+                    "book_id": None,
+                },
+                "correlation_id": "corr-rfc38",
+            },
+            "http://dpm/api/v1/dpm/command-center",
+            "GET",
+        ),
+        (
+            "run_monitoring_once",
+            {
+                "body": {"mandate_ids": ["MANDATE_PB_SG_GLOBAL_BAL_001"]},
+                "correlation_id": "corr-rfc38",
+            },
+            "http://dpm/api/v1/dpm/monitoring/run-once",
+            "POST",
+        ),
+        (
+            "list_monitoring_runs",
+            {
+                "params": {"status_filter": "SUCCEEDED", "cursor": None},
+                "correlation_id": "corr-rfc38",
+            },
+            "http://dpm/api/v1/dpm/monitoring/runs",
+            "GET",
+        ),
+        (
+            "get_monitoring_run",
+            {"monitoring_run_id": "dmr_1", "correlation_id": "corr-rfc38"},
+            "http://dpm/api/v1/dpm/monitoring/runs/dmr_1",
+            "GET",
+        ),
+        (
+            "list_monitoring_exceptions",
+            {
+                "params": {"portfolio_id": "PB_SG_GLOBAL_BAL_001", "state": "ACTIVE"},
+                "correlation_id": "corr-rfc38",
+            },
+            "http://dpm/api/v1/dpm/exceptions",
+            "GET",
+        ),
+        (
+            "resolve_monitoring_exception",
+            {
+                "exception_id": "me_1",
+                "body": {"resolution_reason": "SOURCE_REPAIRED"},
+                "correlation_id": "corr-rfc38",
+            },
+            "http://dpm/api/v1/dpm/exceptions/me_1/resolve",
+            "POST",
+        ),
+        (
+            "get_mandate_by_portfolio",
+            {"portfolio_id": "PB_SG_GLOBAL_BAL_001", "correlation_id": "corr-rfc38"},
+            "http://dpm/api/v1/mandates/by-portfolio/PB_SG_GLOBAL_BAL_001",
+            "GET",
+        ),
+        (
+            "get_mandate",
+            {"mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001", "correlation_id": "corr-rfc38"},
+            "http://dpm/api/v1/mandates/MANDATE_PB_SG_GLOBAL_BAL_001",
+            "GET",
+        ),
+        (
+            "get_mandate_health",
+            {"mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001", "correlation_id": "corr-rfc38"},
+            "http://dpm/api/v1/mandates/MANDATE_PB_SG_GLOBAL_BAL_001/health",
+            "GET",
+        ),
+        (
+            "get_mandate_diff",
+            {
+                "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+                "params": {"from_version": "2", "to_version": "3"},
+                "correlation_id": "corr-rfc38",
+            },
+            "http://dpm/api/v1/mandates/MANDATE_PB_SG_GLOBAL_BAL_001/diff",
+            "GET",
+        ),
+    ],
+)
+async def test_dpm_client_rfc38_command_center_routes(
+    method_name,
+    kwargs,
+    expected_url,
+    expected_method,
+):
+    client = DpmClient(base_url="http://dpm", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"ok": True})
+
+    method = getattr(client, method_name)
+    status_code, payload = await method(**kwargs)
+
+    assert status_code == 200
+    assert payload["ok"] is True
+    assert _FakeAsyncClient.calls[0]["method"] == expected_method
+    assert _FakeAsyncClient.calls[0]["url"] == expected_url
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Correlation-Id"] == "corr-rfc38"
+    if expected_method == "GET" and "params" in kwargs:
+        assert None not in _FakeAsyncClient.calls[0]["params"].values()
+    if expected_method == "POST":
+        assert _FakeAsyncClient.calls[0]["json"] == kwargs["body"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("method_name", "kwargs", "expected_url"),
     [
         (

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -13,6 +13,10 @@
 - `POST /api/v1/intake/*`
 - `GET /api/v1/lookups/*`
 - `GET /api/v1/portfolio/*`
+- `GET /api/v1/dpm/command-center`
+- `GET` and `POST /api/v1/dpm/command-center/monitoring/*`
+- `GET` and `POST /api/v1/dpm/command-center/exceptions*`
+- `GET /api/v1/dpm/command-center/mandates*`
 - `GET` and `POST /api/v1/dpm/command-center/outcome-reviews*`
 - `GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`
 - `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
@@ -68,6 +72,16 @@
   diagnostics, supportability, selected-alternative state, and lineage. Gateway must not optimize,
   recompute construction metrics, infer source readiness, select alternatives, execute orders, or
   let Workbench bypass Gateway.
+- RFC-0098 mandate command-center composition consumes `lotus-manage` RFC-0038 mandate health,
+  monitoring run, exception queue, and mandate read APIs. Gateway now exposes
+  `/api/v1/dpm/command-center`, `/api/v1/dpm/command-center/monitoring/*`,
+  `/api/v1/dpm/command-center/exceptions*`, and `/api/v1/dpm/command-center/mandates*` for
+  Workbench command-center consumers. These routes preserve manage-published health distribution,
+  health dimensions, source readiness, supportability, latest monitoring run identity, active
+  exceptions, reason codes, recommended actions, mandate source lineage, and version diffs.
+  Gateway must not discover PM-book membership, calculate health scores, reconstruct source
+  readiness, merge exceptions across monitoring runs, resolve exceptions locally, or let Workbench
+  call `lotus-manage` directly.
 - RFC36-WTBD-003 portfolio-level DPM operations posture is exposed on Workbench overview and
   portfolio-360 `rebalance_snapshot`. Gateway reads manage rebalance runs through
   `/api/v1/rebalance/runs`, reads manage supportability summary through
@@ -122,8 +136,9 @@
 - proposal simulation, create, list, detail, version, workflow-event, approval, and lineage routes
   call `lotus-advise` `/advisory/proposals/*`; they do not call `lotus-manage`
 - gateway calls `lotus-manage` only through versioned `/api/v1/*` paths for discretionary
-  management run lookup, supportability summary, capability posture, RFC-0039 construction
-  alternative-set authority APIs, and RFC-0042 outcome-review authority APIs
+  management run lookup, supportability summary, capability posture, RFC-0038 mandate
+  command-center authority APIs, RFC-0039 construction alternative-set authority APIs, and
+  RFC-0042 outcome-review authority APIs
 - `/metrics` includes RFC-0108 gateway analytics fan-out metrics for selected Workbench analytics
   operations plus the central `lotus-advise`, `lotus-manage`, `lotus-report`, `lotus-archive`,
   `lotus-ai`, direct `lotus-core` query/control-plane, and `lotus-core` ingestion client seams:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -17,14 +17,16 @@
   proposal simulation, proposal persistence, workflow events, approvals, and lineage through
   `/advisory/proposals/*`
 - `lotus-manage`
-  discretionary management run lookup, supportability summary, capabilities, RFC-0039
+  discretionary management run lookup, supportability summary, capabilities, RFC-0038 mandate
+  command-center summary/monitoring/exception/mandate drill-down authority APIs, RFC-0039
   construction alternative-set authority APIs, RFC-0040
   proof-pack authority APIs, RFC-0041 rebalance-wave orchestration authority APIs, and RFC-0042
   post-trade outcome-review authority APIs. RFC-0098 remains the strategic Gateway DPM
-  command-center contract; the RFC-0039 construction alternative-set BFF route family and
-  RFC-0042 outcome-review BFF route family are now implementation-backed, while broader mandate
-  health, RFC-0041 wave composition, proof-pack modules, report materialization, archive, and
-  optional AI posture remain governed follow-on slices until implemented and proven
+  command-center contract; the RFC-0038 mandate command-center BFF route family, RFC-0039
+  construction alternative-set BFF route family, and RFC-0042 outcome-review BFF route family are
+  now implementation-backed, while RFC-0041 wave composition, proof-pack modules, report
+  materialization, archive, and optional AI posture remain governed follow-on slices until
+  implemented and proven
 - `lotus-report`
   reporting snapshot, summary, and review payloads
 - `lotus-archive`
@@ -74,14 +76,21 @@
    the DPM operating-state, rebalance-wave, and proof-pack authority, `lotus-report` remains report
    materialization authority, `lotus-risk` and `lotus-performance` remain analytics authorities,
    and Workbench remains a renderer of Gateway truth.
-10. RFC-0042 outcome reviews remain `lotus-manage` truth. Gateway outcome-review realization must
+10. RFC-0038 mandate command-center truth remains in `lotus-manage`. Gateway realization exposes
+    `/api/v1/dpm/command-center`, `/api/v1/dpm/command-center/monitoring/*`,
+    `/api/v1/dpm/command-center/exceptions*`, and `/api/v1/dpm/command-center/mandates*` for
+    Workbench. Gateway forwards filters and request bodies to manage, then preserves health
+    distribution, monitoring-run state, active exceptions, reason codes, recommended actions,
+    mandate source lineage, version diffs, and supportability without calculating health,
+    discovering PM books, inferring source readiness, or resolving exceptions locally.
+11. RFC-0042 outcome reviews remain `lotus-manage` truth. Gateway outcome-review realization must
     compose expected-versus-realized review summaries, dimension outcomes, source lineage,
     supportability, report-input posture, and AI-evidence posture without recomputing outcome
     values or calling source-owner apps behind manage's review authority. The implemented Gateway
     route family is `/api/v1/dpm/command-center/outcome-reviews*`,
     `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`, and
     `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`.
-11. RFC-0039 construction alternatives remain `lotus-manage` truth. Gateway construction
+12. RFC-0039 construction alternatives remain `lotus-manage` truth. Gateway construction
     realization exposes `/api/v1/dpm/command-center/construction/alternative-sets/generate`,
     `/api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}`, and
     `/api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}/selections`
@@ -89,7 +98,7 @@
     then preserves alternatives, method status, diagnostics, comparison metrics, supportability,
     and selection decisions without performing optimization, recomputation, readiness inference, or
     order execution.
-12. RFC36-WTBD-003 portfolio-level DPM operations dashboards consume Gateway Workbench
+13. RFC36-WTBD-003 portfolio-level DPM operations dashboards consume Gateway Workbench
     `rebalance_snapshot` only. Gateway reads manage rebalance runs, preserves manage
     supportability summary and bounded recent-run posture, and keeps Workbench from calling
     `lotus-manage` directly or inventing workflow/error semantics. Supportability comes from

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -50,6 +50,59 @@ Operational behavior:
 2. manage upstream errors are returned using product-safe Gateway error detail,
 3. OpenAPI documents What/When/How guidance and request/response examples for each route.
 
+## DPM Mandate Command Center
+
+Status: implementation-backed in Gateway for RFC38-WTBD-001.
+
+Business outcome:
+
+1. portfolio managers, supervision users, and operations teams can query mandate health,
+   monitoring-run, active-exception, and mandate drill-down posture through Gateway,
+2. Workbench can build the command-center cockpit without calling `lotus-manage` directly,
+3. Gateway preserves manage source readiness, supportability, reason codes, recommended actions,
+   and mandate lineage without becoming the mandate-health authority.
+
+Supported routes:
+
+1. `GET /api/v1/dpm/command-center`
+2. `POST /api/v1/dpm/command-center/monitoring/run-once`
+3. `GET /api/v1/dpm/command-center/monitoring/runs`
+4. `GET /api/v1/dpm/command-center/monitoring/runs/{monitoring_run_id}`
+5. `GET /api/v1/dpm/command-center/exceptions`
+6. `POST /api/v1/dpm/command-center/exceptions/{exception_id}/resolve`
+7. `GET /api/v1/dpm/command-center/mandates/by-portfolio/{portfolio_id}`
+8. `GET /api/v1/dpm/command-center/mandates/{mandate_id}`
+9. `GET /api/v1/dpm/command-center/mandates/{mandate_id}/health`
+10. `GET /api/v1/dpm/command-center/mandates/{mandate_id}/diff`
+
+Authority and integrations:
+
+1. `lotus-manage` remains the RFC-0038 mandate digital twin, health, monitoring, exception, and
+   command-center authority.
+2. Gateway forwards filters, monitoring requests, and exception-resolution reasons to manage.
+3. Gateway preserves health distribution, health dimensions, monitoring-run state, active
+   exceptions, reason codes, recommended actions, source lineage, version diffs, and
+   supportability.
+4. Gateway does not discover PM-book membership, calculate health scores, reconstruct health
+   dimensions, infer source readiness, merge exceptions across monitoring runs, or resolve
+   exceptions locally.
+
+```mermaid
+flowchart LR
+    Workbench[lotus-workbench DPM cockpit] --> Gateway[lotus-gateway DPM command-center routes]
+    Gateway --> Manage[lotus-manage RFC-0038 mandate health and monitoring authority]
+    Manage --> Core[lotus-core source products]
+    Manage --> Gateway
+    Gateway --> Workbench
+```
+
+Operational behavior:
+
+1. empty and partial command-center states remain valid product states,
+2. manage upstream errors are returned using product-safe Gateway error detail,
+3. Workbench cockpit implementation and canonical UI proof remain separate owning-repository
+   work under RFC38-WTBD-002.
+
 ## Portfolio-Level DPM Operations Posture
 
 Status: implementation-backed in Gateway for RFC36-WTBD-003.


### PR DESCRIPTION
## Summary
- add Gateway RFC38 mandate command-center BFF routes for summary, monitoring runs, exception queue/resolution, and mandate drill-down
- add typed manage client methods and Gateway envelopes that preserve manage supportability and payloads without recalculating mandate health or source readiness
- update RFC-0098, repository context, and repo-authored wiki source for the new implementation-backed route family

## Validation
- `python -m pytest tests/contract/test_dpm_command_center_contract.py tests/unit/test_dpm_command_center_service.py tests/integration/test_dpm_command_center_router.py tests/unit/test_upstream_clients.py::test_dpm_client_rfc38_command_center_routes -q`
- `make check`
- `powershell -ExecutionPolicy Bypass -File C:/Users/Sandeep/projects/lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reports expected pre-merge drift for `API-Surface.md`, `Integrations.md`, and `Supported-Features.md` because this PR updates repo-authored wiki source

## Notes
- This completes the Gateway composition slice for RFC38-WTBD-001 only.
- Workbench cockpit implementation and canonical UI proof remain RFC38-WTBD-002 in `lotus-workbench`.
- Gateway does not discover PM-book membership, calculate health scores, reconstruct source readiness, merge exceptions across monitoring runs, or resolve exceptions locally.