### PR TITLE
RFC 049 composite performance gateway realization

### DIFF
--- a/src/app/clients/lotus_analytics_client.py
+++ b/src/app/clients/lotus_analytics_client.py
@@ -349,6 +349,34 @@ class LotusAnalyticsClient:
             correlation_id=correlation_id,
         )
 
+    async def post_composite_twr(
+        self,
+        *,
+        payload: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post_analytics_request(
+            path="/performance/composites/twr",
+            payload=payload,
+            correlation_id=correlation_id,
+            operation="performance.composites.twr",
+            async_poll_attempts=40,
+        )
+
+    async def post_composite_inspection(
+        self,
+        *,
+        payload: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post_analytics_request(
+            path="/performance/composites/inspect",
+            payload=payload,
+            correlation_id=correlation_id,
+            operation="performance.composites.inspect",
+            async_poll_attempts=40,
+        )
+
     async def get_contribution_analytics(
         self,
         *,

--- a/src/app/contracts/composite_performance.py
+++ b/src/app/contracts/composite_performance.py
@@ -1,0 +1,87 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class CompositePerformanceTwrRequest(BaseModel):
+    calculation_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional caller-provided composite calculation identifier. When omitted, "
+            "lotus-performance generates the idempotency and lineage identifier."
+        ),
+        examples=["7f2b08b0-58e5-49be-b3ef-7a9cfb0321ce"],
+    )
+    composite_id: str = Field(
+        description=(
+            "Stable private-banking composite identifier owned by the composite source authority."
+        ),
+        examples=["PB_GLOBAL_BALANCED_USD"],
+    )
+    period_start: str = Field(
+        description="Inclusive composite calculation start date in ISO-8601 format.",
+        examples=["2026-01-01"],
+    )
+    period_end: str = Field(
+        description="Inclusive composite calculation end date in ISO-8601 format.",
+        examples=["2026-03-31"],
+    )
+
+
+class CompositePerformanceInspectionRequest(BaseModel):
+    inspection_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional caller-provided inspection identifier. When omitted, lotus-performance "
+            "generates the support and audit evidence identifier."
+        ),
+        examples=["8d1e37d2-aeca-488c-bd43-77dbf6739103"],
+    )
+    composite_id: str = Field(
+        description="Stable private-banking composite identifier to inspect.",
+        examples=["PB_GLOBAL_BALANCED_USD"],
+    )
+    period_start: str = Field(
+        description="Inclusive inspection start date in ISO-8601 format.",
+        examples=["2026-01-01"],
+    )
+    period_end: str = Field(
+        description="Inclusive inspection end date in ISO-8601 format.",
+        examples=["2026-03-31"],
+    )
+
+
+class CompositePerformanceGatewayResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Gateway correlation identifier propagated to lotus-performance.",
+        examples=["corr-composite-performance-1"],
+    )
+    contract_version: str = Field(
+        default="composite-performance-gateway.v1",
+        description="Gateway response contract version for composite performance operations.",
+        examples=["composite-performance-gateway.v1"],
+    )
+    source_service: str = Field(
+        default="lotus-performance",
+        description="Authoritative service that calculated or inspected the composite result.",
+        examples=["lotus-performance"],
+    )
+    upstream_status: int = Field(
+        description="HTTP status returned by lotus-performance before Gateway response projection.",
+        examples=[200],
+    )
+    data: dict[str, Any] = Field(
+        description=(
+            "Source-owned composite payload from lotus-performance. Gateway preserves this "
+            "payload without recalculating returns, member weights, dispersion, findings, "
+            "lineage, restatement evidence, or classified inspection artifacts."
+        ),
+        examples=[
+            {
+                "composite_id": "PB_GLOBAL_BALANCED_USD",
+                "status": "READY",
+                "methodology": "persisted_member_return_asset_weighted_twr_v1",
+                "periods": [],
+            }
+        ],
+    )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -12,6 +12,7 @@ from app.enterprise_readiness import (
 from app.middleware.correlation import correlation_id_var, correlation_middleware, setup_logging
 from app.routers.analytics_diagnostics import router as analytics_diagnostics_router
 from app.routers.archive_documents import router as archive_documents_router
+from app.routers.composite_performance import router as composite_performance_router
 from app.routers.domain_products import router as domain_products_router
 from app.routers.dpm_command_center import router as dpm_command_center_router
 from app.routers.dpm_construction import router as dpm_construction_router
@@ -72,6 +73,13 @@ app = FastAPI(
             ),
         },
         {
+            "name": "Composite Performance",
+            "description": (
+                "Gateway-facing composite performance operations backed by lotus-performance "
+                "source-owned calculation, inspection, lineage, and evidence contracts."
+            ),
+        },
+        {
             "name": "DPM Command Center",
             "description": (
                 "Gateway BFF composition APIs for DPM command-center, construction, proof-pack, "
@@ -92,6 +100,7 @@ app.include_router(domain_products_router)
 app.include_router(intake_router)
 app.include_router(foundation_router)
 app.include_router(portfolio_router)
+app.include_router(composite_performance_router)
 app.include_router(dpm_command_center_router)
 app.include_router(dpm_construction_router)
 app.include_router(dpm_proof_packs_router)

--- a/src/app/routers/composite_performance.py
+++ b/src/app/routers/composite_performance.py
@@ -1,0 +1,142 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Header, HTTPException, status
+
+from app.clients.lotus_analytics_client import LotusAnalyticsClient
+from app.config import settings
+from app.contracts.composite_performance import (
+    CompositePerformanceGatewayResponse,
+    CompositePerformanceInspectionRequest,
+    CompositePerformanceTwrRequest,
+)
+from app.middleware.correlation import correlation_id_var
+from app.services.caller_context import caller_context_headers
+
+router = APIRouter(prefix="/api/v1/performance/composites", tags=["Composite Performance"])
+
+
+def _analytics_client() -> LotusAnalyticsClient:
+    return LotusAnalyticsClient(
+        base_url=settings.performance_analytics_base_url,
+        timeout_seconds=settings.performance_analytics_timeout_seconds,
+        max_retries=settings.upstream_max_retries,
+        retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+    )
+
+
+def _required_caller_context(
+    *,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> dict[str, str]:
+    return caller_context_headers(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+
+
+def _raise_upstream_error(*, status_code: int, payload: dict[str, object]) -> None:
+    if status_code < 400:
+        return
+    detail = {
+        "source_service": "lotus-performance",
+        "upstream_status": status_code,
+        "error": payload,
+    }
+    if status_code == status.HTTP_404_NOT_FOUND:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+    if status_code in {status.HTTP_400_BAD_REQUEST, status.HTTP_422_UNPROCESSABLE_ENTITY}:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+    raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=detail)
+
+
+@router.post(
+    "/twr",
+    response_model=CompositePerformanceGatewayResponse,
+    summary="Calculate Persisted Composite TWR",
+    description=(
+        "Calculates an asset-weighted composite time-weighted return through lotus-performance "
+        "from persisted member-return facts. Gateway is only the governed experience boundary: "
+        "it propagates caller context and correlation, preserves the source-owned payload, and "
+        "does not calculate returns, member weights, dispersion, lineage, or restatement truth."
+    ),
+)
+async def calculate_composite_twr(
+    request: CompositePerformanceTwrRequest,
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> CompositePerformanceGatewayResponse:
+    _required_caller_context(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+    correlation_id = correlation_id_var.get()
+    payload = request.model_dump(exclude_none=True)
+    upstream_status, upstream_payload = await _analytics_client().post_composite_twr(
+        payload=payload,
+        correlation_id=correlation_id,
+    )
+    _raise_upstream_error(status_code=upstream_status, payload=upstream_payload)
+    return CompositePerformanceGatewayResponse(
+        correlation_id=correlation_id,
+        upstream_status=upstream_status,
+        data=upstream_payload,
+    )
+
+
+@router.post(
+    "/inspect",
+    response_model=CompositePerformanceGatewayResponse,
+    summary="Inspect Composite Performance Evidence",
+    description=(
+        "Runs lotus-performance composite inspection for support, audit, and methodology evidence. "
+        "The response carries source-owned findings, evidence summaries, and classified artifacts "
+        "such as member inputs, period weights, composite returns, lineage manifest, and support "
+        "brief content. Gateway preserves the artifact payloads and does not generate audit truth."
+    ),
+)
+async def inspect_composite_performance(
+    request: CompositePerformanceInspectionRequest,
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+) -> CompositePerformanceGatewayResponse:
+    _required_caller_context(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+    correlation_id = correlation_id_var.get()
+    payload = request.model_dump(exclude_none=True)
+    upstream_status, upstream_payload = await _analytics_client().post_composite_inspection(
+        payload=payload,
+        correlation_id=correlation_id,
+    )
+    _raise_upstream_error(status_code=upstream_status, payload=upstream_payload)
+    return CompositePerformanceGatewayResponse(
+        correlation_id=correlation_id,
+        upstream_status=upstream_status,
+        data=upstream_payload,
+    )

--- a/tests/integration/test_composite_performance_router.py
+++ b/tests/integration/test_composite_performance_router.py
@@ -1,0 +1,162 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+CALLER_CONTEXT_HEADERS = {
+    "X-Actor-Id": "advisor_1",
+    "X-Caller-Application": "lotus-workbench",
+    "X-Tenant-Id": "tenant-sg",
+    "X-Region": "APAC",
+    "X-Booking-Center-Code": "SG",
+    "X-Role": "advisor",
+    "X-Correlation-Id": "corr-composite-1",
+}
+
+
+def test_composite_twr_route_preserves_lotus_performance_payload(monkeypatch):
+    async def _post_composite_twr(self, payload, correlation_id):  # noqa: ARG001
+        assert correlation_id == "corr-composite-1"
+        assert payload == {
+            "calculation_id": "calc-1",
+            "composite_id": "PB_GLOBAL_BALANCED_USD",
+            "period_start": "2026-01-01",
+            "period_end": "2026-03-31",
+        }
+        return 200, {
+            "calculation_id": "calc-1",
+            "composite_id": "PB_GLOBAL_BALANCED_USD",
+            "status": "READY",
+            "methodology": "persisted_member_return_asset_weighted_twr_v1",
+            "periods": [
+                {
+                    "period_start": "2026-01-01",
+                    "period_end": "2026-01-31",
+                    "status": "READY",
+                    "return_value": "0.012500000000",
+                    "source_fingerprints": ["sha256:fact-1"],
+                    "restatement_versions": ["v1"],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.post_composite_twr",
+        _post_composite_twr,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/performance/composites/twr",
+        headers=CALLER_CONTEXT_HEADERS,
+        json={
+            "calculation_id": "calc-1",
+            "composite_id": "PB_GLOBAL_BALANCED_USD",
+            "period_start": "2026-01-01",
+            "period_end": "2026-03-31",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["correlation_id"] == "corr-composite-1"
+    assert body["contract_version"] == "composite-performance-gateway.v1"
+    assert body["source_service"] == "lotus-performance"
+    assert body["upstream_status"] == 200
+    assert body["data"]["methodology"] == "persisted_member_return_asset_weighted_twr_v1"
+    assert body["data"]["periods"][0]["source_fingerprints"] == ["sha256:fact-1"]
+
+
+def test_composite_inspection_route_preserves_classified_artifacts(monkeypatch):
+    async def _post_composite_inspection(self, payload, correlation_id):  # noqa: ARG001
+        assert payload["inspection_id"] == "insp-1"
+        return 200, {
+            "inspection_id": "insp-1",
+            "composite_id": "PB_GLOBAL_BALANCED_USD",
+            "status": "complete",
+            "verdict": "supportable_with_warnings",
+            "findings": [
+                {
+                    "code": "DEGRADED_PERIOD",
+                    "severity": "warning",
+                    "category": "member_return_fact_quality",
+                    "owner_repo": "lotus-performance",
+                    "summary": "One period is degraded.",
+                    "recommended_action": "Review member fact lineage.",
+                    "evidence": {"period": "2026-01"},
+                }
+            ],
+            "artifacts": [
+                {
+                    "artifact_name": "member_inputs.csv",
+                    "content_type": "text/csv",
+                    "access_classification": "operator_only",
+                    "artifact_content": "portfolio_id,return_value\nPB_SG_GLOBAL_BAL_001,0.0125\n",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.post_composite_inspection",
+        _post_composite_inspection,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/performance/composites/inspect",
+        headers=CALLER_CONTEXT_HEADERS,
+        json={
+            "inspection_id": "insp-1",
+            "composite_id": "PB_GLOBAL_BALANCED_USD",
+            "period_start": "2026-01-01",
+            "period_end": "2026-03-31",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["verdict"] == "supportable_with_warnings"
+    assert body["data"]["findings"][0]["owner_repo"] == "lotus-performance"
+    assert body["data"]["artifacts"][0]["artifact_name"] == "member_inputs.csv"
+    assert "artifact_content" in body["data"]["artifacts"][0]
+
+
+def test_composite_routes_require_governed_caller_context():
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/performance/composites/twr",
+        json={
+            "composite_id": "PB_GLOBAL_BALANCED_USD",
+            "period_start": "2026-01-01",
+            "period_end": "2026-03-31",
+        },
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["code"] == "missing_caller_context"
+    assert detail["missing_headers"] == ["X-Actor-Id", "X-Tenant-Id", "X-Region"]
+
+
+def test_composite_performance_openapi_contract_registered():
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+
+    twr_route = spec["paths"]["/api/v1/performance/composites/twr"]["post"]
+    inspect_route = spec["paths"]["/api/v1/performance/composites/inspect"]["post"]
+    request_schema = spec["components"]["schemas"]["CompositePerformanceTwrRequest"]
+    inspect_request_schema = spec["components"]["schemas"]["CompositePerformanceInspectionRequest"]
+    response_schema = spec["components"]["schemas"]["CompositePerformanceGatewayResponse"]
+
+    assert twr_route["summary"] == "Calculate Persisted Composite TWR"
+    assert "does not calculate returns" in twr_route["description"]
+    assert inspect_route["summary"] == "Inspect Composite Performance Evidence"
+    assert "classified artifacts" in inspect_route["description"]
+    assert request_schema["properties"]["composite_id"]["description"]
+    assert request_schema["properties"]["period_start"]["examples"] == ["2026-01-01"]
+    assert inspect_request_schema["properties"]["inspection_id"]["description"]
+    assert response_schema["properties"]["data"]["description"]
+    assert (
+        "source-owned composite payload"
+        in response_schema["properties"]["data"]["description"].lower()
+    )

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -282,6 +282,61 @@ async def test_lotus_analytics_client_performance_workspace_requests_use_owned_c
 
 
 @pytest.mark.asyncio
+async def test_lotus_analytics_client_calls_composite_performance_routes():
+    client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(
+        200,
+        {
+            "calculation_id": "calc-1",
+            "composite_id": "PB_GLOBAL_BALANCED_USD",
+            "status": "READY",
+            "periods": [],
+        },
+    )
+    _FakeAsyncClient.queue_json(
+        200,
+        {
+            "inspection_id": "insp-1",
+            "composite_id": "PB_GLOBAL_BALANCED_USD",
+            "verdict": "supportable",
+            "artifacts": [],
+        },
+    )
+
+    twr_status, twr_payload = await client.post_composite_twr(
+        payload={
+            "calculation_id": "calc-1",
+            "composite_id": "PB_GLOBAL_BALANCED_USD",
+            "period_start": "2026-01-01",
+            "period_end": "2026-03-31",
+        },
+        correlation_id="corr-composite",
+    )
+    inspection_status, inspection_payload = await client.post_composite_inspection(
+        payload={
+            "inspection_id": "insp-1",
+            "composite_id": "PB_GLOBAL_BALANCED_USD",
+            "period_start": "2026-01-01",
+            "period_end": "2026-03-31",
+        },
+        correlation_id="corr-composite",
+    )
+
+    assert twr_status == 200
+    assert twr_payload["status"] == "READY"
+    assert inspection_status == 200
+    assert inspection_payload["verdict"] == "supportable"
+    twr_post = _FakeAsyncClient.calls[0]
+    inspection_post = _FakeAsyncClient.calls[1]
+    assert twr_post["url"] == "http://analytics/performance/composites/twr"
+    assert twr_post["json"]["composite_id"] == "PB_GLOBAL_BALANCED_USD"
+    assert twr_post["headers"]["X-Correlation-Id"] == "corr-composite"
+    assert inspection_post["url"] == "http://analytics/performance/composites/inspect"
+    assert inspection_post["json"]["inspection_id"] == "insp-1"
+    assert inspection_post["headers"]["X-Correlation-Id"] == "corr-composite"
+
+
+@pytest.mark.asyncio
 async def test_lotus_analytics_client_omits_stateful_dimension_filter_for_currency_attribution():
     client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(


### PR DESCRIPTION
Implements the lotus-gateway downstream realization for lotus-performance RFC 049 composite performance.\n\n- Adds Gateway composite TWR and inspection routes backed by lotus-performance.\n- Preserves source-owned composite calculation, inspection, lineage, restatement, and artifact payloads.\n- Adds typed contracts, OpenAPI coverage, and focused unit/integration tests.\n\nValidation run locally:\n- python -m ruff check src\\app\\contracts\\composite_performance.py src\\app\\routers\\composite_performance.py src\\app\\clients\\lotus_analytics_client.py tests\\unit\\test_upstream_clients.py tests\\integration\\test_composite_performance_router.py\n- python -m ruff format --check src\\app\\contracts\\composite_performance.py src\\app\\routers\\composite_performance.py src\\app\\clients\\lotus_analytics_client.py tests\\unit\\test_upstream_clients.py tests\\integration\\test_composite_performance_router.py\n- python -m pytest tests\\unit\\test_upstream_clients.py -q\n- python -m pytest tests\\integration\\test_composite_performance_router.py -q\n- python -m mypy --config-file pyproject.toml src\n- git diff --check