### PR TITLE
Implement RFC41 wave Gateway composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/summary.md`,
   `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/report-input`,
   `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-evidence-input`,
+  `/api/v1/dpm/command-center/waves*`,
   `/api/v1/dpm/command-center/outcome-reviews*`,
   `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`,
   `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
@@ -264,6 +265,11 @@ Important current parameter conventions:
    statuses, objective traces, constraint traces, comparison metrics, diagnostics, supportability,
    selected-alternative state, and lineage without optimizing, recomputing, or selecting
    alternatives locally
+15. DPM command-center wave routes under `/api/v1/dpm/command-center/waves*` consume
+   `lotus-manage` RFC-0041 rebalance-wave APIs and preserve manage-owned `wave_id`, lifecycle
+   state, item states, aggregate metrics, selected alternative refs, proof-pack refs, handoff refs,
+   supportability, and reason codes without calculating affected portfolios, source readiness,
+   alternatives, proof-pack state, or execution posture locally
 
 Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 
@@ -277,9 +283,11 @@ Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 - downstream ownership rule:
   proposal routes call `lotus-advise` `/advisory/proposals/*`; `lotus-manage` calls are limited to
   certified `/api/v1` discretionary management APIs, including run lookup, supportability summary,
-  platform capabilities, RFC-0039 construction alternative-set generate/get/select APIs, and
-  RFC-0042 outcome-review preview/create/search/detail/source-refresh, supportability,
-  report-input, AI-evidence, run lookup, and wave lookup
+  platform capabilities, RFC-0039 construction alternative-set generate/get/select APIs,
+  RFC-0041 rebalance-wave preview/create/search/detail/items/source-check/simulate/select/approve/
+  stage/handoff/cancel/proof-pack/supportability APIs, and RFC-0042 outcome-review
+  preview/create/search/detail/source-refresh, supportability, report-input, AI-evidence, run
+  lookup, and wave lookup
 - contract rule:
   gateway may reshape, aggregate, and annotate upstream data for product use, but must not assume
   upstream business authority

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -214,7 +214,16 @@ Most relevant current governance:
     `proof_pack_id`, section states, reason codes, content hashes, source hashes, source refs,
     report refs, and AI refs, and must not build proof-pack sections, recalculate hashes, infer
     source readiness, render reports, or generate AI narrative locally.
-14. The Workbench overview and portfolio-360 `rebalance_snapshot` now carry bounded
+14. RFC-0041 rebalance-wave Gateway routes are active under
+    `/api/v1/dpm/command-center/waves*`. Gateway forwards preview, durable create, search, detail,
+    item list, source-check, simulation, item selection, approval, staging, internal handoff,
+    cancellation, proof-pack posture, and supportability requests to `lotus-manage`; preserves
+    manage-owned `wave_id`, lifecycle state, item states, reason codes, aggregate metrics,
+    selected alternative refs, proof-pack refs, handoff refs, supportability issues, and
+    `external_execution_claimed=false`; and must not calculate affected portfolios, classify
+    source readiness, generate alternatives, select alternatives, approve items, stage items,
+    create handoff evidence, rebuild proof packs, or claim external execution locally.
+15. The Workbench overview and portfolio-360 `rebalance_snapshot` now carry bounded
     portfolio-level DPM operations posture for RFC36-WTBD-003: latest rebalance status, last run,
     manage action-register supportability from `/api/v1/rebalance/supportability/summary`, and up
     to five recent manage runs from `/api/v1/rebalance/runs` with bounded status, timestamp,

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -21,5 +21,5 @@ Governance boundary:
 | RFC-0013 | Workbench Position Valuation Fields | IMPLEMENTED | `docs/rfcs/RFC-0013-workbench-position-valuation-fields.md` |
 | RFC-0014 | Experience API Foundation and Pre-Live Replacement Strategy | PROPOSED | `docs/rfcs/RFC-0014-experience-api-foundation-and-prelive-replacement-strategy.md` |
 | RFC-0015 | Foundation Workspace Experience Contract | IMPLEMENTED | `docs/rfcs/RFC-0015-foundation-workspace-experience-contract.md` |
-| RFC-0098 | DPM Command Center Composition Contract | PARTIAL IMPLEMENTATION - RFC-0038 MANDATE COMMAND-CENTER, RFC-0039 CONSTRUCTION, RFC-0040 PROOF-PACK, AND RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER WAVE/REPORT/ARCHIVE MODULES PENDING | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
+| RFC-0098 | DPM Command Center Composition Contract | PARTIAL IMPLEMENTATION - RFC-0038 MANDATE COMMAND-CENTER, RFC-0039 CONSTRUCTION, RFC-0040 PROOF-PACK, RFC-0041 REBALANCE-WAVE, AND RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER REPORT/ARCHIVE MODULES AND WORKBENCH WAVE UI PENDING | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
 

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -1133,18 +1133,19 @@ To be completed during the final closure slice:
 
 This RFC is not fully implemented. Ledger-driven slices have delivered the RFC-0038 mandate
 command-center route family, the RFC-0039 construction alternative-set route family, the RFC-0040
