### PR TITLE
Add DPM wave AI memo gateway handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-pm-memo`,
   `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`,
   `/api/v1/dpm/command-center/waves*`,
+  `/api/v1/dpm/command-center/waves/{wave_id}/report-input`,
+  `/api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`,
   `/api/v1/dpm/command-center/outcome-reviews*`,
   `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`,
   `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
@@ -271,8 +273,11 @@ Important current parameter conventions:
 15. DPM command-center wave routes under `/api/v1/dpm/command-center/waves*` consume
    `lotus-manage` RFC-0041 rebalance-wave APIs and preserve manage-owned `wave_id`, lifecycle
    state, item states, aggregate metrics, selected alternative refs, proof-pack refs, handoff refs,
-   supportability, and reason codes without calculating affected portfolios, source readiness,
-   alternatives, proof-pack state, or execution posture locally
+   supportability, report-input evidence, and reason codes without calculating affected portfolios,
+   source readiness, alternatives, proof-pack state, report evidence, or execution posture locally.
+   Gateway also exposes a governed `dpm_wave_pm_memo.pack@v1` handoff to `lotus-ai` from
+   manage-owned wave report input; it does not generate memo narrative, score PMs, approve trades,
+   contact clients, place orders, or invent missing evidence.
 16. DPM portfolio-memory route
    `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory` consumes `lotus-manage`
    RFC-0040/RFC-0041/RFC-0042 portfolio-memory truth and preserves event order, event type
@@ -295,7 +300,7 @@ Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
   platform capabilities, RFC-0039 construction alternative-set generate/get/select APIs,
   RFC-0040/RFC-0041/RFC-0042 portfolio-memory read APIs,
   RFC-0041 rebalance-wave preview/create/search/detail/items/source-check/simulate/select/approve/
-  stage/handoff/cancel/proof-pack/supportability APIs, and RFC-0042 outcome-review
+  stage/handoff/cancel/proof-pack/supportability/report-input APIs, and RFC-0042 outcome-review
   preview/create/search/detail/source-refresh, supportability, report-input, AI-evidence, run
   lookup, and wave lookup
 - contract rule:

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -232,12 +232,16 @@ Most relevant current governance:
 15. RFC-0041 rebalance-wave Gateway routes are active under
     `/api/v1/dpm/command-center/waves*`. Gateway forwards preview, durable create, search, detail,
     item list, source-check, simulation, item selection, approval, staging, internal handoff,
-    cancellation, proof-pack posture, and supportability requests to `lotus-manage`; preserves
-    manage-owned `wave_id`, lifecycle state, item states, reason codes, aggregate metrics,
-    selected alternative refs, proof-pack refs, handoff refs, supportability issues, and
-    `external_execution_claimed=false`; and must not calculate affected portfolios, classify
-    source readiness, generate alternatives, select alternatives, approve items, stage items,
-    create handoff evidence, rebuild proof packs, or claim external execution locally.
+    cancellation, proof-pack posture, supportability, and report-input requests to `lotus-manage`;
+    preserves manage-owned `wave_id`, lifecycle state, item states, reason codes, aggregate
+    metrics, selected alternative refs, proof-pack refs, handoff refs, supportability issues,
+    report-input evidence, and `external_execution_claimed=false`; and must not calculate affected
+    portfolios, classify source readiness, generate alternatives, select alternatives, approve
+    items, stage items, create handoff evidence, rebuild proof packs, generate report evidence, or
+    claim external execution locally. Gateway can request `lotus-ai`
+    `dpm_wave_pm_memo.pack@v1` from manage-owned wave report input as a review-required PM/control
+    support artifact, but it must not generate AI narrative locally, score PMs, approve trades,
+    contact clients, place orders, or invent missing evidence.
 16. The Workbench overview and portfolio-360 `rebalance_snapshot` now carry bounded
     portfolio-level DPM operations posture for RFC36-WTBD-003: latest rebalance status, last run,
     manage action-register supportability from `/api/v1/rebalance/supportability/summary`, and up

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -480,6 +480,18 @@ class DpmClient:
             operation="manage.rebalance.waves.supportability",
         )
 
+    async def get_wave_report_input(
+        self,
+        wave_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/waves/{wave_id}/report-input",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.report_input",
+        )
+
     async def generate_construction_alternative_set(
         self,
         body: dict[str, Any],

--- a/src/app/contracts/dpm_waves.py
+++ b/src/app/contracts/dpm_waves.py
@@ -32,6 +32,36 @@ class DpmWaveCreateRequest(DpmWaveForwardRequest):
     )
 
 
