### PR TITLE
Expose DPM campaign definition gateway routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-evidence-input`,
   `/api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-pm-memo`,
   `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`,
+  `/api/v1/dpm/command-center/waves/campaign-definitions*`,
   `/api/v1/dpm/command-center/waves*`,
   `/api/v1/dpm/command-center/waves/{wave_id}/report-input`,
   `/api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`,
@@ -278,6 +279,10 @@ Important current parameter conventions:
    state, item states, aggregate metrics, selected alternative refs, proof-pack refs, handoff refs,
    supportability, report-input evidence, and reason codes without calculating affected portfolios,
    source readiness, alternatives, proof-pack state, report evidence, or execution posture locally.
+   Gateway also exposes campaign-definition list, get, and upsert routes under
+   `/api/v1/dpm/command-center/waves/campaign-definitions*` so Workbench can discover and preserve
+   manage-owned campaign/cohort definitions without recomputing cohort facts, portfolio
+   eligibility, maker-checker posture, or membership locally.
    Gateway also exposes a governed `dpm_wave_pm_memo.pack@v1` handoff to `lotus-ai` from
    manage-owned wave report input; it does not generate memo narrative, score PMs, approve trades,
    contact clients, place orders, or invent missing evidence.

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -244,13 +244,15 @@ Most relevant current governance:
 15. RFC-0041 rebalance-wave Gateway routes are active under
     `/api/v1/dpm/command-center/waves*`. Gateway forwards preview, durable create, search, detail,
     item list, source-check, simulation, item selection, approval, staging, internal handoff,
-    cancellation, proof-pack posture, supportability, and report-input requests to `lotus-manage`;
+    cancellation, proof-pack posture, supportability, report-input, and campaign-definition list,
+    get, and upsert requests to `lotus-manage`;
     preserves manage-owned `wave_id`, lifecycle state, item states, reason codes, aggregate
-    metrics, selected alternative refs, proof-pack refs, handoff refs, supportability issues,
-    report-input evidence, and `external_execution_claimed=false`; and must not calculate affected
-    portfolios, classify source readiness, generate alternatives, select alternatives, approve
-    items, stage items, create handoff evidence, rebuild proof packs, generate report evidence, or
-    claim external execution locally. Gateway can request `lotus-ai`
+    metrics, selected alternative refs, proof-pack refs, handoff refs, campaign definition payloads,
+    supportability issues, report-input evidence, and `external_execution_claimed=false`; and must
+    not calculate affected portfolios, classify source readiness, discover cohorts, recompute
+    campaign membership, generate alternatives, select alternatives, approve items, stage items,
+    create handoff evidence, rebuild proof packs, generate report evidence, or claim external
+    execution locally. Gateway can request `lotus-ai`
     `dpm_wave_pm_memo.pack@v1` from manage-owned wave report input as a review-required PM/control
     support artifact, but it must not generate AI narrative locally, score PMs, approve trades,
     contact clients, place orders, or invent missing evidence.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -21,5 +21,5 @@ Governance boundary:
 | RFC-0013 | Workbench Position Valuation Fields | IMPLEMENTED | `docs/rfcs/RFC-0013-workbench-position-valuation-fields.md` |
 | RFC-0014 | Experience API Foundation and Pre-Live Replacement Strategy | PROPOSED | `docs/rfcs/RFC-0014-experience-api-foundation-and-prelive-replacement-strategy.md` |
 | RFC-0015 | Foundation Workspace Experience Contract | IMPLEMENTED | `docs/rfcs/RFC-0015-foundation-workspace-experience-contract.md` |
-| RFC-0098 | DPM Command Center Composition Contract | PARTIAL IMPLEMENTATION - RFC-0038 MANDATE COMMAND-CENTER, RFC-0039 CONSTRUCTION, RFC-0040 PROOF-PACK AND PORTFOLIO-MEMORY, RFC-0041 REBALANCE-WAVE, AND RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER REPORT/ARCHIVE MODULES AND WORKBENCH WAVE/TIMELINE UI PENDING | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
+| RFC-0098 | DPM Command Center Composition Contract | PARTIAL IMPLEMENTATION - RFC-0038 MANDATE COMMAND-CENTER, RFC-0039 CONSTRUCTION, RFC-0040 PROOF-PACK AND PORTFOLIO-MEMORY, RFC-0041 REBALANCE-WAVE PLUS CAMPAIGN-DEFINITION DISCOVERY, AND RFC-0042 OUTCOME-REVIEW BFF ROUTES IMPLEMENTED; BROADER REPORT/ARCHIVE MODULES AND WORKBENCH WAVE/TIMELINE UI PENDING | `docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md` |
 

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -1182,6 +1182,7 @@ route family so Workbench can consume Gateway/BFF instead of calling `lotus-mana
 | RFC40-WTBD-005 Gateway proof-pack AI PM memo handoff | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | Gateway reads manage-owned `DpmProofPackAiEvidenceInput`, executes `lotus-ai` `dpm_pm_memo.pack@v1` as `lotus-gateway`, preserves manage evidence authority and lotus-ai workflow-pack posture, and exposes `POST /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-pm-memo` |
 | RFC40-WTBD-010 Gateway portfolio-memory composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | Gateway reads manage-owned `/api/v1/rebalance/portfolio-memory/{portfolio_id}` through `GET /api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`, preserves event order, event types, source systems, source refs, artifact refs, reason codes, supportability state, bounded metadata, and content hash, and does not reconstruct timeline nodes or calculate source-owner truth |
 | RFC41-WTBD-005 Gateway wave composition | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | `src/app/routers/dpm_waves.py`, `src/app/services/dpm_wave_service.py`, `src/app/contracts/dpm_waves.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_wave_service.py`, `tests/integration/test_dpm_wave_router.py`, `tests/contract/test_dpm_wave_contract.py`, `tests/unit/test_upstream_clients.py` |
