### PR TITLE
Add DPM operations handoff summary gateway handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ It depends on:
   archived generated-document metadata and controlled binary retrieval
 - `lotus-ai`
   evidence-grounded advisor-brief support, outcome-review narrative support, DPM exception-summary
-  support, and proof-pack PM memo support through explicit workflow-pack execution seams and shared
-  run-ledger surfaces
+  support, proof-pack PM memo support, wave PM memo support, and operations handoff support through
+  explicit workflow-pack execution seams and shared run-ledger surfaces
 - `lotus-platform`
   generated domain-product catalog, dependency-graph, and live trust certification artifacts for
   read-only product discovery
@@ -106,6 +106,7 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/dpm/command-center/waves*`,
   `/api/v1/dpm/command-center/waves/{wave_id}/report-input`,
   `/api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`,
+  `/api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`,
   `/api/v1/dpm/command-center/outcome-reviews*`,
   `/api/v1/dpm/command-center/exceptions/{exception_id}/ai-summary`,
   `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`,
@@ -280,6 +281,9 @@ Important current parameter conventions:
    Gateway also exposes a governed `dpm_wave_pm_memo.pack@v1` handoff to `lotus-ai` from
    manage-owned wave report input; it does not generate memo narrative, score PMs, approve trades,
    contact clients, place orders, or invent missing evidence.
+   Gateway also exposes a governed `dpm_operations_handoff_summary.pack@v1` handoff to `lotus-ai`
+   from the same manage-owned wave report input and internal handoff refs; it does not route
+   orders, claim external execution, approve trades, contact clients, or invent missing evidence.
 16. DPM portfolio-memory route
    `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory` consumes `lotus-manage`
    RFC-0040/RFC-0041/RFC-0042 portfolio-memory truth and preserves event order, event type

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -64,13 +64,19 @@ Current repository posture:
     authority, `lotus-ai` remains workflow-pack execution authority, and Gateway does not generate
     exception summaries locally, score PMs, approve trades, contact clients, route orders, or
     invent evidence,
-12. RFC-0040 proof-pack AI PM memo handoff now reads manage-owned
+12. RFC-0041 operations-handoff summary now reads manage-owned `DpmWaveReportInput` handoff
+    evidence and executes `lotus-ai` `dpm_operations_handoff_summary.pack@v1` as
+    `lotus-gateway`; manage remains wave and handoff evidence authority, `lotus-ai` remains
+    workflow-pack execution authority, and Gateway does not generate handoff summaries locally,
+    score PMs, approve trades, contact clients, route orders, claim external execution, or invent
+    evidence,
+13. RFC-0040 proof-pack AI PM memo handoff now reads manage-owned
     `DpmProofPackAiEvidenceInput` and executes `lotus-ai` `dpm_pm_memo.pack@v1` as
     `lotus-gateway`; manage remains proof-pack evidence authority, `lotus-ai` remains workflow-pack
     execution authority, and Gateway does not generate memos, score PMs, approve trades, contact
     clients, place orders, or invent evidence,
-13. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
-14. RFC-0108 analytics UI observability is active for selected Workbench performance summary,
+14. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
+15. RFC-0108 analytics UI observability is active for selected Workbench performance summary,
     risk summary, advisor-brief read, and advisor-brief review-action paths, and has expanded
     fan-out coverage for central `lotus-advise`, `lotus-manage`,
     `lotus-report`, `lotus-archive`, `lotus-ai`, direct `lotus-core` query/control-plane, and

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -1185,6 +1185,7 @@ route family so Workbench can consume Gateway/BFF instead of calling `lotus-mana
 | RFC42-WTBD-001 Gateway outcome-review composition and BFF contract | Implemented and merged before this slice | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/contract/test_dpm_command_center_contract.py`, `make ci` |
 | RFC42-WTBD-005 Gateway AI narrative handoff | Implemented and merged before this slice | Gateway reads manage-owned `DpmOutcomeAiEvidenceInput`, executes `lotus-ai` `outcome_review_narrative.pack@v1` as `lotus-gateway`, preserves manage workflow authority, and exposes `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative` |
 | RFC38/RFC43-WTBD Gateway exception-summary AI handoff | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | Gateway reads manage-owned monitoring-exception evidence from the command-center exception queue, executes `lotus-ai` `dpm_exception_summary.pack@v1` as `lotus-gateway`, preserves source refs/content hashes/supportability, and exposes `POST /api/v1/dpm/command-center/exceptions/{exception_id}/ai-summary` |
+| RFC41/RFC43-WTBD Gateway operations-handoff summary AI handoff | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | Gateway reads manage-owned `DpmWaveReportInput` with bounded internal handoff refs, executes `lotus-ai` `dpm_operations_handoff_summary.pack@v1` as `lotus-gateway`, preserves manage handoff evidence authority and lotus-ai workflow-pack posture, and exposes `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary` |
 | RFC-0042 manage authority preservation | Implemented for BFF envelope; Gateway forwards payloads and preserves manage supportability | Service tests prove payload preservation and upstream error forwarding; contract tests prove OpenAPI route family registration and What/When/How guidance |
 | Broader RFC-0098 report/archive modules and Workbench cockpit | Not implemented in this slice | Gateway wave composition is a backend BFF contract only; Workbench UI, report materialization, archive, and broader optional AI posture remain governed follow-up work |
 
@@ -1253,13 +1254,20 @@ Implementation boundaries:
    `POST /api/v1/dpm/command-center/waves/{wave_id}/handoff`,
    `POST /api/v1/dpm/command-center/waves/{wave_id}/cancel`,
    `GET /api/v1/dpm/command-center/waves/{wave_id}/proof-pack`, and
-   `GET /api/v1/dpm/command-center/waves/{wave_id}/supportability`.
+   `GET /api/v1/dpm/command-center/waves/{wave_id}/supportability`,
+   `GET /api/v1/dpm/command-center/waves/{wave_id}/report-input`,
+   `POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`, and
+   `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`.
 14. Wave routes preserve manage-owned `wave_id`, lifecycle state, item states, reason codes,
    aggregate metrics, selected alternative refs, proof-pack refs, handoff refs, supportability
    issues, source-owner remediation, and the no-external-execution boundary.
 15. Gateway does not calculate affected portfolios, classify source readiness, generate
    alternatives, select alternatives, approve items, stage items, create handoff evidence, rebuild
    proof packs, or claim external execution locally.
+   The operations-handoff summary AI handoff reads manage-owned wave report input with bounded
+   internal handoff refs and calls `lotus-ai` `dpm_operations_handoff_summary.pack@v1`. Gateway
+   does not generate summaries locally, score PMs, approve trades, contact clients, route orders,
+   claim external execution, or invent evidence.
 16. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,
    `POST /api/v1/dpm/command-center/outcome-reviews`,
    `GET /api/v1/dpm/command-center/outcome-reviews`,
@@ -1275,8 +1283,8 @@ Implementation boundaries:
    lineage, source freshness, supportability, or review state.
 18. Gateway does not generate reports, render artifacts, archive documents, generate AI narrative
    locally, score PM quality, approve trades, contact clients, route orders, or claim Workbench UI
-   support in this slice. The AI narrative and exception-summary endpoints are governed handoffs
-   to `lotus-ai` over manage evidence.
+   support in this slice. The AI narrative, exception-summary, wave PM memo, and operations
+   handoff summary endpoints are governed handoffs to `lotus-ai` over manage evidence.
 19. Workbench product realization remains a separate owning-repository implementation item.
 
 Latest portfolio-memory Gateway validation performed on 2026-05-08:

--- a/src/app/contracts/dpm_waves.py
+++ b/src/app/contracts/dpm_waves.py
@@ -62,6 +62,36 @@ class DpmWaveMemoRequest(BaseModel):
     )
 
 
+class DpmOperationsHandoffSummaryRequest(BaseModel):
+    requested_outputs: list[str] = Field(
+        default_factory=lambda: [
+            "operations_summary",
+            "execution_prerequisites",
+            "blocking_conditions",
+            "support_references",
+            "evidence_gaps",
+        ],
+        min_length=1,
+        description=(
+            "Bounded support-only outputs requested from lotus-ai "
+            "dpm_operations_handoff_summary.pack@v1. Gateway forwards these labels as caller "
+            "intent and does not allow outputs that approve trades, place orders, contact "
+            "clients, score PMs, route execution, or invent missing evidence."
+        ),
+        examples=[["operations_summary", "execution_prerequisites", "blocking_conditions"]],
+    )
+    audience: list[str] = Field(
+        default_factory=lambda: ["operations", "portfolio_manager", "investment_control"],
+        min_length=1,
+        description=(
+            "Intended internal review audiences for the generated operations handoff summary. "
+            "The lotus-ai pack returns review-required support text; Gateway does not route the "
+            "output to clients or external execution systems."
+        ),
+        examples=[["operations", "portfolio_manager", "investment_control"]],
+    )
+
+
 class DpmWaveSupportability(BaseModel):
     source_service: str = Field(
         default="lotus-manage",
@@ -224,6 +254,68 @@ class DpmWaveMemoGatewayResponse(BaseModel):
         description=(
             "lotus-ai workflow-pack execution response. Gateway preserves the AI authority "
             "payload and does not post-process generated memo content into execution actions."
+        )
+    )
+
+
+class DpmOperationsHandoffSummaryGatewayResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated across Gateway, lotus-manage, and lotus-ai.",
+        examples=["corr-rfc41-operations-handoff-summary"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway BFF contract version for DPM operations handoff summary responses.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        default="lotus-ai",
+        description="Service that executed the governed operations handoff summary workflow pack.",
+        examples=["lotus-ai"],
+    )
+    evidence_source_service: str = Field(
+        default="lotus-manage",
+        description="Service that supplied the authoritative wave handoff evidence.",
+        examples=["lotus-manage"],
+    )
+    manage_upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage for the wave report-input request.",
+        examples=[200],
+    )
+    ai_upstream_status: int = Field(
+        description="HTTP status returned by lotus-ai for workflow-pack execution.",
+        examples=[200],
+    )
+    supportability: DpmWaveSupportability = Field(
+        description=(
+            "Gateway-normalized supportability summary derived only from manage-published wave "
+            "report-input fields and carried into the lotus-ai guardrail request."
+        )
+    )
+    wave_report_input: dict[str, object] = Field(
+        description=(
+            "Authoritative manage DpmWaveReportInput payload preserved for traceability. Gateway "
+            "does not rewrite handoff refs, item evidence, source refs, hashes, approval posture, "
+            "or proof-pack posture before calling lotus-ai."
+        ),
+    )
+    handoff_summary_request: dict[str, object] = Field(
+        description=(
+            "Bounded caller intent sent to lotus-ai for operations handoff support. This object "
+            "excludes trade approval, order placement, client contact, PM scoring, routing "
+            "instructions, and evidence invention."
+        ),
+        examples=[
+            {
+                "requested_outputs": ["operations_summary", "blocking_conditions"],
+                "audience": ["operations", "portfolio_manager"],
+            }
+        ],
+    )
+    data: dict[str, object] = Field(
+        description=(
+            "lotus-ai workflow-pack execution response. Gateway preserves the AI authority "
+            "payload and does not post-process generated handoff text into execution actions."
         )
     )
 

--- a/src/app/routers/dpm_waves.py
+++ b/src/app/routers/dpm_waves.py
@@ -6,6 +6,8 @@ from app.clients.dpm_client import DpmClient
 from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_waves import (
+    DpmOperationsHandoffSummaryGatewayResponse,
+    DpmOperationsHandoffSummaryRequest,
     DpmWaveCreateRequest,
     DpmWaveErrorDetail,
     DpmWaveForwardRequest,
@@ -432,6 +434,36 @@ async def request_wave_pm_memo(
     ),
 ) -> DpmWaveMemoGatewayResponse:
     return await _dpm_wave_service().request_wave_pm_memo(
+        wave_id=wave_id,
+        request=request,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{wave_id}/operations-handoff-summary",
+    response_model=DpmOperationsHandoffSummaryGatewayResponse,
+    summary="Request DPM operations handoff AI summary",
+    description=(
+        "What: requests a governed lotus-ai operations handoff workflow-pack run from "
+        "manage-owned DPM wave report-input and handoff evidence. When: call this after manage "
+        "has staged or handoff-ready wave evidence and operations need review-gated support text. "
+        "How: Gateway first reads manage's DpmWaveReportInput, then executes lotus-ai "
+        "dpm_operations_handoff_summary.pack@v1 as lotus-gateway; Gateway does not generate "
+        "handoff narrative locally, score PMs, approve trades, contact clients, route orders, "
+        "claim external execution, or invent evidence."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def request_operations_handoff_summary(
+    request: DpmOperationsHandoffSummaryRequest,
+    wave_id: str = Path(
+        ...,
+        description="Manage-owned rebalance-wave identifier for the bounded AI handoff.",
+        examples=["dwv_001"],
+    ),
+) -> DpmOperationsHandoffSummaryGatewayResponse:
+    return await _dpm_wave_service().request_operations_handoff_summary(
         wave_id=wave_id,
         request=request,
         correlation_id=correlation_id_var.get(),

--- a/src/app/services/dpm_wave_service.py
+++ b/src/app/services/dpm_wave_service.py
@@ -6,6 +6,8 @@ from app.clients.dpm_client import DpmClient
 from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_waves import (
+    DpmOperationsHandoffSummaryGatewayResponse,
+    DpmOperationsHandoffSummaryRequest,
     DpmWaveErrorDetail,
     DpmWaveGatewayResponse,
     DpmWaveMemoGatewayResponse,
@@ -25,6 +27,13 @@ _WAVE_PM_MEMO_UNSUPPORTED_CLAIMS = [
     "trade_approval",
     "portfolio_manager_scoring",
     "execution_instruction",
+]
+_OPERATIONS_HANDOFF_UNSUPPORTED_CLAIMS = [
+    "client_contact",
+    "trade_approval",
+    "portfolio_manager_scoring",
+    "execution_instruction",
+    "order_routing",
 ]
 
 
@@ -296,6 +305,89 @@ class DpmWaveService:
             supportability=supportability,
             wave_report_input=manage_payload,
             memo_request=memo_request,
+            data=ai_payload,
+        )
+
+    async def request_operations_handoff_summary(
+        self,
+        wave_id: str,
+        request: DpmOperationsHandoffSummaryRequest,
+        correlation_id: str,
+    ) -> DpmOperationsHandoffSummaryGatewayResponse:
+        if self._lotus_ai_client is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="lotus-ai workflow-pack execution is not configured for Gateway.",
+            )
+
+        manage_status, manage_payload = await self._dpm_client.get_wave_report_input(
+            wave_id=wave_id,
+            correlation_id=correlation_id,
+        )
+        if manage_status >= status.HTTP_400_BAD_REQUEST:
+            raise self._upstream_error(manage_status, manage_payload)
+
+        supportability = _supportability_from(manage_payload)
+        handoff_summary_request: dict[str, object] = {
+            "requested_outputs": request.requested_outputs,
+            "audience": request.audience,
+        }
+        task_payload = {
+            "wave_report_input": manage_payload,
+            "handoff_summary_request": handoff_summary_request,
+            "supportability": {
+                "source_state": supportability.state,
+                "reason_codes": supportability.reason_codes,
+                "blocked_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
+                "forbidden_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
+                "requires_human_review": True,
+                "unsupported_claims": _OPERATIONS_HANDOFF_UNSUPPORTED_CLAIMS,
+            },
+        }
+        ai_status, ai_payload = await self._lotus_ai_client.execute_workflow_pack(
+            pack_id="dpm_operations_handoff_summary.pack",
+            version="v1",
+            environment="DEVELOPMENT",
+            caller_identity_class="INTERNAL_SERVICE",
+            workflow_surface="dpm-operations-handoff-ai-evidence",
+            task_request={
+                "task_id": "explain.v1",
+                "input_mode": "STRUCTURED_CONTEXT",
+                "caller": {
+                    "caller_app": "lotus-gateway",
+                    "correlation_id": correlation_id,
+                },
+                "context": {
+                    "summary": (
+                        "Generate review-gated DPM operations handoff summary from "
+                        f"manage-owned handoff evidence for {wave_id}."
+                    ),
+                    "payload": task_payload,
+                    "source_refs": _wave_report_source_refs(manage_payload, wave_id),
+                },
+                "expected_output_label": "EXPLANATION_ONLY",
+            },
+            correlation_id=correlation_id,
+        )
+        if ai_status >= status.HTTP_400_BAD_REQUEST:
+            raise HTTPException(
+                status_code=ai_status,
+                detail={
+                    "source_service": "lotus-ai",
+                    "upstream_status": ai_status,
+                    "error_code": "AI_OPERATIONS_HANDOFF_SUMMARY_UPSTREAM_ERROR",
+                    "detail": _safe_upstream_detail(ai_payload),
+                },
+            )
+
+        return DpmOperationsHandoffSummaryGatewayResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            manage_upstream_status=manage_status,
+            ai_upstream_status=ai_status,
+            supportability=supportability,
+            wave_report_input=manage_payload,
+            handoff_summary_request=handoff_summary_request,
             data=ai_payload,
         )
 

--- a/tests/contract/test_dpm_wave_contract.py
+++ b/tests/contract/test_dpm_wave_contract.py
@@ -1,6 +1,10 @@
 from fastapi.testclient import TestClient
 
-from app.contracts.dpm_waves import DpmWaveGatewayResponse, DpmWaveMemoGatewayResponse
+from app.contracts.dpm_waves import (
+    DpmOperationsHandoffSummaryGatewayResponse,
+    DpmWaveGatewayResponse,
+    DpmWaveMemoGatewayResponse,
+)
 from app.main import app
 
 
@@ -54,6 +58,30 @@ def test_dpm_wave_memo_gateway_response_contract_shape() -> None:
     assert response.wave_report_input["wave_id"] == "dwv_001"
 
 
+def test_dpm_operations_handoff_summary_gateway_response_contract_shape() -> None:
+    response = DpmOperationsHandoffSummaryGatewayResponse(
+        correlation_id="corr-wave-handoff-summary",
+        manage_upstream_status=200,
+        ai_upstream_status=200,
+        supportability={"state": "ready", "reason_codes": ["wave_report_input_ready"]},
+        wave_report_input={
+            "wave_id": "dwv_001",
+            "handoff_refs": [{"ref_id": "handoff_001"}],
+            "external_execution_claimed": False,
+        },
+        handoff_summary_request={
+            "requested_outputs": ["operations_summary", "blocking_conditions"],
+            "audience": ["operations", "portfolio_manager"],
+        },
+        data={"run_id": "wf_run_handoff_001", "status": "REVIEW_REQUIRED"},
+    )
+
+    assert response.source_service == "lotus-ai"
+    assert response.evidence_source_service == "lotus-manage"
+    assert response.supportability.authority == "lotus-manage:RFC-0041"
+    assert response.wave_report_input["external_execution_claimed"] is False
+
+
 def test_dpm_wave_openapi_contract_registered() -> None:
     client = TestClient(app)
     spec = client.get("/openapi.json").json()
@@ -74,6 +102,7 @@ def test_dpm_wave_openapi_contract_registered() -> None:
         ("/api/v1/dpm/command-center/waves/{wave_id}/supportability", "get"),
         ("/api/v1/dpm/command-center/waves/{wave_id}/report-input", "get"),
         ("/api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo", "post"),
+        ("/api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary", "post"),
     ]
 
     for path, method in expected_paths:
@@ -95,6 +124,8 @@ def test_dpm_wave_openapi_models_are_described() -> None:
         "DpmWaveCreateRequest",
         "DpmWaveForwardRequest",
         "DpmWaveGatewayResponse",
+        "DpmOperationsHandoffSummaryGatewayResponse",
+        "DpmOperationsHandoffSummaryRequest",
         "DpmWaveMemoGatewayResponse",
         "DpmWaveMemoRequest",
         "DpmWaveSupportability",

--- a/tests/integration/test_dpm_wave_router.py
+++ b/tests/integration/test_dpm_wave_router.py
@@ -294,3 +294,109 @@ def test_dpm_wave_ai_pm_memo_uses_lotus_ai_workflow_pack(monkeypatch) -> None:
     supportability = ai_kwargs["task_request"]["context"]["payload"]["supportability"]
     assert supportability["requires_human_review"] is True
     assert "approve_rebalance" in supportability["blocked_actions"]
+
+
+def test_dpm_wave_operations_handoff_summary_uses_lotus_ai_workflow_pack(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_get_wave_report_input(self, wave_id, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["manage_wave_id"] = wave_id
+        captured["manage_correlation_id"] = correlation_id
+        return 200, _wave_report_input_with_handoff(wave_id)
+
+    async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN001, ANN003
+        _ = self
+        captured["ai_kwargs"] = kwargs
+        return 200, {"run_id": "wf_run_handoff_001", "status": "REVIEW_REQUIRED"}
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_wave_report_input",
+        _fake_get_wave_report_input,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_ai_client.LotusAiClient.execute_workflow_pack",
+        _fake_execute_workflow_pack,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/waves/dwv_001/operations-handoff-summary",
+        json={
+            "requested_outputs": ["operations_summary", "blocking_conditions"],
+            "audience": ["operations", "portfolio_manager"],
+        },
+        headers={"X-Correlation-Id": "corr-wave-router-handoff-summary"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source_service"] == "lotus-ai"
+    assert payload["evidence_source_service"] == "lotus-manage"
+    assert payload["wave_report_input"]["handoff_refs"][0]["ref_id"] == "handoff_001"
+    assert payload["handoff_summary_request"]["requested_outputs"] == [
+        "operations_summary",
+        "blocking_conditions",
+    ]
+    ai_kwargs = captured["ai_kwargs"]
+    assert ai_kwargs["pack_id"] == "dpm_operations_handoff_summary.pack"
+    assert ai_kwargs["workflow_surface"] == "dpm-operations-handoff-ai-evidence"
+    assert ai_kwargs["correlation_id"] == "corr-wave-router-handoff-summary"
+    assert ai_kwargs["task_request"]["caller"]["caller_app"] == "lotus-gateway"
+    supportability = ai_kwargs["task_request"]["context"]["payload"]["supportability"]
+    assert supportability["requires_human_review"] is True
+    assert "approve_rebalance" in supportability["forbidden_actions"]
+    assert "order_routing" in supportability["unsupported_claims"]
+    assert "memo_request" not in ai_kwargs["task_request"]["context"]["payload"]
+
+
+def _wave_report_input_with_handoff(wave_id: str) -> dict[str, object]:
+    return {
+        "contract_version": "1.0",
+        "wave_id": wave_id,
+        "wave_content_hash": "sha256:wave-content",
+        "wave_state": "HANDOFF_READY",
+        "trigger_type": "EXPLICIT_PORTFOLIO_LIST",
+        "trigger_id": "manual-wave-001",
+        "trigger_rationale": "CIO model update for the Singapore balanced DPM book.",
+        "as_of_date": "2026-05-12",
+        "generated_at": "2026-05-12T08:00:00Z",
+        "aggregate_metrics": {"item_count": 1, "handoff_ready_item_count": 1},
+        "supportability": {
+            "supportability_state": "ready",
+            "reason_codes": ["wave_report_input_ready"],
+            "item_count": 1,
+        },
+        "proof_pack_posture": {"ready_count": 1, "blocked_count": 0},
+        "items": [
+            {
+                "wave_item_id": "dwi_001",
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "state": "HANDOFF_READY",
+                "proof_pack_id": "dpp_wave_001",
+            }
+        ],
+        "events": [{"event_type": "HANDOFF_READY", "event_time": "2026-05-12T08:00:00Z"}],
+        "handoff_refs": [
+            {
+                "ref_type": "INTERNAL_OPERATIONS_HANDOFF",
+                "ref_id": "handoff_001",
+                "source_system": "lotus-manage",
+                "content_hash": "sha256:handoff",
+            }
+        ],
+        "source_refs": [
+            f"lotus-manage:wave:{wave_id}",
+            "lotus-manage:handoff:handoff_001",
+        ],
+        "redaction_policy": "NO_RAW_PAYLOADS",
+        "external_execution_claimed": False,
+        "evidence_ref": {
+            "source_system": "lotus-manage",
+            "source_type": "DPM_WAVE_REPORT_INPUT",
+            "source_id": wave_id,
+            "content_hash": "sha256:wave-report-input",
+        },
+        "content_hash": "sha256:wave-report-input",
+        "report_input_ref": f"report-input:{wave_id}",
+    }

--- a/tests/unit/test_dpm_wave_service.py
+++ b/tests/unit/test_dpm_wave_service.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
-from app.contracts.dpm_waves import DpmWaveMemoRequest
+from app.contracts.dpm_waves import DpmOperationsHandoffSummaryRequest, DpmWaveMemoRequest
 from app.services.dpm_wave_service import DpmWaveService
 
 
@@ -312,4 +312,155 @@ async def test_dpm_wave_pm_memo_ai_errors_are_product_safe() -> None:
         "upstream_status": 503,
         "error_code": "AI_WAVE_PM_MEMO_UPSTREAM_ERROR",
         "detail": "workflow pack unavailable",
+    }
+
+
+@pytest.mark.asyncio
+async def test_dpm_operations_handoff_summary_uses_manage_handoff_evidence_and_lotus_ai() -> None:
+    manage_payload = _wave_report_input_with_handoff()
+    ai_payload = {
+        "run_id": "wf_run_operations_handoff_001",
+        "output": {"review_required": True, "sections": ["Operations summary"]},
+    }
+    dpm_client = _FakeDpmClient((200, manage_payload))
+    ai_client = _FakeLotusAiClient((200, ai_payload))
+    service = DpmWaveService(
+        dpm_client=dpm_client,  # type: ignore[arg-type]
+        lotus_ai_client=ai_client,  # type: ignore[arg-type]
+    )
+
+    response = await service.request_operations_handoff_summary(
+        wave_id="dwv_001",
+        request=DpmOperationsHandoffSummaryRequest(
+            requested_outputs=["operations_summary", "blocking_conditions"],
+            audience=["operations", "portfolio_manager"],
+        ),
+        correlation_id="corr-operations-handoff-summary",
+    )
+
+    assert response.source_service == "lotus-ai"
+    assert response.evidence_source_service == "lotus-manage"
+    assert response.manage_upstream_status == 200
+    assert response.ai_upstream_status == 200
+    assert response.wave_report_input == manage_payload
+    assert response.handoff_summary_request == {
+        "requested_outputs": ["operations_summary", "blocking_conditions"],
+        "audience": ["operations", "portfolio_manager"],
+    }
+    assert response.data == ai_payload
+    assert dpm_client.calls == [
+        {
+            "method": "get_wave_report_input",
+            "wave_id": "dwv_001",
+            "correlation_id": "corr-operations-handoff-summary",
+        }
+    ]
+    ai_call = ai_client.calls[0]
+    assert ai_call["pack_id"] == "dpm_operations_handoff_summary.pack"
+    assert ai_call["version"] == "v1"
+    assert ai_call["workflow_surface"] == "dpm-operations-handoff-ai-evidence"
+    task_request = ai_call["task_request"]
+    assert task_request["caller"] == {
+        "caller_app": "lotus-gateway",
+        "correlation_id": "corr-operations-handoff-summary",
+    }
+    payload = task_request["context"]["payload"]
+    assert payload["wave_report_input"] == manage_payload
+    assert "memo_request" not in payload
+    assert payload["handoff_summary_request"] == response.handoff_summary_request
+    assert payload["supportability"]["requires_human_review"] is True
+    assert "place_orders" in payload["supportability"]["forbidden_actions"]
+    assert "order_routing" in payload["supportability"]["unsupported_claims"]
+    assert task_request["context"]["source_refs"] == [
+        "lotus-manage:handoff:handoff_001",
+        "lotus-manage:wave-report-input:dwv_001",
+        "lotus-manage:wave:dwv_001",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_operations_handoff_summary_ai_errors_are_product_safe() -> None:
+    service = DpmWaveService(
+        dpm_client=_FakeDpmClient((200, _wave_report_input_with_handoff())),  # type: ignore[arg-type]
+        lotus_ai_client=_FakeLotusAiClient(
+            (
+                422,
+                {
+                    "detail": (
+                        "OPERATIONS_HANDOFF_SUMMARY_GUARDRAIL_BLOCKED: "
+                        "Forbidden operations handoff outputs requested: order_ticket."
+                    )
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.request_operations_handoff_summary(
+            wave_id="dwv_001",
+            request=DpmOperationsHandoffSummaryRequest(requested_outputs=["order_ticket"]),
+            correlation_id="corr-operations-handoff-error",
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == {
+        "source_service": "lotus-ai",
+        "upstream_status": 422,
+        "error_code": "AI_OPERATIONS_HANDOFF_SUMMARY_UPSTREAM_ERROR",
+        "detail": (
+            "OPERATIONS_HANDOFF_SUMMARY_GUARDRAIL_BLOCKED: "
+            "Forbidden operations handoff outputs requested: order_ticket."
+        ),
+    }
+
+
+def _wave_report_input_with_handoff() -> dict[str, object]:
+    return {
+        "contract_version": "1.0",
+        "wave_id": "dwv_001",
+        "wave_content_hash": "sha256:wave-content",
+        "wave_state": "HANDOFF_READY",
+        "trigger_type": "EXPLICIT_PORTFOLIO_LIST",
+        "trigger_id": "manual-wave-001",
+        "trigger_rationale": "CIO model update for the Singapore balanced DPM book.",
+        "as_of_date": "2026-05-12",
+        "generated_at": "2026-05-12T08:00:00Z",
+        "aggregate_metrics": {"item_count": 1, "handoff_ready_item_count": 1},
+        "supportability": {
+            "supportability_state": "ready",
+            "reason_codes": ["wave_report_input_ready"],
+            "item_count": 1,
+        },
+        "proof_pack_posture": {"ready_count": 1, "blocked_count": 0},
+        "items": [
+            {
+                "wave_item_id": "dwi_001",
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "state": "HANDOFF_READY",
+                "proof_pack_id": "dpp_wave_001",
+            }
+        ],
+        "events": [{"event_type": "HANDOFF_READY", "event_time": "2026-05-12T08:00:00Z"}],
+        "handoff_refs": [
+            {
+                "ref_type": "INTERNAL_OPERATIONS_HANDOFF",
+                "ref_id": "handoff_001",
+                "source_system": "lotus-manage",
+                "content_hash": "sha256:handoff",
+            }
+        ],
+        "source_refs": [
+            "lotus-manage:wave:dwv_001",
+            "lotus-manage:handoff:handoff_001",
+        ],
+        "redaction_policy": "NO_RAW_PAYLOADS",
+        "external_execution_claimed": False,
+        "evidence_ref": {
+            "source_system": "lotus-manage",
+            "source_type": "DPM_WAVE_REPORT_INPUT",
+            "source_id": "dwv_001",
+            "content_hash": "sha256:wave-report-input",
+        },
+        "content_hash": "sha256:wave-report-input",
+        "report_input_ref": "report-input:dwv_001",
     }

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -24,6 +24,7 @@
 - `GET` and `POST /api/v1/dpm/command-center/waves*`
 - `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
 - `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`