+class DpmWaveMemoRequest(BaseModel):
+    requested_outputs: list[str] = Field(
+        default_factory=lambda: [
+            "wave_pm_memo",
+            "wave_rationale_summary",
+            "approval_checklist",
+            "risk_caveats",
+            "operations_handoff",
+            "evidence_gaps",
+        ],
+        min_length=1,
+        description=(
+            "Bounded support-only outputs requested from lotus-ai dpm_wave_pm_memo.pack@v1. "
+            "Gateway forwards these labels as caller intent and does not allow outputs that "
+            "approve trades, place orders, contact clients, score PMs, or invent missing evidence."
+        ),
+        examples=[["wave_pm_memo", "approval_checklist", "evidence_gaps"]],
+    )
+    audience: list[str] = Field(
+        default_factory=lambda: ["portfolio_manager", "investment_control", "operations"],
+        min_length=1,
+        description=(
+            "Intended human review audiences for the generated support memo. The lotus-ai pack "
+            "still returns review-required evidence text; Gateway does not route the output to "
+            "clients or operational execution systems."
+        ),
+        examples=[["portfolio_manager", "investment_control", "operations"]],
+    )
+
+
 class DpmWaveSupportability(BaseModel):
     source_service: str = Field(
         default="lotus-manage",
@@ -127,6 +157,74 @@ class DpmWaveGatewayResponse(BaseModel):
                 "durable": True,
             }
         ],
+    )
+
+
+class DpmWaveMemoGatewayResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated across Gateway, lotus-manage, and lotus-ai.",
+        examples=["corr-rfc41-wave-ai-pm-memo"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway BFF contract version for DPM wave AI memo handoff responses.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        default="lotus-ai",
+        description="Service that executed the governed workflow-pack run.",
+        examples=["lotus-ai"],
+    )
+    evidence_source_service: str = Field(
+        default="lotus-manage",
+        description="Service that supplied the authoritative wave report-input evidence.",
+        examples=["lotus-manage"],
+    )
+    manage_upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage for the wave report-input request.",
+        examples=[200],
+    )
+    ai_upstream_status: int = Field(
+        description="HTTP status returned by lotus-ai for workflow-pack execution.",
+        examples=[200],
+    )
+    supportability: DpmWaveSupportability = Field(
+        description=(
+            "Gateway-normalized supportability summary derived only from manage-published wave "
+            "report-input fields and carried into the lotus-ai guardrail request."
+        )
+    )
+    wave_report_input: dict[str, object] = Field(
+        description=(
+            "Authoritative manage DpmWaveReportInput payload preserved for traceability. Gateway "
+            "does not rewrite item evidence, source refs, hashes, approval posture, or proof-pack "
+            "posture before calling lotus-ai."
+        ),
+        examples=[
+            {
+                "wave_id": "dwv_001",
+                "report_input_ref": "report-input:dwv_001",
+                "source_refs": ["lotus-manage:wave:dwv_001"],
+            }
+        ],
+    )
+    memo_request: dict[str, object] = Field(
+        description=(
+            "Bounded caller intent sent to lotus-ai. This object is support-only and excludes "
+            "trade approval, order placement, client contact, PM scoring, and evidence invention."
+        ),
+        examples=[
+            {
+                "requested_outputs": ["wave_pm_memo", "approval_checklist"],
+                "audience": ["portfolio_manager", "investment_control"],
+            }
+        ],
+    )
+    data: dict[str, object] = Field(
+        description=(
+            "lotus-ai workflow-pack execution response. Gateway preserves the AI authority "
+            "payload and does not post-process generated memo content into execution actions."
+        )
     )
 
 

--- a/src/app/routers/dpm_waves.py
+++ b/src/app/routers/dpm_waves.py
@@ -3,12 +3,15 @@ from typing import Any
 from fastapi import APIRouter, Path, Query
 
 from app.clients.dpm_client import DpmClient
+from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_waves import (
     DpmWaveCreateRequest,
     DpmWaveErrorDetail,
     DpmWaveForwardRequest,
     DpmWaveGatewayResponse,
+    DpmWaveMemoGatewayResponse,
+    DpmWaveMemoRequest,
 )
 from app.middleware.correlation import correlation_id_var
 from app.services.dpm_wave_service import DpmWaveService
@@ -42,6 +45,12 @@ def _dpm_wave_service() -> DpmWaveService:
         dpm_client=DpmClient(
             base_url=settings.management_service_base_url,
             timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        ),
+        lotus_ai_client=LotusAiClient(
+            base_url=settings.ai_service_base_url,
+            timeout_seconds=settings.ai_service_timeout_seconds,
             max_retries=settings.upstream_max_retries,
             retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
         ),
