### PR TITLE
feat: preserve attribution supportability contract

### DIFF
--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-05-10T13:48:24Z",
+  "generated_at": "2026-05-10T23:37:28Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -112,12 +112,6 @@
       "review_by": "2026-09-25"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:229:active_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
       "finding": "src/app/contracts/performance_workspace.py:23:begin_market_value: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
@@ -131,6 +125,12 @@
     },
     {
       "finding": "src/app/contracts/performance_workspace.py:27:flow_adjusted_end_market_value: float | None = None",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:327:active_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-06"
@@ -190,96 +190,6 @@
       "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:516:begin_market_value: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:521:end_market_value: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:536:flow_adjusted_end_market_value: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:551:net_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:556:gross_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:561:portfolio_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:566:benchmark_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:573:active_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:578:cumulative_net_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:583:cumulative_gross_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:588:cumulative_benchmark_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:593:cumulative_active_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:598:annualized_net_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:603:annualized_gross_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
-      "finding": "src/app/contracts/performance_workspace.py:608:annualized_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
       "finding": "src/app/contracts/performance_workspace.py:60:begin_market_value: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
@@ -292,7 +202,97 @@
       "review_by": "2026-11-06"
     },
     {
+      "finding": "src/app/contracts/performance_workspace.py:622:begin_market_value: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:627:end_market_value: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:642:flow_adjusted_end_market_value: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
       "finding": "src/app/contracts/performance_workspace.py:64:flow_adjusted_end_market_value: float | None = None",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:657:net_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:662:gross_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:667:portfolio_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:672:benchmark_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:679:active_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:684:cumulative_net_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:689:cumulative_gross_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:694:cumulative_benchmark_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:699:cumulative_active_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:704:annualized_net_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:709:annualized_gross_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:714:annualized_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-06"
@@ -310,12 +310,6 @@
       "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/performance_workspace.py:816:active_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-06"
-    },
-    {
       "finding": "src/app/contracts/performance_workspace.py:83:weight_avg_pct: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
@@ -323,6 +317,12 @@
     },
     {
       "finding": "src/app/contracts/performance_workspace.py:84:total_return_pct: float | None = None",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-06"
+    },
+    {
+      "finding": "src/app/contracts/performance_workspace.py:922:active_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-06"

--- a/src/app/contracts/performance_workspace.py
+++ b/src/app/contracts/performance_workspace.py
@@ -201,7 +201,105 @@ class AttributionLevelView(BaseModel):
     )
 
 
+class AttributionReasonView(BaseModel):
+    code: str = Field(
+        description="Source-owned attribution supportability reason code.",
+        examples=["off_benchmark_exposure"],
+    )
+    severity: str = Field(
+        description="Source-owned bounded severity for the reason.",
+        examples=["warning"],
+    )
+    message: str = Field(
+        description="Client-safe reason message authored by lotus-performance.",
+        examples=["Portfolio holds one or more groups that are absent from the benchmark."],
+    )
+    affected_group_count: int = Field(
+        default=0,
+        description="Count of attribution groups affected by the reason.",
+        examples=[1],
+    )
+
+
+class AttributionResidualMaterialityView(BaseModel):
+    classification: str = Field(
+        description="Source-owned residual materiality classification.",
+        examples=["immaterial"],
+    )
+    treatment: str = Field(
+        description="Source-owned operational treatment for the residual.",
+        examples=["no_action"],
+    )
+    absolute_residual_pct: float = Field(
+        description="Absolute residual in percentage-point output units.",
+        examples=[0.00002],
+    )
+    warning_threshold_pct: float = Field(
+        description="Warning threshold in percentage-point output units.",
+        examples=[0.001],
+    )
+    material_threshold_pct: float = Field(
+        description="Material threshold in percentage-point output units.",
+        examples=[0.01],
+    )
+
+
+class AttributionSupportabilityEvidenceView(BaseModel):
+    portfolio_only_group_count: int = Field(
+        default=0,
+        description="Count of groups with portfolio exposure and no benchmark exposure.",
+        examples=[1],
+    )
+    benchmark_only_group_count: int = Field(
+        default=0,
+        description="Count of groups with benchmark exposure and no portfolio exposure.",
+        examples=[0],
+    )
+    unclassified_group_count: int = Field(
+        default=0,
+        description="Count of groups resolved to the governed unclassified bucket.",
+        examples=[0],
+    )
+    missing_benchmark_return_count: int = Field(
+        default=0,
+        description="Count of benchmark-exposed groups with missing benchmark return.",
+        examples=[0],
+    )
+    negative_weight_count: int = Field(
+        default=0,
+        description="Count of attribution rows with negative portfolio or benchmark weights.",
+        examples=[0],
+    )
+    zero_portfolio_exposure_count: int = Field(
+        default=0,
+        description="Count of rows with zero portfolio and benchmark exposure after alignment.",
+        examples=[0],
+    )
+    currency_attribution_status: str = Field(
+        description="Currency attribution evidence status for the period.",
+        examples=["not_requested"],
+    )
+    linking_status: str = Field(
+        description="Linking evidence status for the period.",
+        examples=["linked"],
+    )
+
+
 class AttributionSummaryView(BaseModel):
