### PR TITLE
Fix performance evidence lineage readiness

### DIFF
--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -68,6 +68,8 @@ SUPPORTED_CONTRIBUTION_DIMENSIONS = ("asset_class", "sector", "country")
 SUPPORTED_ATTRIBUTION_DIMENSIONS = ("asset_class", "sector", "country", "currency")
 SUPPORTED_WORKSPACE_FREQUENCIES = ("monthly", "quarterly")
 SUPPORTED_WORKSPACE_SUMMARY_PERIODS = ("YTD", "1Y", "2Y", "5Y", "10Y", "SI", "EXPLICIT")
+LINEAGE_COMPLETION_POLL_ATTEMPTS = 3
+LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS = 0.25
 
 UpstreamPayload: TypeAlias = dict[str, Any]
 UpstreamResult: TypeAlias = tuple[int, UpstreamPayload]
@@ -1208,12 +1210,106 @@ class PerformanceWorkspaceService:
                 correlation_id=correlation_id,
             ),
         )
+        execution_result, lineage_result = await self._await_recent_evidence_completion(
+            calculation_id=calculation_id,
+            correlation_id=correlation_id,
+            execution_result=execution_result,
+            lineage_result=lineage_result,
+        )
         return self._build_calculation_evidence_view(
             portfolio_id=portfolio_id,
             calculation_role=calculation_role,
             calculation_id=calculation_id,
             execution_result=execution_result,
             lineage_result=lineage_result,
+        )
+
+    async def _await_recent_evidence_completion(
+        self,
+        *,
+        calculation_id: str,
+        correlation_id: str,
+        execution_result: UpstreamResult,
+        lineage_result: UpstreamResult,
+    ) -> tuple[UpstreamResult, UpstreamResult]:
+        if not self._execution_is_complete(execution_result):
+            return execution_result, lineage_result
+        if self._lineage_is_complete(lineage_result):
+            refreshed_execution = await self._refresh_execution_after_lineage_completion(
+                calculation_id=calculation_id,
+                correlation_id=correlation_id,
+                execution_result=execution_result,
+            )
+            return refreshed_execution, lineage_result
+        if not self._lineage_is_transient(lineage_result):
+            return execution_result, lineage_result
+
+        latest_result = lineage_result
+        for _ in range(LINEAGE_COMPLETION_POLL_ATTEMPTS):
+            if LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS > 0:
+                await asyncio.sleep(LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS)
+            latest_result = await self._analytics_client.get_lineage(
+                calculation_id=calculation_id,
+                correlation_id=correlation_id,
+            )
+            if self._lineage_is_complete(latest_result):
+                refreshed_execution = await self._refresh_execution_after_lineage_completion(
+                    calculation_id=calculation_id,
+                    correlation_id=correlation_id,
+                    execution_result=execution_result,
+                )
+                return refreshed_execution, latest_result
+            if not self._lineage_is_transient(latest_result):
+                return execution_result, latest_result
+        return execution_result, latest_result
+
+    async def _refresh_execution_after_lineage_completion(
+        self,
+        *,
+        calculation_id: str,
+        correlation_id: str,
+        execution_result: UpstreamResult,
+    ) -> UpstreamResult:
+        if self._execution_lineage_stage_complete(execution_result):
+            return execution_result
+        refreshed_result = await self._analytics_client.get_execution(
+            calculation_id=calculation_id,
+            correlation_id=correlation_id,
+        )
+        if refreshed_result[0] >= 400:
+            return execution_result
+        return refreshed_result
+
+    def _execution_is_complete(self, execution_result: UpstreamResult) -> bool:
+        status_code, payload = execution_result
+        if status_code >= 400 or not isinstance(payload, Mapping):
+            return False
+        return str(payload.get("status", "")).lower() == "complete"
+
+    def _lineage_is_complete(self, lineage_result: UpstreamResult) -> bool:
+        status_code, payload = lineage_result
+        if status_code >= 400 or not isinstance(payload, Mapping):
+            return False
+        return str(payload.get("status", "")).lower() == "complete"
+
+    def _lineage_is_transient(self, lineage_result: UpstreamResult) -> bool:
+        status_code, payload = lineage_result
+        if status_code >= 400 or not isinstance(payload, Mapping):
+            return False
+        return str(payload.get("status", "")).lower() in {"pending", "in_progress"}
+
+    def _execution_lineage_stage_complete(self, execution_result: UpstreamResult) -> bool:
+        status_code, payload = execution_result
+        if status_code >= 400 or not isinstance(payload, Mapping):
+            return False
+        stages = payload.get("stages", [])
+        if not isinstance(stages, list):
+            return False
+        return any(
+            isinstance(stage, Mapping)
+            and str(stage.get("stage_name", "")).lower() == "lineage_materialization"
+            and str(stage.get("status", "")).lower() == "complete"
+            for stage in stages
         )
 
     def _build_calculation_evidence_view(

--- a/tests/unit/test_performance_workspace_service.py
+++ b/tests/unit/test_performance_workspace_service.py
@@ -2172,6 +2172,110 @@ async def test_performance_workspace_service_marks_pending_lineage_as_partial_ev
 
 
 @pytest.mark.asyncio
+async def test_performance_workspace_service_promotes_recently_materialized_lineage(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.performance_workspace_service.LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS",
+        0,
+    )
+
+    class _EventuallyCompleteLineageAnalyticsClient(_StubAnalyticsClient):
+        def __init__(self):
+            super().__init__()
+            self._execution_attempts = 0
+            self._lineage_attempts = 0
+
+        async def get_execution(self, *, calculation_id: str, correlation_id: str):
+            _ = correlation_id
+            self._execution_attempts += 1
+            self.execution_calls.append(calculation_id)
+            lineage_stage_status = "in_progress" if self._execution_attempts == 1 else "complete"
+            return 200, {
+                "calculation_id": calculation_id,
+                "analytics_type": "WORKSPACE_SUMMARY",
+                "execution_mode": "sync",
+                "status": "complete",
+                "stages": [
+                    {
+                        "stage_name": "execution",
+                        "status": "complete",
+                        "completed_at_utc": "2026-03-27T12:00:00Z",
+                    },
+                    {
+                        "stage_name": "lineage_materialization",
+                        "status": lineage_stage_status,
+                        "completed_at_utc": (
+                            "2026-03-27T12:00:01Z" if lineage_stage_status == "complete" else None
+                        ),
+                    },
+                ],
+                "upstream_snapshots": [
+                    {
+                        "upstream_endpoint": "portfolio_timeseries",
+                        "source_identifier": "DEMO_ADV_USD_001",
+                        "as_of_date": "2026-03-27",
+                        "retrieval_status": "200",
+                    }
+                ],
+            }
+
+        async def get_lineage(self, *, calculation_id: str, correlation_id: str):
+            _ = correlation_id
+            self._lineage_attempts += 1
+            self.lineage_calls.append(calculation_id)
+            if self._lineage_attempts == 1:
+                return 200, {
+                    "calculation_id": calculation_id,
+                    "status": "pending",
+                    "artifacts": {},
+                }
+            return 200, {
+                "calculation_id": calculation_id,
+                "status": "complete",
+                "artifacts": {
+                    "request.json": {
+                        "url": (
+                            "http://performance.dev.lotus/performance/lineage/"
+                            f"{calculation_id}/artifacts/request.json"
+                        )
+                    },
+                    "response.json": {
+                        "url": (
+                            "http://performance.dev.lotus/performance/lineage/"
+                            f"{calculation_id}/artifacts/response.json"
+                        )
+                    },
+                },
+            }
+
+    analytics_client = _EventuallyCompleteLineageAnalyticsClient()
+    service = PerformanceWorkspaceService(
+        workbench_service=_StubWorkbenchService(),
+        analytics_client=analytics_client,
+        lotus_core_query_client=_StubLotusCoreQueryClient(),
+    )
+
+    response = await service.get_performance_workspace_summary(
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-performance",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+    )
+
+    assert response.capabilities.evidence.state == "supported"
+    assert response.evidence_view is not None
+    assert response.evidence_view.state == "supported"
+    assert response.evidence_view.calculations[0].lineage_status == "complete"
+    assert response.evidence_view.calculations[0].stage_statuses[1].status == "complete"
+    assert len(analytics_client.execution_calls) == 2
+    assert len(analytics_client.lineage_calls) == 2
+    assert "PERFORMANCE_EVIDENCE_PARTIAL" not in response.warnings
+
+
+@pytest.mark.asyncio
 async def test_performance_workspace_service_marks_missing_execution_and_lineage_as_unavailable():
     class _UnavailableEvidenceAnalyticsClient(_StubAnalyticsClient):
         async def get_execution(self, *, calculation_id: str, correlation_id: str):


### PR DESCRIPTION
## Summary
- wait briefly for recently materialized performance lineage before classifying Gateway evidence
- refresh execution metadata once lineage becomes complete so stage status is accurate
- add a regression covering pending-to-complete lineage promotion

## Validation
- python -m pytest tests/unit/test_performance_workspace_service.py -q
- python -m ruff check src/app/services/performance_workspace_service.py tests/unit/test_performance_workspace_service.py
- python -m ruff format --check src/app/services/performance_workspace_service.py tests/unit/test_performance_workspace_service.py
- git diff --check
- live Gateway performance summary returned evidence_view.state=supported, lineage=complete, artifacts=4
- Gateway logs checked for ERROR/CRITICAL/Traceback/5xx in the validation window