### PR TITLE
Add PM quality summary Gateway handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`,
   `/api/v1/dpm/command-center/pm-operating-quality/policies*`,
   `/api/v1/dpm/command-center/pm-operating-quality/score-runs*`,
+  `/api/v1/dpm/command-center/pm-operating-quality/score-runs/{score_run_id}/ai-summary`,
   `/api/v1/dpm/command-center/pm-operating-quality/fairness-analyses/preview`,
   `/api/v1/dpm/command-center/waves/campaign-definitions*`,
   `/api/v1/dpm/command-center/waves*`,
@@ -307,13 +308,14 @@ Important current parameter conventions:
    route orders, or invent missing evidence.
 18. DPM PM operating quality routes under
    `/api/v1/dpm/command-center/pm-operating-quality/*` consume `lotus-manage`
-   PM operating quality policy, score-run lifecycle, and fairness-analysis preview APIs. Gateway
-   preserves Manage policy configuration, score-run state, fairness-analysis state, segment
-   posture, governance evidence, source refs, reason codes, content hashes, and forbidden-use
-   posture without calculating scores, discovering segments, calculating fairness spread, inferring
-   protected classes, ranking PMs, administering bank policy locally, or creating HR,
-   compensation, conduct-enforcement, approval, client-contact, order-routing, or execution
-   decisions.
+   PM operating quality policy, score-run lifecycle, and fairness-analysis lifecycle APIs. Gateway
+   also reads Manage-owned score-run evidence before invoking `lotus-ai`
+   `pm_quality_summary.pack@v1` for review-gated support-only summaries. Gateway preserves Manage
+   policy configuration, score-run state, fairness-analysis state, segment posture, governance
+   evidence, source refs, reason codes, content hashes, and forbidden-use posture without
+   calculating scores, discovering segments, calculating fairness spread, inferring protected
+   classes, ranking PMs, administering bank policy locally, or creating HR, compensation,
+   conduct-enforcement, approval, client-contact, order-routing, OMS, or execution decisions.
 
 Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -265,12 +265,15 @@ Most relevant current governance:
 16. PM operating quality Gateway routes are active under
     `/api/v1/dpm/command-center/pm-operating-quality/*`. Gateway forwards policy list/get/upsert,
     score-run preview/create/list/get, and fairness-analysis preview/create/list/get requests to
-    `lotus-manage`, preserves Manage policy configuration, score-run state, fairness-analysis state,
-    source-defined segment posture, governance evidence, source refs, reason codes, content
-    hashes, and forbidden-use posture, and must not calculate scores, discover segments,
-    calculate segment averages or fairness spread, infer protected classes, rank PMs, administer
-    bank policy locally, create HR or compensation decisions, perform conduct enforcement,
-    approve trades, contact clients, route orders, claim execution, or invent missing evidence.
+    `lotus-manage`, and exposes a governed
+    `/score-runs/{score_run_id}/ai-summary` route that reads Manage score-run evidence before
+    executing `lotus-ai` `pm_quality_summary.pack@v1` as `lotus-gateway`. Gateway preserves Manage
+    policy configuration, score-run state, fairness-analysis state, source-defined segment posture,
+    governance evidence, source refs, reason codes, content hashes, supportability, and
+    forbidden-use posture, and must not calculate scores, discover segments, calculate segment
+    averages or fairness spread, infer protected classes, rank PMs, administer bank policy locally,
+    create HR or compensation decisions, perform conduct enforcement, approve trades, contact
+    clients, route orders, claim OMS/execution, or invent missing evidence.
 17. The Workbench overview and portfolio-360 `rebalance_snapshot` now carry bounded
     portfolio-level DPM operations posture for RFC36-WTBD-003: latest rebalance status, last run,
     manage action-register supportability from `/api/v1/rebalance/supportability/summary`, and up

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -1186,7 +1186,7 @@ Gateway/BFF instead of calling `lotus-manage` directly.
 | RFC41-WTBD-003 Gateway campaign-definition discovery/upsert | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | Gateway forwards manage-owned campaign definition list, get, lifecycle-events, upsert, and bounded campaign-discovery APIs through `/api/v1/dpm/command-center/waves/campaign-definitions*` and `/api/v1/dpm/command-center/waves/campaign-discovery`, preserves campaign payloads unchanged, and does not discover cohorts beyond the Manage-owned persisted campaign read model, recompute campaign membership, or own maker-checker posture |
 | RFC42-WTBD-001 Gateway outcome-review composition and BFF contract | Implemented and merged before this slice | `src/app/routers/dpm_command_center.py`, `src/app/services/dpm_command_center_service.py`, `src/app/contracts/dpm_command_center.py`, `src/app/clients/dpm_client.py`, `tests/unit/test_dpm_command_center_service.py`, `tests/integration/test_dpm_command_center_router.py`, `tests/contract/test_dpm_command_center_contract.py`, `make ci` |
 | RFC42-WTBD-005 Gateway AI narrative handoff | Implemented and merged before this slice | Gateway reads manage-owned `DpmOutcomeAiEvidenceInput`, executes `lotus-ai` `outcome_review_narrative.pack@v1` as `lotus-gateway`, preserves manage workflow authority, and exposes `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative` |
-| RFC42-WTBD-008 Gateway PM operating quality composition | Implemented and merged; Gateway docs/wiki truth present on main | Gateway forwards manage-owned PM operating quality policy list/get/upsert, score-run preview/create/list/get, and fairness-analysis preview/create/list/get APIs through `/api/v1/dpm/command-center/pm-operating-quality/*`, preserves policy configuration, score-run state, fairness-analysis state, segment posture, governance evidence, source refs, reason codes, content hashes, and forbidden-use posture, and does not calculate scores, discover segments, calculate segment averages or fairness spread, infer protected classes, rank PMs, administer policy locally, or create HR, compensation, conduct-enforcement, approval, client-contact, or execution decisions |
+| RFC42-WTBD-008 Gateway PM operating quality composition | Implemented and merged; PM-quality summary invocation added in current Gateway branch pending PR/merge/CI/wiki closure | Gateway forwards manage-owned PM operating quality policy list/get/upsert, score-run preview/create/list/get, and fairness-analysis preview/create/list/get APIs through `/api/v1/dpm/command-center/pm-operating-quality/*`; reads Manage-owned score-run evidence before invoking `lotus-ai` `pm_quality_summary.pack@v1`; preserves policy configuration, score-run state, fairness-analysis state, segment posture, governance evidence, source refs, reason codes, content hashes, supportability, and forbidden-use posture; and does not calculate scores, discover segments, calculate segment averages or fairness spread, infer protected classes, rank PMs, administer policy locally, or create HR, compensation, conduct-enforcement, approval, client-contact, OMS, or execution decisions |
 | RFC38/RFC43-WTBD Gateway exception-summary AI handoff | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | Gateway reads manage-owned monitoring-exception evidence from the command-center exception queue, executes `lotus-ai` `dpm_exception_summary.pack@v1` as `lotus-gateway`, preserves source refs/content hashes/supportability, and exposes `POST /api/v1/dpm/command-center/exceptions/{exception_id}/ai-summary` |
 | RFC41/RFC43-WTBD Gateway operations-handoff summary AI handoff | Implemented in current Gateway branch; pending PR/merge/CI/wiki closure | Gateway reads manage-owned `DpmWaveReportInput` with bounded internal handoff refs, executes `lotus-ai` `dpm_operations_handoff_summary.pack@v1` as `lotus-gateway`, preserves manage handoff evidence authority and lotus-ai workflow-pack posture, and exposes `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary` |
 | RFC-0042 manage authority preservation | Implemented for BFF envelope; Gateway forwards payloads and preserves manage supportability | Service tests prove payload preservation and upstream error forwarding; contract tests prove OpenAPI route family registration and What/When/How guidance |
@@ -1285,18 +1285,22 @@ Implementation boundaries:
    `POST /api/v1/dpm/command-center/pm-operating-quality/score-runs`,
    `GET /api/v1/dpm/command-center/pm-operating-quality/score-runs`, and
    `GET /api/v1/dpm/command-center/pm-operating-quality/score-runs/{score_run_id}`, plus
+   `POST /api/v1/dpm/command-center/pm-operating-quality/score-runs/{score_run_id}/ai-summary`,
    `POST /api/v1/dpm/command-center/pm-operating-quality/fairness-analyses/preview`,
    `POST /api/v1/dpm/command-center/pm-operating-quality/fairness-analyses`,
    `GET /api/v1/dpm/command-center/pm-operating-quality/fairness-analyses`, and
    `GET /api/v1/dpm/command-center/pm-operating-quality/fairness-analyses/{fairness_analysis_id}`.
-17. PM operating quality routes preserve manage-owned policy configuration, score-run state,
+17. The PM quality summary route reads Manage-owned score-run evidence before invoking
+   `lotus-ai` `pm_quality_summary.pack@v1` as `lotus-gateway` for review-gated support-only
+   summaries.
+18. PM operating quality routes preserve manage-owned policy configuration, score-run state,
    fairness-analysis state, segment posture, governance evidence, source refs, reason codes,
-   content hashes, and forbidden-use posture.
-18. Gateway does not calculate scores, discover segments, calculate segment averages or fairness
+   content hashes, supportability, and forbidden-use posture.
+19. Gateway does not calculate scores, discover segments, calculate segment averages or fairness
    spread, infer protected classes, rank PMs, administer bank policy locally, create HR or
    compensation decisions, perform conduct enforcement, approve trades, contact clients, route
-   orders, claim execution, or invent missing evidence.
-19. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,
+   orders, claim OMS/execution, or invent missing evidence.
+20. Gateway now exposes `POST /api/v1/dpm/command-center/outcome-reviews/preview`,
    `POST /api/v1/dpm/command-center/outcome-reviews`,
    `GET /api/v1/dpm/command-center/outcome-reviews`,
    `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}`,

--- a/src/app/contracts/dpm_command_center.py
+++ b/src/app/contracts/dpm_command_center.py
@@ -170,6 +170,42 @@ class DpmPmOperatingQualityForwardRequest(BaseModel):
     )
 
 
+class DpmPmOperatingQualitySummaryRequest(BaseModel):
+    requested_outputs: list[str] = Field(
+        default_factory=lambda: [
+            "score_run_summary",
+            "governance_summary",
+            "fairness_review_posture",
+            "support_references",
+            "evidence_gaps",
+        ],
+        description=(
+            "Support-only PM quality summary sections requested from lotus-ai. Gateway forwards "
+            "these labels to pm_quality_summary.pack@v1 and does not allow PM ranking, HR, "
+            "compensation, conduct, client-contact, approval, execution, OMS, or invented-fact "
+            "outputs."
+        ),
+        examples=[
+            [
+                "score_run_summary",
+                "governance_summary",
+                "fairness_review_posture",
+                "support_references",
+                "evidence_gaps",
+            ]
+        ],
+    )
+    audience: list[str] = Field(
+        default_factory=lambda: [
+            "portfolio_manager",
+            "investment_control",
+            "cio_office",
+        ],
+        description="Intended internal audience labels for the support-only PM quality summary.",
+        examples=[["portfolio_manager", "investment_control", "cio_office"]],
+    )
+
+
 class DpmOutcomeReviewNarrativeRequest(BaseModel):
     requested_outputs: list[str] = Field(
         default_factory=lambda: [
@@ -517,6 +553,62 @@ class DpmPmOperatingQualityGatewayResponse(BaseModel):
             "calculate fairness spread, infer protected classes, rank PMs, or convert the "
             "payload into HR, compensation, conduct, approval, client contact, or execution "
             "decisions."
+        ),
+    )
+
+
+class DpmPmOperatingQualitySummaryGatewayResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated across Gateway, lotus-manage, and lotus-ai.",
+        examples=["corr-pmq-summary-1"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway BFF contract version for PM quality AI summary handoff.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        default="lotus-ai",
+        description="Service that executed the governed PM quality summary workflow pack.",
+        examples=["lotus-ai"],
+    )
+    evidence_source_service: str = Field(
+        default="lotus-manage",
+        description="Service that supplied the Manage-owned PM quality score-run evidence.",
+        examples=["lotus-manage"],
+    )
+    manage_upstream_status: int = Field(
+        description="HTTP status returned by lotus-manage for the score-run evidence read.",
+        examples=[200],
+    )
+    ai_upstream_status: int = Field(
+        description="HTTP status returned by lotus-ai for workflow-pack execution.",
+        examples=[200],
+    )
+    supportability: DpmPmOperatingQualitySupportability = Field(
+        description="Manage-derived supportability summary for the PM quality score-run handoff.",
+    )
+    score_run: dict[str, object] = Field(
+        description=(
+            "Manage-owned PmOperatingQualityScoreRun evidence supplied to lotus-ai. Gateway "
+            "preserves score-run identity, policy refs, source refs, governance posture, "
+            "supportability, reason codes, and content hash without calculating or modifying "
+            "scores."
+        ),
+    )
+    summary_request: dict[str, object] = Field(
+        description="Bounded PM quality summary request forwarded to lotus-ai.",
+        examples=[
+            {
+                "requested_outputs": ["score_run_summary", "governance_summary"],
+                "audience": ["portfolio_manager", "investment_control"],
+            }
+        ],
+    )
+    data: dict[str, object] = Field(
+        description=(
+            "Authoritative lotus-ai workflow-pack execution response, including execution audit, "
+            "workflow-pack run posture, review state, and guardrail-supported structured output."
         ),
     )
 

--- a/src/app/routers/dpm_command_center.py
+++ b/src/app/routers/dpm_command_center.py
@@ -16,6 +16,8 @@ from app.contracts.dpm_command_center import (
     DpmOutcomeReviewRefreshRequest,
     DpmPmOperatingQualityForwardRequest,
     DpmPmOperatingQualityGatewayResponse,
+    DpmPmOperatingQualitySummaryGatewayResponse,
+    DpmPmOperatingQualitySummaryRequest,
     DpmPortfolioMemoryGatewayResponse,
 )
 from app.middleware.correlation import correlation_id_var
@@ -598,6 +600,37 @@ async def get_pm_operating_quality_score_run(
 ) -> DpmPmOperatingQualityGatewayResponse:
     return await _dpm_command_center_service().get_pm_operating_quality_score_run(
         score_run_id=score_run_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/pm-operating-quality/score-runs/{score_run_id}/ai-summary",
+    response_model=DpmPmOperatingQualitySummaryGatewayResponse,
+    summary="Request PM operating quality AI summary",
+    description=(
+        "What: requests a governed lotus-ai PM quality summary workflow-pack run from one "
+        "Manage-owned PM operating quality score run. When: use this for review-gated internal "
+        "PM, CIO office, or investment-control support after the score run is visible in "
+        "Workbench. How: Gateway first reads the score run from lotus-manage, then executes "
+        "pm_quality_summary.pack@v1 as lotus-gateway with support-only outputs, preserving "
+        "score-run identity, policy refs, source refs, governance posture, reason codes, "
+        "supportability, content hash, and correlation id. Gateway does not calculate scores, "
+        "rank PMs, administer policy, create HR, compensation, conduct, approval, client-contact, "
+        "execution, or OMS decisions, or invent facts."
+    ),
+)
+async def request_pm_operating_quality_summary(
+    request: DpmPmOperatingQualitySummaryRequest,
+    score_run_id: str = Path(
+        ...,
+        description="Manage-owned PM operating quality score-run identifier.",
+        examples=["pmq_run_001"],
+    ),
+) -> DpmPmOperatingQualitySummaryGatewayResponse:
+    return await _dpm_command_center_service().request_pm_operating_quality_summary(
+        score_run_id=score_run_id,
+        request=request,
         correlation_id=correlation_id_var.get(),
     )
 

--- a/src/app/services/dpm_command_center_service.py
+++ b/src/app/services/dpm_command_center_service.py
@@ -19,10 +19,33 @@ from app.contracts.dpm_command_center import (
     DpmOutcomeReviewNarrativeRequest,
     DpmOutcomeReviewSupportability,
     DpmPmOperatingQualityGatewayResponse,
+    DpmPmOperatingQualitySummaryGatewayResponse,
+    DpmPmOperatingQualitySummaryRequest,
     DpmPmOperatingQualitySupportability,
     DpmPortfolioMemoryGatewayResponse,
     DpmPortfolioMemorySupportability,
 )
+
+_PM_QUALITY_SUMMARY_FORBIDDEN_ACTIONS = [
+    "rank_portfolio_managers",
+    "make_hr_decisions",
+    "make_compensation_decisions",
+    "enforce_conduct_action",
+    "approve_rebalance",
+    "contact_client",
+    "place_orders",
+    "invent_missing_evidence",
+]
+_PM_QUALITY_SUMMARY_UNSUPPORTED_CLAIMS = [
+    "pm_ranking",
+    "hr_decision",
+    "compensation_decision",
+    "conduct_enforcement",
+    "client_message",
+    "trade_approval",
+    "execution_instruction",
+    "oms_acknowledgement",
+]
 
 
 class DpmCommandCenterService:
@@ -686,6 +709,113 @@ class DpmCommandCenterService:
             correlation_id,
         )
 
+    async def request_pm_operating_quality_summary(
+        self,
+        score_run_id: str,
+        request: DpmPmOperatingQualitySummaryRequest,
+        correlation_id: str,
+    ) -> DpmPmOperatingQualitySummaryGatewayResponse:
+        if self._lotus_ai_client is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="lotus-ai workflow-pack execution is not configured for Gateway.",
+            )
+
+        manage_status, manage_payload = await self._dpm_client.get_pm_operating_quality_score_run(
+            score_run_id=score_run_id,
+            correlation_id=correlation_id,
+        )
+        if manage_status >= status.HTTP_400_BAD_REQUEST:
+            raise HTTPException(
+                status_code=manage_status,
+                detail=DpmOutcomeReviewErrorDetail(
+                    upstream_status=manage_status,
+                    error_code="MANAGE_PM_OPERATING_QUALITY_UPSTREAM_ERROR",
+                    detail=_safe_upstream_detail(manage_payload),
+                ).model_dump(),
+            )
+
+        score_run = _pm_quality_score_run_from(manage_payload)
+        if score_run is None:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail={
+                    "source_service": "lotus-manage",
+                    "upstream_status": manage_status,
+                    "error_code": "MANAGE_PM_OPERATING_QUALITY_SCORE_RUN_MISSING",
+                    "detail": (
+                        f"Manage response for score run `{score_run_id}` did not include a "
+                        "score_run object."
+                    ),
+                },
+            )
+
+        supportability = _pm_operating_quality_supportability_from(manage_payload)
+        summary_request: dict[str, object] = {
+            "requested_outputs": request.requested_outputs,
+            "audience": request.audience,
+        }
+        task_payload: dict[str, object] = {
+            "score_run": score_run,
+            "summary_request": summary_request,
+            "supportability": {
+                "source_state": supportability.state,
+                "requires_human_review": True,
+                "forbidden_actions": _PM_QUALITY_SUMMARY_FORBIDDEN_ACTIONS,
+                "unsupported_claims": _PM_QUALITY_SUMMARY_UNSUPPORTED_CLAIMS,
+            },
+        }
+        portfolio_memory_context = manage_payload.get("portfolio_memory_context")
+        if isinstance(portfolio_memory_context, dict):
+            task_payload["portfolio_memory_context"] = portfolio_memory_context
+
+        ai_status, ai_payload = await self._lotus_ai_client.execute_workflow_pack(
+            pack_id="pm_quality_summary.pack",
+            version="v1",
+            environment="DEVELOPMENT",
+            caller_identity_class="INTERNAL_SERVICE",
+            workflow_surface="dpm-pm-quality-ai-evidence",
+            task_request={
+                "task_id": "explain.v1",
+                "input_mode": "STRUCTURED_CONTEXT",
+                "caller": {
+                    "caller_app": "lotus-gateway",
+                    "correlation_id": correlation_id,
+                },
+                "context": {
+                    "summary": (
+                        "Generate review-gated PM operating quality summary from "
+                        f"Manage-owned score-run evidence for {score_run_id}."
+                    ),
+                    "payload": task_payload,
+                    "source_refs": _pm_quality_summary_source_refs(score_run),
+                },
+                "expected_output_label": "EXPLANATION_ONLY",
+            },
+            correlation_id=correlation_id,
+        )
+        if ai_status >= status.HTTP_400_BAD_REQUEST:
+            raise HTTPException(
+                status_code=ai_status,
+                detail={
+                    "source_service": "lotus-ai",
+                    "upstream_status": ai_status,
+                    "error_code": "AI_PM_OPERATING_QUALITY_SUMMARY_UPSTREAM_ERROR",
+                    "detail": _safe_upstream_detail(ai_payload),
+                },
+            )
+
+        return DpmPmOperatingQualitySummaryGatewayResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            manage_upstream_status=manage_status,
+            ai_upstream_status=ai_status,
+            supportability=supportability,
+            score_run=score_run,
+            summary_request=summary_request,
+            data=ai_payload,
+        )
+
     async def put_pm_operating_quality_policy(
         self,
         policy_id: str,
@@ -891,6 +1021,48 @@ def _pm_operating_quality_supportability_from(
         fairness_analysis_id=_safe_optional_str(supportability_source.get("fairness_analysis_id")),
         count=_safe_int(payload.get("count")) if "count" in payload else None,
     )
+
+
+def _pm_quality_score_run_from(payload: dict[str, Any]) -> dict[str, object] | None:
+    score_run = payload.get("score_run")
+    if isinstance(score_run, dict):
+        return score_run
+    if payload.get("score_run_id") is not None:
+        return payload
+    return None
+
+
+def _pm_quality_summary_source_refs(score_run: dict[str, object]) -> list[str]:
+    refs: list[str] = []
+    source_refs = score_run.get("source_refs")
+    if isinstance(source_refs, list):
+        for item in source_refs:
+            ref = _source_ref_label(item)
+            if ref is not None:
+                refs.append(ref)
+
+    score_run_id = _safe_optional_str(score_run.get("score_run_id"))
+    if score_run_id is not None:
+        refs.append(f"lotus-manage:pm-quality-score-run:{score_run_id}")
+    policy_id = _safe_optional_str(score_run.get("policy_id"))
+    policy_version = _safe_optional_str(score_run.get("policy_version"))
+    if policy_id is not None and policy_version is not None:
+        refs.append(f"lotus-manage:pm-quality-policy:{policy_id}:{policy_version}")
+
+    return sorted(set(refs))
+
+
+def _source_ref_label(value: object) -> str | None:
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, dict):
+        return None
+    source_system = value.get("source_system") or value.get("sourceSystem") or "lotus-manage"
+    source_type = value.get("source_type") or value.get("sourceType") or value.get("product_name")
+    source_id = value.get("source_id") or value.get("sourceId")
+    if source_type is None or source_id is None:
+        return None
+    return f"{source_system}:{source_type}:{source_id}"
 
 
 def _supportability_from(payload: dict[str, Any]) -> DpmOutcomeReviewSupportability:

--- a/tests/contract/test_dpm_command_center_contract.py
+++ b/tests/contract/test_dpm_command_center_contract.py
@@ -6,6 +6,7 @@ from app.contracts.dpm_command_center import (
     DpmOutcomeReviewGatewayResponse,
     DpmOutcomeReviewNarrativeGatewayResponse,
     DpmPmOperatingQualityGatewayResponse,
+    DpmPmOperatingQualitySummaryGatewayResponse,
     DpmPortfolioMemoryGatewayResponse,
 )
 from app.main import app
@@ -216,6 +217,55 @@ def test_dpm_exception_summary_gateway_response_contract_shape() -> None:
     assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
 
 
+def test_dpm_pm_operating_quality_summary_gateway_response_contract_shape() -> None:
+    response = DpmPmOperatingQualitySummaryGatewayResponse(
+        correlation_id="corr-pmq-summary-1",
+        manage_upstream_status=200,
+        ai_upstream_status=200,
+        supportability={
+            "state": "READY",
+            "reason_codes": ["PM_QUALITY_READY"],
+            "policy_id": "pmq_sg_dpm",
+            "policy_version": "2026.05",
+            "score_run_id": "pmq_run_001",
+        },
+        score_run={
+            "product_name": "PmOperatingQualityScoreRun",
+            "product_version": "1.0",
+            "score_run_id": "pmq_run_001",
+            "policy_id": "pmq_sg_dpm",
+            "policy_version": "2026.05",
+            "state": "READY",
+            "source_refs": [
+                {
+                    "source_system": "lotus-manage",
+                    "source_type": "PmOperatingQualityScoreRun",
+                    "source_id": "pmq_run_001",
+                }
+            ],
+            "content_hash": "sha256:pmq-run-001",
+        },
+        summary_request={
+            "requested_outputs": ["score_run_summary", "support_references"],
+            "audience": ["portfolio_manager", "investment_control"],
+        },
+        data={
+            "execution": {"status": "COMPLETED"},
+            "workflow_pack_run": {"workflow_authority_owner": "lotus-manage"},
+        },
+    )
+
+    assert response.source_service == "lotus-ai"
+    assert response.evidence_source_service == "lotus-manage"
+    assert response.supportability.authority == "lotus-manage:RFC-0042/PM_OPERATING_QUALITY"
+    assert response.score_run["score_run_id"] == "pmq_run_001"
+    assert response.summary_request["requested_outputs"] == [
+        "score_run_summary",
+        "support_references",
+    ]
+    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+
+
 def test_dpm_command_center_openapi_contract_registered() -> None:
     client = TestClient(app)
     spec = client.get("/openapi.json").json()
@@ -249,6 +299,10 @@ def test_dpm_command_center_openapi_contract_registered() -> None:
         (
             "/api/v1/dpm/command-center/pm-operating-quality/score-runs/{score_run_id}",
             "get",
+        ),
+        (
+            "/api/v1/dpm/command-center/pm-operating-quality/score-runs/{score_run_id}/ai-summary",
+            "post",
         ),
         (
             "/api/v1/dpm/command-center/pm-operating-quality/policies/"
@@ -294,6 +348,8 @@ def test_dpm_command_center_openapi_models_are_described() -> None:
     portfolio_memory_supportability_schema = schemas["DpmPortfolioMemorySupportability"]
     pm_quality_response_schema = schemas["DpmPmOperatingQualityGatewayResponse"]
     pm_quality_supportability_schema = schemas["DpmPmOperatingQualitySupportability"]
+    pm_quality_summary_request_schema = schemas["DpmPmOperatingQualitySummaryRequest"]
+    pm_quality_summary_response_schema = schemas["DpmPmOperatingQualitySummaryGatewayResponse"]
     response_schema = schemas["DpmOutcomeReviewGatewayResponse"]
     narrative_response_schema = schemas["DpmOutcomeReviewNarrativeGatewayResponse"]
     exception_summary_request_schema = schemas["DpmExceptionSummaryRequest"]
@@ -318,6 +374,12 @@ def test_dpm_command_center_openapi_models_are_described() -> None:
     for property_schema in pm_quality_supportability_schema["properties"].values():
         assert property_schema.get("description")
 
+    for property_schema in pm_quality_summary_request_schema["properties"].values():
+        assert property_schema.get("description")
+
+    for property_schema in pm_quality_summary_response_schema["properties"].values():
+        assert property_schema.get("description")
+
     for property_schema in response_schema["properties"].values():
         assert property_schema.get("description")
 
@@ -339,6 +401,8 @@ def test_dpm_command_center_openapi_models_are_described() -> None:
     assert portfolio_memory_supportability_schema["properties"]["state"]["examples"]
     assert pm_quality_response_schema["properties"]["data"]["description"]
     assert pm_quality_supportability_schema["properties"]["state"]["examples"]
+    assert pm_quality_summary_request_schema["properties"]["requested_outputs"]["examples"]
+    assert pm_quality_summary_response_schema["properties"]["data"]["description"]
     assert response_schema["properties"]["data"]["description"]
     assert narrative_response_schema["properties"]["data"]["description"]
     assert exception_summary_request_schema["properties"]["requested_outputs"]["examples"]

--- a/tests/integration/test_dpm_command_center_router.py
+++ b/tests/integration/test_dpm_command_center_router.py
@@ -713,6 +713,87 @@ def test_dpm_command_center_exception_summary_executes_lotus_ai(monkeypatch) -> 
     assert payload["data"]["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
 
 
+def test_dpm_command_center_pm_quality_summary_executes_lotus_ai(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_get_pm_operating_quality_score_run(
+        self,
+        score_run_id,
+        correlation_id,
+    ):  # noqa: ANN001
+        _ = self
+        captured["manage"] = {
+            "score_run_id": score_run_id,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"score_run": _pm_quality_score_run(score_run_id)}
+
+    async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN003
+        _ = self
+        captured["ai"] = kwargs
+        return 200, {
+            "execution": {
+                "status": "COMPLETED",
+                "audit": {"workflow_pack_run_id": "packrun_pmq_1"},
+                "result": {
+                    "structured_output": {
+                        "workflow_pack_family": "pm_quality_summary",
+                        "summary_status": "REVIEW_REQUIRED",
+                    }
+                },
+            },
+            "workflow_pack_run": {
+                "run_id": "packrun_pmq_1",
+                "workflow_authority_owner": "lotus-manage",
+            },
+        }
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_pm_operating_quality_score_run",
+        _fake_get_pm_operating_quality_score_run,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_ai_client.LotusAiClient.execute_workflow_pack",
+        _fake_execute_workflow_pack,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/pm-operating-quality/score-runs/pmq_run_001/ai-summary",
+        json={
+            "requested_outputs": ["score_run_summary", "fairness_review_posture"],
+            "audience": ["portfolio_manager", "investment_control"],
+        },
+        headers={"X-Correlation-Id": "corr-pmq-summary-router"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert captured["manage"] == {
+        "score_run_id": "pmq_run_001",
+        "correlation_id": "corr-pmq-summary-router",
+    }
+    ai_call = captured["ai"]
+    assert ai_call["pack_id"] == "pm_quality_summary.pack"
+    assert ai_call["version"] == "v1"
+    assert ai_call["workflow_surface"] == "dpm-pm-quality-ai-evidence"
+    assert ai_call["correlation_id"] == "corr-pmq-summary-router"
+    task_request = ai_call["task_request"]
+    assert task_request["caller"]["caller_app"] == "lotus-gateway"
+    context_payload = task_request["context"]["payload"]
+    assert context_payload["score_run"]["score_run_id"] == "pmq_run_001"
+    assert context_payload["summary_request"] == {
+        "requested_outputs": ["score_run_summary", "fairness_review_posture"],
+        "audience": ["portfolio_manager", "investment_control"],
+    }
+    assert "rank_portfolio_managers" in context_payload["supportability"]["forbidden_actions"]
+    assert "execution_instruction" in context_payload["supportability"]["unsupported_claims"]
+    assert payload["source_service"] == "lotus-ai"
+    assert payload["evidence_source_service"] == "lotus-manage"
+    assert payload["score_run"]["score_run_id"] == "pmq_run_001"
+    assert payload["data"]["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+
+
 def _outcome_ai_evidence(outcome_review_id: str) -> dict[str, object]:
     return {
         "contract_version": "1.0",
@@ -767,4 +848,49 @@ def _exception_page() -> dict[str, object]:
             }
         ],
         "next_cursor": None,
+    }
+
+
+def _pm_quality_score_run(score_run_id: str) -> dict[str, object]:
+    return {
+        "product_name": "PmOperatingQualityScoreRun",
+        "product_version": "1.0",
+        "score_run_id": score_run_id,
+        "policy_id": "pmq_sg_dpm",
+        "policy_version": "2026.05",
+        "portfolio_manager_id": "PM_SG_DPM_001",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "as_of_date": "2026-05-16",
+        "state": "READY",
+        "score": "86.5",
+        "reason_codes": ["PM_QUALITY_READY"],
+        "indicator_results": [
+            {
+                "indicator_id": "source_evidence_completeness",
+                "state": "READY",
+                "score": "92.0",
+                "reason_codes": ["PM_QUALITY_SOURCE_EVIDENCE_COMPLETE"],
+                "source_refs": [
+                    {
+                        "source_system": "lotus-manage",
+                        "source_type": "PmOperatingQualityScoreRun",
+                        "source_id": score_run_id,
+                        "content_hash": "sha256:pmq-run-001",
+                    }
+                ],
+            }
+        ],
+        "governance_evidence": {
+            "approval_ref": "PMQ-APPROVAL-2026-05",
+            "fairness_review_ref": "PMQ-FAIRNESS-2026-05",
+        },
+        "source_refs": [
+            {
+                "source_system": "lotus-manage",
+                "source_type": "PmOperatingQualityScoreRun",
+                "source_id": score_run_id,
+                "content_hash": "sha256:pmq-run-001",
+            }
+        ],
+        "content_hash": "sha256:pmq-run-001",
     }

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -4,6 +4,7 @@ from fastapi import HTTPException
 from app.contracts.dpm_command_center import (
     DpmExceptionSummaryRequest,
     DpmOutcomeReviewNarrativeRequest,
+    DpmPmOperatingQualitySummaryRequest,
 )
 from app.services.dpm_command_center_service import DpmCommandCenterService
 
@@ -886,6 +887,127 @@ async def test_dpm_pm_operating_quality_manage_errors_are_product_safe() -> None
 
 
 @pytest.mark.asyncio
+async def test_dpm_pm_operating_quality_summary_uses_manage_score_run_and_lotus_ai() -> None:
+    manage_payload = {
+        "score_run": _pm_quality_score_run(),
+        "portfolio_memory_context": {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "event_count": 1,
+            "events": [
+                {
+                    "event_id": "pmq-memory-1",
+                    "event_type": "PM_QUALITY_SCORE_RUN",
+                    "source_refs": [
+                        {
+                            "source_system": "lotus-manage",
+                            "source_type": "PmOperatingQualityScoreRun",
+                            "source_id": "pmq_run_001",
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+    dpm_client = _FakeDpmClient((200, manage_payload))
+    ai_client = _FakeLotusAiClient(
+        (
+            200,
+            {
+                "execution": {
+                    "status": "COMPLETED",
+                    "audit": {"workflow_pack_run_id": "packrun_pmq_1"},
+                    "result": {
+                        "structured_output": {
+                            "workflow_pack_family": "pm_quality_summary",
+                            "summary_status": "REVIEW_REQUIRED",
+                        }
+                    },
+                },
+                "workflow_pack_run": {
+                    "run_id": "packrun_pmq_1",
+                    "workflow_authority_owner": "lotus-manage",
+                },
+            },
+        )
+    )
+    service = DpmCommandCenterService(
+        dpm_client=dpm_client,  # type: ignore[arg-type]
+        lotus_ai_client=ai_client,  # type: ignore[arg-type]
+    )
+
+    response = await service.request_pm_operating_quality_summary(
+        score_run_id="pmq_run_001",
+        request=DpmPmOperatingQualitySummaryRequest(
+            requested_outputs=["score_run_summary", "support_references"],
+            audience=["portfolio_manager", "investment_control"],
+        ),
+        correlation_id="corr-pmq-summary",
+    )
+
+    assert response.source_service == "lotus-ai"
+    assert response.evidence_source_service == "lotus-manage"
+    assert response.manage_upstream_status == 200
+    assert response.ai_upstream_status == 200
+    assert response.supportability.score_run_id == "pmq_run_001"
+    assert response.score_run["score_run_id"] == "pmq_run_001"
+    assert response.summary_request == {
+        "requested_outputs": ["score_run_summary", "support_references"],
+        "audience": ["portfolio_manager", "investment_control"],
+    }
+    assert dpm_client.calls == [
+        {
+            "method": "pm_quality_score_run",
+            "score_run_id": "pmq_run_001",
+            "correlation_id": "corr-pmq-summary",
+        }
+    ]
+    ai_call = ai_client.calls[0]
+    assert ai_call["pack_id"] == "pm_quality_summary.pack"
+    assert ai_call["version"] == "v1"
+    assert ai_call["workflow_surface"] == "dpm-pm-quality-ai-evidence"
+    assert ai_call["correlation_id"] == "corr-pmq-summary"
+    task_request = ai_call["task_request"]
+    assert task_request["caller"] == {
+        "caller_app": "lotus-gateway",
+        "correlation_id": "corr-pmq-summary",
+    }
+    payload = task_request["context"]["payload"]
+    assert payload["score_run"] == manage_payload["score_run"]
+    assert payload["summary_request"] == response.summary_request
+    assert payload["supportability"]["requires_human_review"] is True
+    assert "rank_portfolio_managers" in payload["supportability"]["forbidden_actions"]
+    assert "compensation_decision" in payload["supportability"]["unsupported_claims"]
+    assert payload["portfolio_memory_context"] == manage_payload["portfolio_memory_context"]
+    assert "lotus-manage:pm-quality-score-run:pmq_run_001" in task_request["context"]["source_refs"]
+    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+
+
+@pytest.mark.asyncio
+async def test_dpm_pm_operating_quality_summary_preserves_lotus_ai_errors() -> None:
+    dpm_client = _FakeDpmClient((200, {"score_run": _pm_quality_score_run()}))
+    ai_client = _FakeLotusAiClient((422, {"detail": "pm ranking output blocked"}))
+    service = DpmCommandCenterService(
+        dpm_client=dpm_client,  # type: ignore[arg-type]
+        lotus_ai_client=ai_client,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.request_pm_operating_quality_summary(
+            score_run_id="pmq_run_001",
+            request=DpmPmOperatingQualitySummaryRequest(),
+            correlation_id="corr-pmq-summary-error",
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == {
+        "source_service": "lotus-ai",
+        "upstream_status": 422,
+        "error_code": "AI_PM_OPERATING_QUALITY_SUMMARY_UPSTREAM_ERROR",
+        "detail": "pm ranking output blocked",
+    }
+
+
+@pytest.mark.asyncio
 async def test_dpm_command_center_requests_ai_narrative_from_manage_evidence_only() -> None:
     ai_evidence = _outcome_ai_evidence()
     dpm_client = _FakeDpmClient((200, ai_evidence))
@@ -1155,6 +1277,57 @@ def _outcome_ai_evidence() -> dict[str, object]:
             "content_hash": "sha256:outcome-ai-evidence-001",
         },
         "content_hash": "sha256:outcome-ai-evidence-001",
+    }
+
+
+def _pm_quality_score_run() -> dict[str, object]:
+    return {
+        "product_name": "PmOperatingQualityScoreRun",
+        "product_version": "1.0",
+        "score_run_id": "pmq_run_001",
+        "policy_id": "pmq_sg_dpm",
+        "policy_version": "2026.05",
+        "portfolio_manager_id": "PM_SG_DPM_001",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "as_of_date": "2026-05-16",
+        "state": "READY",
+        "score": "86.5",
+        "reason_codes": ["PM_QUALITY_READY"],
+        "indicator_results": [
+            {
+                "indicator_id": "source_evidence_completeness",
+                "state": "READY",
+                "score": "92.0",
+                "reason_codes": ["PM_QUALITY_SOURCE_EVIDENCE_COMPLETE"],
+                "source_refs": [
+                    {
+                        "source_system": "lotus-manage",
+                        "source_type": "PmOperatingQualityScoreRun",
+                        "source_id": "pmq_run_001",
+                        "content_hash": "sha256:pmq-run-001",
+                    }
+                ],
+            }
+        ],
+        "governance_evidence": {
+            "approval_ref": "PMQ-APPROVAL-2026-05",
+            "fairness_review_ref": "PMQ-FAIRNESS-2026-05",
+        },
+        "source_refs": [
+            {
+                "source_system": "lotus-manage",
+                "source_type": "PmOperatingQualityScoreRun",
+                "source_id": "pmq_run_001",
+                "content_hash": "sha256:pmq-run-001",
+            }
+        ],
+        "content_hash": "sha256:pmq-run-001",
+        "forbidden_uses": [
+            "compensation_decision",
+            "hr_decision",
+            "conduct_enforcement",
+            "autonomous_pm_ranking",
+        ],
     }
 
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -91,12 +91,14 @@
 - PM operating quality composition consumes `lotus-manage`
   `/api/v1/rebalance/pm-operating-quality/*` through
   `/api/v1/dpm/command-center/pm-operating-quality/*`. Gateway exposes policy list/get/upsert
-  score-run preview/create/list/get routes, and fairness-analysis preview/create/list/get for Workbench,
-  preserving manage-owned policy configuration, score-run state, fairness-analysis state, segment
-  posture, governance evidence, source refs, reason codes, content hashes, and forbidden-use
-  posture. Gateway must not calculate scores, discover segments, calculate segment averages or
-  fairness spread, infer protected classes, rank PMs, administer bank policy locally, or create HR,
-  compensation, conduct-enforcement, approval, client-contact, order, or execution decisions.
+  score-run preview/create/list/get routes, fairness-analysis preview/create/list/get, and a
+  score-run AI summary handoff that executes `lotus-ai` `pm_quality_summary.pack@v1` only after
+  reading Manage-owned score-run evidence. Gateway preserves manage-owned policy configuration,
+  score-run state, fairness-analysis state, segment posture, governance evidence, source refs,
+  reason codes, content hashes, supportability, and forbidden-use posture. Gateway must not
+  calculate scores, discover segments, calculate segment averages or fairness spread, infer
+  protected classes, rank PMs, administer bank policy locally, or create HR, compensation,
+  conduct-enforcement, approval, client-contact, order, OMS, or execution decisions.
 - RFC-0098 construction-alternative composition consumes `lotus-manage` RFC-0039 construction
   APIs through `/api/v1/dpm/command-center/construction/alternative-sets*`. Gateway exposes
   generate, get, and select routes for Workbench, preserving manage alternative-set ids, method

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -150,12 +150,14 @@
 16. PM operating quality remains `lotus-manage` truth. Gateway realization exposes
     `/api/v1/dpm/command-center/pm-operating-quality/*` for Workbench. Gateway forwards policy
     list/get/upsert, score-run preview/create/list/get, and fairness-analysis preview/create/list/get
-    requests to manage, then preserves policy configuration, score-run state, fairness-analysis state, segment
-    posture, governance evidence, source refs, reason codes, content hashes, and forbidden-use
-    posture without calculating scores, discovering segments, calculating segment averages or
-    fairness spread, inferring protected classes, ranking PMs, administering policy locally,
-    creating HR or compensation decisions, performing conduct enforcement, approving trades,
-    contacting clients, routing orders, or inventing evidence.
+    requests to manage, and reads Manage score-run evidence before invoking `lotus-ai`
+    `pm_quality_summary.pack@v1` for review-gated support-only summaries. Gateway preserves policy
+    configuration, score-run state, fairness-analysis state, segment posture, governance evidence,
+    source refs, reason codes, content hashes, supportability, and forbidden-use posture without
+    calculating scores, discovering segments, calculating segment averages or fairness spread,
+    inferring protected classes, ranking PMs, administering policy locally, creating HR or
+    compensation decisions, performing conduct enforcement, approving trades, contacting clients,
+    routing orders, claiming OMS/execution, or inventing evidence.
 17. RFC36-WTBD-003 portfolio-level DPM operations dashboards consume Gateway Workbench
     `rebalance_snapshot` only. Gateway reads manage rebalance runs, preserves manage
     supportability summary and bounded recent-run posture, and keeps Workbench from calling

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -171,8 +171,8 @@ product path.
 Business outcome:
 
 1. portfolio managers, supervisors, and operations users can access PM operating quality policy,
-   score-run lifecycle, and fairness-analysis preview/create/list/get evidence through the Gateway command-center
-   boundary,
+   score-run lifecycle, fairness-analysis preview/create/list/get evidence, and review-gated
+   support-only PM quality summaries through the Gateway command-center boundary,
 2. Workbench can prepare PM quality product surfaces without calling `lotus-manage` directly,
 3. sales/pre-sales and control users can describe the API layer as implementation-backed while
    preserving explicit non-claims around PM ranking, HR, compensation, conduct enforcement,
@@ -191,6 +191,7 @@ Supported routes:
 9. `POST /api/v1/dpm/command-center/pm-operating-quality/fairness-analyses`
 10. `GET /api/v1/dpm/command-center/pm-operating-quality/fairness-analyses`
 11. `GET /api/v1/dpm/command-center/pm-operating-quality/fairness-analyses/{fairness_analysis_id}`
+12. `POST /api/v1/dpm/command-center/pm-operating-quality/score-runs/{score_run_id}/ai-summary`
 
 Authority and integrations:
 
@@ -198,23 +199,27 @@ Authority and integrations:
    authority.
 2. Gateway forwards policy list/get/upsert, score-run preview/create/list/get, and
    fairness-analysis preview/create/list/get requests to `lotus-manage`.
-3. Gateway preserves manage-owned policy configuration, score-run state, fairness-analysis state,
+3. Gateway executes `lotus-ai` `pm_quality_summary.pack@v1` only after reading Manage-owned
+   `PmOperatingQualityScoreRun` evidence for the requested score-run id.
+4. Gateway preserves manage-owned policy configuration, score-run state, fairness-analysis state,
    segment posture, governance evidence, source refs, reason codes, content hashes, and
    forbidden-use posture.
-4. Gateway does not calculate scores, discover segments, calculate segment averages or fairness
+5. Gateway does not calculate scores, discover segments, calculate segment averages or fairness
    spread, infer protected classes, rank PMs, administer bank policy locally, create HR or
    compensation decisions, perform conduct enforcement, approve trades, contact clients, route
-   orders, claim execution, or invent missing evidence.
+   orders, claim OMS/execution, or invent missing evidence.
 
 ```mermaid
 flowchart LR
     Workbench[lotus-workbench future PM quality UI] --> Gateway[lotus-gateway PM quality routes]
     Gateway --> Manage[lotus-manage PM operating quality authority]
+    Gateway --> AI[lotus-ai pm_quality_summary.pack@v1]
     Manage --> Policy[Bank policy versions]
     Manage --> ScoreRun[PmOperatingQualityScoreRun:v1]
     Manage --> Fairness[PmOperatingQualityFairnessAnalysis:v1]
     Manage --> Sources[Source refs and governance evidence]
     Manage --> Gateway
+    AI --> Gateway
     Gateway --> Workbench
 ```
 
@@ -225,7 +230,9 @@ Operational behavior:
    counts when available,
 2. upstream manage errors are surfaced as product-safe Gateway errors with
    `MANAGE_PM_OPERATING_QUALITY_UPSTREAM_ERROR`,
-3. Workbench PM quality UI is a Gateway-backed owning-repository slice in `lotus-workbench`;
+3. upstream lotus-ai summary errors are surfaced as product-safe Gateway errors with
+   `AI_PM_OPERATING_QUALITY_SUMMARY_UPSTREAM_ERROR`,
+4. Workbench PM quality UI is a Gateway-backed owning-repository slice in `lotus-workbench`;
    end-to-end product support still depends on the corresponding Manage endpoint being available
    on its owning branch/main and validated through the governed Workbench/Gateway runtime path.
 


### PR DESCRIPTION
## Summary
- adds a governed PM operating quality score-run AI summary BFF route over pm_quality_summary.pack@v1
- reads Manage-owned score-run evidence before invoking lotus-ai and preserves score-run identity, supportability, source refs, reason codes, content hash, and correlation id
- updates OpenAPI/contract coverage plus README/RFC/wiki truth for RFC42-WTBD-008

## Boundaries
- no PM ranking, local score calculation, fairness spread calculation, protected-class inference, policy administration, HR/compensation/conduct/client-contact/approval/execution/OMS decisions, or invented evidence
- Gateway fairness-analysis lifecycle routes were already present on main and are left intact

## Validation
- python -m pytest tests/unit/test_dpm_command_center_service.py tests/integration/test_dpm_command_center_router.py tests/contract/test_dpm_command_center_contract.py
- make typecheck
- make lint
- git diff --check
- make check
- make ci
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway (expected source drift: API-Surface.md, Integrations.md, Supported-Features.md; publish required after merge)