+    status: str = Field(
+        default="valid",
+        description="Source-owned attribution period status for degraded-state handling.",
+        examples=["partial"],
+    )
+    reason_codes: list[str] = Field(
+        default_factory=list,
+        description="Source-owned bounded reason codes for the attribution period.",
+        examples=[["off_benchmark_exposure"]],
+    )
+    reasons: list[AttributionReasonView] = Field(
+        default_factory=list,
+        description="Detailed source-owned supportability reasons for the attribution period.",
+    )
     metric_basis: str = Field(
         description="Performance basis used by the attribution response.",
         examples=["NET"],
@@ -240,6 +338,14 @@ class AttributionSummaryView(BaseModel):
         default=None,
         description="Residual percentage left after attribution reconciliation.",
         examples=[0.02],
+    )
+    residual_materiality: AttributionResidualMaterialityView | None = Field(
+        default=None,
+        description="Source-owned materiality classification for the attribution residual.",
+    )
+    supportability_evidence: AttributionSupportabilityEvidenceView | None = Field(
+        default=None,
+        description="Support-safe source-owned attribution evidence summary.",
     )
     levels: list[AttributionLevelView] = Field(
         default_factory=list,
@@ -822,6 +928,24 @@ class PerformanceAttributionTrendRow(BaseModel):
         default=None,
         description="Residual attribution percentage left after explicit effect reconciliation.",
         examples=[0.01],
+    )
+    status: str = Field(
+        default="valid",
+        description="Source-owned attribution period status for this trend bucket.",
+        examples=["valid"],
+    )
+    reason_codes: list[str] = Field(
+        default_factory=list,
+        description="Source-owned reason codes for this trend bucket.",
+        examples=[[]],
+    )
+    residual_materiality: AttributionResidualMaterialityView | None = Field(
+        default=None,
+        description="Source-owned residual materiality classification for this trend bucket.",
+    )
+    supportability_evidence: AttributionSupportabilityEvidenceView | None = Field(
+        default=None,
+        description="Support-safe source-owned evidence for this trend bucket.",
     )
 
 

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -12,8 +12,11 @@ from app.clients.lotus_core_query_client import LotusCoreQueryClient
 from app.config import settings
 from app.contracts.performance_workspace import (
     AttributionLevelView,
+    AttributionReasonView,
+    AttributionResidualMaterialityView,
     AttributionRowView,
     AttributionSummaryView,
+    AttributionSupportabilityEvidenceView,
     ContributionLevelView,
     ContributionPositionView,
     ContributionRowView,
@@ -2841,6 +2844,7 @@ class PerformanceWorkspaceService:
             benchmark_context = {}
         levels_payload = result_payload.get("levels", [])
         reconciliation_payload = result_payload.get("reconciliation", {})
+        supportability_evidence_payload = result_payload.get("supportability_evidence")
         if not isinstance(reconciliation_payload, dict):
             reconciliation_payload = {}
         levels: list[AttributionLevelView] = []
@@ -2906,6 +2910,9 @@ class PerformanceWorkspaceService:
                     )
                 )
         return AttributionSummaryView(
+            status=self._safe_str(result_payload.get("status")) or "valid",
+            reason_codes=self._safe_str_list(result_payload.get("reason_codes")),
+            reasons=self._parse_attribution_reasons(result_payload.get("reasons")),
             metric_basis=self._safe_str(attribution_payload.get("metric_basis")) or "NET",
             model=self._safe_str(attribution_payload.get("model")),
             linking=self._safe_str(attribution_payload.get("linking")),
@@ -2918,6 +2925,12 @@ class PerformanceWorkspaceService:
                 reconciliation_payload.get("sum_of_effects")
             ),
             residual_pct=self._quantize_optional(reconciliation_payload.get("residual")),