+- `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`
 - `GET` and `POST /api/v1/dpm/command-center/construction/alternative-sets*`
 - `GET` and `POST /api/v1/dpm/command-center/proof-packs*`
 - `POST /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-pm-memo`
@@ -127,6 +128,11 @@
   PM/control support text. Gateway must not calculate affected portfolios, readiness,
   alternatives, proof-pack state, report evidence, AI narrative, PM scoring, trade approval,
   client contact, order placement, or external execution posture.
+  The operations-handoff summary action reads manage-owned `DpmWaveReportInput` handoff evidence
+  and calls `lotus-ai` `dpm_operations_handoff_summary.pack@v1` as `lotus-gateway`. Gateway
+  preserves manage handoff refs, source refs, hashes, item posture, and the
+  `external_execution_claimed=false` boundary; it must not generate handoff narrative locally,
+  approve trades, contact clients, route orders, claim execution, or invent evidence.
 - RFC-0098 outcome-review composition must consume `lotus-manage` RFC-0042 outcome-review APIs
   for preview, durable create, search, detail, source refresh, supportability, report input, AI
   evidence input, run lookup, and wave lookup. Gateway now exposes the first implementation-backed

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -139,6 +139,11 @@
     `DpmWaveReportInput`, then calls `lotus-ai` `dpm_wave_pm_memo.pack@v1` for review-required
     support text; Gateway does not generate narrative locally, score PMs, approve trades, contact
     clients, place orders, or invent evidence.