-proof-pack route family, and the RFC-0042 outcome-review route family so Workbench can consume
-Gateway/BFF instead of calling `lotus-manage` directly.
+proof-pack route family, the RFC-0041 rebalance-wave route family, and the RFC-0042 outcome-review
+route family so Workbench can consume Gateway/BFF instead of calling `lotus-manage` directly.
 
 | Item | Status | Evidence |
 | --- | --- | --- |
 | RFC38-WTBD-001 Gateway DPM command-center composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/unit/test_upstream_clients.py` |
 | RFC39-WTBD-001 Gateway construction-alternatives composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_construction.py`, `src/app/services/dpm_construction_service.py`, `src/app/contracts/dpm_construction.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_construction_service.py`, `tests/integration/test_dpm_construction_router.py`, `tests/contract/test_dpm_construction_contract.py` |
 | RFC40-WTBD-001 Gateway proof-pack composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_proof_packs.py`, `src/app/services/dpm_proof_pack_service.py`, `src/app/contracts/dpm_proof_packs.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_proof_pack_service.py`, `tests/integration/test_dpm_proof_pack_router.py`, `tests/contract/test_dpm_proof_pack_contract.py` |
+| RFC41-WTBD-005 Gateway wave composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_waves.py`, `src/app/services/dpm_wave_service.py`, `src/app/contracts/dpm_waves.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_wave_service.py`, `tests/integration/test_dpm_wave_router.py`, `tests/contract/test_dpm_wave_contract.py`, `tests/unit/test_upstream_clients.py` |
 | RFC42-WTBD-001 Gateway outcome-review composition and BFF contract | Implemented and merged before this slice | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/contract/test_dpm_command_center_contract.py`, `make ci` |
 | RFC42-WTBD-005 Gateway AI narrative handoff | Implemented and merged before this slice | Gateway reads manage-owned `DpmOutcomeAiEvidenceInput`, executes `lotus-ai` `outcome_review_narrative.pack@v1` as `lotus-gateway`, preserves manage workflow authority, and exposes `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative` |
 | RFC-0042 manage authority preservation | Implemented for BFF envelope; Gateway forwards payloads and preserves manage supportability | Service tests prove payload preservation and upstream error forwarding; contract tests prove OpenAPI route family registration and What/When/How guidance |
-| Broader RFC-0098 wave composition, report/archive modules, and Workbench cockpit | Not implemented in this slice | Remains governed by this RFC and the work-to-be-done ledger; no supported-feature claim is made |
+| Broader RFC-0098 report/archive modules and Workbench cockpit | Not implemented in this slice | Gateway wave composition is a backend BFF contract only; Workbench UI, report materialization, archive, and broader optional AI posture remain governed follow-up work |
 
 Implementation boundaries:
 
@@ -1182,7 +1183,27 @@ Implementation boundaries:
    payloads, and AI-evidence payloads.
 9. Gateway does not generate proof-pack sections, recalculate hashes, infer source readiness,
    render reports, generate AI narrative, or treat `lotus-report` as proof-pack authority.
-10. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,
+10. Gateway now exposes `POST /api/v1/dpm/command-center/waves/preview`,
+   `POST /api/v1/dpm/command-center/waves`,
+   `GET /api/v1/dpm/command-center/waves`,
+   `GET /api/v1/dpm/command-center/waves/{wave_id}`,
+   `GET /api/v1/dpm/command-center/waves/{wave_id}/items`,
+   `POST /api/v1/dpm/command-center/waves/{wave_id}/source-check`,
+   `POST /api/v1/dpm/command-center/waves/{wave_id}/simulate`,
+   `POST /api/v1/dpm/command-center/waves/{wave_id}/items/{wave_item_id}/select`,
+   `POST /api/v1/dpm/command-center/waves/{wave_id}/approve`,
+   `POST /api/v1/dpm/command-center/waves/{wave_id}/stage`,
+   `POST /api/v1/dpm/command-center/waves/{wave_id}/handoff`,
+   `POST /api/v1/dpm/command-center/waves/{wave_id}/cancel`,
+   `GET /api/v1/dpm/command-center/waves/{wave_id}/proof-pack`, and
+   `GET /api/v1/dpm/command-center/waves/{wave_id}/supportability`.
+11. Wave routes preserve manage-owned `wave_id`, lifecycle state, item states, reason codes,
+   aggregate metrics, selected alternative refs, proof-pack refs, handoff refs, supportability
+   issues, source-owner remediation, and the no-external-execution boundary.
+12. Gateway does not calculate affected portfolios, classify source readiness, generate
+   alternatives, select alternatives, approve items, stage items, create handoff evidence, rebuild
+   proof packs, or claim external execution locally.
+13. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,
    `POST /api/v1/dpm/command-center/outcome-reviews`,
    `GET /api/v1/dpm/command-center/outcome-reviews`,
    `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}`,
@@ -1193,12 +1214,12 @@ Implementation boundaries:
    `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`,
    `GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`, and
    `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`.
-11. Gateway does not calculate expected values, realized values, variance, tolerance, hashes,
+14. Gateway does not calculate expected values, realized values, variance, tolerance, hashes,
    lineage, source freshness, supportability, or review state.
-12. Gateway does not generate reports, render artifacts, archive documents, generate AI narrative
+15. Gateway does not generate reports, render artifacts, archive documents, generate AI narrative
    locally, score PM quality, approve trades, contact clients, or claim Workbench UI support in
    this slice. The AI narrative endpoint is a governed handoff to `lotus-ai` over manage evidence.
-13. Workbench product realization remains a separate owning-repository implementation item.
+16. Workbench product realization remains a separate owning-repository implementation item.
 
 Validation performed on 2026-05-05:
 

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -302,6 +302,184 @@ class DpmClient:
             operation="manage.rebalance.waves.outcome_reviews",
         )
 
+    async def preview_wave(
+        self,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/api/v1/rebalance/waves/preview",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.preview",
+        )
+
+    async def create_wave(
+        self,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/api/v1/rebalance/waves",
+            body=body,
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="manage.rebalance.waves.create",
+        )
+
+    async def list_waves(
+        self,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        cleaned_params = {key: value for key, value in params.items() if value is not None}
+        return await self._get(
+            "/api/v1/rebalance/waves",
+            params=cleaned_params,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.list",
+        )
+
+    async def get_wave(
+        self,
+        wave_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/waves/{wave_id}",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.get",
+        )
+
+    async def get_wave_items(
+        self,
+        wave_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/waves/{wave_id}/items",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.items",
+        )
+
+    async def source_check_wave(
+        self,
+        wave_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/api/v1/rebalance/waves/{wave_id}/source-check",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.source_check",
+        )
+
+    async def simulate_wave(
+        self,
+        wave_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/api/v1/rebalance/waves/{wave_id}/simulate",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.simulate",
+        )
+
+    async def select_wave_item(
+        self,
+        wave_id: str,
+        wave_item_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/api/v1/rebalance/waves/{wave_id}/items/{wave_item_id}/select",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.items.select",
+        )
+
+    async def approve_wave(
+        self,
+        wave_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/api/v1/rebalance/waves/{wave_id}/approve",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.approve",
+        )
+
+    async def stage_wave(
+        self,
+        wave_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/api/v1/rebalance/waves/{wave_id}/stage",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.stage",
+        )
+
+    async def handoff_wave(
+        self,
+        wave_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/api/v1/rebalance/waves/{wave_id}/handoff",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.handoff",
+        )
+
+    async def cancel_wave(
+        self,
+        wave_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/api/v1/rebalance/waves/{wave_id}/cancel",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.cancel",
+        )
+
+    async def get_wave_proof_pack_posture(
+        self,
+        wave_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/waves/{wave_id}/proof-pack",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.proof_pack",
+        )
+
+    async def get_wave_supportability(
+        self,
+        wave_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/waves/{wave_id}/supportability",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.supportability",
+        )
+
     async def generate_construction_alternative_set(
         self,
         body: dict[str, Any],

--- a/src/app/contracts/dpm_waves.py
+++ b/src/app/contracts/dpm_waves.py
@@ -1,0 +1,150 @@
+from pydantic import BaseModel, Field
+
+
+class DpmWaveForwardRequest(BaseModel):
+    body: dict[str, object] = Field(
+        description=(
+            "Request payload forwarded unchanged to the lotus-manage RFC-0041 rebalance-wave "
+            "authority. Gateway does not discover PM books, infer affected portfolios, classify "
+            "source readiness, simulate construction alternatives, approve items, stage items, "
+            "create handoff evidence, or cancel wave state locally."
+        ),
+        examples=[
+            {
+                "trigger_type": "EXPLICIT_PORTFOLIO_LIST",
+                "trigger_id": "manual-wave-20260503-001",
+                "rationale": "CIO model update for the Singapore balanced DPM book.",
+                "as_of_date": "2026-05-03",
+                "actor_id": "pm_sg_1",
+                "portfolios": [{"portfolio_id": "PB_SG_GLOBAL_BAL_001"}],
+            }
+        ],
+    )
+
+
+class DpmWaveCreateRequest(DpmWaveForwardRequest):
+    idempotency_key: str = Field(
+        description=(
+            "Required manage idempotency token for durable wave creation. Gateway forwards it as "
+            "the `Idempotency-Key` header and does not derive replay keys."
+        ),
+        examples=["wave-idem-001"],
+    )
+
+
+class DpmWaveSupportability(BaseModel):
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Authoritative service that owns rebalance-wave state and supportability.",
+        examples=["lotus-manage"],
+    )
+    authority: str = Field(
+        default="lotus-manage:RFC-0041",
+        description="Business authority and RFC provenance for DPM rebalance waves.",
+        examples=["lotus-manage:RFC-0041"],
+    )
+    state: str = Field(
+        description=(
+            "Manage-published supportability state. Gateway preserves this value and defaults to "
+            "UNKNOWN only when the upstream payload omits explicit supportability."
+        ),
+        examples=["ready", "degraded", "blocked", "UNKNOWN"],
+    )
+    reason_codes: list[str] = Field(
+        default_factory=list,
+        description="Manage-published bounded reason codes for blocked or degraded wave posture.",
+        examples=[["wave_supportability_ready"]],
+    )
+    blocked_actions: list[str] = Field(
+        default_factory=list,
+        description="Manage-published action identifiers that Workbench should disable.",
+        examples=[["simulate", "approve"]],
+    )
+    wave_id: str | None = Field(
+        default=None,
+        description="Manage-owned rebalance-wave identifier when available.",
+        examples=["dwv_001"],
+    )
+    wave_state: str | None = Field(
+        default=None,
+        description="Manage-owned wave lifecycle state when available.",
+        examples=["HANDOFF_READY"],
+    )
+    item_count: int | None = Field(
+        default=None,
+        description="Manage-published item count when available.",
+        examples=[12],
+    )
+    issue_count: int = Field(
+        default=0,
+        description="Count of manage-published supportability issues, if supplied.",
+        examples=[0],
+    )
+    remediation_owner: str | None = Field(
+        default=None,
+        description="Manage-published owner for source repair or operational remediation.",
+        examples=["Portfolio Operations"],
+    )
+
+
+class DpmWaveGatewayResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated across Gateway and lotus-manage.",
+        examples=["corr-rfc41-wave-1"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway BFF contract version for DPM command-center wave responses.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Upstream service that supplied the authoritative rebalance-wave payload.",
+        examples=["lotus-manage"],
+    )
+    upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage before Gateway envelope composition.",
+        examples=[200],
+    )
+    supportability: DpmWaveSupportability = Field(
+        description=(
+            "Gateway-normalized supportability summary derived only from manage-published fields."
+        )
+    )
+    data: dict[str, object] = Field(
+        description=(
+            "Authoritative manage wave payload preserved for Workbench composition. Gateway does "
+            "not alter wave_id, lifecycle state, item states, reason codes, aggregate metrics, "
+            "proof-pack refs, handoff refs, source refs, or supportability."
+        ),
+        examples=[
+            {
+                "wave": {
+                    "wave_id": "dwv_001",
+                    "state": "HANDOFF_READY",
+                    "aggregate_metrics": {"item_count": 1, "ready_item_count": 1},
+                },
+                "durable": True,
+            }
+        ],
+    )
+
+
+class DpmWaveErrorDetail(BaseModel):
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Upstream service that rejected or failed the rebalance-wave request.",
+        examples=["lotus-manage"],
+    )
+    upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage.",
+        examples=[422],
+    )
+    error_code: str = Field(
+        description="Gateway error classification for the failed manage wave request.",
+        examples=["MANAGE_WAVE_UPSTREAM_ERROR"],
+    )
+    detail: str = Field(
+        description="Product-safe summary of the manage error payload.",
+        examples=["Wave dwv_001 cannot be simulated from state DRAFT."],
+    )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -16,6 +16,7 @@ from app.routers.domain_products import router as domain_products_router
 from app.routers.dpm_command_center import router as dpm_command_center_router
 from app.routers.dpm_construction import router as dpm_construction_router
 from app.routers.dpm_proof_packs import router as dpm_proof_packs_router
+from app.routers.dpm_waves import router as dpm_waves_router
 from app.routers.foundation import router as foundation_router
 from app.routers.intake import router as intake_router
 from app.routers.platform import router as platform_router
@@ -94,6 +95,7 @@ app.include_router(portfolio_router)
 app.include_router(dpm_command_center_router)
 app.include_router(dpm_construction_router)
 app.include_router(dpm_proof_packs_router)
+app.include_router(dpm_waves_router)
 app.include_router(workbench_router)
 app.include_router(reporting_router)
 app.include_router(reporting_jobs_router)

--- a/src/app/routers/dpm_waves.py
+++ b/src/app/routers/dpm_waves.py
@@ -1,0 +1,378 @@
+from typing import Any
+
+from fastapi import APIRouter, Path, Query
+
+from app.clients.dpm_client import DpmClient
+from app.config import settings
+from app.contracts.dpm_waves import (
+    DpmWaveCreateRequest,
+    DpmWaveErrorDetail,
+    DpmWaveForwardRequest,
+    DpmWaveGatewayResponse,
+)
+from app.middleware.correlation import correlation_id_var
+from app.services.dpm_wave_service import DpmWaveService
+
+router = APIRouter(
+    prefix="/api/v1/dpm/command-center/waves",
+    tags=["DPM Command Center"],
+)
+_UPSTREAM_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
+    404: {
+        "model": DpmWaveErrorDetail,
+        "description": "lotus-manage could not find the requested rebalance wave.",
+    },
+    409: {
+        "model": DpmWaveErrorDetail,
+        "description": "lotus-manage rejected the rebalance-wave request as conflicting.",
+    },
+    422: {
+        "model": DpmWaveErrorDetail,
+        "description": "lotus-manage rejected the rebalance-wave payload as invalid.",
+    },
+    503: {
+        "model": DpmWaveErrorDetail,
+        "description": "lotus-manage rebalance-wave authority is unavailable or degraded.",
+    },
+}
+
+
+def _dpm_wave_service() -> DpmWaveService:
+    return DpmWaveService(
+        dpm_client=DpmClient(
+            base_url=settings.management_service_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+    )
+
+
+@router.post(
+    "/preview",
+    response_model=DpmWaveGatewayResponse,
+    summary="Preview DPM rebalance wave",
+    description=(
+        "What: asks lotus-manage to preview a non-durable RFC-0041 rebalance wave for explicit "
+        "affected portfolios. When: call this before creating a durable PM/CIO review wave. How: "
+        "Gateway forwards the request unchanged and preserves manage candidate, blocked, source "
+        "ref, aggregate, and supportability truth without discovering books or classifying items."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def preview_wave(request: DpmWaveForwardRequest) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().preview_wave(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "",
+    response_model=DpmWaveGatewayResponse,
+    summary="Create DPM rebalance wave",
+    description=(
+        "What: creates a durable manage-owned RFC-0041 rebalance wave. When: call this after "
+        "preview confirms the explicit portfolio list is the intended operating scope. How: "
+        "Gateway forwards the body and idempotency key to lotus-manage and preserves wave_id, "
+        "state, item states, reason codes, source refs, aggregate metrics, and supportability."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def create_wave(request: DpmWaveCreateRequest) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().create_wave(
+        body=request.body,
+        idempotency_key=request.idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "",
+    response_model=DpmWaveGatewayResponse,
+    summary="List DPM rebalance waves",
+    description=(
+        "What: lists durable manage-owned RFC-0041 rebalance waves for Workbench queues and "
+        "command-center triage. When: call this by state, trigger, as-of date, or supportability "
+        "posture. How: Gateway forwards filters to manage and preserves returned wave summaries "
+        "without recalculating source readiness, proof-pack posture, or handoff state."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def list_waves(
+    state: str | None = Query(default=None, description="Optional manage wave-state filter."),
+    trigger_type: str | None = Query(
+        default=None,
+        description="Optional manage trigger-type filter.",
+        examples=["EXPLICIT_PORTFOLIO_LIST"],
+    ),
+    as_of_date: str | None = Query(
+        default=None,
+        description="Optional business as-of date filter.",
+        examples=["2026-05-03"],
+    ),
+    supportability_state: str | None = Query(
+        default=None,
+        description="Optional manage-published supportability filter.",
+        examples=["ready"],
+    ),
+    limit: int = Query(default=50, ge=1, le=100, description="Maximum waves to return."),
+    offset: int = Query(default=0, ge=0, description="Zero-based wave-list offset."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().list_waves(
+        filters={
+            "state": state,
+            "trigger_type": trigger_type,
+            "as_of_date": as_of_date,
+            "supportability_state": supportability_state,
+            "limit": limit,
+            "offset": offset,
+        },
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/{wave_id}",
+    response_model=DpmWaveGatewayResponse,
+    summary="Get DPM rebalance wave",
+    description=(
+        "What: returns one durable manage-owned RFC-0041 rebalance wave. When: call this for "
+        "Workbench wave detail, PM review, CIO review, or operations drill-down. How: Gateway "
+        "preserves manage wave detail, item states, events, aggregate metrics, source refs, "
+        "supportability, proof-pack posture, and handoff posture without recomputation."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def get_wave(
+    wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().get_wave(
+        wave_id=wave_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/{wave_id}/items",
+    response_model=DpmWaveGatewayResponse,
+    summary="List DPM rebalance wave items",
+    description=(
+        "What: returns manage-owned item-level wave posture. When: call this for Workbench item "
+        "tables, source-readiness review, construction selection, proof-pack linkage, and "
+        "handoff readiness. How: Gateway preserves item states, reason codes, diagnostics, refs, "
+        "and aggregate metrics without deriving readiness."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def get_wave_items(
+    wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().get_wave_items(
+        wave_id=wave_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{wave_id}/source-check",
+    response_model=DpmWaveGatewayResponse,
+    summary="Source-check DPM rebalance wave",
+    description=(
+        "What: asks lotus-manage to evaluate source readiness for a durable wave. When: call "
+        "this before simulation so source-blocked or review-required items remain explicit. How: "
+        "Gateway forwards controls unchanged and preserves manage item classifications and "
+        "supportability; it never promotes caller-supplied portfolio ids to ready."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def source_check_wave(
+    request: DpmWaveForwardRequest,
+    wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().source_check_wave(
+        wave_id=wave_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{wave_id}/simulate",
+    response_model=DpmWaveGatewayResponse,
+    summary="Simulate DPM rebalance wave",
+    description=(
+        "What: asks lotus-manage to generate construction alternatives for source-ready wave "
+        "items. When: call this after source-check. How: Gateway forwards simulation inputs and "
+        "preserves manage construction refs, item states, and degradation reasons without "
+        "building holdings, market data, model targets, or alternatives locally."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def simulate_wave(
+    request: DpmWaveForwardRequest,
+    wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().simulate_wave(
+        wave_id=wave_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{wave_id}/items/{wave_item_id}/select",
+    response_model=DpmWaveGatewayResponse,
+    summary="Select DPM wave item alternative",
+    description=(
+        "What: records a manage-owned construction alternative selection for one wave item. "
+        "When: call this after PM/CIO review of generated alternatives. How: Gateway forwards "
+        "selection, actor, reason, comment, and proof-pack-generation controls unchanged and "
+        "preserves manage selection, proof-pack, and degraded posture."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def select_wave_item(
+    request: DpmWaveForwardRequest,
+    wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
+    wave_item_id: str = Path(..., description="Manage-owned rebalance-wave item identifier."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().select_wave_item(
+        wave_id=wave_id,
+        wave_item_id=wave_item_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{wave_id}/approve",
+    response_model=DpmWaveGatewayResponse,
+    summary="Approve DPM rebalance wave",
+    description=(
+        "What: forwards PM/CIO approval evidence for eligible manage wave items. When: call this "
+        "after selected items and proof-pack posture have been reviewed. How: Gateway preserves "
+        "manage approval state and exceptions without approving blocked, degraded, or unselected "
+        "items locally."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def approve_wave(
+    request: DpmWaveForwardRequest,
+    wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().approve_wave(
+        wave_id=wave_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{wave_id}/stage",
+    response_model=DpmWaveGatewayResponse,
+    summary="Stage DPM rebalance wave",
+    description=(
+        "What: forwards staging evidence for approved manage wave items. When: call this before "
+        "internal operations handoff. How: Gateway preserves manage staged state and exceptions "
+        "without treating staging as external execution."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def stage_wave(
+    request: DpmWaveForwardRequest,
+    wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().stage_wave(
+        wave_id=wave_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{wave_id}/handoff",
+    response_model=DpmWaveGatewayResponse,
+    summary="Create DPM wave handoff evidence",
+    description=(
+        "What: asks lotus-manage to create append-only internal operations handoff evidence. "
+        "When: call this after approved items are staged. How: Gateway preserves manage handoff "
+        "refs and the `external_execution_claimed=false` boundary; it does not send orders or "
+        "claim client/execution completion."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def handoff_wave(
+    request: DpmWaveForwardRequest,
+    wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().handoff_wave(
+        wave_id=wave_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{wave_id}/cancel",
+    response_model=DpmWaveGatewayResponse,
+    summary="Cancel DPM rebalance wave",
+    description=(
+        "What: forwards a manage-owned cancellation command for an eligible rebalance wave. "
+        "When: call this before external execution exists. How: Gateway preserves manage "
+        "cancellation diagnostics and does not cancel external orders because RFC-0041 handoff is "
+        "internal readiness evidence only."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def cancel_wave(
+    request: DpmWaveForwardRequest,
+    wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().cancel_wave(
+        wave_id=wave_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/{wave_id}/proof-pack",
+    response_model=DpmWaveGatewayResponse,
+    summary="Get DPM wave proof-pack posture",
+    description=(
+        "What: returns manage-owned RFC-0040 proof-pack refs and internal handoff posture for "
+        "one wave. When: call this for Workbench evidence drawers or operations readiness. How: "
+        "Gateway preserves item-level proof_pack_id refs, degraded proof-pack posture, handoff "
+        "refs, and no-external-execution flags without rebuilding proof packs."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def get_wave_proof_pack_posture(
+    wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().get_wave_proof_pack_posture(
+        wave_id=wave_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/{wave_id}/supportability",
+    response_model=DpmWaveGatewayResponse,
+    summary="Get DPM wave supportability",
+    description=(
+        "What: returns product-safe manage supportability diagnostics for one rebalance wave. "
+        "When: call this to decide which Workbench actions are enabled and where operations must "
+        "remediate source or proof gaps. How: Gateway preserves state, reason codes, issue refs, "
+        "source owners, and remediation routes without exposing raw request bodies or trace data."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def get_wave_supportability(
+    wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().get_wave_supportability(
+        wave_id=wave_id,
+        correlation_id=correlation_id_var.get(),
+    )

--- a/src/app/services/dpm_wave_service.py
+++ b/src/app/services/dpm_wave_service.py
@@ -1,0 +1,299 @@
+from typing import Any
+
+from fastapi import HTTPException, status
+
+from app.clients.dpm_client import DpmClient
+from app.config import settings
+from app.contracts.dpm_waves import (
+    DpmWaveErrorDetail,
+    DpmWaveGatewayResponse,
+    DpmWaveSupportability,
+)
+
+
+class DpmWaveService:
+    def __init__(self, dpm_client: DpmClient):
+        self._dpm_client = dpm_client
+
+    async def preview_wave(
+        self,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.preview_wave(
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def create_wave(
+        self,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.create_wave(
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def list_waves(
+        self,
+        filters: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.list_waves(
+            params=filters,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_wave(
+        self,
+        wave_id: str,
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_wave(
+            wave_id=wave_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_wave_items(
+        self,
+        wave_id: str,
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_wave_items(
+            wave_id=wave_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def source_check_wave(
+        self,
+        wave_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.source_check_wave(
+            wave_id=wave_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def simulate_wave(
+        self,
+        wave_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.simulate_wave(
+            wave_id=wave_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def select_wave_item(
+        self,
+        wave_id: str,
+        wave_item_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.select_wave_item(
+            wave_id=wave_id,
+            wave_item_id=wave_item_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def approve_wave(
+        self,
+        wave_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.approve_wave(
+            wave_id=wave_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def stage_wave(
+        self,
+        wave_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.stage_wave(
+            wave_id=wave_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def handoff_wave(
+        self,
+        wave_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.handoff_wave(
+            wave_id=wave_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def cancel_wave(
+        self,
+        wave_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.cancel_wave(
+            wave_id=wave_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_wave_proof_pack_posture(
+        self,
+        wave_id: str,
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_wave_proof_pack_posture(
+            wave_id=wave_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def get_wave_supportability(
+        self,
+        wave_id: str,
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_wave_supportability(
+            wave_id=wave_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    def _compose_response(
+        self,
+        upstream_status: int,
+        upstream_payload: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        if upstream_status >= status.HTTP_400_BAD_REQUEST:
+            raise HTTPException(
+                status_code=upstream_status,
+                detail=DpmWaveErrorDetail(
+                    upstream_status=upstream_status,
+                    error_code="MANAGE_WAVE_UPSTREAM_ERROR",
+                    detail=_safe_upstream_detail(upstream_payload),
+                ).model_dump(),
+            )
+
+        return DpmWaveGatewayResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            upstream_status=upstream_status,
+            supportability=_supportability_from(upstream_payload),
+            data=upstream_payload,
+        )
+
+
+def _supportability_from(payload: dict[str, Any]) -> DpmWaveSupportability:
+    wave = _wave_payload(payload)
+    supportability = _supportability_payload(payload, wave)
+    state = (
+        supportability.get("supportability_state")
+        or supportability.get("supportabilityState")
+        or supportability.get("state")
+        or payload.get("supportability_state")
+        or wave.get("supportability_state")
+        or "UNKNOWN"
+    )
+    reason_codes = _list_of_strings(
+        supportability.get("reason_codes")
+        or supportability.get("reasonCodes")
+        or supportability.get("blocked_actions")
+        or []
+    )
+    reason = supportability.get("reason") or supportability.get("supportability_reason")
+    if reason is not None:
+        reason_codes.append(str(reason))
+    issues = supportability.get("issues") or payload.get("issues")
+    blocked_actions = _list_of_strings(
+        supportability.get("blocked_actions") or supportability.get("blockedActions") or []
+    )
+    remediation_owner = supportability.get("remediation_owner") or supportability.get(
+        "remediationOwner"
+    )
+
+    return DpmWaveSupportability(
+        state=str(state),
+        reason_codes=sorted(set(reason_codes)),
+        blocked_actions=blocked_actions,
+        wave_id=_safe_str(
+            supportability.get("wave_id") or payload.get("wave_id") or wave.get("wave_id")
+        ),
+        wave_state=_safe_str(
+            supportability.get("wave_state") or payload.get("wave_state") or wave.get("state")
+        ),
+        item_count=_safe_int(supportability.get("item_count") or payload.get("item_count")),
+        issue_count=len(issues) if isinstance(issues, list) else 0,
+        remediation_owner=_safe_str(remediation_owner),
+    )
+
+
+def _wave_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    wave = payload.get("wave")
+    return wave if isinstance(wave, dict) else payload
+
+
+def _supportability_payload(
+    payload: dict[str, Any],
+    wave: dict[str, Any],
+) -> dict[str, Any]:
+    supportability = payload.get("supportability") or wave.get("supportability")
+    return supportability if isinstance(supportability, dict) else payload
+
+
+def _list_of_strings(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _safe_int(value: object) -> int | None:
+    return value if isinstance(value, int) else None
+
+
+def _safe_str(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _safe_upstream_detail(payload: dict[str, Any]) -> str:
+    detail = payload.get("detail") or payload.get("message") or payload.get("error")
+    if isinstance(detail, dict):
+        code = detail.get("code")
+        message = detail.get("message")
+        if code and message:
+            return f"{code}: {message}"
+    if isinstance(detail, str):
+        return detail
+    if detail is not None:
+        return str(detail)
+    return "lotus-manage rebalance-wave request failed"

--- a/tests/contract/test_dpm_wave_contract.py
+++ b/tests/contract/test_dpm_wave_contract.py
@@ -1,0 +1,81 @@
+from fastapi.testclient import TestClient
+
+from app.contracts.dpm_waves import DpmWaveGatewayResponse
+from app.main import app
+
+
+def test_dpm_wave_gateway_response_contract_shape() -> None:
+    response = DpmWaveGatewayResponse(
+        correlation_id="corr-wave-1",
+        upstream_status=200,
+        supportability={
+            "state": "ready",
+            "reason_codes": ["wave_supportability_ready"],
+            "wave_id": "dwv_001",
+            "wave_state": "HANDOFF_READY",
+            "item_count": 2,
+        },
+        data={
+            "wave": {
+                "wave_id": "dwv_001",
+                "state": "HANDOFF_READY",
+                "aggregate_metrics": {"item_count": 2},
+            },
+            "durable": True,
+        },
+    )
+
+    assert response.source_service == "lotus-manage"
+    assert response.supportability.authority == "lotus-manage:RFC-0041"
+    assert response.supportability.wave_id == "dwv_001"
+    assert response.data["wave"]["state"] == "HANDOFF_READY"
+
+
+def test_dpm_wave_openapi_contract_registered() -> None:
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+    expected_paths = [
+        ("/api/v1/dpm/command-center/waves/preview", "post"),
+        ("/api/v1/dpm/command-center/waves", "post"),
+        ("/api/v1/dpm/command-center/waves", "get"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}", "get"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/items", "get"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/source-check", "post"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/simulate", "post"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/items/{wave_item_id}/select", "post"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/approve", "post"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/stage", "post"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/handoff", "post"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/cancel", "post"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/proof-pack", "get"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/supportability", "get"),
+    ]
+
+    for path, method in expected_paths:
+        assert path in spec["paths"]
+        operation = spec["paths"][path][method]
+        assert operation["tags"] == ["DPM Command Center"]
+        assert operation["summary"]
+        assert "What:" in operation["description"]
+        assert "When:" in operation["description"]
+        assert "How:" in operation["description"]
+
+
+def test_dpm_wave_openapi_models_are_described() -> None:
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+    schemas = spec["components"]["schemas"]
+
+    for schema_name in [
+        "DpmWaveCreateRequest",
+        "DpmWaveForwardRequest",
+        "DpmWaveGatewayResponse",
+        "DpmWaveSupportability",
+        "DpmWaveErrorDetail",
+    ]:
+        schema = schemas[schema_name]
+        for property_schema in schema["properties"].values():
+            assert property_schema.get("description")
+
+    assert schemas["DpmWaveSupportability"]["properties"]["state"]["examples"]
+    assert schemas["DpmWaveGatewayResponse"]["properties"]["data"]["description"]

--- a/tests/integration/test_dpm_wave_router.py
+++ b/tests/integration/test_dpm_wave_router.py
@@ -1,0 +1,168 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_dpm_wave_create_forwards_body_and_idempotency_key(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_create_wave(self, body, idempotency_key, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["body"] = body
+        captured["idempotency_key"] = idempotency_key
+        captured["correlation_id"] = correlation_id
+        return 201, {
+            "wave": {"wave_id": "dwv_001", "state": "PREVIEWED"},
+            "durable": True,
+            "supportability": {
+                "supportability_state": "ready",
+                "reason": "wave_supportability_ready",
+            },
+        }
+
+    monkeypatch.setattr("app.clients.dpm_client.DpmClient.create_wave", _fake_create_wave)
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/waves",
+        json={
+            "idempotency_key": "wave-idem-1",
+            "body": {
+                "trigger_type": "EXPLICIT_PORTFOLIO_LIST",
+                "trigger_id": "manual-wave-20260503-001",
+                "portfolios": [{"portfolio_id": "PB_SG_GLOBAL_BAL_001"}],
+            },
+        },
+        headers={"X-Correlation-Id": "corr-wave-router-create"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "body": {
+            "trigger_type": "EXPLICIT_PORTFOLIO_LIST",
+            "trigger_id": "manual-wave-20260503-001",
+            "portfolios": [{"portfolio_id": "PB_SG_GLOBAL_BAL_001"}],
+        },
+        "idempotency_key": "wave-idem-1",
+        "correlation_id": "corr-wave-router-create",
+    }
+    payload = response.json()
+    assert payload["supportability"]["state"] == "ready"
+    assert payload["data"]["wave"]["wave_id"] == "dwv_001"
+
+
+def test_dpm_wave_list_passes_filters_without_reconstructing_state(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_list_waves(self, params, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["params"] = params
+        captured["correlation_id"] = correlation_id
+        return 200, {
+            "items": [
+                {
+                    "wave_id": "dwv_001",
+                    "wave_state": "HANDOFF_READY",
+                    "supportability_state": "ready",
+                }
+            ],
+            "limit": 25,
+            "offset": 0,
+            "returned_count": 1,
+        }
+
+    monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_waves", _fake_list_waves)
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/dpm/command-center/waves"
+        "?state=HANDOFF_READY&supportability_state=ready&limit=25&offset=0",
+        headers={"X-Correlation-Id": "corr-wave-router-list"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "params": {
+            "state": "HANDOFF_READY",
+            "trigger_type": None,
+            "as_of_date": None,
+            "supportability_state": "ready",
+            "limit": 25,
+            "offset": 0,
+        },
+        "correlation_id": "corr-wave-router-list",
+    }
+    assert response.json()["data"]["items"][0]["wave_state"] == "HANDOFF_READY"
+
+
+def test_dpm_wave_actions_preserve_manage_payload(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_select_wave_item(self, wave_id, wave_item_id, body, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["wave_id"] = wave_id
+        captured["wave_item_id"] = wave_item_id
+        captured["body"] = body
+        captured["correlation_id"] = correlation_id
+        return 200, {
+            "wave": {
+                "wave_id": wave_id,
+                "state": "SIMULATED",
+                "items": [
+                    {
+                        "wave_item_id": wave_item_id,
+                        "selected_alternative_id": body["alternative_id"],
+                        "proof_pack_id": "dpp_wave_001",
+                    }
+                ],
+            },
+            "supportability": {"supportability_state": "ready"},
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.select_wave_item",
+        _fake_select_wave_item,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/waves/dwv_001/items/dwi_001/select",
+        json={
+            "body": {
+                "alternative_id": "alt_001",
+                "actor_id": "pm_sg_1",
+                "reason_code": "PM_SELECTED",
+                "generate_proof_pack": True,
+            }
+        },
+        headers={"X-Correlation-Id": "corr-wave-router-select"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "wave_id": "dwv_001",
+        "wave_item_id": "dwi_001",
+        "body": {
+            "alternative_id": "alt_001",
+            "actor_id": "pm_sg_1",
+            "reason_code": "PM_SELECTED",
+            "generate_proof_pack": True,
+        },
+        "correlation_id": "corr-wave-router-select",
+    }
+    assert response.json()["data"]["wave"]["items"][0]["proof_pack_id"] == "dpp_wave_001"
+
+
+def test_dpm_wave_error_is_not_marked_ready(monkeypatch) -> None:
+    async def _fake_get_wave(self, wave_id, correlation_id):  # noqa: ANN001
+        _ = self, wave_id, correlation_id
+        return 404, {"detail": "Wave dwv_missing was not found."}
+
+    monkeypatch.setattr("app.clients.dpm_client.DpmClient.get_wave", _fake_get_wave)
+
+    client = TestClient(app)
+    response = client.get("/api/v1/dpm/command-center/waves/dwv_missing")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["error_code"] == "MANAGE_WAVE_UPSTREAM_ERROR"
+    assert response.json()["detail"]["detail"] == "Wave dwv_missing was not found."

--- a/tests/unit/test_dpm_wave_service.py
+++ b/tests/unit/test_dpm_wave_service.py
@@ -1,0 +1,165 @@
+import pytest
+from fastapi import HTTPException
+
+from app.services.dpm_wave_service import DpmWaveService
+
+
+class _FakeDpmClient:
+    def __init__(self, result: tuple[int, dict]):
+        self.result = result
+        self.calls: list[dict[str, object]] = []
+
+    async def create_wave(self, body, idempotency_key, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "create_wave",
+                "body": body,
+                "idempotency_key": idempotency_key,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+    async def simulate_wave(self, wave_id, body, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "simulate_wave",
+                "wave_id": wave_id,
+                "body": body,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+    async def get_wave_supportability(self, wave_id, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "get_wave_supportability",
+                "wave_id": wave_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_dpm_wave_service_preserves_manage_wave_truth_and_supportability() -> None:
+    manage_payload = {
+        "wave": {
+            "wave_id": "dwv_001",
+            "state": "HANDOFF_READY",
+            "aggregate_metrics": {"item_count": 2, "ready_item_count": 2},
+            "items": [
+                {
+                    "wave_item_id": "dwi_001",
+                    "state": "HANDOFF_READY",
+                    "proof_pack_id": "dpp_wave_001",
+                }
+            ],
+        },
+        "durable": True,
+        "supportability": {
+            "supportability_state": "ready",
+            "reason": "wave_supportability_ready",
+            "wave_id": "dwv_001",
+            "wave_state": "HANDOFF_READY",
+            "item_count": 2,
+            "issues": [],
+        },
+    }
+    client = _FakeDpmClient((201, manage_payload))
+    service = DpmWaveService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.create_wave(
+        body={"trigger_type": "EXPLICIT_PORTFOLIO_LIST"},
+        idempotency_key="wave-idem-1",
+        correlation_id="corr-wave-create",
+    )
+
+    assert response.correlation_id == "corr-wave-create"
+    assert response.source_service == "lotus-manage"
+    assert response.upstream_status == 201
+    assert response.supportability.authority == "lotus-manage:RFC-0041"
+    assert response.supportability.state == "ready"
+    assert response.supportability.reason_codes == ["wave_supportability_ready"]
+    assert response.supportability.wave_id == "dwv_001"
+    assert response.supportability.wave_state == "HANDOFF_READY"
+    assert response.supportability.item_count == 2
+    assert response.data == manage_payload
+    assert client.calls == [
+        {
+            "method": "create_wave",
+            "body": {"trigger_type": "EXPLICIT_PORTFOLIO_LIST"},
+            "idempotency_key": "wave-idem-1",
+            "correlation_id": "corr-wave-create",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_wave_service_forwards_simulation_without_local_reconstruction() -> None:
+    manage_payload = {
+        "wave": {
+            "wave_id": "dwv_001",
+            "state": "PARTIALLY_SIMULATED",
+            "items": [{"wave_item_id": "dwi_001", "state": "SIMULATION_BLOCKED"}],
+        },
+        "supportability": {
+            "supportability_state": "degraded",
+            "reason": "wave_degraded_items",
+            "issues": [{"support_ref": "wave:dwv_001:item:1"}],
+        },
+    }
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmWaveService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.simulate_wave(
+        wave_id="dwv_001",
+        body={"actor_id": "pm_sg_1", "item_inputs": []},
+        correlation_id="corr-wave-simulate",
+    )
+
+    assert response.supportability.state == "degraded"
+    assert response.supportability.reason_codes == ["wave_degraded_items"]
+    assert response.supportability.issue_count == 1
+    assert response.data["wave"] == manage_payload["wave"]
+    assert client.calls == [
+        {
+            "method": "simulate_wave",
+            "wave_id": "dwv_001",
+            "body": {"actor_id": "pm_sg_1", "item_inputs": []},
+            "correlation_id": "corr-wave-simulate",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_wave_service_manage_errors_are_product_safe() -> None:
+    client = _FakeDpmClient(
+        (
+            422,
+            {
+                "detail": {
+                    "code": "DPM_WAVE_INVALID_TRANSITION",
+                    "message": "Wave dwv_001 cannot be approved from state DRAFT.",
+                }
+            },
+        )
+    )
+    service = DpmWaveService(dpm_client=client)  # type: ignore[arg-type]
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.get_wave_supportability(
+            wave_id="dwv_001",
+            correlation_id="corr-wave-error",
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == {
+        "source_service": "lotus-manage",
+        "upstream_status": 422,
+        "error_code": "MANAGE_WAVE_UPSTREAM_ERROR",
+        "detail": (
+            "DPM_WAVE_INVALID_TRANSITION: Wave dwv_001 cannot be approved from state DRAFT."
+        ),
+    }

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -20,6 +20,11 @@ def test_rfc0098_ownership_matches_manage_rfc0040_rfc0041_and_rfc0042() -> None:
     assert "treat `lotus-report` as the proof-pack authority" in rfc
     assert "calculate affected portfolios, source readiness, aggregate metrics" in rfc
     assert "`GET /api/v1/dpm/command-center/waves/{wave_id}/supportability`" in rfc
+    assert "RFC41-WTBD-005 Gateway wave composition" in rfc
+    assert "`POST /api/v1/dpm/command-center/waves/{wave_id}/cancel`" in rfc
+    assert "DPM Rebalance-Wave Composition" in (ROOT / "wiki" / "Supported-Features.md").read_text(
+        encoding="utf-8"
+    )
     assert "proof_pack_evidence" in rfc
     assert "wave_summary" in rfc
     assert "DpmPreTradeProofPack:v1" in rfc
@@ -37,4 +42,5 @@ def test_rfc0098_ownership_matches_manage_rfc0040_rfc0041_and_rfc0042() -> None:
     assert "`/api/v1/dpm/command-center/proof-packs*`" in api_surface
     assert "proof-pack BFF route family" in integrations
     assert "must not calculate affected portfolios" in api_surface
+    assert "`/api/v1/dpm/command-center/waves*`" in api_surface
     assert "Gateway does not generate proof packs. That belongs to `lotus-report`." not in rfc

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1653,6 +1653,34 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
             {"wave_id": "wave_1", "params": {"state": None}, "correlation_id": "corr-5"},
             "http://dpm/api/v1/rebalance/waves/wave_1/outcome-reviews",
         ),
+        (
+            "list_waves",
+            {
+                "params": {"state": "HANDOFF_READY", "trigger_type": None},
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/waves",
+        ),
+        (
+            "get_wave",
+            {"wave_id": "dwv_001", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/waves/dwv_001",
+        ),
+        (
+            "get_wave_items",
+            {"wave_id": "dwv_001", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/waves/dwv_001/items",
+        ),
+        (
+            "get_wave_proof_pack_posture",
+            {"wave_id": "dwv_001", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/waves/dwv_001/proof-pack",
+        ),
+        (
+            "get_wave_supportability",
+            {"wave_id": "dwv_001", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/waves/dwv_001/supportability",
+        ),
     ],
 )
 async def test_dpm_client_manage_routes(method_name, kwargs, expected_url):
@@ -1758,6 +1786,98 @@ async def test_dpm_client_uses_only_canonical_manage_api_v1_contracts():
                 "params": {"state": "READY"},
                 "correlation_id": "corr-rfc36-canonical",
             },
+        ),
+        (
+            client.preview_wave,
+            {
+                "body": {"trigger_type": "EXPLICIT_PORTFOLIO_LIST"},
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.create_wave,
+            {
+                "body": {"trigger_type": "EXPLICIT_PORTFOLIO_LIST"},
+                "idempotency_key": "idem-wave-canonical",
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.list_waves,
+            {"params": {"state": "HANDOFF_READY"}, "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.get_wave,
+            {"wave_id": "dwv_001", "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.get_wave_items,
+            {"wave_id": "dwv_001", "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.source_check_wave,
+            {
+                "wave_id": "dwv_001",
+                "body": {"actor_id": "pm_sg_1"},
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.simulate_wave,
+            {
+                "wave_id": "dwv_001",
+                "body": {"actor_id": "pm_sg_1", "item_inputs": []},
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.select_wave_item,
+            {
+                "wave_id": "dwv_001",
+                "wave_item_id": "dwi_001",
+                "body": {"alternative_id": "alt_1", "actor_id": "pm_sg_1"},
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.approve_wave,
+            {
+                "wave_id": "dwv_001",
+                "body": {"actor_id": "pm_sg_1", "reason_code": "APPROVED"},
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.stage_wave,
+            {
+                "wave_id": "dwv_001",
+                "body": {"actor_id": "ops_sg_1", "reason_code": "STAGED"},
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.handoff_wave,
+            {
+                "wave_id": "dwv_001",
+                "body": {"actor_id": "ops_sg_1", "reason_code": "HANDOFF_READY"},
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.cancel_wave,
+            {
+                "wave_id": "dwv_001",
+                "body": {"actor_id": "pm_sg_1", "reason_code": "CANCELLED"},
+                "correlation_id": "corr-rfc36-canonical",
+            },
+        ),
+        (
+            client.get_wave_proof_pack_posture,
+            {"wave_id": "dwv_001", "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.get_wave_supportability,
+            {"wave_id": "dwv_001", "correlation_id": "corr-rfc36-canonical"},
         ),
         (
             client.generate_construction_alternative_set,
@@ -1881,6 +2001,84 @@ async def test_dpm_client_uses_only_canonical_manage_api_v1_contracts():
                 "correlation_id": "corr-5",
             },
             "http://dpm/api/v1/rebalance/proof-packs",
+        ),
+        (
+            "preview_wave",
+            {"body": {"trigger_type": "EXPLICIT_PORTFOLIO_LIST"}, "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/waves/preview",
+        ),
+        (
+            "create_wave",
+            {
+                "body": {"trigger_type": "EXPLICIT_PORTFOLIO_LIST"},
+                "idempotency_key": "idem-wave-1",
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/waves",
+        ),
+        (
+            "source_check_wave",
+            {
+                "wave_id": "dwv_001",
+                "body": {"actor_id": "pm_sg_1"},
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/waves/dwv_001/source-check",
+        ),
+        (
+            "simulate_wave",
+            {
+                "wave_id": "dwv_001",
+                "body": {"actor_id": "pm_sg_1", "item_inputs": []},
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/waves/dwv_001/simulate",
+        ),
+        (
+            "select_wave_item",
+            {
+                "wave_id": "dwv_001",
+                "wave_item_id": "dwi_001",
+                "body": {"alternative_id": "alt_1", "actor_id": "pm_sg_1"},
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/waves/dwv_001/items/dwi_001/select",
+        ),
+        (
+            "approve_wave",
+            {
+                "wave_id": "dwv_001",
+                "body": {"actor_id": "pm_sg_1", "reason_code": "APPROVED"},
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/waves/dwv_001/approve",
+        ),
+        (
+            "stage_wave",
+            {
+                "wave_id": "dwv_001",
+                "body": {"actor_id": "ops_sg_1", "reason_code": "STAGED"},
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/waves/dwv_001/stage",
+        ),
+        (
+            "handoff_wave",
+            {
+                "wave_id": "dwv_001",
+                "body": {"actor_id": "ops_sg_1", "reason_code": "HANDOFF_READY"},
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/waves/dwv_001/handoff",
+        ),
+        (
+            "cancel_wave",
+            {
+                "wave_id": "dwv_001",
+                "body": {"actor_id": "pm_sg_1", "reason_code": "CANCELLED"},
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/waves/dwv_001/cancel",
         ),
     ],
 )

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -19,6 +19,7 @@
 - `GET /api/v1/dpm/command-center/mandates*`
 - `GET` and `POST /api/v1/dpm/command-center/outcome-reviews*`
 - `GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`
+- `GET` and `POST /api/v1/dpm/command-center/waves*`
 - `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
 - `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`
 - `GET` and `POST /api/v1/dpm/command-center/construction/alternative-sets*`
