### PR TITLE
test(gateway): harden PM quality fairness preview contract

### DIFF
--- a/tests/integration/test_dpm_command_center_router.py
+++ b/tests/integration/test_dpm_command_center_router.py
@@ -226,6 +226,109 @@ def test_dpm_command_center_portfolio_memory_passes_limit_and_preserves_events(m
     ]
 
 
+def test_dpm_command_center_pm_quality_fairness_preview_forwards_segment_refs(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_preview_pm_operating_quality_fairness_analysis(
+        self,
+        body,
+        correlation_id,
+    ):  # noqa: ANN001
+        _ = self
+        captured["body"] = body
+        captured["correlation_id"] = correlation_id
+        return 200, {
+            "fairness_analysis": {
+                "product_name": "PmOperatingQualityFairnessAnalysis",
+                "product_version": "v1",
+                "fairness_analysis_id": "pmq_fair_001",
+                "policy_id": "pmq_sg_dpm",
+                "policy_version": "2026.05",
+                "state": "PENDING_REVIEW",
+                "as_of_date": "2026-05-13",
+                "minimum_segment_score_run_count": 2,
+                "maximum_average_score_spread": "15.00",
+                "observed_average_score_spread": "31.00",
+                "reason_codes": ["PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED"],
+                "blocked_actions": ["CREATE_SCORE_RUN"],
+                "forbidden_uses": [
+                    "protected_class_inference",
+                    "autonomous_pm_ranking",
+                    "hr_decision",
+                ],
+                "segment_results": [
+                    {
+                        "segment_ref": "MANDATE_TYPE:DISCRETIONARY_BALANCED",
+                        "segment_type": "MANDATE_TYPE",
+                        "score_run_ids": ["pmq_run_001", "pmq_run_002"],
+                        "source_refs": [
+                            {
+                                "source_system": "lotus-core",
+                                "source_product": "MandateSegment",
+                                "source_id": "disc_balanced",
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.preview_pm_operating_quality_fairness_analysis",
+        _fake_preview_pm_operating_quality_fairness_analysis,
+    )
+
+    request_body = {
+        "policy_id": "pmq_sg_dpm",
+        "policy_version": "2026.05",
+        "as_of_date": "2026-05-13",
+        "score_run_ids": ["pmq_run_001", "pmq_run_002"],
+        "segments": [
+            {
+                "segment_ref": "MANDATE_TYPE:DISCRETIONARY_BALANCED",
+                "segment_type": "MANDATE_TYPE",
+                "score_run_ids": ["pmq_run_001", "pmq_run_002"],
+                "source_refs": [
+                    {
+                        "source_system": "lotus-core",
+                        "source_product": "MandateSegment",
+                        "source_id": "disc_balanced",
+                    }
+                ],
+            }
+        ],
+    }
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/pm-operating-quality/fairness-analyses/preview",
+        json={"body": request_body},
+        headers={"X-Correlation-Id": "corr-pmq-fairness-router"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "body": request_body,
+        "correlation_id": "corr-pmq-fairness-router",
+    }
+    payload = response.json()
+    assert payload["source_service"] == "lotus-manage"
+    assert payload["supportability"]["state"] == "PENDING_REVIEW"
+    assert payload["supportability"]["policy_id"] == "pmq_sg_dpm"
+    assert payload["supportability"]["fairness_analysis_id"] == "pmq_fair_001"
+    assert payload["supportability"]["blocked_actions"] == ["CREATE_SCORE_RUN"]
+    analysis = payload["data"]["fairness_analysis"]
+    assert analysis["observed_average_score_spread"] == "31.00"
+    assert analysis["forbidden_uses"] == [
+        "protected_class_inference",
+        "autonomous_pm_ranking",
+        "hr_decision",
+    ]
+    assert analysis["segment_results"][0]["source_refs"][0]["source_product"] == ("MandateSegment")
+
+
 def test_dpm_command_center_outcome_review_create_preserves_manage_truth(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -633,6 +633,8 @@ async def test_dpm_pm_operating_quality_fairness_preview_preserves_manage_analys
             "policy_version": "2026.05",
             "as_of_date": "2026-05-13",
             "state": "PENDING_REVIEW",
+            "minimum_segment_score_run_count": 2,
+            "maximum_average_score_spread": "15.00",
             "observed_average_score_spread": "31.00",
             "reason_codes": ["PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED"],
             "blocked_actions": ["CREATE_SCORE_RUN"],
@@ -647,8 +649,23 @@ async def test_dpm_pm_operating_quality_fairness_preview_preserves_manage_analys
                 {
                     "segment_ref": "MANDATE_TYPE:DISCRETIONARY_BALANCED",
                     "segment_type": "MANDATE_TYPE",
+                    "display_name": "Discretionary Balanced",
                     "state": "REVIEW_REQUIRED",
                     "score_run_ids": ["pmq_run_001", "pmq_run_002"],
+                    "score_run_refs": [
+                        {
+                            "source_system": "lotus-manage",
+                            "source_product": "PmOperatingQualityScoreRun",
+                            "source_id": "pmq_run_001",
+                        }
+                    ],
+                    "source_refs": [
+                        {
+                            "source_system": "lotus-core",
+                            "source_product": "MandateSegment",
+                            "source_id": "disc_balanced",
+                        }
+                    ],
                 }
             ],
             "source_refs": [
@@ -666,8 +683,23 @@ async def test_dpm_pm_operating_quality_fairness_preview_preserves_manage_analys
     body = {
         "policy_id": "pmq_sg_dpm",
         "policy_version": "2026.05",
+        "as_of_date": "2026-05-13",
         "score_run_ids": ["pmq_run_001", "pmq_run_002"],
-        "segments": [{"segment_ref": "MANDATE_TYPE:DISCRETIONARY_BALANCED"}],
+        "segments": [
+            {
+                "segment_ref": "MANDATE_TYPE:DISCRETIONARY_BALANCED",
+                "segment_type": "MANDATE_TYPE",
+                "display_name": "Discretionary Balanced",
+                "score_run_ids": ["pmq_run_001", "pmq_run_002"],
+                "source_refs": [
+                    {
+                        "source_system": "lotus-core",
+                        "source_product": "MandateSegment",
+                        "source_id": "disc_balanced",
+                    }
+                ],
+            }
+        ],
     }
     response = await service.preview_pm_operating_quality_fairness_analysis(
         body=body,
@@ -684,6 +716,24 @@ async def test_dpm_pm_operating_quality_fairness_preview_preserves_manage_analys
     assert response.supportability.reason_codes == ["PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED"]
     assert response.supportability.blocked_actions == ["CREATE_SCORE_RUN"]
     assert response.data == manage_payload
+    analysis = response.data["fairness_analysis"]
+    assert analysis["minimum_segment_score_run_count"] == 2
+    assert analysis["maximum_average_score_spread"] == "15.00"
+    assert analysis["observed_average_score_spread"] == "31.00"
+    assert analysis["forbidden_uses"] == [
+        "protected_class_inference",
+        "autonomous_pm_ranking",
+        "hr_decision",
+        "compensation_decision",
+        "conduct_enforcement",
+    ]
+    assert analysis["segment_results"][0]["source_refs"] == [
+        {
+            "source_system": "lotus-core",
+            "source_product": "MandateSegment",
+            "source_id": "disc_balanced",
+        }
+    ]
     assert client.calls == [
         {
             "method": "pm_quality_fairness_preview",


### PR DESCRIPTION
## Summary
- harden the PM operating-quality fairness preview contract around source-defined segment refs
- prove Gateway forwards the request body unchanged to Manage and preserves returned fairness spread, source refs, reason codes, blocked actions, and forbidden-use boundaries
- add router-level coverage for the public BFF route `/api/v1/dpm/command-center/pm-operating-quality/fairness-analyses/preview`

## Validation
- python -m pytest tests/unit/test_dpm_command_center_service.py::test_dpm_pm_operating_quality_fairness_preview_preserves_manage_analysis tests/integration/test_dpm_command_center_router.py::test_dpm_command_center_pm_quality_fairness_preview_forwards_segment_refs -q
- python -m pytest tests/unit/test_dpm_command_center_service.py tests/integration/test_dpm_command_center_router.py tests/contract/test_dpm_command_center_contract.py -q
- python -m ruff check tests/unit/test_dpm_command_center_service.py tests/integration/test_dpm_command_center_router.py
- python -m ruff format --check tests/unit/test_dpm_command_center_service.py tests/integration/test_dpm_command_center_router.py
- make typecheck
- make openapi-gate
- make lint
- git diff --check

## Notes
- Test-only Gateway hardening; no Manage or Workbench files touched.
- No wiki update required: supported route/docs truth already exists and no operator-facing contract changed.
- Gateway still does not score PMs, discover segments, calculate fairness analytics, infer protected classes, rank PMs, administer HR/compensation/conduct decisions, approve trades, contact clients, route orders, or claim execution truth.