@@ -374,5 +383,56 @@ async def get_wave_supportability(
 ) -> DpmWaveGatewayResponse:
     return await _dpm_wave_service().get_wave_supportability(
         wave_id=wave_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/{wave_id}/report-input",
+    response_model=DpmWaveGatewayResponse,
+    summary="Get DPM wave report input",
+    description=(
+        "What: returns manage-owned deterministic report-input evidence for one RFC-0041 wave. "
+        "When: call this before report composition or AI memo support for PM/CIO wave review. "
+        "How: Gateway preserves the DpmWaveReportInput payload, source refs, hashes, item "
+        "posture, approval posture, and proof-pack posture without rendering reports or "
+        "reconstructing evidence."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def get_wave_report_input(
+    wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
+) -> DpmWaveGatewayResponse:
+    return await _dpm_wave_service().get_wave_report_input(
+        wave_id=wave_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{wave_id}/ai-pm-memo",
+    response_model=DpmWaveMemoGatewayResponse,
+    summary="Request DPM wave AI PM memo",
+    description=(
+        "What: requests a governed lotus-ai PM memo workflow-pack run from manage-owned "
+        "DPM wave report input. When: call this after manage supportability and wave evidence "
+        "are available and the user needs review-gated PM/control support text. How: Gateway "
+        "first reads manage's DpmWaveReportInput, then executes lotus-ai "
+        "dpm_wave_pm_memo.pack@v1 as lotus-gateway; Gateway does not generate narrative, score "
+        "PMs, approve trades, contact clients, place orders, or invent evidence."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def request_wave_pm_memo(
+    request: DpmWaveMemoRequest,
+    wave_id: str = Path(
+        ...,
+        description="Manage-owned rebalance-wave identifier for the bounded AI handoff.",
+        examples=["dwv_001"],
+    ),
+) -> DpmWaveMemoGatewayResponse:
+    return await _dpm_wave_service().request_wave_pm_memo(
+        wave_id=wave_id,
+        request=request,
         correlation_id=correlation_id_var.get(),
     )

--- a/src/app/services/dpm_wave_service.py
+++ b/src/app/services/dpm_wave_service.py
@@ -3,17 +3,35 @@ from typing import Any
 from fastapi import HTTPException, status
 
 from app.clients.dpm_client import DpmClient
+from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_waves import (
     DpmWaveErrorDetail,
     DpmWaveGatewayResponse,
+    DpmWaveMemoGatewayResponse,
+    DpmWaveMemoRequest,
     DpmWaveSupportability,
 )
 
+_WAVE_PM_MEMO_BLOCKED_ACTIONS = [
+    "place_orders",
+    "approve_rebalance",
+    "override_controls",
+    "invent_missing_evidence",
+    "contact_client",
+]
+_WAVE_PM_MEMO_UNSUPPORTED_CLAIMS = [
+    "client_contact",
+    "trade_approval",
+    "portfolio_manager_scoring",
+    "execution_instruction",
+]
+
 
 class DpmWaveService:
-    def __init__(self, dpm_client: DpmClient):
+    def __init__(self, dpm_client: DpmClient, lotus_ai_client: LotusAiClient | None = None):
         self._dpm_client = dpm_client
+        self._lotus_ai_client = lotus_ai_client
 
     async def preview_wave(
         self,
@@ -187,6 +205,99 @@ class DpmWaveService:
         )
         return self._compose_response(upstream_status, upstream_payload, correlation_id)
 
+    async def get_wave_report_input(
+        self,
+        wave_id: str,
+        correlation_id: str,
+    ) -> DpmWaveGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_wave_report_input(
+            wave_id=wave_id,
+            correlation_id=correlation_id,
+        )
+        return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def request_wave_pm_memo(
+        self,
+        wave_id: str,
+        request: DpmWaveMemoRequest,
+        correlation_id: str,
+    ) -> DpmWaveMemoGatewayResponse:
+        if self._lotus_ai_client is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="lotus-ai workflow-pack execution is not configured for Gateway.",
+            )
+
+        manage_status, manage_payload = await self._dpm_client.get_wave_report_input(
+            wave_id=wave_id,
+            correlation_id=correlation_id,
+        )
+        if manage_status >= status.HTTP_400_BAD_REQUEST:
+            raise self._upstream_error(manage_status, manage_payload)
+
+        supportability = _supportability_from(manage_payload)
+        memo_request: dict[str, object] = {
+            "requested_outputs": request.requested_outputs,
+            "audience": request.audience,
+        }
+        task_payload = {
+            "wave_report_input": manage_payload,
+            "memo_request": memo_request,
+            "supportability": {
+                "source_state": supportability.state,
+                "reason_codes": supportability.reason_codes,
+                "blocked_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
+                "requires_human_review": True,
+                "unsupported_claims": _WAVE_PM_MEMO_UNSUPPORTED_CLAIMS,
+            },
+        }
+        ai_status, ai_payload = await self._lotus_ai_client.execute_workflow_pack(
+            pack_id="dpm_wave_pm_memo.pack",
+            version="v1",
+            environment="DEVELOPMENT",
+            caller_identity_class="INTERNAL_SERVICE",
+            workflow_surface="dpm-wave-ai-evidence",
+            task_request={
+                "task_id": "explain.v1",
+                "input_mode": "STRUCTURED_CONTEXT",
+                "caller": {
+                    "caller_app": "lotus-gateway",
+                    "correlation_id": correlation_id,
+                },
+                "context": {
+                    "summary": (
+                        "Generate review-gated DPM wave PM memo from manage-owned report input "
+                        f"for {wave_id}."
+                    ),
+                    "payload": task_payload,
+                    "source_refs": _wave_report_source_refs(manage_payload, wave_id),
+                },
+                "expected_output_label": "EXPLANATION_ONLY",
+            },
+            correlation_id=correlation_id,
+        )
+        if ai_status >= status.HTTP_400_BAD_REQUEST:
+            raise HTTPException(
+                status_code=ai_status,
+                detail={
+                    "source_service": "lotus-ai",
+                    "upstream_status": ai_status,
+                    "error_code": "AI_WAVE_PM_MEMO_UPSTREAM_ERROR",
+                    "detail": _safe_upstream_detail(ai_payload),
+                },
+            )
+
+        return DpmWaveMemoGatewayResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            manage_upstream_status=manage_status,
+            ai_upstream_status=ai_status,
+            supportability=supportability,
+            wave_report_input=manage_payload,
+            memo_request=memo_request,
+            data=ai_payload,
+        )
+
     def _compose_response(
         self,
         upstream_status: int,
@@ -194,14 +305,7 @@ class DpmWaveService:
         correlation_id: str,
     ) -> DpmWaveGatewayResponse:
         if upstream_status >= status.HTTP_400_BAD_REQUEST:
-            raise HTTPException(
-                status_code=upstream_status,
-                detail=DpmWaveErrorDetail(
-                    upstream_status=upstream_status,
-                    error_code="MANAGE_WAVE_UPSTREAM_ERROR",
-                    detail=_safe_upstream_detail(upstream_payload),
-                ).model_dump(),
-            )
+            raise self._upstream_error(upstream_status, upstream_payload)
 
         return DpmWaveGatewayResponse(
             correlation_id=correlation_id,
@@ -209,6 +313,20 @@ class DpmWaveService:
             upstream_status=upstream_status,
             supportability=_supportability_from(upstream_payload),
             data=upstream_payload,
+        )
+
+    def _upstream_error(
+        self,
+        upstream_status: int,
+        upstream_payload: dict[str, Any],
+    ) -> HTTPException:
+        return HTTPException(
+            status_code=upstream_status,
+            detail=DpmWaveErrorDetail(
+                upstream_status=upstream_status,
+                error_code="MANAGE_WAVE_UPSTREAM_ERROR",
+                detail=_safe_upstream_detail(upstream_payload),
+            ).model_dump(),
         )
 
 
@@ -283,6 +401,23 @@ def _safe_str(value: object) -> str | None:
     if value is None:
         return None
     return str(value)
+
+
+def _wave_report_source_refs(payload: dict[str, Any], wave_id: str) -> list[str]:
+    refs = set(_list_of_strings(payload.get("source_refs") or payload.get("sourceRefs") or []))
+    report_input_ref = payload.get("report_input_ref") or payload.get("reportInputRef")
+    if report_input_ref:
+        refs.add(f"lotus-manage:wave-report-input:{_source_ref_token(report_input_ref)}")
+    payload_wave_id = payload.get("wave_id") or payload.get("waveId")
+    if payload_wave_id:
+        refs.add(f"lotus-manage:wave:{payload_wave_id}")
+    refs.add(f"lotus-manage:wave-report-input:{wave_id}")
+    return sorted(refs)
+
+
+def _source_ref_token(value: object) -> str:
+    token = str(value)
+    return token.removeprefix("report-input:")
 
 
 def _safe_upstream_detail(payload: dict[str, Any]) -> str:

--- a/tests/contract/test_dpm_wave_contract.py
+++ b/tests/contract/test_dpm_wave_contract.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from app.contracts.dpm_waves import DpmWaveGatewayResponse
+from app.contracts.dpm_waves import DpmWaveGatewayResponse, DpmWaveMemoGatewayResponse
 from app.main import app
 
 
@@ -31,6 +31,29 @@ def test_dpm_wave_gateway_response_contract_shape() -> None:
     assert response.data["wave"]["state"] == "HANDOFF_READY"
 
 
+def test_dpm_wave_memo_gateway_response_contract_shape() -> None:
+    response = DpmWaveMemoGatewayResponse(
+        correlation_id="corr-wave-ai-memo",
+        manage_upstream_status=200,
+        ai_upstream_status=200,
+        supportability={"state": "ready", "reason_codes": ["wave_report_input_ready"]},
+        wave_report_input={
+            "wave_id": "dwv_001",
+            "report_input_ref": "report-input:dwv_001",
+        },
+        memo_request={
+            "requested_outputs": ["wave_pm_memo", "approval_checklist"],
+            "audience": ["portfolio_manager", "investment_control"],
+        },
+        data={"run_id": "wf_run_wave_memo_001", "status": "REVIEW_REQUIRED"},
+    )
+
+    assert response.source_service == "lotus-ai"
+    assert response.evidence_source_service == "lotus-manage"
+    assert response.supportability.authority == "lotus-manage:RFC-0041"
+    assert response.wave_report_input["wave_id"] == "dwv_001"
+
+
 def test_dpm_wave_openapi_contract_registered() -> None:
     client = TestClient(app)
     spec = client.get("/openapi.json").json()
@@ -49,6 +72,8 @@ def test_dpm_wave_openapi_contract_registered() -> None:
         ("/api/v1/dpm/command-center/waves/{wave_id}/cancel", "post"),
         ("/api/v1/dpm/command-center/waves/{wave_id}/proof-pack", "get"),
         ("/api/v1/dpm/command-center/waves/{wave_id}/supportability", "get"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/report-input", "get"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo", "post"),
     ]
 
     for path, method in expected_paths:
@@ -70,6 +95,8 @@ def test_dpm_wave_openapi_models_are_described() -> None:
         "DpmWaveCreateRequest",
         "DpmWaveForwardRequest",
         "DpmWaveGatewayResponse",
+        "DpmWaveMemoGatewayResponse",
+        "DpmWaveMemoRequest",
         "DpmWaveSupportability",
         "DpmWaveErrorDetail",
     ]:

