### PR TITLE
Preserve MWR supportability metadata in Workbench contract

### DIFF
--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-05-06T09:37:53Z",
+  "generated_at": "2026-05-10T00:31:19Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -52,28 +52,28 @@
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:103:portfolio_weight_avg_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:111:portfolio_weight_avg_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:108:benchmark_weight_avg_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:116:benchmark_weight_avg_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:113:portfolio_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:121:portfolio_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:118:benchmark_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:126:benchmark_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-06"
     },
     {
       "finding": "src/app/contracts/performance_workspace.py:12:portfolio_return_pct: float | None = None",
@@ -100,16 +100,16 @@
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:196:active_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
       "finding": "src/app/contracts/performance_workspace.py:19:begin_market_value: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-09-28"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:204:active_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
     },
     {
       "finding": "src/app/contracts/performance_workspace.py:20:end_market_value: float | None = None",
@@ -172,160 +172,166 @@
       "review_by": "2026-09-28"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:483:begin_market_value: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:44:holding_period_return_pct: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:488:end_market_value: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:491:begin_market_value: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:48:begin_market_value: float | None = None",
+      "finding": "src/app/contracts/performance_workspace.py:496:end_market_value: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-28"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:49:end_market_value: float | None = None",
+      "finding": "src/app/contracts/performance_workspace.py:511:flow_adjusted_end_market_value: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-28"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:503:flow_adjusted_end_market_value: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:526:net_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:518:net_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:531:gross_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:523:gross_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:536:portfolio_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:528:portfolio_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:541:benchmark_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:52:flow_adjusted_end_market_value: float | None = None",
+      "finding": "src/app/contracts/performance_workspace.py:548:active_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-28"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:533:benchmark_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:553:cumulative_net_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:540:active_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:558:cumulative_gross_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:545:cumulative_net_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:563:cumulative_benchmark_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:550:cumulative_gross_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:568:cumulative_active_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:555:cumulative_benchmark_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:56:begin_market_value: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:560:cumulative_active_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:573:annualized_net_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:565:annualized_net_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:578:annualized_gross_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:570:annualized_gross_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:57:end_market_value: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:575:annualized_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:583:annualized_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:61:weight_avg_pct: float | None = None",
+      "finding": "src/app/contracts/performance_workspace.py:60:flow_adjusted_end_market_value: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-28"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:62:total_return_pct: float | None = None",
+      "finding": "src/app/contracts/performance_workspace.py:69:weight_avg_pct: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-28"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:71:weight_avg_pct: float | None = None",
+      "finding": "src/app/contracts/performance_workspace.py:70:total_return_pct: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-28"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:72:total_return_pct: float | None = None",
+      "finding": "src/app/contracts/performance_workspace.py:791:active_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-28"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:783:active_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/performance_workspace.py:79:weight_avg_pct: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:82:total_weight_avg_pct: float | None = None",
+      "finding": "src/app/contracts/performance_workspace.py:80:total_return_pct: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-28"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:83:total_portfolio_return_pct: float | None = None",
+      "finding": "src/app/contracts/performance_workspace.py:90:total_weight_avg_pct: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-28"
+      "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:90:total_portfolio_return_pct: float | None = None",
+      "finding": "src/app/contracts/performance_workspace.py:91:total_portfolio_return_pct: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-28"
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:98:total_portfolio_return_pct: float | None = None",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
     },
     {
       "finding": "src/app/contracts/portfolio.py:165:invested_market_value_base: float = Field(",

--- a/src/app/contracts/performance_workspace.py
+++ b/src/app/contracts/performance_workspace.py
@@ -41,8 +41,16 @@ class PerformanceChartPoint(BaseModel):
 class MoneyWeightedReturnSummary(BaseModel):
     money_weighted_return_pct: float | None = None
     annualized_return_pct: float | None = None
+    holding_period_return_pct: float | None = None
     input_mode: str | None = None
     method: str | None = None
+    status: str | None = None
+    reason_codes: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    is_annualized_primary: bool | None = None
+    fallback_from: str | None = None
+    fallback_reason: str | None = None
+    is_approximation: bool | None = None
     start_date: str | None = None
     end_date: str | None = None
     begin_market_value: float | None = None

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -2594,8 +2594,18 @@ class PerformanceWorkspaceService:
         return MoneyWeightedReturnSummary(
             money_weighted_return_pct=self._quantize_optional(mwr_payload.get("period_return")),
             annualized_return_pct=self._quantize_optional(mwr_payload.get("annualized_return")),
+            holding_period_return_pct=self._quantize_optional(
+                mwr_payload.get("holding_period_return")
+            ),
             input_mode=self._safe_str(mwr_payload.get("input_mode")),
             method=self._safe_str(mwr_payload.get("method")),
+            status=self._safe_str(mwr_payload.get("status")),
+            reason_codes=self._safe_str_list(mwr_payload.get("reason_codes")),
+            warnings=self._safe_str_list(mwr_payload.get("warnings")),
+            is_annualized_primary=self._safe_bool(mwr_payload.get("is_annualized_primary")),
+            fallback_from=self._safe_str(mwr_payload.get("fallback_from")),
+            fallback_reason=self._safe_str(mwr_payload.get("fallback_reason")),
+            is_approximation=self._safe_bool(mwr_payload.get("is_approximation")),
             start_date=self._safe_str(mwr_payload.get("start_date")),
             end_date=self._safe_str(mwr_payload.get("end_date")),
             begin_market_value=self._quantize_optional(economics_payload.get("begin_market_value")),
@@ -3166,7 +3176,15 @@ class PerformanceWorkspaceService:
         return MoneyWeightedReturnSummary(
             money_weighted_return_pct=self._quantize_optional(payload.get("money_weighted_return")),
             annualized_return_pct=self._quantize_optional(payload.get("mwr_annualized")),
+            holding_period_return_pct=self._quantize_optional(payload.get("holding_period_return")),
             method=self._safe_str(payload.get("method")),
+            status=self._safe_str(payload.get("status")),
+            reason_codes=self._safe_str_list(payload.get("reason_codes")),
+            warnings=self._safe_str_list(payload.get("warnings")),
+            is_annualized_primary=self._safe_bool(payload.get("is_annualized_primary")),
+            fallback_from=self._safe_str(payload.get("fallback_from")),
+            fallback_reason=self._safe_str(payload.get("fallback_reason")),
+            is_approximation=self._safe_bool(payload.get("is_approximation")),
             start_date=self._safe_str(payload.get("start_date")),
             end_date=self._safe_str(payload.get("end_date")),
             notes=[str(note) for note in notes] if isinstance(notes, list) else [],
@@ -3693,6 +3711,16 @@ class PerformanceWorkspaceService:
         if value is None:
             return None
         return str(value)
+
+    def _safe_str_list(self, value: Any) -> list[str]:
+        if not isinstance(value, list):
+            return []
+        return [str(item) for item in value]
+
+    def _safe_bool(self, value: Any) -> bool | None:
+        if isinstance(value, bool):
+            return value
+        return None
 
     def _performance_failure(
         self,

--- a/tests/unit/test_performance_workspace_service.py
+++ b/tests/unit/test_performance_workspace_service.py
@@ -341,8 +341,14 @@ def _workspace_summary_payload(*, include_detail_blocks: bool = True) -> dict:
                 "money_weighted_return": {
                     "period_return": 4.11,
                     "annualized_return": 4.11,
+                    "holding_period_return": 4.11,
                     "input_mode": "stateful",
                     "method": "XIRR",
+                    "status": "CALCULATED",
+                    "reason_codes": [],
+                    "warnings": [],
+                    "is_annualized_primary": True,
+                    "is_approximation": False,
                     "start_date": "2026-01-01",
                     "end_date": "2026-03-27",
                     "economics": {
@@ -572,8 +578,14 @@ def _workspace_summary_payload(*, include_detail_blocks: bool = True) -> dict:
                 "money_weighted_return": {
                     "period_return": 14.05,
                     "annualized_return": 14.05,
+                    "holding_period_return": 3.05,
                     "input_mode": "stateful",
                     "method": "XIRR",
+                    "status": "CALCULATED",
+                    "reason_codes": [],
+                    "warnings": [],
+                    "is_annualized_primary": True,
+                    "is_approximation": False,
                     "start_date": "2026-01-01",
                     "end_date": "2026-03-27",
                     "economics": {
@@ -1062,6 +1074,7 @@ async def test_performance_workspace_service_returns_workspace_summary_contract(
     assert response.gross_performance.portfolio_return_pct == 15.13
     assert response.money_weighted_return is not None
     assert response.money_weighted_return.money_weighted_return_pct == 14.05
+    assert response.money_weighted_return.holding_period_return_pct == 3.05
     assert response.money_weighted_return.input_mode == "stateful"
     assert response.money_weighted_return.begin_market_value == 450000.0
     assert response.money_weighted_return.end_market_value == 508870.0
@@ -1191,6 +1204,11 @@ async def test_performance_workspace_service_projects_summary_contract():
     assert response.money_weighted_return is not None
     assert response.money_weighted_return.input_mode == "stateful"
     assert response.money_weighted_return.method == "XIRR"
+    assert response.money_weighted_return.status == "CALCULATED"
+    assert response.money_weighted_return.reason_codes == []
+    assert response.money_weighted_return.warnings == []
+    assert response.money_weighted_return.is_annualized_primary is True
+    assert response.money_weighted_return.is_approximation is False
     assert response.money_weighted_return.flow_adjusted_end_market_value == 486370.0
     assert response.benchmark_options[0].benchmark_name == "Global Balanced 60/40"
     assert response.capabilities.return_path.state == "supported"


### PR DESCRIPTION
## Summary
- preserve MWR holding-period return, status, reason codes, warnings, annualized-primary flag, fallback metadata, and approximation flag in the Workbench performance summary contract
- keep `lotus-gateway` as a product-facing preservation layer; performance calculation truth remains owned by `lotus-performance`
- update monetary-float governance for the changed contract shape

## Producer coordination
- paired with `sgajbi/lotus-performance` branch/PR `feat/mwr-industry-controls`, which introduces the source MWR response contract fields

## Validation
- `make check` in `lotus-gateway` passed: ruff, format, monetary-float guard, mypy, workbench contract gate, and 485 unit/contract tests