+            residual_materiality=self._parse_attribution_residual_materiality(
+                reconciliation_payload.get("residual_materiality")
+            ),
+            supportability_evidence=self._parse_attribution_supportability_evidence(
+                supportability_evidence_payload
+            ),
             levels=levels,
         )
 
@@ -3505,6 +3518,7 @@ class PerformanceWorkspaceService:
         reconciliation_payload = period_payload.get("reconciliation", {})
         benchmark_context = payload.get("benchmark_context", {})
         levels_payload = period_payload.get("levels", [])
+        supportability_evidence_payload = period_payload.get("supportability_evidence")
         if not isinstance(reconciliation_payload, dict):
             reconciliation_payload = {}
         if not isinstance(benchmark_context, dict):
@@ -3570,6 +3584,9 @@ class PerformanceWorkspaceService:
                     )
                 )
         return AttributionSummaryView(
+            status=self._safe_str(period_payload.get("status")) or "valid",
+            reason_codes=self._safe_str_list(period_payload.get("reason_codes")),
+            reasons=self._parse_attribution_reasons(period_payload.get("reasons")),
             metric_basis=metric_basis,
             model=self._safe_str(payload.get("model")),
             linking=self._safe_str(payload.get("linking")),
@@ -3582,7 +3599,75 @@ class PerformanceWorkspaceService:
                 reconciliation_payload.get("sum_of_effects")
             ),
             residual_pct=self._quantize_optional(reconciliation_payload.get("residual")),
+            residual_materiality=self._parse_attribution_residual_materiality(
+                reconciliation_payload.get("residual_materiality")
+            ),
+            supportability_evidence=self._parse_attribution_supportability_evidence(
+                supportability_evidence_payload
+            ),
             levels=levels,
+        )
+
+    def _parse_attribution_reasons(self, payload: Any) -> list[AttributionReasonView]:
+        if not isinstance(payload, list):
+            return []
+        reasons: list[AttributionReasonView] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            reasons.append(
+                AttributionReasonView(
+                    code=self._safe_str(item.get("code")) or "unknown",
+                    severity=self._safe_str(item.get("severity")) or "warning",
+                    message=(
+                        self._safe_str(item.get("message")) or "Attribution supportability reason."
+                    ),
+                    affected_group_count=self._safe_int(item.get("affected_group_count")) or 0,
+                )
+            )
+        return reasons
+
+    def _parse_attribution_residual_materiality(
+        self, payload: Any
+    ) -> AttributionResidualMaterialityView | None:
+        if not isinstance(payload, dict):
+            return None
+        absolute_residual = self._quantize_optional(payload.get("absolute_residual"))
+        warning_threshold = self._quantize_optional(payload.get("warning_threshold"))
+        material_threshold = self._quantize_optional(payload.get("material_threshold"))
+        if absolute_residual is None or warning_threshold is None or material_threshold is None:
+            return None
+        return AttributionResidualMaterialityView(
+            classification=self._safe_str(payload.get("classification")) or "immaterial",
+            treatment=self._safe_str(payload.get("treatment")) or "no_action",
+            absolute_residual_pct=absolute_residual,
+            warning_threshold_pct=warning_threshold,
+            material_threshold_pct=material_threshold,
+        )
+
+    def _parse_attribution_supportability_evidence(
+        self, payload: Any
+    ) -> AttributionSupportabilityEvidenceView | None:
+        if not isinstance(payload, dict):
+            return None
+        return AttributionSupportabilityEvidenceView(
+            portfolio_only_group_count=self._safe_int(payload.get("portfolio_only_group_count"))
+            or 0,
+            benchmark_only_group_count=self._safe_int(payload.get("benchmark_only_group_count"))
+            or 0,
+            unclassified_group_count=self._safe_int(payload.get("unclassified_group_count")) or 0,
+            missing_benchmark_return_count=self._safe_int(
+                payload.get("missing_benchmark_return_count")
+            )
+            or 0,
+            negative_weight_count=self._safe_int(payload.get("negative_weight_count")) or 0,
+            zero_portfolio_exposure_count=self._safe_int(
+                payload.get("zero_portfolio_exposure_count")
+            )
+            or 0,
+            currency_attribution_status=self._safe_str(payload.get("currency_attribution_status"))
+            or "not_requested",
+            linking_status=self._safe_str(payload.get("linking_status")) or "not_requested",
         )
 
     def _merge_contribution_summary_views(
@@ -3756,6 +3841,7 @@ class PerformanceWorkspaceService:
             return None
         if not isinstance(reconciliation_payload, dict):
             reconciliation_payload = {}
+        supportability_evidence_payload = period_payload.get("supportability_evidence")
 
         level_payload = levels_payload[0]
         if not isinstance(level_payload, dict):
@@ -3781,6 +3867,14 @@ class PerformanceWorkspaceService:
                 reconciliation_payload.get("total_active_return")
             ),
             residual_pct=self._quantize_optional(reconciliation_payload.get("residual")),