@@ -94,12 +95,12 @@
   includes a bounded recent-run list with run id, status, timestamp, workflow posture, and error
   code for Workbench operations dashboards. Gateway must not calculate supportability, workflow
   posture, or error semantics locally.
-- RFC-0098 wave composition must consume `lotus-manage` RFC-0041 wave APIs for preview, create,
-  source-check, simulation, selection, approval, staging, handoff, and supportability. Target
-  Gateway routes belong under `/api/v1/dpm/command-center/waves*`, preserve manage `wave_id`,
-  item states, aggregate metrics, selected alternative refs, proof-pack refs, handoff refs, and
-  supportability refs, and must not calculate affected portfolios, readiness, alternatives,
-  proof-pack state, or external execution posture.
+- RFC-0098 wave composition consumes `lotus-manage` RFC-0041 wave APIs for preview, create,
+  search, detail, items, source-check, simulation, selection, approval, staging, handoff, cancel,
+  proof-pack posture, and supportability through `/api/v1/dpm/command-center/waves*`. Gateway now
+  exposes the implementation-backed wave BFF route family, preserves manage `wave_id`, item
+  states, aggregate metrics, selected alternative refs, proof-pack refs, handoff refs,
+  supportability issues, reason codes, and the no-external-execution boundary. Gateway must not calculate affected portfolios, readiness, alternatives, proof-pack state, or external execution posture.
 - RFC-0098 outcome-review composition must consume `lotus-manage` RFC-0042 outcome-review APIs
   for preview, durable create, search, detail, source refresh, supportability, report input, AI
   evidence input, run lookup, and wave lookup. Gateway now exposes the first implementation-backed