+| RFC41-WTBD-003 Gateway campaign-definition discovery/upsert | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | Gateway forwards manage-owned campaign definition list, get, and upsert APIs through `/api/v1/dpm/command-center/waves/campaign-definitions*`, preserves campaign payloads unchanged, and does not discover cohorts, recompute campaign membership, or own maker-checker posture |
 | RFC42-WTBD-001 Gateway outcome-review composition and BFF contract | Implemented and merged before this slice | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/contract/test_dpm_command_center_contract.py`, `make ci` |
 | RFC42-WTBD-005 Gateway AI narrative handoff | Implemented and merged before this slice | Gateway reads manage-owned `DpmOutcomeAiEvidenceInput`, executes `lotus-ai` `outcome_review_narrative.pack@v1` as `lotus-gateway`, preserves manage workflow authority, and exposes `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative` |
 | RFC38/RFC43-WTBD Gateway exception-summary AI handoff | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | Gateway reads manage-owned monitoring-exception evidence from the command-center exception queue, executes `lotus-ai` `dpm_exception_summary.pack@v1` as `lotus-gateway`, preserves source refs/content hashes/supportability, and exposes `POST /api/v1/dpm/command-center/exceptions/{exception_id}/ai-summary` |
@@ -1258,12 +1259,17 @@ Implementation boundaries:
    `GET /api/v1/dpm/command-center/waves/{wave_id}/report-input`,
    `POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`, and
    `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`.
+   Gateway also exposes `GET /api/v1/dpm/command-center/waves/campaign-definitions`,
+   `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`,
+   and `PUT /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`.
 14. Wave routes preserve manage-owned `wave_id`, lifecycle state, item states, reason codes,
-   aggregate metrics, selected alternative refs, proof-pack refs, handoff refs, supportability
-   issues, source-owner remediation, and the no-external-execution boundary.
+   aggregate metrics, selected alternative refs, proof-pack refs, handoff refs, campaign
+   definition payloads, supportability issues, source-owner remediation, and the
+   no-external-execution boundary.
 15. Gateway does not calculate affected portfolios, classify source readiness, generate
-   alternatives, select alternatives, approve items, stage items, create handoff evidence, rebuild
-   proof packs, or claim external execution locally.
+   alternatives, discover cohorts, recompute campaign membership, select alternatives, approve
+   items, stage items, create handoff evidence, rebuild proof packs, or claim external execution
+   locally.
    The operations-handoff summary AI handoff reads manage-owned wave report input with bounded
    internal handoff refs and calls `lotus-ai` `dpm_operations_handoff_summary.pack@v1`. Gateway
    does not generate summaries locally, score PMs, approve trades, contact clients, route orders,

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -952,19 +952,19 @@
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:1702:def _safe_float(value: Any) -> float | None:",
+      "finding": "src/app/services/risk_workspace_service.py:1756:def _safe_float(value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:1706:return float(value)",
+      "finding": "src/app/services/risk_workspace_service.py:1760:return float(value)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/risk_workspace_service.py:804:value=float(value) if isinstance(value, int | float) else None,",
+      "finding": "src/app/services/risk_workspace_service.py:858:value=float(value) if isinstance(value, int | float) else None,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -352,6 +352,46 @@ class DpmClient:
             operation="manage.rebalance.waves.get",
         )
 
+    async def put_campaign_definition(
+        self,
+        campaign_id: str,
+        campaign_version: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._put(
+            f"/api/v1/rebalance/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.campaign_definitions.put",
+        )
+
+    async def list_campaign_definitions(
+        self,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        cleaned_params = {key: value for key, value in params.items() if value is not None}
+        return await self._get(
+            "/api/v1/rebalance/waves/campaign-definitions",
+            params=cleaned_params,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.campaign_definitions.list",
+        )
+
+    async def get_campaign_definition(
+        self,
+        campaign_id: str,
+        campaign_version: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.campaign_definitions.get",
+        )
+
     async def get_wave_items(
         self,
         wave_id: str,
@@ -679,6 +719,27 @@ class DpmClient:
             service="lotus-manage",
             operation=operation,
             method="POST",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=headers,
+            json_body=body,
+        )
+
+    async def _put(
+        self,
+        path: str,
+        body: dict[str, Any],
+        headers: dict[str, str],
+        operation: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}{path}"
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-manage",
+            operation=operation,
+            method="PUT",
             url=url,
             timeout_seconds=self._timeout,
             max_retries=self._max_retries,

--- a/src/app/clients/http_resilience.py
+++ b/src/app/clients/http_resilience.py
@@ -36,8 +36,11 @@ async def request_with_retry(
                 timeout=timeout_seconds,
                 follow_redirects=True,
             ) as client:
-                if method.upper() == "GET":
+                request_method = method.upper()
+                if request_method == "GET":
                     response = await client.get(url, params=params, headers=headers)
+                elif request_method == "PUT":
+                    response = await client.put(url, headers=headers, json=json_body)
                 else:
                     response = await client.post(
                         url,

--- a/src/app/contracts/dpm_waves.py
+++ b/src/app/contracts/dpm_waves.py
@@ -32,6 +32,41 @@ class DpmWaveCreateRequest(DpmWaveForwardRequest):
     )
 
 
+class DpmCampaignDefinitionForwardRequest(BaseModel):
+    body: dict[str, object] = Field(
+        description=(
+            "BulkReviewCampaignDefinition:v1 payload forwarded unchanged to lotus-manage. "
+            "Gateway does not discover global portfolios, infer source facts, run maker-checker "
+            "workflow, calculate campaign membership, or claim OMS execution."
+        ),
+        examples=[
+            {
+                "display_name": "May 2026 concentrated holdings review",
+                "status": "ACTIVE",
+                "as_of_date": "2026-05-14",
+                "rationale": "Review source-backed DPM candidates with concentrated holdings.",
+                "eligible_portfolio_types": ["DPM_DISCRETIONARY"],
+                "candidates": [
+                    {
+                        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                        "portfolio_type": "DPM_DISCRETIONARY",
+                        "source_refs": [
+                            {
+                                "source_system": "lotus-risk",
+                                "source_type": "RiskEventAffectedCohort",
+                                "source_id": "risk-event:concentration:2026-05-14",
+                                "content_hash": "sha256:campaign-candidate",
+                            }
+                        ],
+                    }
+                ],
+                "created_by": "pm_sg_1",
+                "correlation_id": "corr-campaign-definition-001",
+            }
+        ],
+    )
+
+
 class DpmWaveMemoRequest(BaseModel):
     requested_outputs: list[str] = Field(
         default_factory=lambda: [
@@ -185,6 +220,42 @@ class DpmWaveGatewayResponse(BaseModel):
                     "aggregate_metrics": {"item_count": 1, "ready_item_count": 1},
                 },
                 "durable": True,
+            }
+        ],
+    )
+
+
+class DpmCampaignDefinitionGatewayResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated across Gateway and lotus-manage.",
+        examples=["corr-campaign-definition-001"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway BFF contract version for DPM campaign-definition responses.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        default="lotus-manage",
+        description="Upstream service that supplied the authoritative campaign-definition payload.",
+        examples=["lotus-manage"],
+    )
+    upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage before Gateway envelope composition.",
+        examples=[200],
+    )
+    data: dict[str, object] = Field(
+        description=(
+            "Authoritative manage BulkReviewCampaignDefinition:v1 payload or page preserved for "
+            "Workbench composition. Gateway does not alter candidates, source refs, governance, "
+            "content hashes, status, or as-of posture."
+        ),
+        examples=[
+            {
+                "campaign_id": "campaign-holdings-apple-tesla-20260510",
+                "campaign_version": "2026.05",
+                "product_name": "BulkReviewCampaignDefinition",
+                "status": "ACTIVE",
             }
         ],
     )

--- a/src/app/routers/dpm_waves.py
+++ b/src/app/routers/dpm_waves.py
@@ -6,6 +6,8 @@ from app.clients.dpm_client import DpmClient
 from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_waves import (
+    DpmCampaignDefinitionForwardRequest,
+    DpmCampaignDefinitionGatewayResponse,
     DpmOperationsHandoffSummaryGatewayResponse,
     DpmOperationsHandoffSummaryRequest,
     DpmWaveCreateRequest,
@@ -139,6 +141,93 @@ async def list_waves(
             "limit": limit,
             "offset": offset,
         },
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.put(
+    "/campaign-definitions/{campaign_id}/versions/{campaign_version}",
+    response_model=DpmCampaignDefinitionGatewayResponse,
+    summary="Persist DPM bulk-review campaign definition",
+    description=(
+        "What: persists an immutable manage-owned BulkReviewCampaignDefinition:v1 over a "
+        "source-backed candidate set. When: use this before previewing or creating "
+        "BULK_REVIEW_CAMPAIGN waves from a governed campaign definition. How: Gateway forwards "
+        "the payload unchanged to lotus-manage and preserves candidate, governance, source-ref, "
+        "content-hash, and status truth without discovering portfolios or running maker-checker "
+        "workflow locally."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def put_campaign_definition(
+    request: DpmCampaignDefinitionForwardRequest,
+    campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
+    campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await _dpm_wave_service().put_campaign_definition(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/campaign-definitions",
+    response_model=DpmCampaignDefinitionGatewayResponse,
+    summary="List DPM bulk-review campaign definitions",
+    description=(
+        "What: lists immutable manage-owned BulkReviewCampaignDefinition:v1 definitions for "
+        "Workbench campaign selection and operating review. When: filter by campaign id, status, "
+        "or as-of date. How: Gateway forwards filters to lotus-manage and does not discover "
+        "global portfolio cohorts or infer campaign membership locally."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def list_campaign_definitions(
+    campaign_id: str | None = Query(default=None, description="Optional campaign id filter."),
+    campaign_status: str | None = Query(
+        default=None, description="Optional campaign status filter."
+    ),
+    as_of_date: str | None = Query(
+        default=None,
+        description="Optional campaign as-of date filter.",
+        examples=["2026-05-14"],
+    ),
+    limit: int = Query(default=50, ge=1, le=200, description="Maximum definitions to return."),
+    offset: int = Query(default=0, ge=0, description="Zero-based definition-list offset."),
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await _dpm_wave_service().list_campaign_definitions(
+        filters={
+            "campaign_id": campaign_id,
+            "campaign_status": campaign_status,
+            "as_of_date": as_of_date,
+            "limit": limit,
+            "offset": offset,
+        },
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/campaign-definitions/{campaign_id}/versions/{campaign_version}",
+    response_model=DpmCampaignDefinitionGatewayResponse,
+    summary="Get DPM bulk-review campaign definition",
+    description=(
+        "What: retrieves one immutable manage-owned BulkReviewCampaignDefinition:v1 definition. "
+        "When: use this for campaign drill-down or before creating a campaign-backed wave. How: "
+        "Gateway preserves the manage payload without recalculating candidate facts, governance, "
+        "content hashes, or membership."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def get_campaign_definition(
+    campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
+    campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await _dpm_wave_service().get_campaign_definition(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
         correlation_id=correlation_id_var.get(),
     )
 

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -380,6 +380,18 @@ async def get_workbench_risk_summary(
         description="Optional business as-of date in YYYY-MM-DD format.",
         examples=["2026-02-24"],
     ),
+    report_start_date: str | None = Query(
+        default=None,
+        description=(
+            "Inclusive explicit start date when the caller requests an explicit risk window."
+        ),
+        examples=["2026-01-01"],
+    ),
+    report_end_date: str | None = Query(
+        default=None,
+        description="Inclusive explicit end date when the caller requests an explicit risk window.",
+        examples=["2026-03-27"],
+    ),
     reporting_currency: str = Query(
         default="USD",
         description="Reporting currency used for stateful risk and risk-free-rate sourcing.",
@@ -409,6 +421,8 @@ async def get_workbench_risk_summary(
         detail_basis=detail_basis,
         benchmark_code=benchmark_code,
         as_of_date=as_of_date,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
         reporting_currency=reporting_currency,
     )
 
@@ -448,6 +462,18 @@ async def get_workbench_risk_concentration(
         description="Optional business as-of date in YYYY-MM-DD format.",
         examples=["2026-02-24"],
     ),
+    report_start_date: str | None = Query(
+        default=None,
+        description=(
+            "Inclusive explicit start date when the caller requests an explicit risk window."
+        ),
+        examples=["2026-01-01"],
+    ),
+    report_end_date: str | None = Query(
+        default=None,
+        description="Inclusive explicit end date when the caller requests an explicit risk window.",
+        examples=["2026-03-27"],
+    ),
     reporting_currency: str = Query(
         default="USD",
         description="Reporting currency used for stateful concentration analytics.",
@@ -461,6 +487,8 @@ async def get_workbench_risk_concentration(
         correlation_id=correlation_id,
         period=period,
         as_of_date=as_of_date,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
         reporting_currency=reporting_currency,
         benchmark_code=benchmark_code,
     )
@@ -505,6 +533,18 @@ async def get_workbench_risk_drawdown(
         description="Optional business as-of date in YYYY-MM-DD format.",
         examples=["2026-02-24"],
     ),
+    report_start_date: str | None = Query(
+        default=None,
+        description=(
+            "Inclusive explicit start date when the caller requests an explicit risk window."
+        ),
+        examples=["2026-01-01"],
+    ),
+    report_end_date: str | None = Query(
+        default=None,
+        description="Inclusive explicit end date when the caller requests an explicit risk window.",
+        examples=["2026-03-27"],
+    ),
     reporting_currency: str = Query(
         default="USD",
         description="Reporting currency used for stateful drawdown analytics.",
@@ -525,6 +565,8 @@ async def get_workbench_risk_drawdown(
         detail_basis=detail_basis,
         benchmark_code=benchmark_code,
         as_of_date=as_of_date,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
         reporting_currency=reporting_currency,
         include_underwater_series=include_underwater_series,
     )
@@ -570,6 +612,18 @@ async def get_workbench_risk_rolling(
         description="Optional business as-of date in YYYY-MM-DD format.",
         examples=["2026-02-24"],
     ),
+    report_start_date: str | None = Query(
+        default=None,
+        description=(
+            "Inclusive explicit start date when the caller requests an explicit risk window."
+        ),
+        examples=["2026-01-01"],
+    ),
+    report_end_date: str | None = Query(
+        default=None,
+        description="Inclusive explicit end date when the caller requests an explicit risk window.",
+        examples=["2026-03-27"],
+    ),
     reporting_currency: str = Query(
         default="USD",
         description=(
@@ -594,6 +648,8 @@ async def get_workbench_risk_rolling(
         detail_basis=detail_basis,
         benchmark_code=benchmark_code,
         as_of_date=as_of_date,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
         reporting_currency=reporting_currency,
         include_time_series=include_time_series,
     )
@@ -639,6 +695,18 @@ async def get_workbench_risk_attribution(
         description="Optional business as-of date in YYYY-MM-DD format.",
         examples=["2026-02-24"],
     ),
+    report_start_date: str | None = Query(
+        default=None,
+        description=(
+            "Inclusive explicit start date when the caller requests an explicit risk window."
+        ),
+        examples=["2026-01-01"],
+    ),
+    report_end_date: str | None = Query(
+        default=None,
+        description="Inclusive explicit end date when the caller requests an explicit risk window.",
+        examples=["2026-03-27"],
+    ),
     reporting_currency: str = Query(
         default="USD",
         description="Reporting currency used for stateful risk attribution analytics.",
@@ -670,6 +738,8 @@ async def get_workbench_risk_attribution(
         detail_basis=detail_basis,
         benchmark_code=benchmark_code,
         as_of_date=as_of_date,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
         reporting_currency=reporting_currency,
         attribution_type=attribution_type,
         grouping_dimension=grouping_dimension,

--- a/src/app/services/dpm_wave_service.py
+++ b/src/app/services/dpm_wave_service.py
@@ -6,6 +6,7 @@ from app.clients.dpm_client import DpmClient
 from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_waves import (
+    DpmCampaignDefinitionGatewayResponse,
     DpmOperationsHandoffSummaryGatewayResponse,
     DpmOperationsHandoffSummaryRequest,
     DpmWaveErrorDetail,
@@ -87,6 +88,57 @@ class DpmWaveService:
             correlation_id=correlation_id,
         )
         return self._compose_response(upstream_status, upstream_payload, correlation_id)
+
+    async def put_campaign_definition(
+        self,
+        campaign_id: str,
+        campaign_version: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmCampaignDefinitionGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.put_campaign_definition(
+            campaign_id=campaign_id,
+            campaign_version=campaign_version,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_campaign_definition_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
+    async def list_campaign_definitions(
+        self,
+        filters: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmCampaignDefinitionGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.list_campaign_definitions(
+            params=filters,
+            correlation_id=correlation_id,
+        )
+        return self._compose_campaign_definition_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
+    async def get_campaign_definition(
+        self,
+        campaign_id: str,
+        campaign_version: str,
+        correlation_id: str,
+    ) -> DpmCampaignDefinitionGatewayResponse:
+        upstream_status, upstream_payload = await self._dpm_client.get_campaign_definition(
+            campaign_id=campaign_id,
+            campaign_version=campaign_version,
+            correlation_id=correlation_id,
+        )
+        return self._compose_campaign_definition_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
 
     async def get_wave_items(
         self,
@@ -405,6 +457,22 @@ class DpmWaveService:
             contract_version=settings.contract_version,
             upstream_status=upstream_status,
             supportability=_supportability_from(upstream_payload),
+            data=upstream_payload,
+        )
+
+    def _compose_campaign_definition_response(
+        self,
+        upstream_status: int,
+        upstream_payload: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmCampaignDefinitionGatewayResponse:
+        if upstream_status >= status.HTTP_400_BAD_REQUEST:
+            raise self._upstream_error(upstream_status, upstream_payload)
+
+        return DpmCampaignDefinitionGatewayResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            upstream_status=upstream_status,
             data=upstream_payload,
         )
 

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -142,6 +142,8 @@ class RiskWorkspaceService:
         detail_basis: str,
         benchmark_code: str | None,
         as_of_date: str | None,
+        report_start_date: str | None = None,
+        report_end_date: str | None = None,
         reporting_currency: str | None,
     ) -> WorkbenchRiskSummaryResponse:
         resolved_as_of_date = _resolve_as_of_date(as_of_date)
@@ -152,6 +154,8 @@ class RiskWorkspaceService:
             detail_basis,
             benchmark_code or "",
             resolved_as_of_date,
+            report_start_date or "",
+            report_end_date or "",
             reporting_currency or "",
         )
 
@@ -161,6 +165,8 @@ class RiskWorkspaceService:
                 period=period,
                 detail_basis=detail_basis,
                 as_of_date=resolved_as_of_date,
+                report_start_date=report_start_date,
+                report_end_date=report_end_date,
                 reporting_currency=reporting_currency,
             )
             upstream_status, upstream_payload = await self._risk_client.post_risk_calculate(
@@ -207,6 +213,8 @@ class RiskWorkspaceService:
         correlation_id: str,
         period: str,
         as_of_date: str | None,
+        report_start_date: str | None = None,
+        report_end_date: str | None = None,
         reporting_currency: str | None,
         benchmark_code: str | None,
     ) -> WorkbenchRiskConcentrationResponse:
@@ -216,6 +224,8 @@ class RiskWorkspaceService:
             portfolio_id,
             period,
             resolved_as_of_date,
+            report_start_date or "",
+            report_end_date or "",
             reporting_currency or "",
             benchmark_code or "",
         )
@@ -272,6 +282,8 @@ class RiskWorkspaceService:
         detail_basis: str,
         benchmark_code: str | None,
         as_of_date: str | None,
+        report_start_date: str | None = None,
+        report_end_date: str | None = None,
         reporting_currency: str | None,
         include_underwater_series: bool,
     ) -> WorkbenchRiskDrawdownResponse:
@@ -283,6 +295,8 @@ class RiskWorkspaceService:
             detail_basis,
             benchmark_code or "",
             resolved_as_of_date,
+            report_start_date or "",
+            report_end_date or "",
             reporting_currency or "",
             include_underwater_series,
         )
@@ -294,6 +308,8 @@ class RiskWorkspaceService:
                 detail_basis=detail_basis,
                 benchmark_code=benchmark_code,
                 as_of_date=resolved_as_of_date,
+                report_start_date=report_start_date,
+                report_end_date=report_end_date,
                 reporting_currency=reporting_currency,
                 include_underwater_series=include_underwater_series,
             )
@@ -345,6 +361,8 @@ class RiskWorkspaceService:
         detail_basis: str,
         benchmark_code: str | None,
         as_of_date: str | None,
+        report_start_date: str | None = None,
+        report_end_date: str | None = None,
         reporting_currency: str | None,
         include_time_series: bool,
     ) -> WorkbenchRiskRollingResponse:
@@ -356,6 +374,8 @@ class RiskWorkspaceService:
             detail_basis,
             benchmark_code or "",
             resolved_as_of_date,
+            report_start_date or "",
+            report_end_date or "",
             reporting_currency or "",
             include_time_series,
         )
@@ -367,6 +387,8 @@ class RiskWorkspaceService:
                 detail_basis=detail_basis,
                 benchmark_code=benchmark_code,
                 as_of_date=resolved_as_of_date,
+                report_start_date=report_start_date,
+                report_end_date=report_end_date,
                 reporting_currency=reporting_currency,
                 include_time_series=include_time_series,
                 include_sharpe=True,
@@ -387,6 +409,8 @@ class RiskWorkspaceService:
                     detail_basis=detail_basis,
                     benchmark_code=benchmark_code,
                     as_of_date=resolved_as_of_date,
+                    report_start_date=report_start_date,
+                    report_end_date=report_end_date,
                     reporting_currency=reporting_currency,
                     include_time_series=include_time_series,
                     include_sharpe=False,
@@ -445,6 +469,8 @@ class RiskWorkspaceService:
         detail_basis: str,
         benchmark_code: str | None,
         as_of_date: str | None,
+        report_start_date: str | None = None,
+        report_end_date: str | None = None,
         reporting_currency: str | None,
         attribution_type: str,
         grouping_dimension: str,
@@ -471,6 +497,8 @@ class RiskWorkspaceService:
             detail_basis,
             benchmark_code or "",
             resolved_as_of_date,
+            report_start_date or "",
+            report_end_date or "",
             reporting_currency or "",
             normalized_type,
             normalized_grouping,
@@ -483,6 +511,8 @@ class RiskWorkspaceService:
                 detail_basis=detail_basis,
                 benchmark_code=benchmark_code,
                 as_of_date=resolved_as_of_date,
+                report_start_date=report_start_date,
+                report_end_date=report_end_date,
                 reporting_currency=reporting_currency,
                 attribution_type=normalized_type,
                 grouping_dimension=normalized_grouping,
@@ -538,6 +568,8 @@ def _build_summary_request(
     period: str,
     detail_basis: str,
     as_of_date: str,
+    report_start_date: str | None,
+    report_end_date: str | None,
     reporting_currency: str | None,
 ) -> dict[str, Any]:
     stateful_input: dict[str, Any] = {
@@ -545,7 +577,11 @@ def _build_summary_request(
         "as_of_date": as_of_date,
         "reporting_currency": _resolve_reporting_currency(reporting_currency),
         "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
-        "periods": [{"type": _normalize_period(period), "name": period.upper()}],
+        "periods": _build_risk_periods(
+            period=period,
+            report_start_date=report_start_date,
+            report_end_date=report_end_date,
+        ),
         "metrics": _SUMMARY_METRICS,
         "options": {
             "frequency": "DAILY",
@@ -590,6 +626,8 @@ def _build_drawdown_request(
     detail_basis: str,
     benchmark_code: str | None,
     as_of_date: str,
+    report_start_date: str | None,
+    report_end_date: str | None,
     reporting_currency: str | None,
     include_underwater_series: bool,
 ) -> dict[str, Any]:
@@ -598,7 +636,11 @@ def _build_drawdown_request(
         "as_of_date": as_of_date,
         "reporting_currency": _resolve_reporting_currency(reporting_currency),
         "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
-        "periods": [{"type": _normalize_period(period), "name": period.upper()}],
+        "periods": _build_risk_periods(
+            period=period,
+            report_start_date=report_start_date,
+            report_end_date=report_end_date,
+        ),
         "benchmark_policy": {
             "include_benchmark": bool(benchmark_code),
             "missing_benchmark_policy": "IGNORE",
@@ -625,6 +667,8 @@ def _build_rolling_request(
     detail_basis: str,
     benchmark_code: str | None,
     as_of_date: str,
+    report_start_date: str | None,
+    report_end_date: str | None,
     reporting_currency: str | None,
     include_time_series: bool,
     include_sharpe: bool,
@@ -639,7 +683,11 @@ def _build_rolling_request(
         "as_of_date": as_of_date,
         "reporting_currency": _resolve_reporting_currency(reporting_currency),
         "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
-        "periods": [{"type": _normalize_period(period), "name": period.upper()}],
+        "periods": _build_risk_periods(
+            period=period,
+            report_start_date=report_start_date,
+            report_end_date=report_end_date,
+        ),
         "rolling_options": {
             "window_lengths": _ROLLING_DEFAULT_WINDOWS,
             "metrics": metrics,
@@ -659,6 +707,8 @@ def _build_attribution_request(
     detail_basis: str,
     benchmark_code: str | None,
     as_of_date: str,
+    report_start_date: str | None,
+    report_end_date: str | None,
     reporting_currency: str | None,
     attribution_type: str,
     grouping_dimension: str,
@@ -668,7 +718,11 @@ def _build_attribution_request(
         "as_of_date": as_of_date,
         "reporting_currency": _resolve_reporting_currency(reporting_currency),
         "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
-        "periods": [{"type": _normalize_period(period), "name": period.upper()}],
+        "periods": _build_risk_periods(
+            period=period,
+            report_start_date=report_start_date,
+            report_end_date=report_end_date,
+        ),
         "attribution_options": {
             "attribution_types": [attribution_type],
             "metrics": ["TRACKING_ERROR" if attribution_type == "ACTIVE_RISK" else "VOLATILITY"],
@@ -2030,6 +2084,20 @@ def _normalize_period(value: str) -> str:
     if normalized == "ITD":
         return "SI"
     return "YTD"
+
+
+def _build_risk_periods(
+    *,
+    period: str,
+    report_start_date: str | None,
+    report_end_date: str | None,
+) -> list[dict[str, Any]]:
+    normalized_period = _normalize_period(period)
+    period_payload: dict[str, Any] = {"type": normalized_period, "name": normalized_period}
+    if normalized_period == "EXPLICIT" and report_start_date and report_end_date:
+        period_payload["from_date"] = report_start_date
+        period_payload["to_date"] = report_end_date
+    return [period_payload]
 
 
 def _map_drawdown_summary(summary_payload: dict[str, Any]) -> WorkbenchRiskDrawdownSummary:

--- a/tests/contract/test_dpm_wave_contract.py
+++ b/tests/contract/test_dpm_wave_contract.py
@@ -89,6 +89,15 @@ def test_dpm_wave_openapi_contract_registered() -> None:
         ("/api/v1/dpm/command-center/waves/preview", "post"),
         ("/api/v1/dpm/command-center/waves", "post"),
         ("/api/v1/dpm/command-center/waves", "get"),
+        (
+            "/api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}",
+            "put",
+        ),
+        ("/api/v1/dpm/command-center/waves/campaign-definitions", "get"),
+        (
+            "/api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}",
+            "get",
+        ),
         ("/api/v1/dpm/command-center/waves/{wave_id}", "get"),
         ("/api/v1/dpm/command-center/waves/{wave_id}/items", "get"),
         ("/api/v1/dpm/command-center/waves/{wave_id}/source-check", "post"),
@@ -122,6 +131,8 @@ def test_dpm_wave_openapi_models_are_described() -> None:
 
     for schema_name in [
         "DpmWaveCreateRequest",
+        "DpmCampaignDefinitionForwardRequest",
+        "DpmCampaignDefinitionGatewayResponse",
         "DpmWaveForwardRequest",
         "DpmWaveGatewayResponse",
         "DpmOperationsHandoffSummaryGatewayResponse",

--- a/tests/integration/test_dpm_wave_router.py
+++ b/tests/integration/test_dpm_wave_router.py
@@ -131,6 +131,121 @@ def test_dpm_wave_list_passes_filters_without_reconstructing_state(monkeypatch) 
     assert response.json()["data"]["items"][0]["wave_state"] == "HANDOFF_READY"
 
 
+def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_put_campaign_definition(  # noqa: ANN001
+        self, campaign_id, campaign_version, body, correlation_id
+    ):
+        _ = self
+        captured["put"] = {
+            "campaign_id": campaign_id,
+            "campaign_version": campaign_version,
+            "body": body,
+            "correlation_id": correlation_id,
+        }
+        return 200, {
+            "campaign_id": campaign_id,
+            "campaign_version": campaign_version,
+            "product_name": "BulkReviewCampaignDefinition",
+            "status": body["status"],
+            "content_hash": "sha256:campaign-definition",
+        }
+
+    async def _fake_list_campaign_definitions(self, params, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["list"] = {"params": params, "correlation_id": correlation_id}
+        return 200, {
+            "items": [
+                {
+                    "campaign_id": "campaign-holdings-202605",
+                    "campaign_version": "2026.05",
+                    "product_name": "BulkReviewCampaignDefinition",
+                }
+            ],
+            "limit": params["limit"],
+            "offset": params["offset"],
+            "count": 1,
+        }
+
+    async def _fake_get_campaign_definition(  # noqa: ANN001
+        self, campaign_id, campaign_version, correlation_id
+    ):
+        _ = self
+        captured["get"] = {
+            "campaign_id": campaign_id,
+            "campaign_version": campaign_version,
+            "correlation_id": correlation_id,
+        }
+        return 200, {
+            "campaign_id": campaign_id,
+            "campaign_version": campaign_version,
+            "product_name": "BulkReviewCampaignDefinition",
+            "status": "ACTIVE",
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.put_campaign_definition",
+        _fake_put_campaign_definition,
+    )
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.list_campaign_definitions",
+        _fake_list_campaign_definitions,
+    )
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_campaign_definition",
+        _fake_get_campaign_definition,
+    )
+
+    client = TestClient(app)
+    put_response = client.put(
+        "/api/v1/dpm/command-center/waves/campaign-definitions/"
+        "campaign-holdings-202605/versions/2026.05",
+        json={"body": {"status": "ACTIVE", "candidates": []}},
+        headers={"X-Correlation-Id": "corr-campaign-put"},
+    )
+    list_response = client.get(
+        "/api/v1/dpm/command-center/waves/campaign-definitions"
+        "?campaign_status=ACTIVE&limit=25&offset=0",
+        headers={"X-Correlation-Id": "corr-campaign-list"},
+    )
+    get_response = client.get(
+        "/api/v1/dpm/command-center/waves/campaign-definitions/"
+        "campaign-holdings-202605/versions/2026.05",
+        headers={"X-Correlation-Id": "corr-campaign-get"},
+    )
+
+    assert put_response.status_code == 200
+    assert put_response.json()["data"]["product_name"] == "BulkReviewCampaignDefinition"
+    assert list_response.status_code == 200
+    assert list_response.json()["data"]["items"][0]["campaign_id"] == "campaign-holdings-202605"
+    assert get_response.status_code == 200
+    assert get_response.json()["data"]["campaign_version"] == "2026.05"
+    assert captured == {
+        "put": {
+            "campaign_id": "campaign-holdings-202605",
+            "campaign_version": "2026.05",
+            "body": {"status": "ACTIVE", "candidates": []},
+            "correlation_id": "corr-campaign-put",
+        },
+        "list": {
+            "params": {
+                "campaign_id": None,
+                "campaign_status": "ACTIVE",
+                "as_of_date": None,
+                "limit": 25,
+                "offset": 0,
+            },
+            "correlation_id": "corr-campaign-list",
+        },
+        "get": {
+            "campaign_id": "campaign-holdings-202605",
+            "campaign_version": "2026.05",
+            "correlation_id": "corr-campaign-get",
+        },
+    }
+
+
 def test_dpm_wave_actions_preserve_manage_payload(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/unit/test_dpm_wave_service.py
+++ b/tests/unit/test_dpm_wave_service.py
@@ -52,6 +52,43 @@ class _FakeDpmClient:
         )
         return self.result
 
+    async def list_campaign_definitions(self, params, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "list_campaign_definitions",
+                "params": params,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+    async def get_campaign_definition(  # noqa: ANN001
+        self, campaign_id, campaign_version, correlation_id
+    ):
+        self.calls.append(
+            {
+                "method": "get_campaign_definition",
+                "campaign_id": campaign_id,
+                "campaign_version": campaign_version,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+    async def put_campaign_definition(  # noqa: ANN001
+        self, campaign_id, campaign_version, body, correlation_id
+    ):
+        self.calls.append(
+            {
+                "method": "put_campaign_definition",
+                "campaign_id": campaign_id,
+                "campaign_version": campaign_version,
+                "body": body,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
 
 class _FakeLotusAiClient:
     def __init__(self, result: tuple[int, dict]):
@@ -113,6 +150,40 @@ async def test_dpm_wave_service_preserves_manage_wave_truth_and_supportability()
             "body": {"trigger_type": "EXPLICIT_PORTFOLIO_LIST"},
             "idempotency_key": "wave-idem-1",
             "correlation_id": "corr-wave-create",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_wave_service_preserves_campaign_definition_payloads() -> None:
+    manage_payload = {
+        "campaign_id": "campaign-holdings-202605",
+        "campaign_version": "2026.05",
+        "product_name": "BulkReviewCampaignDefinition",
+        "status": "ACTIVE",
+        "content_hash": "sha256:campaign-definition",
+    }
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmWaveService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.put_campaign_definition(
+        campaign_id="campaign-holdings-202605",
+        campaign_version="2026.05",
+        body={"status": "ACTIVE"},
+        correlation_id="corr-campaign-definition",
+    )
+
+    assert response.correlation_id == "corr-campaign-definition"
+    assert response.source_service == "lotus-manage"
+    assert response.upstream_status == 200
+    assert response.data == manage_payload
+    assert client.calls == [
+        {
+            "method": "put_campaign_definition",
+            "campaign_id": "campaign-holdings-202605",
+            "campaign_version": "2026.05",
+            "body": {"status": "ACTIVE"},
+            "correlation_id": "corr-campaign-definition",
         }
     ]
 

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -20,7 +20,10 @@ def test_rfc0098_ownership_matches_manage_rfc0040_rfc0041_and_rfc0042() -> None:
     assert "treat `lotus-report` as the proof-pack authority" in rfc
     assert "calculate affected portfolios, source readiness, aggregate metrics" in rfc
     assert "`GET /api/v1/dpm/command-center/waves/{wave_id}/supportability`" in rfc
+    assert "`GET /api/v1/dpm/command-center/waves/campaign-definitions`" in rfc
+    assert "does not discover cohorts" in rfc
     assert "RFC41-WTBD-005 Gateway wave composition" in rfc
+    assert "RFC41-WTBD-003 Gateway campaign-definition discovery/upsert" in rfc
     assert "RFC40-WTBD-010 Gateway portfolio-memory composition" in rfc
     assert "`GET /api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`" in rfc
     assert "does not reconstruct timeline nodes" in rfc
@@ -48,5 +51,6 @@ def test_rfc0098_ownership_matches_manage_rfc0040_rfc0041_and_rfc0042() -> None:
     assert "proof-pack BFF route family" in integrations
     assert "portfolio memory remains `lotus-manage` truth" in integrations
     assert "must not calculate affected portfolios" in api_surface
+    assert "calculate campaign membership" in api_surface
     assert "`/api/v1/dpm/command-center/waves*`" in api_surface
     assert "Gateway does not generate proof packs. That belongs to `lotus-report`." not in rfc

--- a/tests/unit/test_risk_workspace_service.py
+++ b/tests/unit/test_risk_workspace_service.py
@@ -357,6 +357,44 @@ async def test_risk_summary_uses_stateful_request_and_maps_supportability() -> N
 
 
 @pytest.mark.asyncio
+async def test_risk_workspace_explicit_window_reaches_lotus_risk_period_contract() -> None:
+    client = _StubRiskClient()
+    service = RiskWorkspaceService(client, cache_ttl_seconds=60)
+
+    common = {
+        "portfolio_id": "PF_1",
+        "correlation_id": "corr-explicit",
+        "period": "EXPLICIT",
+        "detail_basis": "NET",
+        "benchmark_code": "BMK_1",
+        "as_of_date": "2026-04-10",
+        "report_start_date": "2026-01-01",
+        "report_end_date": "2026-04-10",
+        "reporting_currency": "USD",
+    }
+
+    await service.get_summary(**common)
+    await service.get_drawdown(**common, include_underwater_series=False)
+    await service.get_rolling(**common, include_time_series=False)
+    await service.get_attribution(
+        **common,
+        attribution_type="TOTAL_RISK",
+        grouping_dimension="SECTOR",
+    )
+
+    expected_period = {
+        "type": "EXPLICIT",
+        "name": "EXPLICIT",
+        "from_date": "2026-01-01",
+        "to_date": "2026-04-10",
+    }
+    assert client.calculate_calls[0]["payload"]["stateful_input"]["periods"] == [expected_period]
+    assert client.drawdown_calls[0]["payload"]["stateful_input"]["periods"] == [expected_period]
+    assert client.rolling_calls[0]["payload"]["stateful_input"]["periods"] == [expected_period]
+    assert client.attribution_calls[0]["payload"]["stateful_input"]["periods"] == [expected_period]
+
+
+@pytest.mark.asyncio
 async def test_risk_summary_reports_partial_when_benchmark_metrics_have_errors() -> None:
     client = _StubRiskClient()
     client.calculate_payload["results"]["YTD"]["metrics"]["TRACKING_ERROR"] = {

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -47,6 +47,17 @@ class _FakeAsyncClient:
         )
         return self._next_response("POST", url)
 
+    async def put(self, url, json=None, headers=None):
+        self.calls.append(
+            {
+                "method": "PUT",
+                "url": url,
+                "json": json,
+                "headers": headers or {},
+            }
+        )
+        return self._next_response("PUT", url)
+
     @classmethod
     def _next_response(cls, method: str, url: str) -> httpx.Response:
         if not cls.responses:
@@ -1765,6 +1776,24 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
             "http://dpm/api/v1/rebalance/waves/dwv_001",
         ),
         (
+            "list_campaign_definitions",
+            {
+                "params": {"campaign_status": "ACTIVE", "campaign_id": None},
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/waves/campaign-definitions",
+        ),
+        (
+            "get_campaign_definition",
+            {
+                "campaign_id": "campaign-holdings-202605",
+                "campaign_version": "2026.05",
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/waves/campaign-definitions/"
+            "campaign-holdings-202605/versions/2026.05",
+        ),
+        (
             "get_wave_items",
             {"wave_id": "dwv_001", "correlation_id": "corr-5"},
             "http://dpm/api/v1/rebalance/waves/dwv_001/items",
@@ -2210,6 +2239,29 @@ async def test_dpm_client_outcome_review_command_routes(method_name, kwargs, exp
     assert _FakeAsyncClient.calls[0]["json"] == kwargs["body"]
     if "idempotency_key" in kwargs:
         assert _FakeAsyncClient.calls[0]["headers"]["Idempotency-Key"] == kwargs["idempotency_key"]
+
+
+@pytest.mark.asyncio
+async def test_dpm_client_put_campaign_definition_uses_manage_contract():
+    client = DpmClient(base_url="http://dpm", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"ok": True})
+
+    status_code, payload = await client.put_campaign_definition(
+        campaign_id="campaign-holdings-202605",
+        campaign_version="2026.05",
+        body={"status": "ACTIVE"},
+        correlation_id="corr-5",
+    )
+
+    assert status_code == 200
+    assert payload["ok"] is True
+    assert _FakeAsyncClient.calls[0]["method"] == "PUT"
+    assert (
+        _FakeAsyncClient.calls[0]["url"]
+        == "http://dpm/api/v1/rebalance/waves/campaign-definitions/"
+        "campaign-holdings-202605/versions/2026.05"
+    )
+    assert _FakeAsyncClient.calls[0]["json"] == {"status": "ACTIVE"}
 
 
 @pytest.mark.asyncio

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -22,6 +22,7 @@
 - `POST /api/v1/dpm/command-center/exceptions/{exception_id}/ai-summary`
 - `GET /api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`
 - `GET` and `POST /api/v1/dpm/command-center/waves*`
+- `GET` and `PUT /api/v1/dpm/command-center/waves/campaign-definitions*`
 - `GET /api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`
 - `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`
 - `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`
@@ -119,11 +120,17 @@
   posture, or error semantics locally.
 - RFC-0098 wave composition consumes `lotus-manage` RFC-0041 wave APIs for preview, create,
   search, detail, items, source-check, simulation, selection, approval, staging, handoff, cancel,
-  proof-pack posture, supportability, and report input through
+  proof-pack posture, supportability, report input, and campaign-definition discovery/upsert through
   `/api/v1/dpm/command-center/waves*`. Gateway now exposes the implementation-backed wave BFF
   route family, preserves manage `wave_id`, item states, aggregate metrics, selected alternative
   refs, proof-pack refs, handoff refs, report-input evidence, supportability issues, reason codes,
-  and the no-external-execution boundary. Gateway also exposes a governed handoff from
+  campaign definition payloads, and the no-external-execution boundary. Gateway also exposes
+  `GET /api/v1/dpm/command-center/waves/campaign-definitions`,
+  `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`,
+  and `PUT /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`
+  for manage-owned campaign/cohort definition discovery. Gateway does not discover cohorts,
+  calculate campaign membership, evaluate portfolio eligibility, or own maker-checker posture.
+  Gateway also exposes a governed handoff from
   manage-owned `DpmWaveReportInput` to `lotus-ai` `dpm_wave_pm_memo.pack@v1` for review-required
   PM/control support text. Gateway must not calculate affected portfolios, readiness,
   alternatives, proof-pack state, report evidence, AI narrative, PM scoring, trade approval,

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -130,12 +130,14 @@
     call `lotus-manage` directly.
 15. RFC-0041 rebalance waves remain `lotus-manage` truth. Gateway wave realization exposes
     `/api/v1/dpm/command-center/waves*` for Workbench. Gateway forwards request bodies,
-    idempotency keys, query filters, and correlation context to manage, then preserves wave ids,
-    lifecycle state, item states, aggregate metrics, selected-alternative refs, proof-pack refs,
-    internal handoff refs, report-input evidence, supportability issues, remediation routes, and
-    no-external-execution posture without discovering affected portfolios, classifying readiness,
-    generating alternatives, approving/staging locally, rebuilding proof packs, generating report
-    evidence, or claiming execution. The wave AI PM memo route first reads manage-owned
+    idempotency keys, query filters, campaign-definition payloads, and correlation context to
+    manage, then preserves wave ids, lifecycle state, item states, aggregate metrics,
+    selected-alternative refs, proof-pack refs, internal handoff refs, campaign definition payloads,
+    report-input evidence, supportability issues, remediation routes, and no-external-execution
+    posture without discovering affected portfolios, discovering cohorts, recomputing campaign
+    membership, classifying readiness, generating alternatives, approving/staging locally,
+    rebuilding proof packs, generating report evidence, or claiming execution. The wave AI PM memo
+    route first reads manage-owned
     `DpmWaveReportInput`, then calls `lotus-ai` `dpm_wave_pm_memo.pack@v1` for review-required
     support text; Gateway does not generate narrative locally, score PMs, approve trades, contact
     clients, place orders, or invent evidence.

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -20,7 +20,8 @@
    The RFC now includes implementation-backed RFC-0041 rebalance-wave realization under
    `/api/v1/dpm/command-center/waves*` for wave preview, create, search, detail, item list,
    source-check, simulation, selection, approval, staging, handoff, cancellation, proof-pack
-   posture, and supportability composition without becoming the wave authority. It also includes
+   posture, supportability, and campaign-definition discovery/upsert composition without becoming
+   the wave or cohort authority. It also includes
    RFC-0042 post-trade outcome-review realization; the first implementation-backed outcome-review
    BFF route family is active under
    `/api/v1/dpm/command-center/outcome-reviews*`, run lookup, and wave lookup routes, preserving

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -174,7 +174,10 @@ Business outcome:
 2. operations users can inspect item-level source readiness, simulation, selection, proof-pack,
    approval, staging, internal handoff, cancellation, report-input, AI memo support, and
    supportability posture from one product route family,
-3. sales/pre-sales and client-demo teams can describe wave orchestration as implementation-backed
+3. portfolio managers can discover and upsert manage-owned campaign definitions for tactical
+   house-view, risk-event, and bulk-review waves without Gateway recomputing source-owned cohort
+   facts,
+4. sales/pre-sales and client-demo teams can describe wave orchestration as implementation-backed
    backend composition while keeping Workbench wave cockpit UI as the next owning-repository slice.
 
 Supported routes:
@@ -182,26 +185,30 @@ Supported routes:
 1. `POST /api/v1/dpm/command-center/waves/preview`
 2. `POST /api/v1/dpm/command-center/waves`
 3. `GET /api/v1/dpm/command-center/waves`
-4. `GET /api/v1/dpm/command-center/waves/{wave_id}`
-5. `GET /api/v1/dpm/command-center/waves/{wave_id}/items`
-6. `POST /api/v1/dpm/command-center/waves/{wave_id}/source-check`
-7. `POST /api/v1/dpm/command-center/waves/{wave_id}/simulate`
-8. `POST /api/v1/dpm/command-center/waves/{wave_id}/items/{wave_item_id}/select`
-9. `POST /api/v1/dpm/command-center/waves/{wave_id}/approve`
-10. `POST /api/v1/dpm/command-center/waves/{wave_id}/stage`
-11. `POST /api/v1/dpm/command-center/waves/{wave_id}/handoff`
-12. `POST /api/v1/dpm/command-center/waves/{wave_id}/cancel`
-13. `GET /api/v1/dpm/command-center/waves/{wave_id}/proof-pack`
-14. `GET /api/v1/dpm/command-center/waves/{wave_id}/supportability`
-15. `GET /api/v1/dpm/command-center/waves/{wave_id}/report-input`
-16. `POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`
-17. `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`
+4. `GET /api/v1/dpm/command-center/waves/campaign-definitions`
+5. `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`
+6. `PUT /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`
+7. `GET /api/v1/dpm/command-center/waves/{wave_id}`
+8. `GET /api/v1/dpm/command-center/waves/{wave_id}/items`
+9. `POST /api/v1/dpm/command-center/waves/{wave_id}/source-check`
+10. `POST /api/v1/dpm/command-center/waves/{wave_id}/simulate`
+11. `POST /api/v1/dpm/command-center/waves/{wave_id}/items/{wave_item_id}/select`
+12. `POST /api/v1/dpm/command-center/waves/{wave_id}/approve`
+13. `POST /api/v1/dpm/command-center/waves/{wave_id}/stage`
+14. `POST /api/v1/dpm/command-center/waves/{wave_id}/handoff`
+15. `POST /api/v1/dpm/command-center/waves/{wave_id}/cancel`
+16. `GET /api/v1/dpm/command-center/waves/{wave_id}/proof-pack`
+17. `GET /api/v1/dpm/command-center/waves/{wave_id}/supportability`
+18. `GET /api/v1/dpm/command-center/waves/{wave_id}/report-input`
+19. `POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`
+20. `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`
 
 Authority and integrations:
 
 1. `lotus-manage` remains the RFC-0041 rebalance-wave authority.
-2. Gateway forwards preview, create, source-check, simulate, select, approve, stage, handoff,
-   cancel, proof-pack posture, supportability, and report-input requests to manage.
+2. Gateway forwards preview, create, campaign-definition list/get/upsert, source-check, simulate,
+   select, approve, stage, handoff, cancel, proof-pack posture, supportability, and report-input
+   requests to manage.
 3. Gateway preserves manage-owned `wave_id`, lifecycle state, item states, reason codes,
    aggregate metrics, selected alternative refs, proof-pack refs, handoff refs, supportability
    issues, report-input evidence, remediation routes, and `external_execution_claimed=false`.
@@ -209,11 +216,11 @@ Authority and integrations:
    `dpm_wave_pm_memo.pack@v1` for review-required PM/control support text.
 5. Gateway reads manage-owned wave report input with internal handoff refs before calling
    `lotus-ai` `dpm_operations_handoff_summary.pack@v1`.
-6. Gateway does not calculate affected portfolios, classify source readiness, generate
-   alternatives, select alternatives, approve items, stage items, create handoff evidence, rebuild
-   proof packs, generate report evidence, generate AI narrative locally, score PMs, approve trades,
-   contact clients, place orders, invent missing evidence, cancel external orders, or claim external
-   execution.
+6. Gateway does not calculate affected portfolios, classify source readiness, discover cohorts,
+   recompute campaign membership, generate alternatives, select alternatives, approve items, stage
+   items, create handoff evidence, rebuild proof packs, generate report evidence, generate AI
+   narrative locally, score PMs, approve trades, contact clients, place orders, invent missing
+   evidence, cancel external orders, or claim external execution.
 
 ```mermaid
 flowchart LR