+    The operations-handoff summary route also reads manage-owned `DpmWaveReportInput`, including
+    bounded internal `handoff_refs`, then calls `lotus-ai`
+    `dpm_operations_handoff_summary.pack@v1` for review-required operations support text; Gateway
+    does not route orders, claim external execution, approve trades, contact clients, or invent
+    evidence.
 16. RFC36-WTBD-003 portfolio-level DPM operations dashboards consume Gateway Workbench
     `rebalance_snapshot` only. Gateway reads manage rebalance runs, preserves manage
     supportability summary and bounded recent-run posture, and keeps Workbench from calling

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -195,6 +195,7 @@ Supported routes:
 14. `GET /api/v1/dpm/command-center/waves/{wave_id}/supportability`
 15. `GET /api/v1/dpm/command-center/waves/{wave_id}/report-input`
 16. `POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`
+17. `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`
 
 Authority and integrations:
 
@@ -206,7 +207,9 @@ Authority and integrations:
    issues, report-input evidence, remediation routes, and `external_execution_claimed=false`.
 4. Gateway reads manage-owned wave report input before calling `lotus-ai`
    `dpm_wave_pm_memo.pack@v1` for review-required PM/control support text.
-5. Gateway does not calculate affected portfolios, classify source readiness, generate
+5. Gateway reads manage-owned wave report input with internal handoff refs before calling
+   `lotus-ai` `dpm_operations_handoff_summary.pack@v1`.
+6. Gateway does not calculate affected portfolios, classify source readiness, generate
    alternatives, select alternatives, approve items, stage items, create handoff evidence, rebuild
    proof packs, generate report evidence, generate AI narrative locally, score PMs, approve trades,
    contact clients, place orders, invent missing evidence, cancel external orders, or claim external