+            status=self._safe_str(period_payload.get("status")) or "valid",
+            reason_codes=self._safe_str_list(period_payload.get("reason_codes")),
+            residual_materiality=self._parse_attribution_residual_materiality(
+                reconciliation_payload.get("residual_materiality")
+            ),
+            supportability_evidence=self._parse_attribution_supportability_evidence(
+                supportability_evidence_payload
+            ),
         )
 
     def _format_attribution_trend_label(

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -2161,7 +2161,12 @@ def test_workbench_performance_details_attribution_openapi_contract():
     attribution_row_schema = schema["components"]["schemas"]["AttributionRowView"]
 
     assert details_route["description"]
+    assert attribution_schema["properties"]["status"]["description"]
+    assert attribution_schema["properties"]["reason_codes"]["description"]
+    assert attribution_schema["properties"]["reasons"]["description"]
     assert attribution_schema["properties"]["active_return_pct"]["description"]
+    assert attribution_schema["properties"]["residual_materiality"]["description"]
+    assert attribution_schema["properties"]["supportability_evidence"]["description"]
     assert attribution_schema["properties"]["levels"]["description"]
     assert attribution_level_schema["properties"]["allocation_total_pct"]["description"]
     assert attribution_level_schema["properties"]["selection_total_pct"]["description"]
@@ -2213,6 +2218,10 @@ def test_workbench_performance_attribution_trend_openapi_contract():
     assert row_schema["properties"]["total_effect_pct"]["description"]
     assert row_schema["properties"]["cumulative_total_effect_pct"]["description"]
     assert row_schema["properties"]["residual_pct"]["description"]
+    assert row_schema["properties"]["status"]["description"]
+    assert row_schema["properties"]["reason_codes"]["description"]
+    assert row_schema["properties"]["residual_materiality"]["description"]
+    assert row_schema["properties"]["supportability_evidence"]["description"]
     assert response_schema["example"]["rows"][0]["period_label"] == "2026-01"
     assert response_schema["example"]["rows"][1]["cumulative_total_effect_pct"] == 0.4
 

--- a/tests/unit/test_performance_workspace_service.py
+++ b/tests/unit/test_performance_workspace_service.py
@@ -423,10 +423,39 @@ def _workspace_summary_payload(*, include_detail_blocks: bool = True) -> dict:
                         "return_source": "calculated",
                     },
                     "result": {
+                        "status": "partial",
+                        "reason_codes": ["off_benchmark_exposure"],
+                        "reasons": [
+                            {
+                                "code": "off_benchmark_exposure",
+                                "severity": "warning",
+                                "message": (
+                                    "Portfolio-only exposure was found in the attribution set."
+                                ),
+                                "affected_group_count": 1,
+                            }
+                        ],
+                        "supportability_evidence": {
+                            "portfolio_only_group_count": 1,
+                            "benchmark_only_group_count": 0,
+                            "unclassified_group_count": 0,
+                            "missing_benchmark_return_count": 0,
+                            "negative_weight_count": 0,
+                            "zero_portfolio_exposure_count": 0,
+                            "currency_attribution_status": "not_requested",
+                            "linking_status": "linked",
+                        },
                         "reconciliation": {
                             "total_active_return": 0.3,
                             "sum_of_effects": 0.28,
                             "residual": 0.02,
+                            "residual_materiality": {
+                                "classification": "watch",
+                                "treatment": "review",
+                                "absolute_residual": 0.02,
+                                "warning_threshold": 0.001,
+                                "material_threshold": 0.01,
+                            },
                         },
                         "levels": [
                             {
@@ -866,10 +895,37 @@ def _attribution_payload(*, dimension: str, report_start_date: str, report_end_d
         },
         "results_by_period": {
             "EXPLICIT": {
+                "status": "partial",
+                "reason_codes": ["off_benchmark_exposure"],
+                "reasons": [
+                    {
+                        "code": "off_benchmark_exposure",
+                        "severity": "warning",
+                        "message": "Portfolio-only exposure was found in the attribution set.",
+                        "affected_group_count": 1,
+                    }
+                ],
+                "supportability_evidence": {
+                    "portfolio_only_group_count": 1,
+                    "benchmark_only_group_count": 0,
+                    "unclassified_group_count": 0,
+                    "missing_benchmark_return_count": 0,
+                    "negative_weight_count": 0,
+                    "zero_portfolio_exposure_count": 0,
+                    "currency_attribution_status": "not_requested",
+                    "linking_status": "linked",
+                },
                 "reconciliation": {
                     "total_active_return": totals["total"],
                     "sum_of_effects": totals["total"],
                     "residual": 0.0,
+                    "residual_materiality": {
+                        "classification": "immaterial",
+                        "treatment": "no_action",
+                        "absolute_residual": 0.0,
+                        "warning_threshold": 0.001,
+                        "material_threshold": 0.01,
+                    },
                 },
                 "levels": [
                     {
@@ -908,10 +964,37 @@ def _attribution_detail_payload(*, dimension: str) -> dict:
         },
         "results_by_period": {
             "YTD": {
+                "status": "partial",
+                "reason_codes": ["off_benchmark_exposure"],
+                "reasons": [
+                    {
+                        "code": "off_benchmark_exposure",
+                        "severity": "warning",
+                        "message": "Portfolio-only exposure was found in the attribution set.",
+                        "affected_group_count": 1,
+                    }
+                ],
+                "supportability_evidence": {
+                    "portfolio_only_group_count": 1,
+                    "benchmark_only_group_count": 0,
+                    "unclassified_group_count": 0,
+                    "missing_benchmark_return_count": 0,
+                    "negative_weight_count": 0,
+                    "zero_portfolio_exposure_count": 0,
+                    "currency_attribution_status": "not_requested",
+                    "linking_status": "linked",
+                },
                 "reconciliation": {
                     "total_active_return": 0.52,
                     "sum_of_effects": 0.5,
                     "residual": 0.02,
+                    "residual_materiality": {
+                        "classification": "watch",
+                        "treatment": "review",
+                        "absolute_residual": 0.02,
+                        "warning_threshold": 0.001,
+                        "material_threshold": 0.01,
+                    },
                 },
                 "levels": [
                     {
@@ -1122,6 +1205,15 @@ async def test_performance_workspace_service_returns_workspace_summary_contract(
     assert response.contribution.position_rows[0].position_id == "AAPL_US"
     assert response.attribution is not None
     assert response.attribution.benchmark_id == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert response.attribution.status == "partial"
+    assert response.attribution.reason_codes == ["off_benchmark_exposure"]
+    assert response.attribution.reasons[0].affected_group_count == 1
+    assert response.attribution.residual_materiality is not None
+    assert response.attribution.residual_materiality.classification == "immaterial"
+    assert response.attribution.residual_materiality.treatment == "no_action"
+    assert response.attribution.supportability_evidence is not None
+    assert response.attribution.supportability_evidence.portfolio_only_group_count == 1
+    assert response.attribution.supportability_evidence.linking_status == "linked"
     assert response.attribution.levels[0].rows[0].portfolio_weight_avg_pct == 61.0
     assert response.attribution.levels[0].rows[0].benchmark_return_pct == 6.8
     assert response.benchmark_options[0].is_assigned is True
@@ -1723,6 +1815,12 @@ async def test_performance_workspace_service_builds_attribution_trend_contract()
     assert response.chart_frequency == "monthly"
     assert [row.period_label for row in response.rows] == ["2026-01", "2026-02", "2026-03"]
     assert response.rows[0].allocation_pct == 0.12
+    assert response.rows[0].status == "partial"
+    assert response.rows[0].reason_codes == ["off_benchmark_exposure"]
+    assert response.rows[0].residual_materiality is not None
+    assert response.rows[0].residual_materiality.classification == "immaterial"
+    assert response.rows[0].supportability_evidence is not None
+    assert response.rows[0].supportability_evidence.portfolio_only_group_count == 1
     assert response.rows[1].selection_pct == 0.11
     assert response.rows[2].cumulative_total_effect_pct == 0.34
     assert analytics_client.attribution_calls[0]["period"] == "EXPLICIT"


### PR DESCRIPTION
## Summary
- preserve lotus-performance attribution status, reason codes, detailed reasons, residual materiality, and supportability evidence in Gateway performance workspace contracts
- propagate the same source-owned posture into attribution-trend rows
- update OpenAPI and service tests for downstream RFC 048 realization

## Validation
- make check