@@ -221,6 +228,7 @@ flowchart LR
     Gateway --> Manage[lotus-manage RFC-0041 wave authority]
     Gateway --> AI[lotus-ai dpm_wave_pm_memo.pack@v1]
     Gateway --> OpsAI[lotus-ai dpm_operations_handoff_summary.pack@v1]
+    Manage --> Campaigns[Manage-owned campaign definitions]
     Manage --> Construction[lotus-manage RFC-0039 construction alternatives]
     Manage --> Proof[lotus-manage RFC-0040 proof packs]
     Manage --> ReportInput[DpmWaveReportInput evidence]


### PR DESCRIPTION
## Summary
- expose Gateway BFF routes for manage-owned DPM campaign-definition list, get, and upsert
- preserve BulkReviewCampaignDefinition payloads without Gateway cohort/member recomputation
- update RFC-0098, README, wiki source, repo context, and current-state tests

## Validation
- python -m pytest tests/unit/test_dpm_wave_service.py tests/integration/test_dpm_wave_router.py tests/unit/test_upstream_clients.py tests/contract/test_dpm_wave_contract.py tests/unit/test_rfc0098_documentation.py -q
- make lint
- make typecheck
- make check
- make ci
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- git diff --check

## Wiki
- repo-local wiki source changed; publish after merge
- pre-merge Sync-RepoWikis.ps1 -CheckOnly currently reports expected drift for API-Surface.md, Integrations.md, Roadmap.md, Supported-Features.md because this PR updates wiki source before publication