### PR TITLE
feat(gateway): expose PM quality fairness preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`,
   `/api/v1/dpm/command-center/pm-operating-quality/policies*`,
   `/api/v1/dpm/command-center/pm-operating-quality/score-runs*`,
+  `/api/v1/dpm/command-center/pm-operating-quality/fairness-analyses/preview`,
   `/api/v1/dpm/command-center/waves/campaign-definitions*`,
   `/api/v1/dpm/command-center/waves*`,
   `/api/v1/dpm/command-center/waves/{wave_id}/report-input`,
@@ -306,11 +307,13 @@ Important current parameter conventions:
    route orders, or invent missing evidence.
 18. DPM PM operating quality routes under
    `/api/v1/dpm/command-center/pm-operating-quality/*` consume `lotus-manage`
-   PM operating quality policy and score-run lifecycle APIs. Gateway preserves Manage policy
-   configuration, score-run state, governance evidence, source refs, reason codes, content hashes,
-   and forbidden-use posture without calculating scores, ranking PMs, administering bank policy
-   locally, or creating HR, compensation, conduct-enforcement, approval, client-contact, or
-   execution decisions.
+   PM operating quality policy, score-run lifecycle, and fairness-analysis preview APIs. Gateway
+   preserves Manage policy configuration, score-run state, fairness-analysis state, segment
+   posture, governance evidence, source refs, reason codes, content hashes, and forbidden-use
+   posture without calculating scores, discovering segments, calculating fairness spread, inferring
+   protected classes, ranking PMs, administering bank policy locally, or creating HR,
+   compensation, conduct-enforcement, approval, client-contact, order-routing, or execution
+   decisions.
 
 Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -1282,10 +1282,13 @@ Implementation boundaries:
    `POST /api/v1/dpm/command-center/pm-operating-quality/score-runs/preview`,
    `POST /api/v1/dpm/command-center/pm-operating-quality/score-runs`,
    `GET /api/v1/dpm/command-center/pm-operating-quality/score-runs`, and
-   `GET /api/v1/dpm/command-center/pm-operating-quality/score-runs/{score_run_id}`.
+   `GET /api/v1/dpm/command-center/pm-operating-quality/score-runs/{score_run_id}`, plus
+   `POST /api/v1/dpm/command-center/pm-operating-quality/fairness-analyses/preview`.
 17. PM operating quality routes preserve manage-owned policy configuration, score-run state,
-   governance evidence, source refs, reason codes, content hashes, and forbidden-use posture.
-18. Gateway does not calculate scores, rank PMs, administer bank policy locally, create HR or
+   fairness-analysis state, segment posture, governance evidence, source refs, reason codes,
+   content hashes, and forbidden-use posture.
+18. Gateway does not calculate scores, discover segments, calculate segment averages or fairness
+   spread, infer protected classes, rank PMs, administer bank policy locally, create HR or
    compensation decisions, perform conduct enforcement, approve trades, contact clients, route
    orders, claim execution, or invent missing evidence.
 19. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -681,6 +681,18 @@ class DpmClient:
             operation="manage.rebalance.pm_operating_quality.score_runs.create",
         )
 
+    async def preview_pm_operating_quality_fairness_analysis(
+        self,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/api/v1/rebalance/pm-operating-quality/fairness-analyses/preview",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.pm_operating_quality.fairness_analyses.preview",
+        )
+
     async def list_pm_operating_quality_score_runs(
         self,
         params: dict[str, Any],

--- a/src/app/contracts/dpm_command_center.py
+++ b/src/app/contracts/dpm_command_center.py
@@ -471,6 +471,11 @@ class DpmPmOperatingQualitySupportability(BaseModel):
         description="Manage-owned PM operating quality score-run id when returned.",
         examples=["pmq_run_001"],
     )
+    fairness_analysis_id: str | None = Field(
+        default=None,
+        description="Manage-owned PM operating quality fairness-analysis preview id when returned.",
+        examples=["pmq_fair_001"],
+    )
     count: int | None = Field(
         default=None,
         ge=0,

--- a/src/app/routers/dpm_command_center.py
+++ b/src/app/routers/dpm_command_center.py
@@ -436,6 +436,30 @@ async def create_pm_operating_quality_score_run(
     )
 
 
+@router.post(
+    "/pm-operating-quality/fairness-analyses/preview",
+    response_model=DpmPmOperatingQualityGatewayResponse,
+    summary="Preview PM operating quality fairness analysis",
+    description=(
+        "What: previews a manage-owned PM operating quality fairness analysis over persisted "
+        "score runs and source-defined segment references. When: use this from governance and "
+        "evidence review views to inspect Manage-published segment posture before any broader "
+        "PM-quality operating review. How: Gateway forwards the payload unchanged and preserves "
+        "Manage state, segment results, source refs, reason codes, blocked actions, and forbidden "
+        "uses without discovering segments, calculating segment averages or score spread, "
+        "inferring protected classes, ranking PMs, administering HR/compensation/conduct actions, "
+        "approving trades, contacting clients, routing orders, or claiming execution."
+    ),
+)
+async def preview_pm_operating_quality_fairness_analysis(
+    request: DpmPmOperatingQualityForwardRequest,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await _dpm_command_center_service().preview_pm_operating_quality_fairness_analysis(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/pm-operating-quality/score-runs",
     response_model=DpmPmOperatingQualityGatewayResponse,

--- a/src/app/services/dpm_command_center_service.py
+++ b/src/app/services/dpm_command_center_service.py
@@ -578,6 +578,24 @@ class DpmCommandCenterService:
             correlation_id,
         )
 
+    async def preview_pm_operating_quality_fairness_analysis(
+        self,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> DpmPmOperatingQualityGatewayResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._dpm_client.preview_pm_operating_quality_fairness_analysis(
+            body=body,
+            correlation_id=correlation_id,
+        )
+        return self._compose_pm_operating_quality_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
     async def list_pm_operating_quality_score_runs(
         self,
         filters: dict[str, Any],
@@ -769,8 +787,12 @@ def _pm_operating_quality_supportability_from(
     payload: dict[str, Any],
 ) -> DpmPmOperatingQualitySupportability:
     score_run = payload.get("score_run")
+    fairness_analysis = payload.get("fairness_analysis")
     policy = payload
-    if isinstance(score_run, dict):
+    if isinstance(fairness_analysis, dict):
+        supportability_source = fairness_analysis
+        policy = fairness_analysis
+    elif isinstance(score_run, dict):
         supportability_source = score_run
         policy = score_run
     elif isinstance(payload.get("score_runs"), list):
@@ -803,6 +825,7 @@ def _pm_operating_quality_supportability_from(
         policy_id=_safe_optional_str(policy.get("policy_id")),
         policy_version=_safe_optional_str(policy.get("policy_version")),
         score_run_id=_safe_optional_str(supportability_source.get("score_run_id")),
+        fairness_analysis_id=_safe_optional_str(supportability_source.get("fairness_analysis_id")),
         count=_safe_int(payload.get("count")) if "count" in payload else None,
     )
 

--- a/tests/contract/test_dpm_command_center_contract.py
+++ b/tests/contract/test_dpm_command_center_contract.py
@@ -121,6 +121,45 @@ def test_dpm_pm_operating_quality_gateway_response_contract_shape() -> None:
         "autonomous_pm_ranking",
     ]
 
+    fairness_response = DpmPmOperatingQualityGatewayResponse(
+        correlation_id="corr-pmq-fairness-1",
+        upstream_status=200,
+        supportability={
+            "state": "PENDING_REVIEW",
+            "reason_codes": ["PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED"],
+            "blocked_actions": ["CREATE_SCORE_RUN"],
+            "policy_id": "pmq_sg_dpm",
+            "policy_version": "2026.05",
+            "fairness_analysis_id": "pmq_fair_001",
+        },
+        data={
+            "fairness_analysis": {
+                "product_name": "PmOperatingQualityFairnessAnalysis",
+                "product_version": "v1",
+                "fairness_analysis_id": "pmq_fair_001",
+                "state": "PENDING_REVIEW",
+                "segment_results": [
+                    {
+                        "segment_type": "MANDATE_TYPE",
+                        "segment_ref": "MANDATE_TYPE:DISCRETIONARY_BALANCED",
+                        "state": "REVIEW_REQUIRED",
+                    }
+                ],
+                "forbidden_uses": [
+                    "protected_class_inference",
+                    "autonomous_pm_ranking",
+                    "hr_decision",
+                    "compensation_decision",
+                    "conduct_enforcement",
+                ],
+            }
+        },
+    )
+    assert fairness_response.supportability.fairness_analysis_id == "pmq_fair_001"
+    assert fairness_response.data["fairness_analysis"]["segment_results"][0]["segment_type"] == (
+        "MANDATE_TYPE"
+    )
+
 
 def test_dpm_outcome_review_narrative_gateway_response_contract_shape() -> None:
     response = DpmOutcomeReviewNarrativeGatewayResponse(
@@ -196,6 +235,10 @@ def test_dpm_command_center_openapi_contract_registered() -> None:
         ("/api/v1/dpm/command-center/pm-operating-quality/score-runs/preview", "post"),
         ("/api/v1/dpm/command-center/pm-operating-quality/score-runs", "get"),
         ("/api/v1/dpm/command-center/pm-operating-quality/score-runs", "post"),
+        (
+            "/api/v1/dpm/command-center/pm-operating-quality/fairness-analyses/preview",
+            "post",
+        ),
         (
             "/api/v1/dpm/command-center/pm-operating-quality/score-runs/{score_run_id}",
             "get",

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -92,6 +92,16 @@ class _FakeDpmClient:
         )
         return self.result
 
+    async def preview_pm_operating_quality_fairness_analysis(self, body, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "pm_quality_fairness_preview",
+                "body": body,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
     async def list_pm_operating_quality_score_runs(self, params, correlation_id):  # noqa: ANN001
         self.calls.append(
             {"method": "pm_quality_score_runs", "params": params, "correlation_id": correlation_id}
@@ -608,6 +618,77 @@ async def test_dpm_pm_operating_quality_policy_routes_preserve_manage_policy() -
             "policy_version": "2026.05",
             "body": manage_payload,
             "correlation_id": "corr-pmq-policy",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_pm_operating_quality_fairness_preview_preserves_manage_analysis() -> None:
+    manage_payload = {
+        "fairness_analysis": {
+            "product_name": "PmOperatingQualityFairnessAnalysis",
+            "product_version": "v1",
+            "fairness_analysis_id": "pmq_fair_001",
+            "policy_id": "pmq_sg_dpm",
+            "policy_version": "2026.05",
+            "as_of_date": "2026-05-13",
+            "state": "PENDING_REVIEW",
+            "observed_average_score_spread": "31.00",
+            "reason_codes": ["PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED"],
+            "blocked_actions": ["CREATE_SCORE_RUN"],
+            "forbidden_uses": [
+                "protected_class_inference",
+                "autonomous_pm_ranking",
+                "hr_decision",
+                "compensation_decision",
+                "conduct_enforcement",
+            ],
+            "segment_results": [
+                {
+                    "segment_ref": "MANDATE_TYPE:DISCRETIONARY_BALANCED",
+                    "segment_type": "MANDATE_TYPE",
+                    "state": "REVIEW_REQUIRED",
+                    "score_run_ids": ["pmq_run_001", "pmq_run_002"],
+                }
+            ],
+            "source_refs": [
+                {
+                    "source_system": "lotus-manage",
+                    "source_product": "PmOperatingQualityScoreRun",
+                    "source_id": "pmq_run_001",
+                }
+            ],
+        }
+    }
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmCommandCenterService(dpm_client=client)  # type: ignore[arg-type]
+
+    body = {
+        "policy_id": "pmq_sg_dpm",
+        "policy_version": "2026.05",
+        "score_run_ids": ["pmq_run_001", "pmq_run_002"],
+        "segments": [{"segment_ref": "MANDATE_TYPE:DISCRETIONARY_BALANCED"}],
+    }
+    response = await service.preview_pm_operating_quality_fairness_analysis(
+        body=body,
+        correlation_id="corr-pmq-fairness",
+    )
+
+    assert response.source_service == "lotus-manage"
+    assert response.supportability.authority == "lotus-manage:RFC-0042/PM_OPERATING_QUALITY"
+    assert response.supportability.state == "PENDING_REVIEW"
+    assert response.supportability.policy_id == "pmq_sg_dpm"
+    assert response.supportability.policy_version == "2026.05"
+    assert response.supportability.score_run_id is None
+    assert response.supportability.fairness_analysis_id == "pmq_fair_001"
+    assert response.supportability.reason_codes == ["PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED"]
+    assert response.supportability.blocked_actions == ["CREATE_SCORE_RUN"]
+    assert response.data == manage_payload
+    assert client.calls == [
+        {
+            "method": "pm_quality_fairness_preview",
+            "body": body,
+            "correlation_id": "corr-pmq-fairness",
         }
     ]
 

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -2310,6 +2310,14 @@ async def test_dpm_client_uses_only_canonical_manage_api_v1_contracts():
             {"body": {"pm_id": "PM_SG_DPM_001"}, "correlation_id": "corr-5"},
             "http://dpm/api/v1/rebalance/pm-operating-quality/score-runs",
         ),
+        (
+            "preview_pm_operating_quality_fairness_analysis",
+            {
+                "body": {"score_run_ids": ["pmq_run_001"], "segments": []},
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/pm-operating-quality/fairness-analyses/preview",
+        ),
     ],
 )
 async def test_dpm_client_outcome_review_command_routes(method_name, kwargs, expected_url):

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -91,11 +91,12 @@
 - PM operating quality composition consumes `lotus-manage`
   `/api/v1/rebalance/pm-operating-quality/*` through
   `/api/v1/dpm/command-center/pm-operating-quality/*`. Gateway exposes policy list/get/upsert
-  and score-run preview/create/list/get routes for Workbench, preserving manage-owned policy
-  configuration, score-run state, governance evidence, source refs, reason codes, content hashes,
-  and forbidden-use posture. Gateway must not calculate scores, rank PMs, administer bank policy
-  locally, or create HR, compensation, conduct-enforcement, approval, client-contact, order, or
-  execution decisions.
+  score-run preview/create/list/get routes, and fairness-analysis preview for Workbench,
+  preserving manage-owned policy configuration, score-run state, fairness-analysis state, segment
+  posture, governance evidence, source refs, reason codes, content hashes, and forbidden-use
+  posture. Gateway must not calculate scores, discover segments, calculate segment averages or
+  fairness spread, infer protected classes, rank PMs, administer bank policy locally, or create HR,
+  compensation, conduct-enforcement, approval, client-contact, order, or execution decisions.
 - RFC-0098 construction-alternative composition consumes `lotus-manage` RFC-0039 construction
   APIs through `/api/v1/dpm/command-center/construction/alternative-sets*`. Gateway exposes
   generate, get, and select routes for Workbench, preserving manage alternative-set ids, method

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -149,11 +149,13 @@
     evidence.
 16. PM operating quality remains `lotus-manage` truth. Gateway realization exposes
     `/api/v1/dpm/command-center/pm-operating-quality/*` for Workbench. Gateway forwards policy
-    list/get/upsert and score-run preview/create/list/get requests to manage, then preserves
-    policy configuration, score-run state, governance evidence, source refs, reason codes,
-    content hashes, and forbidden-use posture without calculating scores, ranking PMs,
-    administering policy locally, creating HR or compensation decisions, performing conduct
-    enforcement, approving trades, contacting clients, routing orders, or inventing evidence.
+    list/get/upsert, score-run preview/create/list/get, and fairness-analysis preview requests to
+    manage, then preserves policy configuration, score-run state, fairness-analysis state, segment
+    posture, governance evidence, source refs, reason codes, content hashes, and forbidden-use
+    posture without calculating scores, discovering segments, calculating segment averages or
+    fairness spread, inferring protected classes, ranking PMs, administering policy locally,
+    creating HR or compensation decisions, performing conduct enforcement, approving trades,
+    contacting clients, routing orders, or inventing evidence.
 17. RFC36-WTBD-003 portfolio-level DPM operations dashboards consume Gateway Workbench
     `rebalance_snapshot` only. Gateway reads manage rebalance runs, preserves manage
     supportability summary and bounded recent-run posture, and keeps Workbench from calling

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -170,8 +170,9 @@ product path.
 
 Business outcome:
 
-1. portfolio managers, supervisors, and operations users can access PM operating quality policy
-   and score-run lifecycle evidence through the Gateway command-center boundary,
+1. portfolio managers, supervisors, and operations users can access PM operating quality policy,
+   score-run lifecycle, and fairness-analysis preview evidence through the Gateway command-center
+   boundary,
 2. Workbench can prepare PM quality product surfaces without calling `lotus-manage` directly,
 3. sales/pre-sales and control users can describe the API layer as implementation-backed while
    preserving explicit non-claims around PM ranking, HR, compensation, conduct enforcement,
@@ -186,15 +187,19 @@ Supported routes:
 5. `POST /api/v1/dpm/command-center/pm-operating-quality/score-runs`
 6. `GET /api/v1/dpm/command-center/pm-operating-quality/score-runs`
 7. `GET /api/v1/dpm/command-center/pm-operating-quality/score-runs/{score_run_id}`
+8. `POST /api/v1/dpm/command-center/pm-operating-quality/fairness-analyses/preview`
 
 Authority and integrations:
 
-1. `lotus-manage` remains the PM operating quality policy and score-run authority.
-2. Gateway forwards policy list/get/upsert and score-run preview/create/list/get requests to
-   `lotus-manage`.
-3. Gateway preserves manage-owned policy configuration, score-run state, governance evidence,
-   source refs, reason codes, content hashes, and forbidden-use posture.
-4. Gateway does not calculate scores, rank PMs, administer bank policy locally, create HR or
+1. `lotus-manage` remains the PM operating quality policy, score-run, and fairness-analysis
+   authority.
+2. Gateway forwards policy list/get/upsert, score-run preview/create/list/get, and
+   fairness-analysis preview requests to `lotus-manage`.
+3. Gateway preserves manage-owned policy configuration, score-run state, fairness-analysis state,
+   segment posture, governance evidence, source refs, reason codes, content hashes, and
+   forbidden-use posture.
+4. Gateway does not calculate scores, discover segments, calculate segment averages or fairness
+   spread, infer protected classes, rank PMs, administer bank policy locally, create HR or
    compensation decisions, perform conduct enforcement, approve trades, contact clients, route
    orders, claim execution, or invent missing evidence.
 
@@ -204,6 +209,7 @@ flowchart LR
     Gateway --> Manage[lotus-manage PM operating quality authority]
     Manage --> Policy[Bank policy versions]
     Manage --> ScoreRun[PmOperatingQualityScoreRun:v1]
+    Manage --> Fairness[PmOperatingQualityFairnessAnalysis:v1]
     Manage --> Sources[Source refs and governance evidence]
     Manage --> Gateway
     Gateway --> Workbench
@@ -212,12 +218,13 @@ flowchart LR
 Operational behavior:
 
 1. Gateway returns manage payloads under `data` and adds a supportability summary with state,
-   policy id/version, score-run id, reason codes, blocked actions, and list counts when available,
+   policy id/version, score-run id, fairness-analysis id, reason codes, blocked actions, and list
+   counts when available,
 2. upstream manage errors are surfaced as product-safe Gateway errors with
    `MANAGE_PM_OPERATING_QUALITY_UPSTREAM_ERROR`,
-3. Workbench PM quality UI, canonical browser screenshots, advanced cross-segment fairness
-   analytics, and bank-specific policy content remain separate owning-repository or
-   bank-owned slices before full product support is claimed.
+3. Workbench PM quality UI remains a separate owning-repository slice; Gateway support for the
+   fairness-analysis preview is implementation-backed only after this Gateway branch merges and
+   the corresponding Manage endpoint is available on its owning branch/main.
 
 ## DPM Rebalance-Wave Composition
 


### PR DESCRIPTION
## Summary
- Adds Gateway BFF route `POST /api/v1/dpm/command-center/pm-operating-quality/fairness-analyses/preview`.
- Forwards Manage request/response truth for `PmOperatingQualityFairnessAnalysis:v1` without Gateway scoring, segment discovery, protected-class inference, PM ranking, HR/compensation/conduct decisions, trade approval, client contact, order routing, or execution claims.
- Updates contract tests, upstream client coverage, OpenAPI/docs/wiki/supported-features truth.

## Validation
- `make lint`
- `make typecheck`
- `python -m pytest tests/unit/test_upstream_clients.py tests/unit/test_dpm_command_center_service.py tests/contract/test_dpm_command_center_contract.py`

## Dependency / Truth Note
- This PR is draft until the corresponding `lotus-manage` endpoint `POST /api/v1/rebalance/pm-operating-quality/fairness-analyses/preview` is merged or otherwise available in the target integration environment.
