### PR TITLE
Implement Gateway proof-pack composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ It depends on:
   proposal simulation, persisted proposal lifecycle, workflow, approval, and lineage capability
 - `lotus-manage`
   discretionary management run lookup, supportability summary, platform capability posture, and
-  RFC-0039 construction alternative-set authority and RFC-0042 post-trade outcome-review authority
-  through the DPM command-center BFF routes
+  RFC-0039 construction alternative-set authority, RFC-0040 proof-pack authority, and RFC-0042
+  post-trade outcome-review authority through the DPM command-center BFF routes
 - `lotus-report`
   reporting snapshot, summary, review payloads, portfolio-review and outcome-review durable report
   job initiation/lifecycle/search, and RFC-0104 batch materialization/status/control/operator-run APIs
@@ -94,6 +94,11 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/dpm/command-center/construction/alternative-sets/generate`,
   `/api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}`,
   `/api/v1/dpm/command-center/construction/alternative-sets/{alternative_set_id}/selections`,
+  `/api/v1/dpm/command-center/proof-packs`,
+  `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}`,
+  `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/summary.md`,
+  `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/report-input`,
+  `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-evidence-input`,
   `/api/v1/dpm/command-center/outcome-reviews*`,
   `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`,
   `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -35,7 +35,8 @@ Current repository posture:
    with proposal simulation/lifecycle/workflow/approval/lineage routed to `lotus-advise`
    `/advisory/proposals/*`; `lotus-manage` consumption is through versioned `/api/v1` APIs for
    run lookup, supportability summary, capability posture, RFC-0038 mandate command-center
-   summary/monitoring/exception/mandate drill-down route families, and RFC-0042 outcome-review
+   summary/monitoring/exception/mandate drill-down route families, RFC-0040 proof-pack
+   generate/read/Markdown/report-input/AI-evidence route families, and RFC-0042 outcome-review
    preview/create/search/detail/source-refresh/supportability/report-input/AI-evidence and
    AI-narrative handoff route families,
 4. report job initiation/search/status/event-history/cancellation routes are active for
@@ -207,7 +208,13 @@ Most relevant current governance:
     method status, diagnostics, comparison metrics, selected-alternative state, and supportability,
     and must not optimize portfolios, recompute construction metrics, infer source readiness, or
     choose alternatives locally.
-13. The Workbench overview and portfolio-360 `rebalance_snapshot` now carry bounded
+13. RFC-0040 proof-pack Gateway routes are active under
+    `/api/v1/dpm/command-center/proof-packs*`. Gateway forwards generation, lookup, Markdown,
+    report-input, and AI-evidence-input requests to `lotus-manage`, preserves manage-owned
+    `proof_pack_id`, section states, reason codes, content hashes, source hashes, source refs,
+    report refs, and AI refs, and must not build proof-pack sections, recalculate hashes, infer
+    source readiness, render reports, or generate AI narrative locally.
+14. The Workbench overview and portfolio-360 `rebalance_snapshot` now carry bounded
     portfolio-level DPM operations posture for RFC36-WTBD-003: latest rebalance status, last run,
     manage action-register supportability from `/api/v1/rebalance/supportability/summary`, and up
     to five recent manage runs from `/api/v1/rebalance/runs` with bounded status, timestamp,

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -21,5 +21,5 @@ Governance boundary:
 | RFC-0013 | Workbench Position Valuation Fields | IMPLEMENTED | `docs/rfcs/RFC-0013-workbench-position-valuation-fields.md` |
 | RFC-0014 | Experience API Foundation and Pre-Live Replacement Strategy | PROPOSED | `docs/rfcs/RFC-0014-experience-api-foundation-and-prelive-replacement-strategy.md` |
 | RFC-0015 | Foundation Workspace Experience Contract | IMPLEMENTED | `docs/rfcs/RFC-0015-foundation-workspace-experience-contract.md` |
-| RFC-0098 | DPM Command Center Composition Contract | PARTIAL IMPLEMENTATION - RFC-0039 CONSTRUCTION AND RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER COMMAND CENTER PENDING | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
+| RFC-0098 | DPM Command Center Composition Contract | PARTIAL IMPLEMENTATION - RFC-0038 MANDATE COMMAND-CENTER, RFC-0039 CONSTRUCTION, RFC-0040 PROOF-PACK, AND RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER WAVE/REPORT/ARCHIVE MODULES PENDING | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
 

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -2,7 +2,7 @@
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | PARTIAL IMPLEMENTATION - RFC-0038 MANDATE COMMAND-CENTER, RFC-0039 CONSTRUCTION, AND RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER WAVE/PROOF/REPORT/ARCHIVE MODULES PENDING |
+| **Status** | PARTIAL IMPLEMENTATION - RFC-0038 MANDATE COMMAND-CENTER, RFC-0039 CONSTRUCTION, RFC-0040 PROOF-PACK, AND RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER WAVE/REPORT/ARCHIVE MODULES PENDING |
 | **Created** | 2026-05-03 |
 | **Last Tightened** | 2026-05-05 |
 | **Owner** | `lotus-gateway` |
@@ -1132,18 +1132,19 @@ To be completed during the final closure slice:
 ## 19. Implementation Progress Ledger
 
 This RFC is not fully implemented. Ledger-driven slices have delivered the RFC-0038 mandate
-command-center route family, the RFC-0039 construction alternative-set route family, and the
-RFC-0042 outcome-review route family so Workbench can consume Gateway/BFF instead of calling
-`lotus-manage` directly.
+command-center route family, the RFC-0039 construction alternative-set route family, the RFC-0040
+proof-pack route family, and the RFC-0042 outcome-review route family so Workbench can consume
+Gateway/BFF instead of calling `lotus-manage` directly.
 
 | Item | Status | Evidence |
 | --- | --- | --- |
 | RFC38-WTBD-001 Gateway DPM command-center composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/unit/test_upstream_clients.py` |
 | RFC39-WTBD-001 Gateway construction-alternatives composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_construction.py`, `src/app/services/dpm_construction_service.py`, `src/app/contracts/dpm_construction.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_construction_service.py`, `tests/integration/test_dpm_construction_router.py`, `tests/contract/test_dpm_construction_contract.py` |
+| RFC40-WTBD-001 Gateway proof-pack composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_proof_packs.py`, `src/app/services/dpm_proof_pack_service.py`, `src/app/contracts/dpm_proof_packs.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_proof_pack_service.py`, `tests/integration/test_dpm_proof_pack_router.py`, `tests/contract/test_dpm_proof_pack_contract.py` |
 | RFC42-WTBD-001 Gateway outcome-review composition and BFF contract | Implemented and merged before this slice | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/contract/test_dpm_command_center_contract.py`, `make ci` |
 | RFC42-WTBD-005 Gateway AI narrative handoff | Implemented and merged before this slice | Gateway reads manage-owned `DpmOutcomeAiEvidenceInput`, executes `lotus-ai` `outcome_review_narrative.pack@v1` as `lotus-gateway`, preserves manage workflow authority, and exposes `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative` |
 | RFC-0042 manage authority preservation | Implemented for BFF envelope; Gateway forwards payloads and preserves manage supportability | Service tests prove payload preservation and upstream error forwarding; contract tests prove OpenAPI route family registration and What/When/How guidance |
-| Broader RFC-0098 wave composition, proof-pack composition, report/archive modules, and Workbench cockpit | Not implemented in this slice | Remains governed by this RFC and the work-to-be-done ledger; no supported-feature claim is made |
+| Broader RFC-0098 wave composition, report/archive modules, and Workbench cockpit | Not implemented in this slice | Remains governed by this RFC and the work-to-be-done ledger; no supported-feature claim is made |
 
 Implementation boundaries:
 