@@ -142,8 +143,8 @@
   call `lotus-advise` `/advisory/proposals/*`; they do not call `lotus-manage`
 - gateway calls `lotus-manage` only through versioned `/api/v1/*` paths for discretionary
   management run lookup, supportability summary, capability posture, RFC-0038 mandate
-  command-center authority APIs, RFC-0039 construction alternative-set authority APIs, and
-  RFC-0042 outcome-review authority APIs
+  command-center authority APIs, RFC-0039 construction alternative-set authority APIs, RFC-0041
+  rebalance-wave authority APIs, and RFC-0042 outcome-review authority APIs
 - `/metrics` includes RFC-0108 gateway analytics fan-out metrics for selected Workbench analytics
   operations plus the central `lotus-advise`, `lotus-manage`, `lotus-report`, `lotus-archive`,
   `lotus-ai`, direct `lotus-core` query/control-plane, and `lotus-core` ingestion client seams:
@@ -314,6 +315,31 @@ curl -X POST "http://127.0.0.1:8111/api/v1/dpm/command-center/outcome-reviews/or
   -H "Content-Type: application/json" \
   -H "X-Correlation-Id: corr-rfc42-outcome-review-ai-narrative" \
   -d "{\"requested_outputs\":[\"pm_summary\",\"cio_summary\",\"control_summary\",\"evidence_gaps\"],\"audience\":[\"portfolio_manager\",\"cio_office\",\"investment_control\"]}"