--- a/tests/integration/test_dpm_wave_router.py
+++ b/tests/integration/test_dpm_wave_router.py
@@ -202,3 +202,95 @@ def test_dpm_wave_error_is_not_marked_ready(monkeypatch) -> None:
     assert response.status_code == 404
     assert response.json()["detail"]["error_code"] == "MANAGE_WAVE_UPSTREAM_ERROR"
     assert response.json()["detail"]["detail"] == "Wave dwv_missing was not found."
+
+
+def test_dpm_wave_report_input_preserves_manage_evidence(monkeypatch) -> None:
+    async def _fake_get_wave_report_input(self, wave_id, correlation_id):  # noqa: ANN001
+        _ = self
+        return 200, {
+            "wave_id": wave_id,
+            "report_input_ref": f"report-input:{wave_id}",
+            "source_refs": [f"lotus-manage:wave:{wave_id}"],
+            "supportability": {
+                "supportability_state": "ready",
+                "reason_codes": ["wave_report_input_ready"],
+            },
+            "correlation_id": correlation_id,
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_wave_report_input",
+        _fake_get_wave_report_input,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/dpm/command-center/waves/dwv_001/report-input",
+        headers={"X-Correlation-Id": "corr-wave-router-report-input"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["supportability"]["state"] == "ready"
+    assert payload["data"]["report_input_ref"] == "report-input:dwv_001"
+    assert payload["data"]["correlation_id"] == "corr-wave-router-report-input"
+
+
+def test_dpm_wave_ai_pm_memo_uses_lotus_ai_workflow_pack(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_get_wave_report_input(self, wave_id, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["manage_wave_id"] = wave_id
+        captured["manage_correlation_id"] = correlation_id
+        return 200, {
+            "wave_id": wave_id,
+            "report_input_ref": f"report-input:{wave_id}",
+            "source_refs": [f"lotus-manage:wave:{wave_id}"],
+            "supportability": {
+                "supportability_state": "ready",
+                "reason_codes": ["wave_report_input_ready"],
+            },
+        }
+
+    async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN001, ANN003
+        _ = self
+        captured["ai_kwargs"] = kwargs
+        return 200, {"run_id": "wf_run_wave_memo_001", "status": "REVIEW_REQUIRED"}
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_wave_report_input",
+        _fake_get_wave_report_input,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_ai_client.LotusAiClient.execute_workflow_pack",
+        _fake_execute_workflow_pack,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/waves/dwv_001/ai-pm-memo",
+        json={
+            "requested_outputs": ["wave_pm_memo", "approval_checklist"],
+            "audience": ["portfolio_manager", "investment_control"],
+        },
+        headers={"X-Correlation-Id": "corr-wave-router-ai-memo"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source_service"] == "lotus-ai"
+    assert payload["evidence_source_service"] == "lotus-manage"
+    assert payload["wave_report_input"]["report_input_ref"] == "report-input:dwv_001"
+    assert payload["memo_request"]["requested_outputs"] == [
+        "wave_pm_memo",
+        "approval_checklist",
+    ]
+    ai_kwargs = captured["ai_kwargs"]
+    assert ai_kwargs["pack_id"] == "dpm_wave_pm_memo.pack"
+    assert ai_kwargs["workflow_surface"] == "dpm-wave-ai-evidence"
+    assert ai_kwargs["correlation_id"] == "corr-wave-router-ai-memo"
+    assert ai_kwargs["task_request"]["caller"]["caller_app"] == "lotus-gateway"
+    supportability = ai_kwargs["task_request"]["context"]["payload"]["supportability"]
+    assert supportability["requires_human_review"] is True
+    assert "approve_rebalance" in supportability["blocked_actions"]

--- a/tests/unit/test_dpm_wave_service.py
+++ b/tests/unit/test_dpm_wave_service.py
@@ -1,6 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
+from app.contracts.dpm_waves import DpmWaveMemoRequest
 from app.services.dpm_wave_service import DpmWaveService
 
 
@@ -39,6 +40,26 @@ class _FakeDpmClient:
                 "correlation_id": correlation_id,
             }
         )
+        return self.result
+
+    async def get_wave_report_input(self, wave_id, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "get_wave_report_input",
+                "wave_id": wave_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+
+class _FakeLotusAiClient:
+    def __init__(self, result: tuple[int, dict]):
+        self.result = result
+        self.calls: list[dict[str, object]] = []
+
+    async def execute_workflow_pack(self, **kwargs):  # noqa: ANN003
+        self.calls.append(kwargs)
         return self.result
 
 
@@ -162,4 +183,132 @@ async def test_dpm_wave_service_manage_errors_are_product_safe() -> None:
         "detail": (
             "DPM_WAVE_INVALID_TRANSITION: Wave dwv_001 cannot be approved from state DRAFT."
         ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_dpm_wave_service_exposes_manage_report_input_without_rebuilding() -> None:
+    manage_payload = {
+        "wave_id": "dwv_001",
+        "report_input_ref": "report-input:dwv_001",
+        "source_refs": ["lotus-manage:wave:dwv_001"],
+        "supportability": {
+            "supportability_state": "ready",
+            "reason_codes": ["wave_report_input_ready"],
+            "item_count": 1,
+        },
+    }
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmWaveService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.get_wave_report_input(
+        wave_id="dwv_001",
+        correlation_id="corr-wave-report-input",
+    )
+
+    assert response.supportability.state == "ready"
+    assert response.supportability.reason_codes == ["wave_report_input_ready"]
+    assert response.data == manage_payload
+    assert client.calls == [
+        {
+            "method": "get_wave_report_input",
+            "wave_id": "dwv_001",
+            "correlation_id": "corr-wave-report-input",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_wave_pm_memo_uses_manage_report_input_and_lotus_ai_pack() -> None:
+    manage_payload = {
+        "wave_id": "dwv_001",
+        "report_input_ref": "report-input:dwv_001",
+        "source_refs": ["lotus-manage:source-check:dwv_001"],
+        "supportability": {
+            "supportability_state": "ready",
+            "reason_codes": ["wave_report_input_ready"],
+            "item_count": 1,
+        },
+    }
+    ai_payload = {
+        "run_id": "wf_run_wave_memo_001",
+        "output": {"review_required": True, "memo_sections": ["PM summary"]},
+    }
+    dpm_client = _FakeDpmClient((200, manage_payload))
+    ai_client = _FakeLotusAiClient((200, ai_payload))
+    service = DpmWaveService(
+        dpm_client=dpm_client,  # type: ignore[arg-type]
+        lotus_ai_client=ai_client,  # type: ignore[arg-type]
+    )
+
+    response = await service.request_wave_pm_memo(
+        wave_id="dwv_001",
+        request=DpmWaveMemoRequest(
+            requested_outputs=["wave_pm_memo", "approval_checklist"],
+            audience=["portfolio_manager", "investment_control"],
+        ),
+        correlation_id="corr-wave-ai-memo",
+    )
+
+    assert response.source_service == "lotus-ai"
+    assert response.evidence_source_service == "lotus-manage"
+    assert response.manage_upstream_status == 200
+    assert response.ai_upstream_status == 200
+    assert response.wave_report_input == manage_payload
+    assert response.memo_request == {
+        "requested_outputs": ["wave_pm_memo", "approval_checklist"],
+        "audience": ["portfolio_manager", "investment_control"],
+    }
+    assert response.data == ai_payload
+    ai_call = ai_client.calls[0]
+    assert ai_call["pack_id"] == "dpm_wave_pm_memo.pack"
+    assert ai_call["version"] == "v1"
+    assert ai_call["workflow_surface"] == "dpm-wave-ai-evidence"
+    task_request = ai_call["task_request"]
+    assert task_request["caller"] == {
+        "caller_app": "lotus-gateway",
+        "correlation_id": "corr-wave-ai-memo",
+    }
+    assert task_request["expected_output_label"] == "EXPLANATION_ONLY"
+    payload = task_request["context"]["payload"]
+    assert payload["wave_report_input"] == manage_payload
+    assert payload["supportability"]["requires_human_review"] is True
+    assert "place_orders" in payload["supportability"]["blocked_actions"]
+    assert "trade_approval" in payload["supportability"]["unsupported_claims"]
+    assert task_request["context"]["source_refs"] == [
+        "lotus-manage:source-check:dwv_001",
+        "lotus-manage:wave-report-input:dwv_001",
+        "lotus-manage:wave:dwv_001",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_wave_pm_memo_ai_errors_are_product_safe() -> None:
+    dpm_client = _FakeDpmClient(
+        (
+            200,
+            {
+                "wave_id": "dwv_001",
+                "supportability": {"supportability_state": "ready"},
+            },
+        )
+    )
+    service = DpmWaveService(
+        dpm_client=dpm_client,  # type: ignore[arg-type]
+        lotus_ai_client=_FakeLotusAiClient((503, {"detail": "workflow pack unavailable"})),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.request_wave_pm_memo(
+            wave_id="dwv_001",
+            request=DpmWaveMemoRequest(),
+            correlation_id="corr-wave-ai-error",
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == {
+        "source_service": "lotus-ai",
+        "upstream_status": 503,
+        "error_code": "AI_WAVE_PM_MEMO_UPSTREAM_ERROR",
+        "detail": "workflow pack unavailable",
     }

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1690,6 +1690,11 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
             {"wave_id": "dwv_001", "correlation_id": "corr-5"},
             "http://dpm/api/v1/rebalance/waves/dwv_001/supportability",
         ),
+        (
+            "get_wave_report_input",
+            {"wave_id": "dwv_001", "correlation_id": "corr-5"},
+            "http://dpm/api/v1/rebalance/waves/dwv_001/report-input",
+        ),
     ],
 )
 async def test_dpm_client_manage_routes(method_name, kwargs, expected_url):
@@ -1886,6 +1891,10 @@ async def test_dpm_client_uses_only_canonical_manage_api_v1_contracts():
         ),
         (
             client.get_wave_supportability,
+            {"wave_id": "dwv_001", "correlation_id": "corr-rfc36-canonical"},
+        ),
+        (
+            client.get_wave_report_input,
             {"wave_id": "dwv_001", "correlation_id": "corr-rfc36-canonical"},
         ),
         (

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -110,10 +110,15 @@
   posture, or error semantics locally.
 - RFC-0098 wave composition consumes `lotus-manage` RFC-0041 wave APIs for preview, create,
   search, detail, items, source-check, simulation, selection, approval, staging, handoff, cancel,
-  proof-pack posture, and supportability through `/api/v1/dpm/command-center/waves*`. Gateway now
-  exposes the implementation-backed wave BFF route family, preserves manage `wave_id`, item
-  states, aggregate metrics, selected alternative refs, proof-pack refs, handoff refs,
-  supportability issues, reason codes, and the no-external-execution boundary. Gateway must not calculate affected portfolios, readiness, alternatives, proof-pack state, or external execution posture.
+  proof-pack posture, supportability, and report input through
+  `/api/v1/dpm/command-center/waves*`. Gateway now exposes the implementation-backed wave BFF
+  route family, preserves manage `wave_id`, item states, aggregate metrics, selected alternative
+  refs, proof-pack refs, handoff refs, report-input evidence, supportability issues, reason codes,
+  and the no-external-execution boundary. Gateway also exposes a governed handoff from
+  manage-owned `DpmWaveReportInput` to `lotus-ai` `dpm_wave_pm_memo.pack@v1` for review-required
+  PM/control support text. Gateway must not calculate affected portfolios, readiness,
+  alternatives, proof-pack state, report evidence, AI narrative, PM scoring, trade approval,
+  client contact, order placement, or external execution posture.
 - RFC-0098 outcome-review composition must consume `lotus-manage` RFC-0042 outcome-review APIs
   for preview, durable create, search, detail, source refresh, supportability, report input, AI
   evidence input, run lookup, and wave lookup. Gateway now exposes the first implementation-backed
@@ -354,6 +359,22 @@ DPM rebalance-wave supportability:
 ```bash
 curl "http://127.0.0.1:8111/api/v1/dpm/command-center/waves/dwv_001/supportability" \
   -H "X-Correlation-Id: corr-rfc41-wave-supportability"
+```
+
+DPM rebalance-wave report input:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/dpm/command-center/waves/dwv_001/report-input" \
+  -H "X-Correlation-Id: corr-rfc41-wave-report-input"
+```
+
+DPM rebalance-wave AI PM memo:
+
+```bash
+curl -X POST "http://127.0.0.1:8111/api/v1/dpm/command-center/waves/dwv_001/ai-pm-memo" \
+  -H "Content-Type: application/json" \
+  -H "X-Correlation-Id: corr-rfc41-wave-ai-pm-memo" \
+  -d "{\"requested_outputs\":[\"wave_pm_memo\",\"approval_checklist\",\"evidence_gaps\"],\"audience\":[\"portfolio_manager\",\"investment_control\",\"operations\"]}"
 ```
 
 DPM rebalance-wave selection with proof-pack generation:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -124,9 +124,13 @@
     `/api/v1/dpm/command-center/waves*` for Workbench. Gateway forwards request bodies,
     idempotency keys, query filters, and correlation context to manage, then preserves wave ids,
     lifecycle state, item states, aggregate metrics, selected-alternative refs, proof-pack refs,
-    internal handoff refs, supportability issues, remediation routes, and no-external-execution
-    posture without discovering affected portfolios, classifying readiness, generating
-    alternatives, approving/staging locally, rebuilding proof packs, or claiming execution.
+    internal handoff refs, report-input evidence, supportability issues, remediation routes, and
+    no-external-execution posture without discovering affected portfolios, classifying readiness,
+    generating alternatives, approving/staging locally, rebuilding proof packs, generating report
+    evidence, or claiming execution. The wave AI PM memo route first reads manage-owned
+    `DpmWaveReportInput`, then calls `lotus-ai` `dpm_wave_pm_memo.pack@v1` for review-required
+    support text; Gateway does not generate narrative locally, score PMs, approve trades, contact
+    clients, place orders, or invent evidence.
 16. RFC36-WTBD-003 portfolio-level DPM operations dashboards consume Gateway Workbench
     `rebalance_snapshot` only. Gateway reads manage rebalance runs, preserves manage
     supportability summary and bounded recent-run posture, and keeps Workbench from calling

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -172,8 +172,8 @@ Business outcome:
 1. portfolio managers and CIO-office users can operate explicit portfolio-list rebalance waves
    through a stable Gateway contract instead of calling `lotus-manage` directly,
 2. operations users can inspect item-level source readiness, simulation, selection, proof-pack,
-   approval, staging, internal handoff, cancellation, and supportability posture from one product
-   route family,
+   approval, staging, internal handoff, cancellation, report-input, AI memo support, and
+   supportability posture from one product route family,
 3. sales/pre-sales and client-demo teams can describe wave orchestration as implementation-backed
    backend composition while keeping Workbench wave cockpit UI as the next owning-repository slice.
 
@@ -193,27 +193,36 @@ Supported routes:
 12. `POST /api/v1/dpm/command-center/waves/{wave_id}/cancel`
 13. `GET /api/v1/dpm/command-center/waves/{wave_id}/proof-pack`
 14. `GET /api/v1/dpm/command-center/waves/{wave_id}/supportability`
+15. `GET /api/v1/dpm/command-center/waves/{wave_id}/report-input`
+16. `POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`
 
 Authority and integrations:
 
 1. `lotus-manage` remains the RFC-0041 rebalance-wave authority.
 2. Gateway forwards preview, create, source-check, simulate, select, approve, stage, handoff,
-   cancel, proof-pack posture, and supportability requests to manage.
+   cancel, proof-pack posture, supportability, and report-input requests to manage.
 3. Gateway preserves manage-owned `wave_id`, lifecycle state, item states, reason codes,
    aggregate metrics, selected alternative refs, proof-pack refs, handoff refs, supportability
-   issues, remediation routes, and `external_execution_claimed=false`.
-4. Gateway does not calculate affected portfolios, classify source readiness, generate
+   issues, report-input evidence, remediation routes, and `external_execution_claimed=false`.
+4. Gateway reads manage-owned wave report input before calling `lotus-ai`
+   `dpm_wave_pm_memo.pack@v1` for review-required PM/control support text.
+5. Gateway does not calculate affected portfolios, classify source readiness, generate
    alternatives, select alternatives, approve items, stage items, create handoff evidence, rebuild
-   proof packs, cancel external orders, or claim external execution.
+   proof packs, generate report evidence, generate AI narrative locally, score PMs, approve trades,
+   contact clients, place orders, invent missing evidence, cancel external orders, or claim external
+   execution.
 
 ```mermaid
 flowchart LR
     Workbench[lotus-workbench future wave cockpit] --> Gateway[lotus-gateway DPM wave routes]
     Gateway --> Manage[lotus-manage RFC-0041 wave authority]
+    Gateway --> AI[lotus-ai dpm_wave_pm_memo.pack@v1]
     Manage --> Construction[lotus-manage RFC-0039 construction alternatives]
     Manage --> Proof[lotus-manage RFC-0040 proof packs]
+    Manage --> ReportInput[DpmWaveReportInput evidence]
     Manage --> Ops[Internal operations handoff evidence]
     Manage --> Gateway
+    AI --> Gateway
     Gateway --> Workbench
 ```
 
@@ -221,7 +230,9 @@ Operational behavior:
 
 1. Gateway wraps every manage response in a product envelope with manage-derived supportability,
 2. unsupported transitions and missing waves return product-safe manage error details,
-3. Workbench wave command-center UI, browser proof, and demo screenshots remain RFC41-WTBD-006 and
+3. lotus-ai failures on the wave PM memo route return product-safe `lotus-ai` error details while
+   preserving manage evidence boundaries,
+4. Workbench wave command-center UI, browser proof, and demo screenshots remain RFC41-WTBD-006 and
    are not claimed by this Gateway slice.
 
 ## DPM Mandate Command Center


### PR DESCRIPTION
## Summary
- Add Gateway route for manage-owned DPM wave report-input evidence: `GET /api/v1/dpm/command-center/waves/{wave_id}/report-input`.
- Add governed Gateway-to-lotus-ai handoff for `dpm_wave_pm_memo.pack@v1`: `POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`.
- Preserve lotus-manage authority for RFC-0041 wave truth and document the no-local-narrative, no-PM-scoring, no-trade-approval, no-client-contact, no-order-placement boundary.
- Update README, repo context, wiki source, OpenAPI/contract tests, router integration tests, service tests, and upstream-client route coverage.

## Proof
- `python -m pytest tests/unit/test_dpm_wave_service.py tests/integration/test_dpm_wave_router.py tests/contract/test_dpm_wave_contract.py tests/unit/test_upstream_clients.py tests/unit/test_rfc0098_documentation.py -q` -> 131 passed
- `make ci-local` -> passed
- `make ci` -> passed
  - lint, format, monetary float guard, mypy
  - OpenAPI gate
  - migration smoke
  - integration tests: 173 passed
  - coverage suite: 658 passed, total coverage 88.11%
  - security audit: no known vulnerabilities
- `git diff --check` -> passed with normal LF-to-CRLF warnings only
- `git branch -r --no-merged origin/main` -> no unmerged Gateway branches before closure

## Wiki
Repo-local wiki source changed in `API-Surface.md`, `Integrations.md`, and `Supported-Features.md`. Pre-merge wiki check-only shows expected drift until this PR is merged and repo wiki is published.