### PR TITLE
Expose campaign lifecycle events

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -250,7 +250,7 @@ Most relevant current governance:
     `/api/v1/dpm/command-center/waves*`. Gateway forwards preview, durable create, search, detail,
     item list, source-check, simulation, item selection, approval, staging, internal handoff,
     cancellation, proof-pack posture, supportability, report-input, and campaign-definition list,
-    get, and upsert requests to `lotus-manage`;
+    get, lifecycle-events, and upsert requests to `lotus-manage`;
     preserves manage-owned `wave_id`, lifecycle state, item states, reason codes, aggregate
     metrics, selected alternative refs, proof-pack refs, handoff refs, campaign definition payloads,
     supportability issues, report-input evidence, and `external_execution_claimed=false`; and must

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -1263,6 +1263,7 @@ Implementation boundaries:
    `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`.
    Gateway also exposes `GET /api/v1/dpm/command-center/waves/campaign-definitions`,
    `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`,
+   `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/lifecycle-events`,
    and `PUT /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`.
 14. Wave routes preserve manage-owned `wave_id`, lifecycle state, item states, reason codes,
    aggregate metrics, selected alternative refs, proof-pack refs, handoff refs, campaign

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -392,6 +392,19 @@ class DpmClient:
             operation="manage.rebalance.waves.campaign_definitions.get",
         )
 