@@ -217,6 +220,7 @@ flowchart LR
     Workbench[lotus-workbench future wave cockpit] --> Gateway[lotus-gateway DPM wave routes]
     Gateway --> Manage[lotus-manage RFC-0041 wave authority]
     Gateway --> AI[lotus-ai dpm_wave_pm_memo.pack@v1]
+    Gateway --> OpsAI[lotus-ai dpm_operations_handoff_summary.pack@v1]
     Manage --> Construction[lotus-manage RFC-0039 construction alternatives]
     Manage --> Proof[lotus-manage RFC-0040 proof packs]
     Manage --> ReportInput[DpmWaveReportInput evidence]
@@ -232,7 +236,11 @@ Operational behavior:
 2. unsupported transitions and missing waves return product-safe manage error details,
 3. lotus-ai failures on the wave PM memo route return product-safe `lotus-ai` error details while
    preserving manage evidence boundaries,
-4. Workbench wave command-center UI, browser proof, and demo screenshots remain RFC41-WTBD-006 and
+4. lotus-ai failures on the operations-handoff summary route return product-safe `lotus-ai` error
+   details while preserving manage evidence boundaries,
+5. Gateway never turns generated operations handoff support text into order routing, external
+   execution, trade approval, client contact, or PM scoring,
+6. Workbench wave command-center UI, browser proof, and demo screenshots remain RFC41-WTBD-006 and
    are not claimed by this Gateway slice.
 
 ## DPM Mandate Command Center


