### PR TITLE
Preserve concentration top-position proof

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -97,7 +97,11 @@ Current repository posture:
     fields remain forbidden. Gateway preserves upstream `metadata.calculation_supportability`
     from `lotus-performance` and `lotus-risk` as product-safe source calculation posture for
     evidence views, risk module supportability, fan-out state, and bounded degraded metrics without
-    recomputing domain calculation truth.
+    recomputing domain calculation truth. For `ConcentrationRiskReport:v1`, Gateway validates and
+    forwards source-owned single-position concentration fields, including
+    `top_position_weight_current`, `top_position_weight_proposed`, `top_position_weight_delta`,
+    `top_position_current`, and `top_position_proposed`; `TOP_POSITION_WEIGHT` methodology truth
+    remains owned by `lotus-risk`.
 
 ## Architecture And Module Map
 

--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -57,6 +57,13 @@ outputs.
    when the product surface depends on it. Gateway preserves upstream
    `metadata.calculation_supportability` from performance and risk calculations as product-safe
    source calculation posture, but it does not recompute or override source-owned supportability.
+   For `ConcentrationRiskReport:v1`, Gateway preserves the source-owned
+   `single_position_concentration.top_position_weight_current`,
+   `single_position_concentration.top_position_weight_proposed`,
+   `single_position_concentration.top_position_weight_delta`,
+   `single_position_concentration.top_position_current`, and
+   `single_position_concentration.top_position_proposed` fields; it does not recompute
+   `TOP_POSITION_WEIGHT`.
 5. Any new upstream dependency must be classified into an RFC-0082 family before becoming a stable
    Workbench-facing contract.
 6. Transport optimization discussions start with query shape, payload shape, caching, export semantics,

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -777,6 +777,13 @@ def test_workbench_risk_concentration_router_maps_stateful_concentration(monkeyp
         body["payload"]["single_position_concentration"]["top_position_current"]["security_name"]
         == "PIMCO GIS Income Fund"
     )
+    assert body["payload"]["single_position_concentration"]["top_position_weight_current"] == 0.2
+    assert body["payload"]["single_position_concentration"]["top_position_weight_proposed"] == 0.21
+    assert body["payload"]["single_position_concentration"]["top_position_weight_delta"] == 0.01
+    assert (
+        body["payload"]["single_position_concentration"]["top_position_proposed"]["security_id"]
+        == "FO_FUND_PIMCO_INC"
+    )
     assert (
         body["payload"]["single_position_concentration"]["top_n_cumulative_weight_proposed"] == 0.52
     )

--- a/tests/unit/test_risk_workspace_service.py
+++ b/tests/unit/test_risk_workspace_service.py
@@ -472,8 +472,14 @@ async def test_risk_concentration_uses_stateful_request_and_maps_issuer_supporta
     assert response.state == "partial"
     assert response.payload is not None
     assert response.payload.portfolio_concentration.hhi_current == 1200.0
+    assert response.payload.single_position_concentration.top_position_weight_current == 0.18
+    assert response.payload.single_position_concentration.top_position_weight_proposed == 0.18
+    assert response.payload.single_position_concentration.top_position_weight_delta == 0.0
     assert response.payload.single_position_concentration.top_position_current.security_name == (
         "PIMCO GIS Income Fund"
+    )
+    assert response.payload.single_position_concentration.top_position_proposed.security_id == (
+        "FO_FUND_PIMCO_INC"
     )
     assert response.payload.issuer_concentration.coverage_ratio_current == 0.8
     assert response.payload.execution_context is not None

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -204,6 +204,11 @@
   correlation, request, response, raw prompt, and model output content are not metric labels.
   Performance and risk upstream `metadata.calculation_supportability` is folded into Gateway
   fan-out state and degraded reason labels using the same bounded label contract.
+- Workbench risk concentration remains a `lotus-risk` source-owned calculation. Gateway preserves
+  `ConcentrationRiskReport:v1` top-position weights and current/proposed driver identities for
+  Workbench, including `top_position_weight_current`, `top_position_weight_proposed`,
+  `top_position_weight_delta`, `top_position_current`, and `top_position_proposed`; Gateway does
+  not recompute `TOP_POSITION_WEIGHT`.
 - analytics UI protected diagnostics lookup is gateway-first under
   `/api/v1/analytics-ui/diagnostics/{support_reference}`. It requires `X-Actor-Id`,
   `X-Tenant-Id`, `X-Region`, and an operator support role in `X-Role`; it returns only safe panel,


### PR DESCRIPTION
## Summary
- preserve source-owned ConcentrationRiskReport:v1 top-position weight/current/proposed/delta fields through Gateway BFF tests
- document that Gateway does not recompute HHI or TOP_POSITION_WEIGHT methodology
- update supported API/wiki context for Workbench risk concentration preservation

## Validation
- python -m pytest tests/unit/test_risk_workspace_service.py tests/integration/test_workbench_router.py -q
- make lint
- make typecheck
- make check
- git diff --check

## Wiki
- repo-local wiki/API-Surface.md updated; publish after merge