+```
+
+DPM rebalance-wave create:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/dpm/command-center/waves" \
+  -H "Content-Type: application/json" \
+  -H "X-Correlation-Id: corr-rfc41-wave-create" \
+  -d "{\"idempotency_key\":\"wave-idem-001\",\"body\":{\"trigger_type\":\"EXPLICIT_PORTFOLIO_LIST\",\"trigger_id\":\"manual-wave-20260503-001\",\"rationale\":\"CIO model update for the Singapore balanced DPM book.\",\"as_of_date\":\"2026-05-03\",\"actor_id\":\"pm_sg_1\",\"portfolios\":[{\"portfolio_id\":\"PB_SG_GLOBAL_BAL_001\"}]}}"
+```
+
+DPM rebalance-wave supportability:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/dpm/command-center/waves/dwv_001/supportability" \
+  -H "X-Correlation-Id: corr-rfc41-wave-supportability"
+```
+
+DPM rebalance-wave selection with proof-pack generation:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/dpm/command-center/waves/dwv_001/items/dwi_001/select" \
+  -H "Content-Type: application/json" \
+  -H "X-Correlation-Id: corr-rfc41-wave-select" \
+  -d "{\"body\":{\"alternative_id\":\"alt_001\",\"actor_id\":\"pm_sg_1\",\"reason_code\":\"PM_SELECTED\",\"generate_proof_pack\":true}}"
 ```
 
 Report job status:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -23,10 +23,10 @@
   proof-pack authority APIs, RFC-0041 rebalance-wave orchestration authority APIs, and RFC-0042
   post-trade outcome-review authority APIs. RFC-0098 remains the strategic Gateway DPM
   command-center contract; the RFC-0038 mandate command-center BFF route family, RFC-0039