@@ -1171,7 +1172,17 @@ Implementation boundaries:
    selected-alternative state, and lineage.
 6. Gateway does not optimize portfolios, recompute construction metrics, infer source readiness,
    select alternatives, execute orders, or fabricate degraded-source values.
-7. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,
+7. Gateway now exposes `POST /api/v1/dpm/command-center/proof-packs`,
+   `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}`,
+   `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/summary.md`,
+   `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/report-input`, and
+   `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-evidence-input`.
+8. Proof-pack routes preserve manage-owned proof-pack identity, section states, reason codes,
+   content hashes, source hashes, source refs, report refs, AI refs, Markdown text, report-input
+   payloads, and AI-evidence payloads.
+9. Gateway does not generate proof-pack sections, recalculate hashes, infer source readiness,
+   render reports, generate AI narrative, or treat `lotus-report` as proof-pack authority.
+10. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,
    `POST /api/v1/dpm/command-center/outcome-reviews`,
    `GET /api/v1/dpm/command-center/outcome-reviews`,
    `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}`,
@@ -1182,12 +1193,12 @@ Implementation boundaries:
    `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`,
    `GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`, and
    `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`.
-8. Gateway does not calculate expected values, realized values, variance, tolerance, hashes,
+11. Gateway does not calculate expected values, realized values, variance, tolerance, hashes,
    lineage, source freshness, supportability, or review state.
-9. Gateway does not generate reports, render artifacts, archive documents, generate AI narrative
+12. Gateway does not generate reports, render artifacts, archive documents, generate AI narrative
    locally, score PM quality, approve trades, contact clients, or claim Workbench UI support in
    this slice. The AI narrative endpoint is a governed handoff to `lotus-ai` over manage evidence.
-10. Workbench product realization remains a separate owning-repository implementation item.
+13. Workbench product realization remains a separate owning-repository implementation item.
 
 Validation performed on 2026-05-05:
 

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from app.clients.observed_fanout import request_observed_fanout
+from app.clients.observed_fanout import request_observed_binary_fanout, request_observed_fanout
 from app.middleware.correlation import propagation_headers
 
 logger = logging.getLogger("analytics_ui.gateway")
@@ -338,6 +338,79 @@ class DpmClient:
             body=body,
             headers=self._headers(correlation_id),
             operation="manage.construction.alternative_sets.select",
+        )
+
+    async def generate_proof_pack(
+        self,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/api/v1/rebalance/proof-packs",
+            body=body,
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="manage.rebalance.proof_packs.generate",
+        )
+
+    async def get_proof_pack(
+        self,
+        proof_pack_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/proof-packs/{proof_pack_id}",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.proof_packs.get",
+        )
+
+    async def get_proof_pack_markdown(
+        self,
+        proof_pack_id: str,
+        correlation_id: str,
+    ) -> tuple[int, str, dict[str, Any]]:
+        (
+            status_code,
+            content,
+            _response_headers,
+            error_payload,
+        ) = await request_observed_binary_fanout(
+            logger=logger,
+            service="lotus-manage",
+            operation="manage.rebalance.proof_packs.markdown",
+            method="GET",
+            url=f"{self._base_url}/api/v1/rebalance/proof-packs/{proof_pack_id}/summary.md",
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            params={},
+            headers=self._headers(correlation_id),
+        )
+        return status_code, content.decode("utf-8", errors="replace"), error_payload
+
+    async def get_proof_pack_report_input(
+        self,
+        proof_pack_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/proof-packs/{proof_pack_id}/report-input",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.proof_packs.report_input",
+        )
+
+    async def get_proof_pack_ai_evidence_input(
+        self,
+        proof_pack_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/proof-packs/{proof_pack_id}/ai-evidence-input",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.proof_packs.ai_evidence_input",
         )
 
     async def get_capabilities(

--- a/src/app/contracts/dpm_proof_packs.py
+++ b/src/app/contracts/dpm_proof_packs.py
@@ -1,0 +1,177 @@
+from pydantic import BaseModel, Field
+
+
+class DpmProofPackGenerateRequest(BaseModel):
+    idempotency_key: str = Field(
+        description=(
+            "Required manage idempotency token for proof-pack generation. Gateway forwards it as "
+            "the `Idempotency-Key` header and does not derive replay keys."
+        ),
+        examples=["proof-pack-idem-001"],
+    )
+    body: dict[str, object] = Field(
+        description=(
+            "Request payload forwarded unchanged to lotus-manage RFC-0040 proof-pack authority. "
+            "Gateway does not build proof-pack sections, calculate hashes, infer source readiness, "
+            "or change handoff flags."
+        ),
+        examples=[
+            {
+                "source_type": "REBALANCE_RUN",
+                "rebalance_run_id": "rr_001",
+                "actor_id": "pm_sg_1",
+                "include_markdown": True,
+                "include_report_input": True,
+                "include_ai_evidence_input": True,
+            }
+        ],
+    )
+
+
+class DpmProofPackSupportability(BaseModel):
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Authoritative service that owns proof-pack readiness and evidence.",
+        examples=["lotus-manage"],
+    )
+    authority: str = Field(
+        default="lotus-manage:RFC-0040",
+        description="Business authority and RFC provenance for DPM proof packs.",
+        examples=["lotus-manage:RFC-0040"],
+    )
+    state: str = Field(
+        description="Manage-published proof-pack state preserved by Gateway.",
+        examples=["READY", "DEGRADED", "BLOCKED", "UNKNOWN"],
+    )
+    proof_pack_id: str | None = Field(
+        default=None,
+        description="Manage-owned immutable proof-pack identifier when available.",
+        examples=["dpp_rr_001"],
+    )
+    reason_codes: list[str] = Field(
+        default_factory=list,
+        description="Manage-published bounded reason codes for supportability and audit review.",
+        examples=[["PROOF_PACK_READY", "REPORT_INPUT_READY"]],
+    )
+    section_state_counts: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Counts of manage-published proof-pack section states. Gateway derives counts from "
+            "section state labels only and does not recalculate evidence."
+        ),
+        examples=[{"READY": 7, "DEGRADED": 1}],
+    )
+    content_hash: str | None = Field(
+        default=None,
+        description="Manage-owned immutable proof-pack content hash when returned.",
+        examples=["sha256:proof-pack"],
+    )
+    markdown_available: bool = Field(
+        default=False,
+        description="Whether the manage payload exposes deterministic Markdown retrieval.",
+        examples=[True],
+    )
+    report_input_available: bool = Field(
+        default=False,
+        description="Whether the manage payload exposes deterministic report-input evidence.",
+        examples=[True],
+    )
+    ai_evidence_input_available: bool = Field(
+        default=False,
+        description="Whether the manage payload exposes deterministic AI-evidence input.",
+        examples=[True],
+    )
+
+
+class DpmProofPackGatewayResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated across Gateway and lotus-manage.",
+        examples=["corr-rfc40-proof-pack-1"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway BFF contract version for proof-pack JSON and evidence responses.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Upstream service that supplied the authoritative proof-pack payload.",
+        examples=["lotus-manage"],
+    )
+    upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage before Gateway envelope composition.",
+        examples=[200],
+    )
+    supportability: DpmProofPackSupportability = Field(
+        description=(
+            "Gateway-normalized supportability summary derived from manage-published fields."
+        )
+    )
+    data: dict[str, object] = Field(
+        description=(
+            "Authoritative manage proof-pack payload preserved for Workbench composition. Gateway "
+            "does not alter proof_pack_id, section states, reason codes, content_hash, "
+            "source_hashes, source refs, report refs, or AI refs."
+        ),
+        examples=[
+            {
+                "proof_pack": {
+                    "proof_pack_id": "dpp_rr_001",
+                    "status": "READY",
+                    "content_hash": "sha256:proof-pack",
+                }
+            }
+        ],
+    )
+
+
+class DpmProofPackMarkdownResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated across Gateway and lotus-manage.",
+        examples=["corr-rfc40-proof-pack-md-1"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway BFF contract version for proof-pack Markdown responses.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Upstream service that supplied deterministic proof-pack Markdown.",
+        examples=["lotus-manage"],
+    )
+    upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage before Gateway envelope composition.",
+        examples=[200],
+    )
+    proof_pack_id: str = Field(
+        description="Manage-owned immutable proof-pack identifier.",
+        examples=["dpp_rr_001"],
+    )
+    markdown: str = Field(
+        description=(
+            "Deterministic Markdown returned by lotus-manage. Gateway preserves the text and does "
+            "not render or summarize proof-pack evidence."
+        ),
+        examples=["# DPM proof pack\n\n- Status: READY\n"],
+    )
+
+
+class DpmProofPackErrorDetail(BaseModel):
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Upstream service that rejected or failed the proof-pack request.",
+        examples=["lotus-manage"],
+    )
+    upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage.",
+        examples=[503],
+    )
+    error_code: str = Field(
+        description="Gateway error classification for the failed proof-pack request.",
+        examples=["MANAGE_PROOF_PACK_UPSTREAM_ERROR"],
+    )
+    detail: str = Field(
+        description="Product-safe summary of the manage error payload.",
+        examples=["PROOF_PACK_NOT_FOUND"],
+    )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -15,6 +15,7 @@ from app.routers.archive_documents import router as archive_documents_router
 from app.routers.domain_products import router as domain_products_router
 from app.routers.dpm_command_center import router as dpm_command_center_router
 from app.routers.dpm_construction import router as dpm_construction_router
