### PR TITLE
Clarify PM quality fairness Gateway boundary

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -259,11 +259,13 @@ Most relevant current governance:
     contact clients, place orders, or invent missing evidence.
 16. PM operating quality Gateway routes are active under
     `/api/v1/dpm/command-center/pm-operating-quality/*`. Gateway forwards policy list/get/upsert,
-    score-run preview/create/list/get requests to `lotus-manage`, preserves Manage policy
-    configuration, score-run state, governance evidence, source refs, reason codes, content
-    hashes, and forbidden-use posture, and must not calculate scores, rank PMs, administer bank
-    policy locally, create HR or compensation decisions, perform conduct enforcement, approve
-    trades, contact clients, route orders, or invent missing evidence.
+    score-run preview/create/list/get, and fairness-analysis preview requests to `lotus-manage`,
+    preserves Manage policy configuration, score-run state, fairness-analysis state,
+    source-defined segment posture, governance evidence, source refs, reason codes, content
+    hashes, and forbidden-use posture, and must not calculate scores, discover segments,
+    calculate segment averages or fairness spread, infer protected classes, rank PMs, administer
+    bank policy locally, create HR or compensation decisions, perform conduct enforcement,
+    approve trades, contact clients, route orders, claim execution, or invent missing evidence.
 17. The Workbench overview and portfolio-360 `rebalance_snapshot` now carry bounded
     portfolio-level DPM operations posture for RFC36-WTBD-003: latest rebalance status, last run,
     manage action-register supportability from `/api/v1/rebalance/supportability/summary`, and up


### PR DESCRIPTION
## Summary
- clarify the Gateway repository context for PM operating quality fairness-analysis preview
- document that Gateway forwards fairness preview requests to `lotus-manage` and preserves source-defined segment posture
- restate the bounded non-calculation boundary: no local score calculation, segment discovery, segment averages, fairness spread, protected-class inference, PM ranking, HR/compensation/conduct, approval, client contact, order routing, execution claims, or invented evidence

## Validation
- `git diff --check`
- `python -m pytest tests/unit/test_dpm_command_center_service.py tests/integration/test_dpm_command_center_router.py tests/contract/test_dpm_command_center_contract.py tests/unit/test_upstream_clients.py -q` (168 passed)

## Integration posture
- Documentation/context-only correction in `lotus-gateway`
- No Gateway route behavior changed
- No `lotus-manage` changes
- End-to-end product support still depends on the Manage fairness-analysis endpoint being available and validated through the governed Gateway/Workbench runtime path

## Wiki
- No wiki change: the repo-local wiki already names the fairness-analysis preview route and dependency boundary; this PR aligns the repository engineering context with that existing truth.