-  construction alternative-set BFF route family, RFC-0040 proof-pack BFF route family, and
-  RFC-0042 outcome-review BFF route family are now implementation-backed, while RFC-0041 wave
-  composition, report materialization, archive, and optional AI posture remain governed follow-on
-  slices until implemented and proven
+  construction alternative-set BFF route family, RFC-0040 proof-pack BFF route family, RFC-0041
+  rebalance-wave BFF route family, and RFC-0042 outcome-review BFF route family are now
+  implementation-backed, while report materialization, archive, and optional AI posture remain
+  governed follow-on slices until implemented and proven
 - `lotus-report`
   reporting snapshot, summary, and review payloads
 - `lotus-archive`
@@ -108,7 +108,14 @@
     preserves proof-pack identity, section states, reason codes, content hashes, source hashes,
     source refs, report refs, and AI refs without generating proof sections, recalculating hashes,
     rendering reports, or generating AI narrative.
-14. RFC36-WTBD-003 portfolio-level DPM operations dashboards consume Gateway Workbench
+14. RFC-0041 rebalance waves remain `lotus-manage` truth. Gateway wave realization exposes
+    `/api/v1/dpm/command-center/waves*` for Workbench. Gateway forwards request bodies,
+    idempotency keys, query filters, and correlation context to manage, then preserves wave ids,
+    lifecycle state, item states, aggregate metrics, selected-alternative refs, proof-pack refs,
+    internal handoff refs, supportability issues, remediation routes, and no-external-execution
+    posture without discovering affected portfolios, classifying readiness, generating
+    alternatives, approving/staging locally, rebuilding proof packs, or claiming execution.
+15. RFC36-WTBD-003 portfolio-level DPM operations dashboards consume Gateway Workbench
     `rebalance_snapshot` only. Gateway reads manage rebalance runs, preserves manage
     supportability summary and bounded recent-run posture, and keeps Workbench from calling
     `lotus-manage` directly or inventing workflow/error semantics. Supportability comes from

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -17,10 +17,12 @@
 2. continue implementing RFC-0098 as the strategic DPM command-center composition contract for
    Workbench,
    preserving domain ownership across core, manage, risk, performance, report, archive, and AI.