+from app.routers.dpm_proof_packs import router as dpm_proof_packs_router
 from app.routers.foundation import router as foundation_router
 from app.routers.intake import router as intake_router
 from app.routers.platform import router as platform_router
@@ -72,8 +73,9 @@ app = FastAPI(
         {
             "name": "DPM Command Center",
             "description": (
-                "Gateway BFF composition APIs for DPM rebalance-wave and post-trade "
-                "outcome-review workflows backed by lotus-manage authority."
+                "Gateway BFF composition APIs for DPM command-center, construction, proof-pack, "
+                "rebalance-wave, and post-trade outcome-review workflows backed by "
+                "lotus-manage authority."
             ),
         },
     ],
@@ -91,6 +93,7 @@ app.include_router(foundation_router)
 app.include_router(portfolio_router)
 app.include_router(dpm_command_center_router)
 app.include_router(dpm_construction_router)
+app.include_router(dpm_proof_packs_router)
 app.include_router(workbench_router)
 app.include_router(reporting_router)
 app.include_router(reporting_jobs_router)

--- a/src/app/routers/dpm_proof_packs.py
+++ b/src/app/routers/dpm_proof_packs.py
@@ -1,0 +1,174 @@
+from typing import Any
+
+from fastapi import APIRouter, Path
+
+from app.clients.dpm_client import DpmClient
+from app.config import settings
+from app.contracts.dpm_proof_packs import (
+    DpmProofPackErrorDetail,
+    DpmProofPackGatewayResponse,
+    DpmProofPackGenerateRequest,
+    DpmProofPackMarkdownResponse,
+)
+from app.middleware.correlation import correlation_id_var
+from app.services.dpm_proof_pack_service import DpmProofPackService
+
+router = APIRouter(
+    prefix="/api/v1/dpm/command-center/proof-packs",
+    tags=["DPM Command Center"],
+)
+_UPSTREAM_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
+    404: {
+        "model": DpmProofPackErrorDetail,
+        "description": "lotus-manage could not find the requested proof pack or source.",
+    },
+    409: {
+        "model": DpmProofPackErrorDetail,
+        "description": "lotus-manage rejected the proof-pack request as conflicting.",
+    },
+    422: {
+        "model": DpmProofPackErrorDetail,
+        "description": "lotus-manage rejected the proof-pack payload as invalid.",
+    },
+    503: {
+        "model": DpmProofPackErrorDetail,
+        "description": "lotus-manage proof-pack authority is unavailable or degraded.",
+    },
+}
+
+
+def _dpm_proof_pack_service() -> DpmProofPackService:
+    return DpmProofPackService(
+        dpm_client=DpmClient(
+            base_url=settings.management_service_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+    )
+
+
+@router.post(
+    "",
+    response_model=DpmProofPackGatewayResponse,
+    summary="Generate DPM proof pack",
+    description=(
+        "What: asks lotus-manage to generate an immutable RFC-0040 DPM proof pack from a "
+        "rebalance run or selected construction alternative. When: call this after manage source "
+        "readiness indicates proof evidence can be assembled for PM, compliance, or operations "
+        "review. How: Gateway forwards the body and idempotency key to manage, then preserves the "
+        "returned proof_pack_id, section states, reason codes, hashes, source refs, report refs, "
+        "and AI refs without rebuilding proof-pack evidence."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def generate_proof_pack(
+    request: DpmProofPackGenerateRequest,
+) -> DpmProofPackGatewayResponse:
+    return await _dpm_proof_pack_service().generate_proof_pack(
+        body=request.body,
+        idempotency_key=request.idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/{proof_pack_id}",
+    response_model=DpmProofPackGatewayResponse,
+    summary="Get DPM proof pack",
+    description=(
+        "What: returns one manage-owned RFC-0040 proof pack for Workbench evidence drawers and "
+        "audit review. When: call this after a rebalance run or wave item links to a "
+        "proof_pack_id. How: Gateway retrieves the manage payload by id and preserves proof-pack "
+        "identity, "
+        "section states, reason codes, hashes, source lineage, report refs, and AI refs without "
+        "recalculation."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def get_proof_pack(
+    proof_pack_id: str = Path(
+        ...,
+        description="Manage-owned immutable proof-pack identifier.",
+        examples=["dpp_rr_001"],
+    ),
+) -> DpmProofPackGatewayResponse:
+    return await _dpm_proof_pack_service().get_proof_pack(
+        proof_pack_id=proof_pack_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/{proof_pack_id}/summary.md",
+    response_model=DpmProofPackMarkdownResponse,
+    summary="Get DPM proof-pack Markdown",
+    description=(
+        "What: returns manage-rendered deterministic Markdown for one RFC-0040 proof pack. "
+        "When: call this for human-readable PM, compliance, operations, or audit review. How: "
+        "Gateway preserves the manage Markdown text in an envelope for Workbench and does not "
+        "summarize, render, or regenerate proof-pack content."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def get_proof_pack_markdown(
+    proof_pack_id: str = Path(
+        ...,
+        description="Manage-owned immutable proof-pack identifier.",
+        examples=["dpp_rr_001"],
+    ),
+) -> DpmProofPackMarkdownResponse:
+    return await _dpm_proof_pack_service().get_proof_pack_markdown(
+        proof_pack_id=proof_pack_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/{proof_pack_id}/report-input",
+    response_model=DpmProofPackGatewayResponse,
+    summary="Get DPM proof-pack report input",
+    description=(
+        "What: returns manage-owned deterministic report-input evidence for one RFC-0040 proof "
+        "pack. When: call this before requesting report materialization from lotus-report. How: "
+        "Gateway preserves the report-input payload and exposes only experience-layer posture; "
+        "lotus-report remains the report materialization authority."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def get_proof_pack_report_input(
+    proof_pack_id: str = Path(
+        ...,
+        description="Manage-owned immutable proof-pack identifier.",
+        examples=["dpp_rr_001"],
+    ),
+) -> DpmProofPackGatewayResponse:
+    return await _dpm_proof_pack_service().get_proof_pack_report_input(
+        proof_pack_id=proof_pack_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/{proof_pack_id}/ai-evidence-input",
+    response_model=DpmProofPackGatewayResponse,
+    summary="Get DPM proof-pack AI evidence input",
+    description=(
+        "What: returns manage-owned deterministic AI-evidence input for one RFC-0040 proof pack. "
+        "When: call this before asking lotus-ai for governed memo or narrative generation. How: "
+        "Gateway preserves source refs, hashes, section states, and reason codes from manage and "
+        "does not generate AI narrative itself."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def get_proof_pack_ai_evidence_input(
+    proof_pack_id: str = Path(
+        ...,
+        description="Manage-owned immutable proof-pack identifier.",
+        examples=["dpp_rr_001"],
+    ),
+) -> DpmProofPackGatewayResponse:
+    return await _dpm_proof_pack_service().get_proof_pack_ai_evidence_input(
+        proof_pack_id=proof_pack_id,
+        correlation_id=correlation_id_var.get(),
+    )

--- a/src/app/services/dpm_proof_pack_service.py
+++ b/src/app/services/dpm_proof_pack_service.py
@@ -1,0 +1,203 @@
+from typing import Any
+
+from fastapi import HTTPException, status
+
+from app.clients.dpm_client import DpmClient
+from app.config import settings
+from app.contracts.dpm_proof_packs import (
+    DpmProofPackErrorDetail,
+    DpmProofPackGatewayResponse,
+    DpmProofPackMarkdownResponse,
+    DpmProofPackSupportability,
+)
+
+
+class DpmProofPackService:
+    def __init__(self, dpm_client: DpmClient):
+        self._dpm_client = dpm_client
+
+    async def generate_proof_pack(
+        self,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> DpmProofPackGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.generate_proof_pack(
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_proof_pack(
+        self,
+        proof_pack_id: str,
+        correlation_id: str,
+    ) -> DpmProofPackGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_proof_pack(
+            proof_pack_id=proof_pack_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_proof_pack_markdown(
+        self,
+        proof_pack_id: str,
+        correlation_id: str,
+    ) -> DpmProofPackMarkdownResponse:
+        (
+            upstream_status,
+            markdown,
+            error_payload,
+        ) = await self._dpm_client.get_proof_pack_markdown(
+            proof_pack_id=proof_pack_id,
+            correlation_id=correlation_id,
+        )
+        if upstream_status >= status.HTTP_400_BAD_REQUEST:
+            raise _upstream_error(upstream_status, error_payload)
+        return DpmProofPackMarkdownResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            upstream_status=upstream_status,
+            proof_pack_id=proof_pack_id,
+            markdown=markdown,
+        )
+
+    async def get_proof_pack_report_input(
+        self,
+        proof_pack_id: str,
+        correlation_id: str,
+    ) -> DpmProofPackGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_proof_pack_report_input(
+            proof_pack_id=proof_pack_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_proof_pack_ai_evidence_input(
+        self,
+        proof_pack_id: str,
+        correlation_id: str,
+    ) -> DpmProofPackGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_proof_pack_ai_evidence_input(
+            proof_pack_id=proof_pack_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    def _compose_response(
+        self,
+        upstream_status: int,
+        upstream_payload: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmProofPackGatewayResponse:
+        if upstream_status >= status.HTTP_400_BAD_REQUEST:
+            raise _upstream_error(upstream_status, upstream_payload)
+
+        return DpmProofPackGatewayResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            upstream_status=upstream_status,
+            supportability=_supportability_from(upstream_payload),
+            data=upstream_payload,
+        )
+
+
+def _supportability_from(payload: dict[str, Any]) -> DpmProofPackSupportability:
+    proof_pack = _proof_pack_payload(payload)
+    reason_codes = _reason_codes_from_payload(payload, proof_pack)
+    return DpmProofPackSupportability(
+        state=_proof_pack_state(payload, proof_pack),
+        proof_pack_id=_safe_str(proof_pack.get("proof_pack_id") or payload.get("proof_pack_id")),
+        reason_codes=sorted(set(reason_codes)),
+        section_state_counts=_section_state_counts(proof_pack),
+        content_hash=_safe_str(proof_pack.get("content_hash") or payload.get("content_hash")),
+        markdown_available=bool(payload.get("markdown_url") or payload.get("markdown")),
+        report_input_available=bool(
+            payload.get("report_input_url")
+            or payload.get("report_input")
+            or proof_pack.get("report_input_ref")
+        ),
+        ai_evidence_input_available=bool(
+            payload.get("ai_evidence_input_url")
+            or payload.get("ai_evidence_input")
+            or proof_pack.get("ai_evidence_input_ref")
+        ),
+    )
+
+
+def _proof_pack_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    proof_pack = payload.get("proof_pack")
+    return proof_pack if isinstance(proof_pack, dict) else payload
+
+
+def _proof_pack_state(payload: dict[str, Any], proof_pack: dict[str, Any]) -> str:
+    state = (
+        proof_pack.get("status") or proof_pack.get("state") or payload.get("status") or "UNKNOWN"
+    )
+    return str(state)
+
+
+def _reason_codes_from_payload(
+    payload: dict[str, Any],
+    proof_pack: dict[str, Any],
+) -> list[str]:
+    reason_codes = _list_of_strings(payload.get("reason_codes") or payload.get("reasonCodes") or [])
+    reason_codes.extend(
+        _list_of_strings(proof_pack.get("reason_codes") or proof_pack.get("reasonCodes") or [])
+    )
+    for section in _sections(proof_pack):
+        reason_codes.extend(
+            _list_of_strings(section.get("reason_codes") or section.get("reasonCodes") or [])
+        )
+    return reason_codes
+
+
+def _section_state_counts(proof_pack: dict[str, Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for section in _sections(proof_pack):
+        state = section.get("state") or section.get("status")
+        if state is None:
+            continue
+        state_label = str(state)
+        counts[state_label] = counts.get(state_label, 0) + 1
+    return counts
+
+
+def _sections(proof_pack: dict[str, Any]) -> list[dict[str, Any]]:
+    sections = proof_pack.get("sections")
+    if not isinstance(sections, list):
+        return []
+    return [section for section in sections if isinstance(section, dict)]
+
+
+def _list_of_strings(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _safe_str(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _safe_upstream_detail(payload: dict[str, Any]) -> str:
+    detail = payload.get("detail") or payload.get("message") or payload.get("error")
+    if isinstance(detail, str):
+        return detail
+    if detail is not None:
+        return str(detail)
+    return "lotus-manage proof-pack request failed"
+
+
+def _upstream_error(upstream_status: int, payload: dict[str, Any]) -> HTTPException:
+    return HTTPException(
+        status_code=upstream_status,
+        detail=DpmProofPackErrorDetail(
+            upstream_status=upstream_status,
+            error_code="MANAGE_PROOF_PACK_UPSTREAM_ERROR",
+            detail=_safe_upstream_detail(payload),
+        ).model_dump(),
+    )

--- a/tests/contract/test_dpm_proof_pack_contract.py
+++ b/tests/contract/test_dpm_proof_pack_contract.py
@@ -1,0 +1,73 @@
+from fastapi.testclient import TestClient
+
+from app.contracts.dpm_proof_packs import DpmProofPackGatewayResponse
+from app.main import app
+
+
+def test_dpm_proof_pack_gateway_response_contract_shape() -> None:
+    response = DpmProofPackGatewayResponse(
+        correlation_id="corr-1",
+        upstream_status=200,
+        supportability={
+            "state": "READY",
+            "reason_codes": ["PROOF_PACK_READY"],
+            "proof_pack_id": "dpp_rr_001",
+            "section_state_counts": {"READY": 2},
+            "content_hash": "sha256:proof-pack",
+            "markdown_available": True,
+        },
+        data={
+            "proof_pack": {
+                "proof_pack_id": "dpp_rr_001",
+                "status": "READY",
+                "content_hash": "sha256:proof-pack",
+            }
+        },
+    )
+
+    assert response.source_service == "lotus-manage"
+    assert response.supportability.authority == "lotus-manage:RFC-0040"
+    assert response.supportability.proof_pack_id == "dpp_rr_001"
+    assert response.data["proof_pack"]["content_hash"] == "sha256:proof-pack"
+
+
+def test_dpm_proof_pack_openapi_contract_registered() -> None:
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+    expected_paths = [
+        ("/api/v1/dpm/command-center/proof-packs", "post"),
+        ("/api/v1/dpm/command-center/proof-packs/{proof_pack_id}", "get"),
+        ("/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/summary.md", "get"),
+        ("/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/report-input", "get"),
+        ("/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-evidence-input", "get"),
+    ]
+
+    for path, method in expected_paths:
+        assert path in spec["paths"]
+        operation = spec["paths"][path][method]
+        assert operation["tags"] == ["DPM Command Center"]
+        assert operation["summary"]
+        assert "What:" in operation["description"]
+        assert "When:" in operation["description"]
+        assert "How:" in operation["description"]
+
+
+def test_dpm_proof_pack_openapi_models_are_described() -> None:
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+    schemas = spec["components"]["schemas"]
+
+    for schema_name in [
+        "DpmProofPackGenerateRequest",
+        "DpmProofPackGatewayResponse",
+        "DpmProofPackMarkdownResponse",
+        "DpmProofPackSupportability",
+        "DpmProofPackErrorDetail",
+    ]:
+        schema = schemas[schema_name]
+        for property_schema in schema["properties"].values():
+            assert property_schema.get("description")
+
+    assert schemas["DpmProofPackGenerateRequest"]["properties"]["body"]["examples"]
+    assert schemas["DpmProofPackGatewayResponse"]["properties"]["data"]["description"]
+    assert schemas["DpmProofPackSupportability"]["properties"]["state"]["examples"]

--- a/tests/integration/test_dpm_proof_pack_router.py
+++ b/tests/integration/test_dpm_proof_pack_router.py
@@ -1,0 +1,170 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_dpm_proof_pack_generate_preserves_manage_truth(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_generate_proof_pack(self, body, idempotency_key, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["body"] = body
+        captured["idempotency_key"] = idempotency_key
+        captured["correlation_id"] = correlation_id
+        return 200, _proof_pack_payload()
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.generate_proof_pack",
+        _fake_generate_proof_pack,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/proof-packs",
+        json={
+            "idempotency_key": "idem-proof-pack-router-1",
+            "body": {"source_type": "REBALANCE_RUN", "rebalance_run_id": "rr_001"},
+        },
+        headers={"X-Correlation-Id": "corr-proof-pack-router-1"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert captured == {
+        "body": {"source_type": "REBALANCE_RUN", "rebalance_run_id": "rr_001"},
+        "idempotency_key": "idem-proof-pack-router-1",
+        "correlation_id": "corr-proof-pack-router-1",
+    }
+    assert payload["correlation_id"] == "corr-proof-pack-router-1"
+    assert payload["source_service"] == "lotus-manage"
+    assert payload["supportability"]["authority"] == "lotus-manage:RFC-0040"
+    assert payload["supportability"]["proof_pack_id"] == "dpp_rr_001"
+    assert payload["data"] == _proof_pack_payload()
+
+
+def test_dpm_proof_pack_get_uses_manage_identifier(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_get_proof_pack(self, proof_pack_id, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["proof_pack_id"] = proof_pack_id
+        captured["correlation_id"] = correlation_id
+        return 200, _proof_pack_payload()
+
+    monkeypatch.setattr("app.clients.dpm_client.DpmClient.get_proof_pack", _fake_get_proof_pack)
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/dpm/command-center/proof-packs/dpp_rr_001",
+        headers={"X-Correlation-Id": "corr-proof-pack-get-router-1"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "proof_pack_id": "dpp_rr_001",
+        "correlation_id": "corr-proof-pack-get-router-1",
+    }
+    assert response.json()["data"]["proof_pack"]["content_hash"] == "sha256:proof-pack"
+
+
+def test_dpm_proof_pack_markdown_is_returned_in_gateway_envelope(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_get_proof_pack_markdown(self, proof_pack_id, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["proof_pack_id"] = proof_pack_id
+        captured["correlation_id"] = correlation_id
+        return 200, "# DPM proof pack\n", {}
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_proof_pack_markdown",
+        _fake_get_proof_pack_markdown,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/dpm/command-center/proof-packs/dpp_rr_001/summary.md",
+        headers={"X-Correlation-Id": "corr-proof-pack-md-router-1"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "proof_pack_id": "dpp_rr_001",
+        "correlation_id": "corr-proof-pack-md-router-1",
+    }
+    assert response.json()["markdown"] == "# DPM proof pack\n"
+
+
+def test_dpm_proof_pack_handoff_routes_preserve_manage_payload(monkeypatch) -> None:
+    captured: list[dict[str, object]] = []
+
+    async def _fake_report_input(self, proof_pack_id, correlation_id):  # noqa: ANN001
+        _ = self
+        captured.append(
+            {
+                "method": "report_input",
+                "proof_pack_id": proof_pack_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return 200, {"proof_pack_id": proof_pack_id, "report_input_ref": "report-input:dpp_rr_001"}
+
+    async def _fake_ai_input(self, proof_pack_id, correlation_id):  # noqa: ANN001
+        _ = self
+        captured.append(
+            {
+                "method": "ai_input",
+                "proof_pack_id": proof_pack_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return 200, {"proof_pack_id": proof_pack_id, "ai_evidence_input_ref": "ai:dpp_rr_001"}
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_proof_pack_report_input",
+        _fake_report_input,
+    )
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_proof_pack_ai_evidence_input",
+        _fake_ai_input,
+    )
+
+    client = TestClient(app)
+    report_response = client.get(
+        "/api/v1/dpm/command-center/proof-packs/dpp_rr_001/report-input",
+        headers={"X-Correlation-Id": "corr-proof-pack-report-router-1"},
+    )
+    ai_response = client.get(
+        "/api/v1/dpm/command-center/proof-packs/dpp_rr_001/ai-evidence-input",
+        headers={"X-Correlation-Id": "corr-proof-pack-ai-router-1"},
+    )
+
+    assert report_response.status_code == 200
+    assert ai_response.status_code == 200
+    assert report_response.json()["data"]["report_input_ref"] == "report-input:dpp_rr_001"
+    assert ai_response.json()["data"]["ai_evidence_input_ref"] == "ai:dpp_rr_001"
+    assert captured == [
+        {
+            "method": "report_input",
+            "proof_pack_id": "dpp_rr_001",
+            "correlation_id": "corr-proof-pack-report-router-1",
+        },
+        {
+            "method": "ai_input",
+            "proof_pack_id": "dpp_rr_001",
+            "correlation_id": "corr-proof-pack-ai-router-1",
+        },
+    ]
+
+
+def _proof_pack_payload() -> dict[str, object]:
+    return {
+        "proof_pack": {
+            "proof_pack_id": "dpp_rr_001",
+            "status": "READY",
+            "content_hash": "sha256:proof-pack",
+            "source_hashes": {"mandate": "sha256:mandate"},
+            "sections": [{"section_id": "mandate", "state": "READY"}],
+        },
+        "markdown_url": "/api/v1/rebalance/proof-packs/dpp_rr_001/summary.md",
+    }

--- a/tests/unit/test_dpm_proof_pack_service.py
+++ b/tests/unit/test_dpm_proof_pack_service.py
@@ -1,0 +1,252 @@
+import pytest
+from fastapi import HTTPException
+
+from app.services.dpm_proof_pack_service import DpmProofPackService
+
+
+class _FakeDpmClient:
+    def __init__(self, result: tuple):
+        self.result = result
+        self.calls: list[dict[str, object]] = []
+
+    async def generate_proof_pack(self, body, idempotency_key, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "proof_pack_generate",
+                "body": body,
+                "idempotency_key": idempotency_key,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+    async def get_proof_pack(self, proof_pack_id, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "proof_pack_get",
+                "proof_pack_id": proof_pack_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+    async def get_proof_pack_markdown(self, proof_pack_id, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "proof_pack_markdown",
+                "proof_pack_id": proof_pack_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+    async def get_proof_pack_report_input(self, proof_pack_id, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "proof_pack_report_input",
+                "proof_pack_id": proof_pack_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+    async def get_proof_pack_ai_evidence_input(self, proof_pack_id, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "proof_pack_ai_evidence_input",
+                "proof_pack_id": proof_pack_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_dpm_proof_pack_generation_preserves_manage_payload() -> None:
+    manage_payload = _proof_pack_generate_payload()
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmProofPackService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.generate_proof_pack(
+        body={"source_type": "REBALANCE_RUN", "rebalance_run_id": "rr_001"},
+        idempotency_key="idem-proof-pack-1",
+        correlation_id="corr-proof-pack-1",
+    )
+
+    assert response.correlation_id == "corr-proof-pack-1"
+    assert response.source_service == "lotus-manage"
+    assert response.upstream_status == 200
+    assert response.supportability.authority == "lotus-manage:RFC-0040"
+    assert response.supportability.state == "READY"
+    assert response.supportability.proof_pack_id == "dpp_rr_001"
+    assert response.supportability.content_hash == "sha256:proof-pack"
+    assert response.supportability.reason_codes == [
+        "AI_EVIDENCE_INPUT_READY",
+        "MANDATE_SECTION_READY",
+        "PROOF_PACK_READY",
+        "REPORT_INPUT_READY",
+        "RUN_SECTION_READY",
+    ]
+    assert response.supportability.section_state_counts == {"READY": 2, "DEGRADED": 1}
+    assert response.supportability.markdown_available is True
+    assert response.supportability.report_input_available is True
+    assert response.supportability.ai_evidence_input_available is True
+    assert response.data == manage_payload
+    assert client.calls == [
+        {
+            "method": "proof_pack_generate",
+            "body": {"source_type": "REBALANCE_RUN", "rebalance_run_id": "rr_001"},
+            "idempotency_key": "idem-proof-pack-1",
+            "correlation_id": "corr-proof-pack-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_proof_pack_lookup_does_not_reconstruct_sections_or_hashes() -> None:
+    manage_payload = _proof_pack_lookup_payload()
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmProofPackService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.get_proof_pack(
+        proof_pack_id="dpp_rr_001",
+        correlation_id="corr-proof-pack-get-1",
+    )
+
+    assert response.data == manage_payload
+    assert response.supportability.state == "DEGRADED"
+    assert response.supportability.section_state_counts == {"READY": 1, "DEGRADED": 1}
+    assert response.data["proof_pack"]["source_hashes"] == {
+        "mandate": "sha256:mandate",
+        "rebalance_run": "sha256:run",
+    }
+    assert client.calls == [
+        {
+            "method": "proof_pack_get",
+            "proof_pack_id": "dpp_rr_001",
+            "correlation_id": "corr-proof-pack-get-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_proof_pack_markdown_preserves_manage_text() -> None:
+    client = _FakeDpmClient((200, "# DPM proof pack\n\n- Status: READY\n", {}))
+    service = DpmProofPackService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.get_proof_pack_markdown(
+        proof_pack_id="dpp_rr_001",
+        correlation_id="corr-proof-pack-md-1",
+    )
+
+    assert response.source_service == "lotus-manage"
+    assert response.proof_pack_id == "dpp_rr_001"
+    assert response.markdown == "# DPM proof pack\n\n- Status: READY\n"
+    assert client.calls == [
+        {
+            "method": "proof_pack_markdown",
+            "proof_pack_id": "dpp_rr_001",
+            "correlation_id": "corr-proof-pack-md-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_proof_pack_handoff_inputs_preserve_manage_payloads() -> None:
+    report_payload = {
+        "proof_pack_id": "dpp_rr_001",
+        "report_input_ref": "report-input:dpp_rr_001",
+        "section_hashes": {"mandate": "sha256:mandate"},
+    }
+    ai_payload = {
+        "proof_pack_id": "dpp_rr_001",
+        "ai_evidence_input_ref": "ai-evidence:dpp_rr_001",
+        "reason_codes": ["AI_EVIDENCE_INPUT_READY"],
+    }
+
+    report_response = await DpmProofPackService(  # type: ignore[arg-type]
+        dpm_client=_FakeDpmClient((200, report_payload))
+    ).get_proof_pack_report_input(
+        proof_pack_id="dpp_rr_001",
+        correlation_id="corr-report-input-1",
+    )
+    ai_response = await DpmProofPackService(  # type: ignore[arg-type]
+        dpm_client=_FakeDpmClient((200, ai_payload))
+    ).get_proof_pack_ai_evidence_input(
+        proof_pack_id="dpp_rr_001",
+        correlation_id="corr-ai-input-1",
+    )
+
+    assert report_response.data == report_payload
+    assert report_response.supportability.report_input_available is True
+    assert ai_response.data == ai_payload
+    assert ai_response.supportability.reason_codes == ["AI_EVIDENCE_INPUT_READY"]
+    assert ai_response.supportability.ai_evidence_input_available is True
+
+
+@pytest.mark.asyncio
+async def test_dpm_proof_pack_forwards_manage_errors_as_product_safe_detail() -> None:
+    client = _FakeDpmClient((503, {"detail": "upstream communication failure: TimeoutException"}))
+    service = DpmProofPackService(dpm_client=client)  # type: ignore[arg-type]
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.get_proof_pack(
+            proof_pack_id="dpp_missing",
+            correlation_id="corr-proof-pack-error-1",
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == {
+        "source_service": "lotus-manage",
+        "upstream_status": 503,
+        "error_code": "MANAGE_PROOF_PACK_UPSTREAM_ERROR",
+        "detail": "upstream communication failure: TimeoutException",
+    }
+
+
+def _proof_pack_generate_payload() -> dict[str, object]:
+    return {
+        "proof_pack": {
+            "proof_pack_id": "dpp_rr_001",
+            "status": "READY",
+            "content_hash": "sha256:proof-pack",
+            "reason_codes": ["PROOF_PACK_READY"],
+            "sections": [
+                {
+                    "section_id": "mandate",
+                    "state": "READY",
+                    "reason_codes": ["MANDATE_SECTION_READY"],
+                },
+                {"section_id": "run", "state": "READY", "reason_codes": ["RUN_SECTION_READY"]},
+                {"section_id": "tax", "state": "DEGRADED"},
+            ],
+            "report_input_ref": "report-input:dpp_rr_001",
+            "ai_evidence_input_ref": "ai-evidence:dpp_rr_001",
+        },
+        "markdown_url": "/api/v1/rebalance/proof-packs/dpp_rr_001/summary.md",
+        "report_input_url": "/api/v1/rebalance/proof-packs/dpp_rr_001/report-input",
+        "ai_evidence_input_url": "/api/v1/rebalance/proof-packs/dpp_rr_001/ai-evidence-input",
+        "reason_codes": ["REPORT_INPUT_READY", "AI_EVIDENCE_INPUT_READY"],
+    }
+
+
+def _proof_pack_lookup_payload() -> dict[str, object]:
+    return {
+        "proof_pack": {
+            "proof_pack_id": "dpp_rr_001",
+            "status": "DEGRADED",
+            "content_hash": "sha256:proof-pack",
+            "source_hashes": {
+                "mandate": "sha256:mandate",
+                "rebalance_run": "sha256:run",
+            },
+            "sections": [
+                {"section_id": "mandate", "state": "READY"},
+                {
+                    "section_id": "tax",
+                    "state": "DEGRADED",
+                    "reason_codes": ["TAX_LOT_SOURCE_MISSING"],
+                },
+            ],
+        }
+    }

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -11,8 +11,8 @@ def test_rfc0098_ownership_matches_manage_rfc0040_rfc0041_and_rfc0042() -> None:
     api_surface = (ROOT / "wiki" / "API-Surface.md").read_text(encoding="utf-8")
     integrations = (ROOT / "wiki" / "Integrations.md").read_text(encoding="utf-8")
 
-    assert "RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED" in rfc
-    assert "RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED" in index
+    assert "RFC-0040 PROOF-PACK" in rfc
+    assert "RFC-0040 PROOF-PACK" in index
     assert "`lotus-manage` RFC-0040" in rfc
     assert "`lotus-manage` RFC-0041" in rfc
     assert "`lotus-manage` RFC-0042" in rfc
@@ -34,5 +34,7 @@ def test_rfc0098_ownership_matches_manage_rfc0040_rfc0041_and_rfc0042() -> None:
     assert "proof-pack authority APIs" in integrations
     assert "RFC-0041 rebalance-wave orchestration" in integrations
     assert "not proof-pack authority" in api_surface
+    assert "`/api/v1/dpm/command-center/proof-packs*`" in api_surface
+    assert "proof-pack BFF route family" in integrations
     assert "must not calculate affected portfolios" in api_surface
     assert "Gateway does not generate proof packs. That belongs to `lotus-report`." not in rfc

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1634,6 +1634,21 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
             "http://dpm/api/v1/construction/alternative-sets/cas_1",
         ),
         (
+            "get_proof_pack",
+            {"proof_pack_id": "dpp_rr_001", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/proof-packs/dpp_rr_001",
+        ),
+        (
+            "get_proof_pack_report_input",
+            {"proof_pack_id": "dpp_rr_001", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/proof-packs/dpp_rr_001/report-input",
+        ),
+        (
+            "get_proof_pack_ai_evidence_input",
+            {"proof_pack_id": "dpp_rr_001", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/proof-packs/dpp_rr_001/ai-evidence-input",
+        ),
+        (
             "list_wave_outcome_reviews",
             {"wave_id": "wave_1", "params": {"state": None}, "correlation_id": "corr-5"},
             "http://dpm/api/v1/rebalance/waves/wave_1/outcome-reviews",
@@ -1767,6 +1782,42 @@ async def test_dpm_client_uses_only_canonical_manage_api_v1_contracts():
                 "correlation_id": "corr-rfc36-canonical",
             },
         ),
+        (
+            client.generate_proof_pack,
+            {
+                "body": {"source_type": "REBALANCE_RUN", "rebalance_run_id": "rr_1"},
+                "idempotency_key": "idem-rfc40-canonical",
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.get_proof_pack,
+            {
+                "proof_pack_id": "dpp_rr_001",
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.get_proof_pack_markdown,
+            {
+                "proof_pack_id": "dpp_rr_001",
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.get_proof_pack_report_input,
+            {
+                "proof_pack_id": "dpp_rr_001",
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.get_proof_pack_ai_evidence_input,
+            {
+                "proof_pack_id": "dpp_rr_001",
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
     ]
     for _method, _kwargs in calls:
         _FakeAsyncClient.queue_json(200, {"ok": True})
@@ -1822,6 +1873,15 @@ async def test_dpm_client_uses_only_canonical_manage_api_v1_contracts():
             },
             "http://dpm/api/v1/construction/alternative-sets/cas_1/selections",
         ),
+        (
+            "generate_proof_pack",
+            {
+                "body": {"source_type": "REBALANCE_RUN", "rebalance_run_id": "rr_1"},
+                "idempotency_key": "idem-proof-pack-1",
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/proof-packs",
+        ),
     ],
 )
 async def test_dpm_client_outcome_review_command_routes(method_name, kwargs, expected_url):
@@ -1835,6 +1895,8 @@ async def test_dpm_client_outcome_review_command_routes(method_name, kwargs, exp
     assert _FakeAsyncClient.calls[0]["method"] == "POST"
     assert _FakeAsyncClient.calls[0]["url"] == expected_url
     assert _FakeAsyncClient.calls[0]["json"] == kwargs["body"]
+    if "idempotency_key" in kwargs:
+        assert _FakeAsyncClient.calls[0]["headers"]["Idempotency-Key"] == kwargs["idempotency_key"]
 
 
 @pytest.mark.asyncio
@@ -1858,6 +1920,29 @@ async def test_dpm_client_construction_generate_route_forwards_idempotency_key()
     assert _FakeAsyncClient.calls[0]["json"] == {"input_mode": "stateless"}
     assert _FakeAsyncClient.calls[0]["headers"]["Idempotency-Key"] == "idem-construction-1"
     assert _FakeAsyncClient.calls[0]["headers"]["X-Correlation-Id"] == "corr-construction-1"
+
+
+@pytest.mark.asyncio
+async def test_dpm_client_proof_pack_markdown_preserves_text_payload():
+    client = DpmClient(base_url="http://dpm", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_text(200, "# DPM proof pack\n")
+
+    status_code, markdown, error_payload = await client.get_proof_pack_markdown(
+        proof_pack_id="dpp_rr_001",
+        correlation_id="corr-proof-pack-md-client-1",
+    )
+
+    assert status_code == 200
+    assert markdown == "# DPM proof pack\n"
+    assert error_payload == {}
+    assert _FakeAsyncClient.calls[0]["method"] == "GET"
+    assert (
+        _FakeAsyncClient.calls[0]["url"]
+        == "http://dpm/api/v1/rebalance/proof-packs/dpp_rr_001/summary.md"
+    )
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Correlation-Id"] == (
+        "corr-proof-pack-md-client-1"
+    )
 
 
 @pytest.mark.asyncio

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -22,6 +22,7 @@
 - `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
 - `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`
 - `GET` and `POST /api/v1/dpm/command-center/construction/alternative-sets*`
+- `GET` and `POST /api/v1/dpm/command-center/proof-packs*`
 - `GET` and `POST /api/v1/workbench/*`
 - `GET` and `POST /api/v1/reports/*`
 - `POST /api/v1/reports/outcome-reviews`
@@ -62,9 +63,13 @@
   `supportability.feature_key=report.observability.evidence_surface_supportability` from
   `lotus-report` integration capabilities so Workbench can record report evidence-surface
   freshness and supportability without direct service coupling
-- RFC-0098 proof-pack composition must consume `lotus-manage` RFC-0040 proof-pack APIs for
-  proof-pack JSON, section states, hashes, Markdown, report-input payloads, and AI-evidence
-  payloads; `lotus-report` remains report materialization authority, not proof-pack authority
+- RFC-0098 proof-pack composition consumes `lotus-manage` RFC-0040 proof-pack APIs through
+  `/api/v1/dpm/command-center/proof-packs*`. Gateway exposes generate, get, Markdown,
+  report-input, and AI-evidence-input routes for Workbench, preserving manage `proof_pack_id`,
+  section states, reason codes, content hashes, source hashes, source refs, report refs, and AI
+  refs. Gateway must not build proof-pack sections, recalculate hashes, infer source readiness,
+  render reports, generate AI narrative, or treat `lotus-report` as proof-pack authority.
+  `lotus-report` remains report materialization authority, not proof-pack authority.
 - RFC-0098 construction-alternative composition consumes `lotus-manage` RFC-0039 construction
   APIs through `/api/v1/dpm/command-center/construction/alternative-sets*`. Gateway exposes
   generate, get, and select routes for Workbench, preserving manage alternative-set ids, method

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -23,10 +23,10 @@
   proof-pack authority APIs, RFC-0041 rebalance-wave orchestration authority APIs, and RFC-0042
   post-trade outcome-review authority APIs. RFC-0098 remains the strategic Gateway DPM
   command-center contract; the RFC-0038 mandate command-center BFF route family, RFC-0039
-  construction alternative-set BFF route family, and RFC-0042 outcome-review BFF route family are
-  now implementation-backed, while RFC-0041 wave composition, proof-pack modules, report
-  materialization, archive, and optional AI posture remain governed follow-on slices until
-  implemented and proven
+  construction alternative-set BFF route family, RFC-0040 proof-pack BFF route family, and
+  RFC-0042 outcome-review BFF route family are now implementation-backed, while RFC-0041 wave
+  composition, report materialization, archive, and optional AI posture remain governed follow-on
+  slices until implemented and proven
 - `lotus-report`
   reporting snapshot, summary, and review payloads
 - `lotus-archive`
@@ -98,7 +98,17 @@
     then preserves alternatives, method status, diagnostics, comparison metrics, supportability,
     and selection decisions without performing optimization, recomputation, readiness inference, or
     order execution.
-13. RFC36-WTBD-003 portfolio-level DPM operations dashboards consume Gateway Workbench
+13. RFC-0040 proof packs remain `lotus-manage` truth. Gateway proof-pack realization exposes
+    `/api/v1/dpm/command-center/proof-packs`,
+    `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}`,
+    `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/summary.md`,
+    `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/report-input`, and
+    `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-evidence-input` for Workbench.
+    Gateway forwards request bodies, idempotency keys, and correlation context to manage, then
+    preserves proof-pack identity, section states, reason codes, content hashes, source hashes,
+    source refs, report refs, and AI refs without generating proof sections, recalculating hashes,
+    rendering reports, or generating AI narrative.
+14. RFC36-WTBD-003 portfolio-level DPM operations dashboards consume Gateway Workbench
     `rebalance_snapshot` only. Gateway reads manage rebalance runs, preserves manage
     supportability summary and bounded recent-run posture, and keeps Workbench from calling
     `lotus-manage` directly or inventing workflow/error semantics. Supportability comes from

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -26,6 +26,9 @@
    expected-versus-realized outcomes. RFC-0039 construction alternative-set composition is also
    implementation-backed under `/api/v1/dpm/command-center/construction/alternative-sets*`,
    preserving manage-owned alternatives, diagnostics, supportability, and selection decisions
-   without Gateway optimization or recomputation.
+   without Gateway optimization or recomputation. RFC-0040 proof-pack composition is
+   implementation-backed under `/api/v1/dpm/command-center/proof-packs*`, preserving manage-owned
+   proof-pack ids, section states, reason codes, hashes, Markdown, report-input payloads, and
+   AI-evidence payloads without Gateway proof-pack reconstruction.
 3. preserve RFC-0082 boundary discipline as integrations evolve
 4. keep request-convention and runtime guidance explicit for operators and future agents

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -50,6 +50,60 @@ Operational behavior:
 2. manage upstream errors are returned using product-safe Gateway error detail,
 3. OpenAPI documents What/When/How guidance and request/response examples for each route.
 
+## DPM Proof-Pack Evidence Composition
+
+Status: implementation-backed in Gateway for RFC40-WTBD-001.
+
+Business outcome:
+
+1. portfolio managers can generate and inspect a source-backed pre-trade proof pack from the DPM
+   command-center workflow,
+2. compliance, audit, and operations users can inspect proof-pack identity, section posture,
+   reason codes, content hashes, source hashes, Markdown, report-input evidence, and AI-evidence
+   input through one Workbench-facing Gateway contract,
+3. sales/pre-sales and client-demo teams can demonstrate proof-backed discretionary management
+   governance without implying Gateway or Workbench computes proof-pack evidence.
+
+Supported routes:
+
+1. `POST /api/v1/dpm/command-center/proof-packs`
+2. `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}`
+3. `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/summary.md`
+4. `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/report-input`
+5. `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-evidence-input`
+
+Authority and integrations:
+
+1. `lotus-manage` remains the RFC-0040 proof-pack authority.
+2. Gateway forwards generation payloads, idempotency keys, proof-pack ids, and correlation context
+   to manage.
+3. Gateway preserves manage-owned `proof_pack_id`, section states, reason codes, `content_hash`,
+   `source_hashes`, source refs, report refs, AI refs, deterministic Markdown, report-input
+   payloads, and AI-evidence payloads.
+4. Gateway does not generate proof-pack sections, recalculate hashes, infer source readiness,
+   render reports, archive documents, generate AI narrative, or treat `lotus-report` as
+   proof-pack authority.
+
+```mermaid
+flowchart LR
+    Workbench[lotus-workbench evidence drawer] --> Gateway[lotus-gateway DPM proof-pack routes]
+    Gateway --> Manage[lotus-manage RFC-0040 proof-pack authority]
+    Manage --> Core[lotus-core source refs and hashes]
+    Manage --> Gateway
+    Gateway --> ReportInput[report-input payload for lotus-report handoff]
+    Gateway --> AiInput[AI-evidence input for lotus-ai handoff]
+    Gateway --> Workbench
+```
+
+Operational behavior:
+
+1. Gateway returns a product envelope for JSON, report-input, and AI-evidence-input payloads while
+   preserving the authoritative manage payload under `data`,
+2. deterministic Markdown is preserved as manage-rendered text in a Gateway envelope so Workbench
+   can render it without owning proof-pack generation,
+3. degraded or unavailable manage states are surfaced using product-safe Gateway error detail and
+   must remain visible to Workbench supportability UI.
+
 ## DPM Mandate Command Center
 
 Status: implementation-backed in Gateway for RFC38-WTBD-001.


### PR DESCRIPTION
## Summary
- add Gateway RFC40-WTBD-001 proof-pack composition routes under `/api/v1/dpm/command-center/proof-packs*`
- forward generate/read/Markdown/report-input/AI-evidence requests to lotus-manage while preserving manage proof-pack ids, section states, reason codes, hashes, source refs, report refs, and AI refs
- update RFC-0098, README, repository context, and repo-authored wiki source with implementation-backed proof-pack coverage and audience-facing feature material

## Validation
- `python -m pytest tests/unit/test_dpm_proof_pack_service.py tests/integration/test_dpm_proof_pack_router.py tests/contract/test_dpm_proof_pack_contract.py tests/unit/test_rfc0098_documentation.py -q` - 13 passed
- `python -m pytest tests/unit/test_upstream_clients.py tests/unit/test_dpm_proof_pack_service.py tests/integration/test_dpm_proof_pack_router.py tests/contract/test_dpm_proof_pack_contract.py tests/unit/test_rfc0098_documentation.py -q` - 110 passed
- `make lint` - passed
- `make check` - 452 unit/contract tests passed; mypy passed; monetary-float guard passed
- `make test-integration` - 164 passed
- `git diff --check` - passed, with normal LF-to-CRLF warnings only
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` - expected drift for `API-Surface.md`, `Integrations.md`, `Roadmap.md`, `Supported-Features.md`; publish after merge

## Governance
- stranded-truth reconciliation run before implementation and before closure: `git fetch origin --prune`; `git branch -r --no-merged origin/main` returned no unmerged governance branches
- Gateway remains an experience API; lotus-manage remains RFC-0040 proof-pack authority
- no live Workbench UI support is claimed in this slice