+    async def get_campaign_definition_lifecycle_events(
+        self,
+        campaign_id: str,
+        campaign_version: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/api/v1/rebalance/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/lifecycle-events",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="manage.rebalance.waves.campaign_definitions.lifecycle_events",
+        )
+
     async def get_wave_items(
         self,
         wave_id: str,

--- a/src/app/contracts/dpm_waves.py
+++ b/src/app/contracts/dpm_waves.py
@@ -246,9 +246,9 @@ class DpmCampaignDefinitionGatewayResponse(BaseModel):
     )
     data: dict[str, object] = Field(
         description=(
-            "Authoritative manage BulkReviewCampaignDefinition:v1 payload or page preserved for "
-            "Workbench composition. Gateway does not alter candidates, source refs, governance, "
-            "content hashes, status, or as-of posture."
+            "Authoritative manage BulkReviewCampaignDefinition:v1 payload, page, or lifecycle "
+            "event list preserved for Workbench composition. Gateway does not alter candidates, "
+            "source refs, governance, content hashes, lifecycle events, status, or as-of posture."
         ),
         examples=[
             {

--- a/src/app/routers/dpm_waves.py
+++ b/src/app/routers/dpm_waves.py
@@ -233,6 +233,30 @@ async def get_campaign_definition(
 
 
 @router.get(
+    "/campaign-definitions/{campaign_id}/versions/{campaign_version}/lifecycle-events",
+    response_model=DpmCampaignDefinitionGatewayResponse,
+    summary="Get DPM campaign-definition lifecycle evidence",
+    description=(
+        "What: retrieves manage-owned lifecycle events for one BulkReviewCampaignDefinition:v1 "
+        "version. When: use this for Workbench evidence review before a campaign-backed rebalance "
+        "wave is previewed or created. How: Gateway forwards the read unchanged to lotus-manage "
+        "and does not infer lifecycle state, recalculate campaign membership, run maker-checker "
+        "workflow, or claim OMS execution."
+    ),
+    responses=_UPSTREAM_ERROR_RESPONSES,
+)
+async def get_campaign_definition_lifecycle_events(
+    campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
+    campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await _dpm_wave_service().get_campaign_definition_lifecycle_events(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
     "/{wave_id}",
     response_model=DpmWaveGatewayResponse,
     summary="Get DPM rebalance wave",

--- a/src/app/services/dpm_wave_service.py
+++ b/src/app/services/dpm_wave_service.py
@@ -140,6 +140,26 @@ class DpmWaveService:
             correlation_id,
         )
 
+    async def get_campaign_definition_lifecycle_events(
+        self,
+        campaign_id: str,
+        campaign_version: str,
+        correlation_id: str,
+    ) -> DpmCampaignDefinitionGatewayResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._dpm_client.get_campaign_definition_lifecycle_events(
+            campaign_id=campaign_id,
+            campaign_version=campaign_version,
+            correlation_id=correlation_id,
+        )
+        return self._compose_campaign_definition_response(
+            upstream_status,
+            upstream_payload,
+            correlation_id,
+        )
+
     async def get_wave_items(
         self,
         wave_id: str,

--- a/tests/contract/test_dpm_wave_contract.py
+++ b/tests/contract/test_dpm_wave_contract.py
@@ -98,6 +98,10 @@ def test_dpm_wave_openapi_contract_registered() -> None:
             "/api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}",
             "get",
         ),
+        (
+            "/api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/lifecycle-events",
+            "get",
+        ),
         ("/api/v1/dpm/command-center/waves/{wave_id}", "get"),
         ("/api/v1/dpm/command-center/waves/{wave_id}/items", "get"),
         ("/api/v1/dpm/command-center/waves/{wave_id}/source-check", "post"),

--- a/tests/integration/test_dpm_wave_router.py
+++ b/tests/integration/test_dpm_wave_router.py
@@ -184,6 +184,27 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
             "status": "ACTIVE",
         }
 
+    async def _fake_get_campaign_definition_lifecycle_events(  # noqa: ANN001
+        self, campaign_id, campaign_version, correlation_id
+    ):
+        _ = self
+        captured["lifecycle_events"] = {
+            "campaign_id": campaign_id,
+            "campaign_version": campaign_version,
+            "correlation_id": correlation_id,
+        }
+        return 200, {
+            "campaign_id": campaign_id,
+            "campaign_version": campaign_version,
+            "events": [
+                {
+                    "event_type": "CAMPAIGN_DEFINITION_CREATED",
+                    "actor_id": "pm_sg_1",
+                    "source_service": "lotus-manage",
+                }
+            ],
+        }
+
     monkeypatch.setattr(
         "app.clients.dpm_client.DpmClient.put_campaign_definition",
         _fake_put_campaign_definition,
@@ -195,6 +216,10 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
     monkeypatch.setattr(
         "app.clients.dpm_client.DpmClient.get_campaign_definition",
         _fake_get_campaign_definition,
+    )
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_campaign_definition_lifecycle_events",
+        _fake_get_campaign_definition_lifecycle_events,
     )
 
     client = TestClient(app)
@@ -214,6 +239,11 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
         "campaign-holdings-202605/versions/2026.05",
         headers={"X-Correlation-Id": "corr-campaign-get"},
     )
+    lifecycle_events_response = client.get(
+        "/api/v1/dpm/command-center/waves/campaign-definitions/"
+        "campaign-holdings-202605/versions/2026.05/lifecycle-events",
+        headers={"X-Correlation-Id": "corr-campaign-lifecycle"},
+    )
 
     assert put_response.status_code == 200
     assert put_response.json()["data"]["product_name"] == "BulkReviewCampaignDefinition"
@@ -221,6 +251,11 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
     assert list_response.json()["data"]["items"][0]["campaign_id"] == "campaign-holdings-202605"
     assert get_response.status_code == 200
     assert get_response.json()["data"]["campaign_version"] == "2026.05"
+    assert lifecycle_events_response.status_code == 200
+    assert (
+        lifecycle_events_response.json()["data"]["events"][0]["event_type"]
+        == "CAMPAIGN_DEFINITION_CREATED"
+    )
     assert captured == {
         "put": {
             "campaign_id": "campaign-holdings-202605",
@@ -242,6 +277,11 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
             "campaign_id": "campaign-holdings-202605",
             "campaign_version": "2026.05",
             "correlation_id": "corr-campaign-get",
+        },
+        "lifecycle_events": {
+            "campaign_id": "campaign-holdings-202605",
+            "campaign_version": "2026.05",
+            "correlation_id": "corr-campaign-lifecycle",
         },
     }
 

--- a/tests/unit/test_dpm_wave_service.py
+++ b/tests/unit/test_dpm_wave_service.py
@@ -75,6 +75,19 @@ class _FakeDpmClient:
         )
         return self.result
 
+    async def get_campaign_definition_lifecycle_events(  # noqa: ANN001
+        self, campaign_id, campaign_version, correlation_id
+    ):
+        self.calls.append(
+            {
+                "method": "get_campaign_definition_lifecycle_events",
+                "campaign_id": campaign_id,
+                "campaign_version": campaign_version,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
     async def put_campaign_definition(  # noqa: ANN001
         self, campaign_id, campaign_version, body, correlation_id
     ):
@@ -184,6 +197,43 @@ async def test_dpm_wave_service_preserves_campaign_definition_payloads() -> None
             "campaign_version": "2026.05",
             "body": {"status": "ACTIVE"},
             "correlation_id": "corr-campaign-definition",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_wave_service_preserves_campaign_lifecycle_events() -> None:
+    manage_payload = {
+        "campaign_id": "campaign-holdings-202605",
+        "campaign_version": "2026.05",
+        "events": [
+            {
+                "event_type": "CAMPAIGN_DEFINITION_CREATED",
+                "actor_id": "pm_sg_1",
+                "occurred_at": "2026-05-14T09:30:00Z",
+                "source_service": "lotus-manage",
+            }
+        ],
+    }
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmWaveService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.get_campaign_definition_lifecycle_events(
+        campaign_id="campaign-holdings-202605",
+        campaign_version="2026.05",
+        correlation_id="corr-campaign-lifecycle",
+    )
+
+    assert response.correlation_id == "corr-campaign-lifecycle"
+    assert response.source_service == "lotus-manage"
+    assert response.upstream_status == 200
+    assert response.data == manage_payload
+    assert client.calls == [
+        {
+            "method": "get_campaign_definition_lifecycle_events",
+            "campaign_id": "campaign-holdings-202605",
+            "campaign_version": "2026.05",
+            "correlation_id": "corr-campaign-lifecycle",
         }
     ]
 

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1818,6 +1818,16 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
             "campaign-holdings-202605/versions/2026.05",
         ),
         (
+            "get_campaign_definition_lifecycle_events",
+            {
+                "campaign_id": "campaign-holdings-202605",
+                "campaign_version": "2026.05",
+                "correlation_id": "corr-5",
+            },
+            "http://dpm/api/v1/rebalance/waves/campaign-definitions/"
+            "campaign-holdings-202605/versions/2026.05/lifecycle-events",
+        ),
+        (
             "get_wave_items",
             {"wave_id": "dwv_001", "correlation_id": "corr-5"},
             "http://dpm/api/v1/rebalance/waves/dwv_001/items",

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -137,9 +137,11 @@
   campaign definition payloads, and the no-external-execution boundary. Gateway also exposes
   `GET /api/v1/dpm/command-center/waves/campaign-definitions`,
   `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`,
+  `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/lifecycle-events`,
   and `PUT /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`
-  for manage-owned campaign/cohort definition discovery. Gateway does not discover cohorts,
-  calculate campaign membership, evaluate portfolio eligibility, or own maker-checker posture.
+  for manage-owned campaign/cohort definition discovery and lifecycle evidence. Gateway does not
+  discover cohorts, calculate campaign membership, evaluate portfolio eligibility, infer campaign
+  lifecycle state, or own maker-checker posture.
   Gateway also exposes a governed handoff from
   manage-owned `DpmWaveReportInput` to `lotus-ai` `dpm_wave_pm_memo.pack@v1` for review-required
   PM/control support text. Gateway must not calculate affected portfolios, readiness,

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -250,26 +250,27 @@ Supported routes:
 3. `GET /api/v1/dpm/command-center/waves`
 4. `GET /api/v1/dpm/command-center/waves/campaign-definitions`
 5. `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`
-6. `PUT /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`
-7. `GET /api/v1/dpm/command-center/waves/{wave_id}`
-8. `GET /api/v1/dpm/command-center/waves/{wave_id}/items`
-9. `POST /api/v1/dpm/command-center/waves/{wave_id}/source-check`
-10. `POST /api/v1/dpm/command-center/waves/{wave_id}/simulate`
-11. `POST /api/v1/dpm/command-center/waves/{wave_id}/items/{wave_item_id}/select`
-12. `POST /api/v1/dpm/command-center/waves/{wave_id}/approve`
-13. `POST /api/v1/dpm/command-center/waves/{wave_id}/stage`
-14. `POST /api/v1/dpm/command-center/waves/{wave_id}/handoff`
-15. `POST /api/v1/dpm/command-center/waves/{wave_id}/cancel`
-16. `GET /api/v1/dpm/command-center/waves/{wave_id}/proof-pack`
-17. `GET /api/v1/dpm/command-center/waves/{wave_id}/supportability`
-18. `GET /api/v1/dpm/command-center/waves/{wave_id}/report-input`
-19. `POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`
-20. `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`
+6. `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/lifecycle-events`
+7. `PUT /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}`
+8. `GET /api/v1/dpm/command-center/waves/{wave_id}`
+9. `GET /api/v1/dpm/command-center/waves/{wave_id}/items`
+10. `POST /api/v1/dpm/command-center/waves/{wave_id}/source-check`
+11. `POST /api/v1/dpm/command-center/waves/{wave_id}/simulate`
+12. `POST /api/v1/dpm/command-center/waves/{wave_id}/items/{wave_item_id}/select`
+13. `POST /api/v1/dpm/command-center/waves/{wave_id}/approve`
+14. `POST /api/v1/dpm/command-center/waves/{wave_id}/stage`
+15. `POST /api/v1/dpm/command-center/waves/{wave_id}/handoff`
+16. `POST /api/v1/dpm/command-center/waves/{wave_id}/cancel`
+17. `GET /api/v1/dpm/command-center/waves/{wave_id}/proof-pack`
+18. `GET /api/v1/dpm/command-center/waves/{wave_id}/supportability`
+19. `GET /api/v1/dpm/command-center/waves/{wave_id}/report-input`
+20. `POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`
+21. `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`
 
 Authority and integrations:
 
 1. `lotus-manage` remains the RFC-0041 rebalance-wave authority.
-2. Gateway forwards preview, create, campaign-definition list/get/upsert, source-check, simulate,
+2. Gateway forwards preview, create, campaign-definition list/get/lifecycle-events/upsert, source-check, simulate,
    select, approve, stage, handoff, cancel, proof-pack posture, supportability, and report-input
    requests to manage.
 3. Gateway preserves manage-owned `wave_id`, lifecycle state, item states, reason codes,


### PR DESCRIPTION
## Summary
- Expose a read-only Gateway BFF route for manage-owned campaign-definition lifecycle events.
- Preserve the existing campaign-definition response envelope and forward Manage payloads unchanged.
- Update Gateway context/RFC/wiki source truth for the new lifecycle evidence endpoint.

## Boundary posture
- No campaign cohort discovery in Gateway.
- No campaign membership, lifecycle-state, maker-checker, OMS, or execution calculation in Gateway.
- Workbench integration intentionally deferred until this Gateway route lands on main.

## Validation
- `python -m pytest tests/unit/test_dpm_wave_service.py tests/integration/test_dpm_wave_router.py tests/contract/test_dpm_wave_contract.py tests/unit/test_upstream_clients.py -q` (151 passed)
- `make check` (520 passed)
- `make ci` (701 passed, coverage 88.39%, no known vulnerabilities)
- `git diff --check`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reports expected branch drift for changed repo-authored wiki source: `API-Surface.md`, `Supported-Features.md`; publish after merge.