-   The RFC now includes RFC-0041 rebalance-wave realization so Gateway can plan wave preview,
-   source-check, simulation, selection, approval, staging, handoff, and supportability composition
-   without becoming the wave authority. It also includes RFC-0042 post-trade outcome-review
-   realization; the first implementation-backed outcome-review BFF route family is active under
+   The RFC now includes implementation-backed RFC-0041 rebalance-wave realization under
+   `/api/v1/dpm/command-center/waves*` for wave preview, create, search, detail, item list,
+   source-check, simulation, selection, approval, staging, handoff, cancellation, proof-pack
+   posture, and supportability composition without becoming the wave authority. It also includes
+   RFC-0042 post-trade outcome-review realization; the first implementation-backed outcome-review
+   BFF route family is active under
    `/api/v1/dpm/command-center/outcome-reviews*`, run lookup, and wave lookup routes, preserving
    manage source-lineage, supportability, report-input, and AI-evidence truth without recomputing
    expected-versus-realized outcomes. RFC-0039 construction alternative-set composition is also

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -104,6 +104,67 @@ Operational behavior:
 3. degraded or unavailable manage states are surfaced using product-safe Gateway error detail and
    must remain visible to Workbench supportability UI.
 
+## DPM Rebalance-Wave Composition
+
+Status: implementation-backed in Gateway for RFC41-WTBD-005.
+
+Business outcome:
+
+1. portfolio managers and CIO-office users can operate explicit portfolio-list rebalance waves
+   through a stable Gateway contract instead of calling `lotus-manage` directly,
+2. operations users can inspect item-level source readiness, simulation, selection, proof-pack,
+   approval, staging, internal handoff, cancellation, and supportability posture from one product
+   route family,
+3. sales/pre-sales and client-demo teams can describe wave orchestration as implementation-backed
+   backend composition while keeping Workbench wave cockpit UI as the next owning-repository slice.
+
+Supported routes:
+
+1. `POST /api/v1/dpm/command-center/waves/preview`
+2. `POST /api/v1/dpm/command-center/waves`
+3. `GET /api/v1/dpm/command-center/waves`
+4. `GET /api/v1/dpm/command-center/waves/{wave_id}`
+5. `GET /api/v1/dpm/command-center/waves/{wave_id}/items`
+6. `POST /api/v1/dpm/command-center/waves/{wave_id}/source-check`
+7. `POST /api/v1/dpm/command-center/waves/{wave_id}/simulate`
+8. `POST /api/v1/dpm/command-center/waves/{wave_id}/items/{wave_item_id}/select`
+9. `POST /api/v1/dpm/command-center/waves/{wave_id}/approve`
+10. `POST /api/v1/dpm/command-center/waves/{wave_id}/stage`
+11. `POST /api/v1/dpm/command-center/waves/{wave_id}/handoff`
+12. `POST /api/v1/dpm/command-center/waves/{wave_id}/cancel`
+13. `GET /api/v1/dpm/command-center/waves/{wave_id}/proof-pack`
+14. `GET /api/v1/dpm/command-center/waves/{wave_id}/supportability`
+
+Authority and integrations:
+
+1. `lotus-manage` remains the RFC-0041 rebalance-wave authority.
+2. Gateway forwards preview, create, source-check, simulate, select, approve, stage, handoff,
+   cancel, proof-pack posture, and supportability requests to manage.
+3. Gateway preserves manage-owned `wave_id`, lifecycle state, item states, reason codes,
+   aggregate metrics, selected alternative refs, proof-pack refs, handoff refs, supportability
+   issues, remediation routes, and `external_execution_claimed=false`.
+4. Gateway does not calculate affected portfolios, classify source readiness, generate
+   alternatives, select alternatives, approve items, stage items, create handoff evidence, rebuild
+   proof packs, cancel external orders, or claim external execution.
+
+```mermaid
+flowchart LR
+    Workbench[lotus-workbench future wave cockpit] --> Gateway[lotus-gateway DPM wave routes]
+    Gateway --> Manage[lotus-manage RFC-0041 wave authority]
+    Manage --> Construction[lotus-manage RFC-0039 construction alternatives]
+    Manage --> Proof[lotus-manage RFC-0040 proof packs]
+    Manage --> Ops[Internal operations handoff evidence]
+    Manage --> Gateway
+    Gateway --> Workbench
+```
+
+Operational behavior:
+
+1. Gateway wraps every manage response in a product envelope with manage-derived supportability,
+2. unsupported transitions and missing waves return product-safe manage error details,
+3. Workbench wave command-center UI, browser proof, and demo screenshots remain RFC41-WTBD-006 and
+   are not claimed by this Gateway slice.
+
 ## DPM Mandate Command Center
 
 Status: implementation-backed in Gateway for RFC38-WTBD-001.


