### PR TITLE
Add proof pack AI PM memo gateway handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ It depends on:
 - `lotus-archive`
   archived generated-document metadata and controlled binary retrieval
 - `lotus-ai`
-  evidence-grounded advisor-brief support through the explicit workflow-pack execution seam and shared run-ledger surfaces
+  evidence-grounded advisor-brief support, outcome-review narrative support, and proof-pack PM
+  memo support through explicit workflow-pack execution seams and shared run-ledger surfaces
 - `lotus-platform`
   generated domain-product catalog, dependency-graph, and live trust certification artifacts for
   read-only product discovery
@@ -99,6 +100,7 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/summary.md`,
   `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/report-input`,
   `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-evidence-input`,
+  `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-pm-memo`,
   `/api/v1/dpm/command-center/waves*`,
   `/api/v1/dpm/command-center/outcome-reviews*`,
   `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`,

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -36,7 +36,7 @@ Current repository posture:
    `/advisory/proposals/*`; `lotus-manage` consumption is through versioned `/api/v1` APIs for
    run lookup, supportability summary, capability posture, RFC-0038 mandate command-center
    summary/monitoring/exception/mandate drill-down route families, RFC-0040 proof-pack
-   generate/read/Markdown/report-input/AI-evidence route families, and RFC-0042 outcome-review
+   generate/read/Markdown/report-input/AI-evidence/AI PM memo route families, and RFC-0042 outcome-review
    preview/create/search/detail/source-refresh/supportability/report-input/AI-evidence and
    AI-narrative handoff route families,
 4. report job initiation/search/status/event-history/cancellation routes are active for
@@ -57,8 +57,13 @@ Current repository posture:
     `DpmOutcomeAiEvidenceInput` and executes `lotus-ai` `outcome_review_narrative.pack@v1` as
     `lotus-gateway`; manage remains outcome evidence and workflow authority, and Gateway does not
     generate narrative locally,
-11. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
-12. RFC-0108 analytics UI observability is active for selected Workbench performance summary,
+11. RFC-0040 proof-pack AI PM memo handoff now reads manage-owned
+    `DpmProofPackAiEvidenceInput` and executes `lotus-ai` `dpm_pm_memo.pack@v1` as
+    `lotus-gateway`; manage remains proof-pack evidence authority, `lotus-ai` remains workflow-pack
+    execution authority, and Gateway does not generate memos, score PMs, approve trades, contact
+    clients, place orders, or invent evidence,
+12. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
+13. RFC-0108 analytics UI observability is active for selected Workbench performance summary,
     risk summary, advisor-brief read, and advisor-brief review-action paths, and has expanded
     fan-out coverage for central `lotus-advise`, `lotus-manage`,
     `lotus-report`, `lotus-archive`, `lotus-ai`, direct `lotus-core` query/control-plane, and
@@ -210,10 +215,12 @@ Most relevant current governance:
     choose alternatives locally.
 13. RFC-0040 proof-pack Gateway routes are active under
     `/api/v1/dpm/command-center/proof-packs*`. Gateway forwards generation, lookup, Markdown,
-    report-input, and AI-evidence-input requests to `lotus-manage`, preserves manage-owned
+    report-input, AI-evidence-input, and AI PM memo requests, preserves manage-owned
     `proof_pack_id`, section states, reason codes, content hashes, source hashes, source refs,
-    report refs, and AI refs, and must not build proof-pack sections, recalculate hashes, infer
-    source readiness, render reports, or generate AI narrative locally.
+    report refs, and AI refs, and executes `lotus-ai` `dpm_pm_memo.pack@v1` only after reading
+    manage-owned AI evidence input. Gateway must not build proof-pack sections, recalculate hashes,
+    infer source readiness, render reports, generate AI narrative or PM memos locally, score PMs,
+    approve trades, contact clients, place orders, or invent missing evidence.
 14. RFC-0041 rebalance-wave Gateway routes are active under
     `/api/v1/dpm/command-center/waves*`. Gateway forwards preview, durable create, search, detail,
     item list, source-check, simulation, item selection, approval, staging, internal handoff,

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -1141,6 +1141,7 @@ route family so Workbench can consume Gateway/BFF instead of calling `lotus-mana
 | RFC38-WTBD-001 Gateway DPM command-center composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/unit/test_upstream_clients.py` |
 | RFC39-WTBD-001 Gateway construction-alternatives composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_construction.py`, `src/app/services/dpm_construction_service.py`, `src/app/contracts/dpm_construction.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_construction_service.py`, `tests/integration/test_dpm_construction_router.py`, `tests/contract/test_dpm_construction_contract.py` |
 | RFC40-WTBD-001 Gateway proof-pack composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_proof_packs.py`, `src/app/services/dpm_proof_pack_service.py`, `src/app/contracts/dpm_proof_packs.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_proof_pack_service.py`, `tests/integration/test_dpm_proof_pack_router.py`, `tests/contract/test_dpm_proof_pack_contract.py` |
+| RFC40-WTBD-005 Gateway proof-pack AI PM memo handoff | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | Gateway reads manage-owned `DpmProofPackAiEvidenceInput`, executes `lotus-ai` `dpm_pm_memo.pack@v1` as `lotus-gateway`, preserves manage evidence authority and lotus-ai workflow-pack posture, and exposes `POST /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-pm-memo` |
 | RFC41-WTBD-005 Gateway wave composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_waves.py`, `src/app/services/dpm_wave_service.py`, `src/app/contracts/dpm_waves.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_wave_service.py`, `tests/integration/test_dpm_wave_router.py`, `tests/contract/test_dpm_wave_contract.py`, `tests/unit/test_upstream_clients.py` |
 | RFC42-WTBD-001 Gateway outcome-review composition and BFF contract | Implemented and merged before this slice | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/contract/test_dpm_command_center_contract.py`, `make ci` |
 | RFC42-WTBD-005 Gateway AI narrative handoff | Implemented and merged before this slice | Gateway reads manage-owned `DpmOutcomeAiEvidenceInput`, executes `lotus-ai` `outcome_review_narrative.pack@v1` as `lotus-gateway`, preserves manage workflow authority, and exposes `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative` |
@@ -1178,11 +1179,15 @@ Implementation boundaries:
    `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/summary.md`,
    `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/report-input`, and
    `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-evidence-input`.
+   The Gateway AI memo handoff additionally exposes
+   `POST /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-pm-memo`.
 8. Proof-pack routes preserve manage-owned proof-pack identity, section states, reason codes,
    content hashes, source hashes, source refs, report refs, AI refs, Markdown text, report-input
-   payloads, and AI-evidence payloads.
+   payloads, and AI-evidence payloads. The AI memo route preserves manage-owned AI evidence input
+   and lotus-ai workflow-pack run posture.
 9. Gateway does not generate proof-pack sections, recalculate hashes, infer source readiness,
-   render reports, generate AI narrative, or treat `lotus-report` as proof-pack authority.
+   render reports, generate AI narrative or PM memos locally, score PMs, approve trades, contact
+   clients, place orders, or treat `lotus-report` as proof-pack authority.
 10. Gateway now exposes `POST /api/v1/dpm/command-center/waves/preview`,
    `POST /api/v1/dpm/command-center/waves`,
    `GET /api/v1/dpm/command-center/waves`,

--- a/src/app/contracts/dpm_proof_packs.py
+++ b/src/app/contracts/dpm_proof_packs.py
@@ -125,6 +125,93 @@ class DpmProofPackGatewayResponse(BaseModel):
     )
 
 
+class DpmProofPackMemoRequest(BaseModel):
+    requested_outputs: list[str] = Field(
+        default_factory=lambda: [
+            "pm_memo",
+            "rationale_summary",
+            "approval_checklist",
+            "risk_caveats",
+            "operations_handoff",
+            "evidence_gaps",
+        ],
+        description=(
+            "Support-only PM memo sections requested from lotus-ai. Gateway forwards these "
+            "requests to the governed proof-pack PM memo workflow pack and does not allow "
+            "trade approval, client messaging, PM scoring, or execution instructions."
+        ),
+        examples=[
+            [
+                "pm_memo",
+                "rationale_summary",
+                "approval_checklist",
+                "risk_caveats",
+                "operations_handoff",
+                "evidence_gaps",
+            ]
+        ],
+    )
+    audience: list[str] = Field(
+        default_factory=lambda: ["portfolio_manager", "investment_control", "operations"],
+        description="Intended internal audience labels for the generated support-only memo.",
+        examples=[["portfolio_manager", "investment_control", "operations"]],
+    )
+
+
+class DpmProofPackMemoGatewayResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated across Gateway, lotus-manage, and lotus-ai.",
+        examples=["corr-rfc40-proof-pack-ai-memo-1"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway BFF contract version for proof-pack AI PM memo handoff.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        default="lotus-ai",
+        description="Service that executed the governed PM memo workflow pack.",
+        examples=["lotus-ai"],
+    )
+    evidence_source_service: str = Field(
+        default="lotus-manage",
+        description="Service that supplied the bounded DPM proof-pack AI evidence input.",
+        examples=["lotus-manage"],
+    )
+    manage_upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage for the AI evidence input read.",
+        examples=[200],
+    )
+    ai_upstream_status: int = Field(
+        description="HTTP status returned by lotus-ai for workflow-pack execution.",
+        examples=[200],
+    )
+    supportability: DpmProofPackSupportability = Field(
+        description="Manage-derived supportability summary for the source AI evidence handoff.",
+    )
+    ai_evidence_input: dict[str, object] = Field(
+        description=(
+            "Manage-owned DpmProofPackAiEvidenceInput used as the sole source for PM memo "
+            "generation. Gateway preserves it without adding facts or removing guardrails."
+        ),
+    )
+    memo_request: dict[str, object] = Field(
+        description="Bounded memo request forwarded to lotus-ai with support-only outputs.",
+        examples=[
+            {
+                "requested_outputs": ["pm_memo", "rationale_summary", "evidence_gaps"],
+                "audience": ["portfolio_manager", "investment_control"],
+            }
+        ],
+    )
+    data: dict[str, object] = Field(
+        description=(
+            "Authoritative lotus-ai workflow-pack execution response, including execution audit, "
+            "workflow-pack run posture, review state, and guardrail-supported structured output."
+        ),
+    )
+
+
 class DpmProofPackMarkdownResponse(BaseModel):
     correlation_id: str = Field(
         description="Correlation identifier propagated across Gateway and lotus-manage.",

--- a/src/app/routers/dpm_proof_packs.py
+++ b/src/app/routers/dpm_proof_packs.py
@@ -3,12 +3,15 @@ from typing import Any
 from fastapi import APIRouter, Path
 
 from app.clients.dpm_client import DpmClient
+from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_proof_packs import (
     DpmProofPackErrorDetail,
     DpmProofPackGatewayResponse,
     DpmProofPackGenerateRequest,
     DpmProofPackMarkdownResponse,
+    DpmProofPackMemoGatewayResponse,
+    DpmProofPackMemoRequest,
 )
 from app.middleware.correlation import correlation_id_var
 from app.services.dpm_proof_pack_service import DpmProofPackService
@@ -42,6 +45,12 @@ def _dpm_proof_pack_service() -> DpmProofPackService:
         dpm_client=DpmClient(
             base_url=settings.management_service_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+        lotus_ai_client=LotusAiClient(
+            base_url=settings.ai_service_base_url,
+            timeout_seconds=settings.ai_service_timeout_seconds,
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
@@ -170,5 +179,34 @@ async def get_proof_pack_ai_evidence_input(
 ) -> DpmProofPackGatewayResponse:
     return await _dpm_proof_pack_service().get_proof_pack_ai_evidence_input(
         proof_pack_id=proof_pack_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{proof_pack_id}/ai-pm-memo",
+    response_model=DpmProofPackMemoGatewayResponse,
+    summary="Request proof-pack AI PM memo",
+    description=(
+        "What: requests a governed lotus-ai PM memo workflow-pack run from manage-owned "
+        "DPM proof-pack AI evidence. When: call this only after manage supportability shows AI "
+        "evidence is available and the user needs review-gated PM/control support text. How: "
+        "Gateway first reads manage's DpmProofPackAiEvidenceInput, then executes lotus-ai "
+        "dpm_pm_memo.pack@v1 as lotus-gateway; Gateway does not generate narrative, score PMs, "
+        "approve trades, contact clients, place orders, or invent evidence."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def request_proof_pack_pm_memo(
+    request: DpmProofPackMemoRequest,
+    proof_pack_id: str = Path(
+        ...,
+        description="Manage-owned immutable proof-pack identifier for the bounded AI handoff.",
+        examples=["dpp_rr_001"],
+    ),
+) -> DpmProofPackMemoGatewayResponse:
+    return await _dpm_proof_pack_service().request_proof_pack_pm_memo(
+        proof_pack_id=proof_pack_id,
+        request=request,
         correlation_id=correlation_id_var.get(),
     )

--- a/src/app/services/dpm_proof_pack_service.py
+++ b/src/app/services/dpm_proof_pack_service.py
@@ -3,18 +3,22 @@ from typing import Any
 from fastapi import HTTPException, status
 
 from app.clients.dpm_client import DpmClient
+from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_proof_packs import (
     DpmProofPackErrorDetail,
     DpmProofPackGatewayResponse,
     DpmProofPackMarkdownResponse,
+    DpmProofPackMemoGatewayResponse,
+    DpmProofPackMemoRequest,
     DpmProofPackSupportability,
 )
 
 
 class DpmProofPackService:
-    def __init__(self, dpm_client: DpmClient):
+    def __init__(self, dpm_client: DpmClient, lotus_ai_client: LotusAiClient | None = None):
         self._dpm_client = dpm_client
+        self._lotus_ai_client = lotus_ai_client
 
     async def generate_proof_pack(
         self,
@@ -85,6 +89,99 @@ class DpmProofPackService:
         )
         return self._compose_response(upstream_status, upstream_payload, correlation_id)
 
+    async def request_proof_pack_pm_memo(
+        self,
+        proof_pack_id: str,
+        request: DpmProofPackMemoRequest,
+        correlation_id: str,
+    ) -> DpmProofPackMemoGatewayResponse:
+        if self._lotus_ai_client is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="lotus-ai workflow-pack execution is not configured for Gateway.",
+            )
+
+        manage_status, manage_payload = await self._dpm_client.get_proof_pack_ai_evidence_input(
+            proof_pack_id=proof_pack_id,
+            correlation_id=correlation_id,
+        )
+        if manage_status >= status.HTTP_400_BAD_REQUEST:
+            raise _upstream_error(manage_status, manage_payload)
+
+        supportability = _supportability_from(manage_payload)
+        memo_request: dict[str, object] = {
+            "requested_outputs": request.requested_outputs,
+            "audience": request.audience,
+        }
+        task_payload = {
+            "ai_evidence_input": manage_payload,
+            "memo_request": memo_request,
+            "supportability": {
+                "source_state": supportability.state,
+                "reason_codes": supportability.reason_codes,
+                "blocked_actions": [
+                    "place_orders",
+                    "approve_rebalance",
+                    "override_controls",
+                    "invent_missing_evidence",
+                    "contact_client",
+                ],
+                "requires_human_review": True,
+                "unsupported_claims": [
+                    "client_contact",
+                    "trade_approval",
+                    "portfolio_manager_scoring",
+                    "execution_instruction",
+                ],
+            },
+        }
+        ai_status, ai_payload = await self._lotus_ai_client.execute_workflow_pack(
+            pack_id="dpm_pm_memo.pack",
+            version="v1",
+            environment="DEVELOPMENT",
+            caller_identity_class="INTERNAL_SERVICE",
+            workflow_surface="dpm-proof-pack-ai-evidence",
+            task_request={
+                "task_id": "explain.v1",
+                "input_mode": "STRUCTURED_CONTEXT",
+                "caller": {
+                    "caller_app": "lotus-gateway",
+                    "correlation_id": correlation_id,
+                },
+                "context": {
+                    "summary": (
+                        "Generate review-gated proof-pack PM memo from bounded AI evidence "
+                        f"for {proof_pack_id}."
+                    ),
+                    "payload": task_payload,
+                    "source_refs": _proof_pack_ai_source_refs(manage_payload, proof_pack_id),
+                },
+                "expected_output_label": "EXPLANATION_ONLY",
+            },
+            correlation_id=correlation_id,
+        )
+        if ai_status >= status.HTTP_400_BAD_REQUEST:
+            raise HTTPException(
+                status_code=ai_status,
+                detail={
+                    "source_service": "lotus-ai",
+                    "upstream_status": ai_status,
+                    "error_code": "AI_PROOF_PACK_PM_MEMO_UPSTREAM_ERROR",
+                    "detail": _safe_upstream_detail(ai_payload),
+                },
+            )
+
+        return DpmProofPackMemoGatewayResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            manage_upstream_status=manage_status,
+            ai_upstream_status=ai_status,
+            supportability=supportability,
+            ai_evidence_input=manage_payload,
+            memo_request=memo_request,
+            data=ai_payload,
+        )
+
     def _compose_response(
         self,
         upstream_status: int,
@@ -133,7 +230,12 @@ def _proof_pack_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
 def _proof_pack_state(payload: dict[str, Any], proof_pack: dict[str, Any]) -> str:
     state = (
-        proof_pack.get("status") or proof_pack.get("state") or payload.get("status") or "UNKNOWN"
+        proof_pack.get("status")
+        or proof_pack.get("state")
+        or payload.get("supportability_status")
+        or payload.get("supportabilityStatus")
+        or payload.get("status")
+        or "UNKNOWN"
     )
     return str(state)
 
@@ -181,6 +283,25 @@ def _safe_str(value: object) -> str | None:
     if value is None:
         return None
     return str(value)
+
+
+def _proof_pack_ai_source_refs(payload: dict[str, Any], proof_pack_id: str) -> list[str]:
+    source_refs: list[str] = []
+    for key in ("source_refs", "sourceRefs"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            source_refs.extend(str(item) for item in value if item)
+
+    evidence_ref = payload.get("evidence_ref") or payload.get("ai_evidence_input_ref")
+    if evidence_ref:
+        source_refs.append(f"lotus-manage:proof-pack-ai-evidence:{evidence_ref}")
+
+    payload_proof_pack_id = payload.get("proof_pack_id")
+    if payload_proof_pack_id:
+        source_refs.append(f"lotus-manage:proof-pack:{payload_proof_pack_id}")
+    source_refs.append(f"lotus-manage:proof-pack-ai-evidence:{proof_pack_id}")
+
+    return sorted(set(source_refs))
 
 
 def _safe_upstream_detail(payload: dict[str, Any]) -> str:

--- a/tests/contract/test_dpm_proof_pack_contract.py
+++ b/tests/contract/test_dpm_proof_pack_contract.py
@@ -1,6 +1,9 @@
 from fastapi.testclient import TestClient
 
-from app.contracts.dpm_proof_packs import DpmProofPackGatewayResponse
+from app.contracts.dpm_proof_packs import (
+    DpmProofPackGatewayResponse,
+    DpmProofPackMemoGatewayResponse,
+)
 from app.main import app
 
 
@@ -31,6 +34,31 @@ def test_dpm_proof_pack_gateway_response_contract_shape() -> None:
     assert response.data["proof_pack"]["content_hash"] == "sha256:proof-pack"
 
 
+def test_dpm_proof_pack_pm_memo_gateway_response_contract_shape() -> None:
+    response = DpmProofPackMemoGatewayResponse(
+        correlation_id="corr-proof-pack-memo-1",
+        manage_upstream_status=200,
+        ai_upstream_status=200,
+        supportability={
+            "state": "SUPPORTED",
+            "reason_codes": ["AI_EVIDENCE_INPUT_READY"],
+            "proof_pack_id": "dpp_rr_001",
+            "ai_evidence_input_available": True,
+        },
+        ai_evidence_input={
+            "proof_pack_id": "dpp_rr_001",
+            "content_hash": "sha256:ai-evidence",
+        },
+        memo_request={"requested_outputs": ["pm_memo"], "audience": ["portfolio_manager"]},
+        data={"workflow_pack_run": {"workflow_authority_owner": "lotus-manage"}},
+    )
+
+    assert response.source_service == "lotus-ai"
+    assert response.evidence_source_service == "lotus-manage"
+    assert response.supportability.authority == "lotus-manage:RFC-0040"
+    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+
+
 def test_dpm_proof_pack_openapi_contract_registered() -> None:
     client = TestClient(app)
     spec = client.get("/openapi.json").json()
@@ -40,6 +68,7 @@ def test_dpm_proof_pack_openapi_contract_registered() -> None:
         ("/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/summary.md", "get"),
         ("/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/report-input", "get"),
         ("/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-evidence-input", "get"),
+        ("/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-pm-memo", "post"),
     ]
 
     for path, method in expected_paths:
@@ -61,6 +90,8 @@ def test_dpm_proof_pack_openapi_models_are_described() -> None:
         "DpmProofPackGenerateRequest",
         "DpmProofPackGatewayResponse",
         "DpmProofPackMarkdownResponse",
+        "DpmProofPackMemoGatewayResponse",
+        "DpmProofPackMemoRequest",
         "DpmProofPackSupportability",
         "DpmProofPackErrorDetail",
     ]:

--- a/tests/integration/test_dpm_proof_pack_router.py
+++ b/tests/integration/test_dpm_proof_pack_router.py
@@ -157,6 +157,93 @@ def test_dpm_proof_pack_handoff_routes_preserve_manage_payload(monkeypatch) -> N
     ]
 
 
+def test_dpm_proof_pack_pm_memo_executes_lotus_ai_workflow_pack(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_ai_input(self, proof_pack_id, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["manage"] = {
+            "proof_pack_id": proof_pack_id,
+            "correlation_id": correlation_id,
+        }
+        return 200, {
+            "contract_version": "DpmProofPackAiEvidenceInput.v1",
+            "proof_pack_id": proof_pack_id,
+            "proof_pack_content_hash": "sha256:proof-pack",
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "as_of_date": "2026-05-03",
+            "permitted_use": ["pm_memo_support"],
+            "forbidden_actions": [
+                "place_orders",
+                "approve_rebalance",
+                "override_controls",
+                "invent_missing_evidence",
+                "contact_client",
+            ],
+            "forbidden_fields_removed": ["client_name"],
+            "decision_summary": {"decision": "rebalance_ready"},
+            "supportability_status": "SUPPORTED",
+            "reason_codes": ["AI_EVIDENCE_INPUT_READY"],
+            "sections": [{"section_id": "mandate", "state": "READY"}],
+            "source_refs": ["lotus-manage:proof-pack:dpp_rr_001"],
+            "evidence_ref": "ai-evidence:dpp_rr_001",
+            "content_hash": "sha256:ai-evidence",
+        }
+
+    async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN003
+        _ = self
+        captured["ai"] = kwargs
+        return 200, {
+            "execution": {
+                "audit": {"workflow_pack_run_id": "packrun_dpp_rr_001"},
+                "result": {"dpm_pm_memo_status": "REVIEW_REQUIRED"},
+            },
+            "workflow_pack_run": {
+                "run_id": "packrun_dpp_rr_001",
+                "workflow_authority_owner": "lotus-manage",
+                "review_state": "AWAITING_REVIEW",
+            },
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_proof_pack_ai_evidence_input",
+        _fake_ai_input,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_ai_client.LotusAiClient.execute_workflow_pack",
+        _fake_execute_workflow_pack,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/proof-packs/dpp_rr_001/ai-pm-memo",
+        json={
+            "requested_outputs": ["pm_memo", "evidence_gaps"],
+            "audience": ["portfolio_manager"],
+        },
+        headers={"X-Correlation-Id": "corr-proof-pack-memo-router-1"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert captured["manage"] == {
+        "proof_pack_id": "dpp_rr_001",
+        "correlation_id": "corr-proof-pack-memo-router-1",
+    }
+    ai_call = captured["ai"]
+    assert ai_call["pack_id"] == "dpm_pm_memo.pack"
+    assert ai_call["version"] == "v1"
+    assert ai_call["workflow_surface"] == "dpm-proof-pack-ai-evidence"
+    assert ai_call["task_request"]["context"]["payload"]["memo_request"] == {
+        "requested_outputs": ["pm_memo", "evidence_gaps"],
+        "audience": ["portfolio_manager"],
+    }
+    assert payload["source_service"] == "lotus-ai"
+    assert payload["evidence_source_service"] == "lotus-manage"
+    assert payload["ai_evidence_input"]["content_hash"] == "sha256:ai-evidence"
+    assert payload["data"]["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+
+
 def _proof_pack_payload() -> dict[str, object]:
     return {
         "proof_pack": {

--- a/tests/unit/test_dpm_proof_pack_service.py
+++ b/tests/unit/test_dpm_proof_pack_service.py
@@ -1,6 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
+from app.contracts.dpm_proof_packs import DpmProofPackMemoRequest
 from app.services.dpm_proof_pack_service import DpmProofPackService
 
 
@@ -58,6 +59,16 @@ class _FakeDpmClient:
                 "correlation_id": correlation_id,
             }
         )
+        return self.result
+
+
+class _FakeLotusAiClient:
+    def __init__(self, result: tuple):
+        self.result = result
+        self.calls: list[dict[str, object]] = []
+
+    async def execute_workflow_pack(self, **kwargs):  # noqa: ANN003
+        self.calls.append(kwargs)
         return self.result
 
 
@@ -182,6 +193,134 @@ async def test_dpm_proof_pack_handoff_inputs_preserve_manage_payloads() -> None:
     assert ai_response.data == ai_payload
     assert ai_response.supportability.reason_codes == ["AI_EVIDENCE_INPUT_READY"]
     assert ai_response.supportability.ai_evidence_input_available is True
+
+
+@pytest.mark.asyncio
+async def test_dpm_proof_pack_pm_memo_executes_lotus_ai_with_manage_evidence() -> None:
+    manage_payload = {
+        "contract_version": "DpmProofPackAiEvidenceInput.v1",
+        "proof_pack_id": "dpp_rr_001",
+        "proof_pack_content_hash": "sha256:proof-pack",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "as_of_date": "2026-05-03",
+        "permitted_use": ["pm_memo_support"],
+        "forbidden_actions": [
+            "place_orders",
+            "approve_rebalance",
+            "override_controls",
+            "invent_missing_evidence",
+            "contact_client",
+        ],
+        "forbidden_fields_removed": ["client_name"],
+        "decision_summary": {"decision": "rebalance_ready"},
+        "supportability_status": "SUPPORTED",
+        "reason_codes": ["AI_EVIDENCE_INPUT_READY"],
+        "sections": [{"section_id": "mandate", "state": "READY"}],
+        "source_refs": ["lotus-manage:proof-pack:dpp_rr_001"],
+        "evidence_ref": "ai-evidence:dpp_rr_001",
+        "content_hash": "sha256:ai-evidence",
+    }
+    ai_payload = {
+        "execution": {
+            "audit": {"workflow_pack_run_id": "packrun_dpp_rr_001"},
+            "result": {"dpm_pm_memo_status": "REVIEW_REQUIRED"},
+        },
+        "workflow_pack_run": {
+            "run_id": "packrun_dpp_rr_001",
+            "workflow_authority_owner": "lotus-manage",
+            "review_state": "AWAITING_REVIEW",
+        },
+    }
+    dpm_client = _FakeDpmClient((200, manage_payload))
+    ai_client = _FakeLotusAiClient((200, ai_payload))
+    service = DpmProofPackService(  # type: ignore[arg-type]
+        dpm_client=dpm_client,
+        lotus_ai_client=ai_client,
+    )
+
+    response = await service.request_proof_pack_pm_memo(
+        proof_pack_id="dpp_rr_001",
+        request=DpmProofPackMemoRequest(
+            requested_outputs=["pm_memo", "evidence_gaps"],
+            audience=["portfolio_manager"],
+        ),
+        correlation_id="corr-proof-pack-memo-1",
+    )
+
+    assert response.source_service == "lotus-ai"
+    assert response.evidence_source_service == "lotus-manage"
+    assert response.manage_upstream_status == 200
+    assert response.ai_upstream_status == 200
+    assert response.supportability.state == "SUPPORTED"
+    assert response.ai_evidence_input == manage_payload
+    assert response.memo_request == {
+        "requested_outputs": ["pm_memo", "evidence_gaps"],
+        "audience": ["portfolio_manager"],
+    }
+    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    [ai_call] = ai_client.calls
+    assert ai_call["pack_id"] == "dpm_pm_memo.pack"
+    assert ai_call["version"] == "v1"
+    assert ai_call["workflow_surface"] == "dpm-proof-pack-ai-evidence"
+    assert ai_call["correlation_id"] == "corr-proof-pack-memo-1"
+    task_request = ai_call["task_request"]
+    assert task_request["task_id"] == "explain.v1"
+    assert task_request["context"]["payload"]["ai_evidence_input"] == manage_payload
+    assert task_request["context"]["payload"]["memo_request"] == response.memo_request
+    assert task_request["context"]["payload"]["supportability"]["blocked_actions"] == [
+        "place_orders",
+        "approve_rebalance",
+        "override_controls",
+        "invent_missing_evidence",
+        "contact_client",
+    ]
+    assert task_request["context"]["source_refs"] == [
+        "lotus-manage:proof-pack-ai-evidence:ai-evidence:dpp_rr_001",
+        "lotus-manage:proof-pack-ai-evidence:dpp_rr_001",
+        "lotus-manage:proof-pack:dpp_rr_001",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_proof_pack_pm_memo_requires_lotus_ai_client() -> None:
+    service = DpmProofPackService(dpm_client=_FakeDpmClient((200, {})))  # type: ignore[arg-type]
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.request_proof_pack_pm_memo(
+            proof_pack_id="dpp_rr_001",
+            request=DpmProofPackMemoRequest(),
+            correlation_id="corr-proof-pack-memo-missing-ai",
+        )
+
+    assert exc_info.value.status_code == 503
+    assert (
+        exc_info.value.detail == "lotus-ai workflow-pack execution is not configured for Gateway."
+    )
+
+
+@pytest.mark.asyncio
+async def test_dpm_proof_pack_pm_memo_preserves_lotus_ai_error() -> None:
+    service = DpmProofPackService(  # type: ignore[arg-type]
+        dpm_client=_FakeDpmClient((200, {"proof_pack_id": "dpp_rr_001"})),
+        lotus_ai_client=_FakeLotusAiClient(
+            (422, {"detail": "PROOF_PACK_PM_MEMO_GUARDRAIL_BLOCKED: missing content_hash"})
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.request_proof_pack_pm_memo(
+            proof_pack_id="dpp_rr_001",
+            request=DpmProofPackMemoRequest(),
+            correlation_id="corr-proof-pack-memo-ai-error",
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == {
+        "source_service": "lotus-ai",
+        "upstream_status": 422,
+        "error_code": "AI_PROOF_PACK_PM_MEMO_UPSTREAM_ERROR",
+        "detail": "PROOF_PACK_PM_MEMO_GUARDRAIL_BLOCKED: missing content_hash",
+    }
 
 
 @pytest.mark.asyncio

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -24,6 +24,7 @@
 - `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`
 - `GET` and `POST /api/v1/dpm/command-center/construction/alternative-sets*`
 - `GET` and `POST /api/v1/dpm/command-center/proof-packs*`
+- `POST /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-pm-memo`
 - `GET` and `POST /api/v1/workbench/*`
 - `GET` and `POST /api/v1/reports/*`
 - `POST /api/v1/reports/outcome-reviews`
@@ -66,10 +67,13 @@
   freshness and supportability without direct service coupling
 - RFC-0098 proof-pack composition consumes `lotus-manage` RFC-0040 proof-pack APIs through
   `/api/v1/dpm/command-center/proof-packs*`. Gateway exposes generate, get, Markdown,
-  report-input, and AI-evidence-input routes for Workbench, preserving manage `proof_pack_id`,
-  section states, reason codes, content hashes, source hashes, source refs, report refs, and AI
-  refs. Gateway must not build proof-pack sections, recalculate hashes, infer source readiness,
-  render reports, generate AI narrative, or treat `lotus-report` as proof-pack authority.
+  report-input, AI-evidence-input, and AI PM memo routes for Workbench, preserving manage
+  `proof_pack_id`, section states, reason codes, content hashes, source hashes, source refs,
+  report refs, and AI refs. The AI PM memo action reads manage-owned
+  `DpmProofPackAiEvidenceInput` and calls `lotus-ai` `dpm_pm_memo.pack@v1` as `lotus-gateway`.
+  Gateway must not build proof-pack sections, recalculate hashes, infer source readiness, render
+  reports, generate AI narrative or PM memos locally, score PMs, approve trades, contact clients,
+  place orders, or treat `lotus-report` as proof-pack authority.
   `lotus-report` remains report materialization authority, not proof-pack authority.
 - RFC-0098 construction-alternative composition consumes `lotus-manage` RFC-0039 construction
   APIs through `/api/v1/dpm/command-center/construction/alternative-sets*`. Gateway exposes
@@ -315,6 +319,15 @@ curl -X POST "http://127.0.0.1:8111/api/v1/dpm/command-center/outcome-reviews/or
   -H "Content-Type: application/json" \
   -H "X-Correlation-Id: corr-rfc42-outcome-review-ai-narrative" \
   -d "{\"requested_outputs\":[\"pm_summary\",\"cio_summary\",\"control_summary\",\"evidence_gaps\"],\"audience\":[\"portfolio_manager\",\"cio_office\",\"investment_control\"]}"
+```
+
+DPM proof-pack AI PM memo handoff:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/dpm/command-center/proof-packs/dpp_rr_001/ai-pm-memo" \
+  -H "Content-Type: application/json" \
+  -H "X-Correlation-Id: corr-rfc40-proof-pack-ai-pm-memo" \
+  -d "{\"requested_outputs\":[\"pm_memo\",\"rationale_summary\",\"evidence_gaps\"],\"audience\":[\"portfolio_manager\",\"investment_control\"]}"
 ```
 
 DPM rebalance-wave create:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -104,10 +104,14 @@
     `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/summary.md`,
     `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/report-input`, and
     `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-evidence-input` for Workbench.
+    Gateway also exposes
+    `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-pm-memo` as a governed handoff to
+    `lotus-ai` `dpm_pm_memo.pack@v1` after reading manage-owned proof-pack AI evidence input.
     Gateway forwards request bodies, idempotency keys, and correlation context to manage, then
     preserves proof-pack identity, section states, reason codes, content hashes, source hashes,
-    source refs, report refs, and AI refs without generating proof sections, recalculating hashes,
-    rendering reports, or generating AI narrative.
+    source refs, report refs, AI refs, and lotus-ai workflow-pack run posture without generating
+    proof sections, recalculating hashes, rendering reports, generating PM memos locally, or
+    generating AI narrative.
 14. RFC-0041 rebalance waves remain `lotus-manage` truth. Gateway wave realization exposes
     `/api/v1/dpm/command-center/waves*` for Workbench. Gateway forwards request bodies,
     idempotency keys, query filters, and correlation context to manage, then preserves wave ids,

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -71,6 +71,7 @@ Supported routes:
 3. `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/summary.md`
 4. `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/report-input`
 5. `GET /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-evidence-input`
+6. `POST /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-pm-memo`
 
 Authority and integrations:
 
@@ -80,9 +81,11 @@ Authority and integrations:
 3. Gateway preserves manage-owned `proof_pack_id`, section states, reason codes, `content_hash`,
    `source_hashes`, source refs, report refs, AI refs, deterministic Markdown, report-input
    payloads, and AI-evidence payloads.
-4. Gateway does not generate proof-pack sections, recalculate hashes, infer source readiness,
-   render reports, archive documents, generate AI narrative, or treat `lotus-report` as
-   proof-pack authority.
+4. Gateway reads manage-owned `DpmProofPackAiEvidenceInput` before requesting `lotus-ai`
+   `dpm_pm_memo.pack@v1`, and preserves the resulting workflow-pack run posture for Workbench.
+5. Gateway does not generate proof-pack sections, recalculate hashes, infer source readiness,
+   render reports, archive documents, generate AI narrative or PM memos locally, score PMs,
+   approve trades, contact clients, place orders, or treat `lotus-report` as proof-pack authority.
 
 ```mermaid
 flowchart LR
@@ -92,6 +95,8 @@ flowchart LR
     Manage --> Gateway
     Gateway --> ReportInput[report-input payload for lotus-report handoff]
     Gateway --> AiInput[AI-evidence input for lotus-ai handoff]
+    Gateway --> LotusAI[lotus-ai dpm_pm_memo.pack]
+    LotusAI --> Gateway
     Gateway --> Workbench
 ```
 
@@ -103,6 +108,9 @@ Operational behavior:
    can render it without owning proof-pack generation,
 3. degraded or unavailable manage states are surfaced using product-safe Gateway error detail and
    must remain visible to Workbench supportability UI.
+4. lotus-ai guardrail rejections are preserved as product-safe Gateway error detail with
+   `AI_PROOF_PACK_PM_MEMO_UPSTREAM_ERROR`, so Workbench can show review/supportability posture
+   without falling back to browser prompt construction.
 
 ## DPM Rebalance-Wave Composition
 


### PR DESCRIPTION
## Summary
- add Gateway proof-pack PM memo handoff route for RFC40-WTBD-005
- read manage-owned DpmProofPackAiEvidenceInput and execute lotus-ai dpm_pm_memo.pack@v1 as lotus-gateway
- preserve manage evidence authority, lotus-ai workflow-pack posture, guardrail error detail, OpenAPI docs, README, RFC, and wiki truth

## Proof
- make check
- python -m pytest tests/unit/test_dpm_proof_pack_service.py tests/integration/test_dpm_proof_pack_router.py tests/contract/test_dpm_proof_pack_contract.py -q
- git diff --check
- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway (expected pre-merge drift: API-Surface.md, Integrations.md, Supported-Features.md)

## Boundaries
- Gateway does not generate PM memos locally, score PMs, approve trades, contact clients, place orders, or invent evidence.
- Workbench product consumption remains the next slice after this Gateway slice is merged and wiki-published.