### PR TITLE
Add wave AI memo forbidden-action guardrails

### DIFF
--- a/src/app/services/dpm_wave_service.py
+++ b/src/app/services/dpm_wave_service.py
@@ -247,6 +247,7 @@ class DpmWaveService:
                 "source_state": supportability.state,
                 "reason_codes": supportability.reason_codes,
                 "blocked_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
+                "forbidden_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
                 "requires_human_review": True,
                 "unsupported_claims": _WAVE_PM_MEMO_UNSUPPORTED_CLAIMS,
             },

--- a/tests/unit/test_dpm_wave_service.py
+++ b/tests/unit/test_dpm_wave_service.py
@@ -274,6 +274,7 @@ async def test_dpm_wave_pm_memo_uses_manage_report_input_and_lotus_ai_pack() -> 
     assert payload["wave_report_input"] == manage_payload
     assert payload["supportability"]["requires_human_review"] is True
     assert "place_orders" in payload["supportability"]["blocked_actions"]
+    assert "place_orders" in payload["supportability"]["forbidden_actions"]
     assert "trade_approval" in payload["supportability"]["unsupported_claims"]
     assert task_request["context"]["source_refs"] == [
         "lotus-manage:source-check:dwv_001",


### PR DESCRIPTION
## Summary\n- add the AI-required forbidden_actions guardrail field to DPM wave PM memo workflow-pack payloads\n- preserve existing blocked_actions product posture for Gateway/Workbench display\n- cover the payload contract in the DPM wave service unit test\n\n## Validation\n- python -m pytest tests/unit/test_dpm_wave_service.py tests/integration/test_dpm_wave_router.py tests/contract/test_dpm_wave_contract.py -q\n- git diff --check