### PR DESCRIPTION
## Summary
- Implements RFC41-WTBD-005 Gateway rebalance-wave composition under `/api/v1/dpm/command-center/waves*`.
- Adds dedicated wave contracts, router, service, and canonical `lotus-manage` `/api/v1/rebalance/waves*` client methods.
- Preserves manage-owned wave state, item state, supportability, proof-pack refs, handoff refs, and no-external-execution posture without Gateway reconstruction.
- Updates README, RFC-0098, repo context, and repo-authored wiki source with implementation-backed wave truth.

## Proof
- `python -m pytest tests/unit/test_dpm_wave_service.py tests/integration/test_dpm_wave_router.py tests/contract/test_dpm_wave_contract.py tests/unit/test_upstream_clients.py tests/unit/test_rfc0098_documentation.py -q` -> 122 passed
- `make check` -> passed, including 472 unit/contract tests
- `make ci` -> passed, including 168 integration tests, 640-test coverage gate at 88.07%, and `pip-audit` no known vulnerabilities
- `git diff --check` -> passed with normal LF-to-CRLF warnings only
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` -> expected drift in `API-Surface.md`, `Integrations.md`, `Roadmap.md`, `Supported-Features.md` because repo-authored wiki source changed and must be published after merge

## Governance
- `lotus-manage` remains RFC-0041 wave authority.
- Gateway does not calculate affected portfolios, classify readiness, generate alternatives, approve/stage/handoff locally, rebuild proof packs, or claim external execution.
- Workbench wave command-center UI remains RFC41-WTBD-006 and is not claimed by this PR.