### PR DESCRIPTION
## Summary
- Add Gateway DPM wave operations-handoff summary handoff at `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`.
- Read manage-owned `DpmWaveReportInput` with bounded internal handoff refs and execute `lotus-ai` `dpm_operations_handoff_summary.pack@v1` as `lotus-gateway`.
- Preserve manage wave/handoff evidence authority, lotus-ai workflow-pack authority, source refs, supportability, redaction policy, and no-external-execution boundaries.
- Update README, RFC-0098 implementation ledger, repository context, and repo-authored wiki source.

## Validation
- `python -m ruff check src/app/contracts/dpm_waves.py src/app/services/dpm_wave_service.py src/app/routers/dpm_waves.py tests/unit/test_dpm_wave_service.py tests/integration/test_dpm_wave_router.py tests/contract/test_dpm_wave_contract.py`
- `python -m pytest tests/unit/test_dpm_wave_service.py tests/integration/test_dpm_wave_router.py tests/contract/test_dpm_wave_contract.py -q` -> 21 passed
- `python -m mypy src`
- `make check` -> 499 unit/contract tests passed
- `make test-integration` -> 175 passed
- `make test-coverage` -> 674 passed, total coverage 88.41%, threshold 84%
- `git diff --check`
- `python automation/validate_engineering_context_system.py` from lotus-platform -> passed

## Governance
- Stranded truth check: `git fetch origin --prune; git branch -r --no-merged origin/main` returned no unmerged remote branches.
- Wiki check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reports expected drift for `API-Surface.md`, `Integrations.md`, and `Supported-Features.md` because this PR intentionally updates repo-authored wiki source. Publish after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-gateway`.