### PR TITLE
Preserve external hedge policy construction diagnostics

### DIFF
--- a/src/app/contracts/dpm_construction.py
+++ b/src/app/contracts/dpm_construction.py
@@ -110,6 +110,30 @@ class DpmConstructionGatewayResponse(BaseModel):
                         "alternative_id": "alt_heuristic_explainable",
                         "method": "HEURISTIC_EXPLAINABLE",
                         "method_status": "READY",
+                        "diagnostics": {
+                            "authority_context": {
+                                "currency_overlay_context": {
+                                    "external_hedge_policy_source_product_name": (
+                                        "ExternalHedgePolicy"
+                                    ),
+                                    "external_hedge_policy_source_product_version": "v1",
+                                    "external_hedge_policy_source_id": (
+                                        "sha256:external-hedge-policy"
+                                    ),
+                                    "external_hedge_policy_content_hash": (
+                                        "sha256:external-hedge-policy-content"
+                                    ),
+                                    "external_hedge_policy_rule_count": 0,
+                                    "external_hedge_policy_rules": [],
+                                    "missing_data_families": ["external_hedge_policy"],
+                                    "blocked_capabilities": [
+                                        "hedge_policy_approval",
+                                        "treasury_instruction",
+                                    ],
+                                    "reason_codes": ["EXTERNAL_HEDGE_POLICY_FAIL_CLOSED"],
+                                }
+                            }
+                        },
                     }
                 ],
             }

--- a/src/app/services/dpm_construction_service.py
+++ b/src/app/services/dpm_construction_service.py
@@ -119,6 +119,17 @@ def _reason_codes_from_payload(payload: dict[str, Any]) -> list[str]:
                         method_plan.get("reason_codes") or method_plan.get("reasonCodes") or []
                     )
                 )
+            authority_context = diagnostics.get("authority_context")
+            if isinstance(authority_context, dict):
+                currency_overlay_context = authority_context.get("currency_overlay_context")
+                if isinstance(currency_overlay_context, dict):
+                    reason_codes.extend(
+                        _list_of_strings(
+                            currency_overlay_context.get("reason_codes")
+                            or currency_overlay_context.get("reasonCodes")
+                            or []
+                        )
+                    )
     return reason_codes
 
 

--- a/tests/integration/test_dpm_construction_router.py
+++ b/tests/integration/test_dpm_construction_router.py
@@ -44,9 +44,18 @@ def test_dpm_construction_generate_preserves_manage_truth(monkeypatch) -> None:
     assert payload["source_service"] == "lotus-manage"
     assert payload["supportability"]["state"] == "READY"
     assert payload["supportability"]["reason_codes"] == [
+        "EXTERNAL_HEDGE_POLICY_FAIL_CLOSED",
         "REGIME_SCENARIO_PACK_READY",
         "TARGET_METHOD_COMPARISON_AVAILABLE",
     ]
+    currency_context = payload["data"]["alternatives"][0]["diagnostics"]["authority_context"][
+        "currency_overlay_context"
+    ]
+    assert currency_context["external_hedge_policy_source_product_name"] == ("ExternalHedgePolicy")
+    assert currency_context["external_hedge_policy_rule_count"] == 0
+    assert currency_context["external_hedge_policy_rules"] == []
+    assert currency_context["missing_data_families"] == ["external_hedge_policy"]
+    assert "hedge_policy_approval" in currency_context["blocked_capabilities"]
     assert payload["data"] == _construction_alternative_set()
 
 
@@ -150,6 +159,28 @@ def _construction_alternative_set() -> dict[str, object]:
                 "constraint_trace": [],
                 "comparison_metrics": {"turnover_weight": "0.05"},
                 "diagnostics": {
+                    "authority_context": {
+                        "currency_overlay_context": {
+                            "supportability_status": "BLOCKED",
+                            "source_system": "lotus-core",
+                            "external_hedge_policy_source_product_name": ("ExternalHedgePolicy"),
+                            "external_hedge_policy_source_product_version": "v1",
+                            "external_hedge_policy_source_id": ("sha256:external-hedge-policy"),
+                            "external_hedge_policy_content_hash": (
+                                "sha256:external-hedge-policy-content"
+                            ),
+                            "external_hedge_policy_rule_count": 0,
+                            "external_hedge_policy_rules": [],
+                            "missing_data_families": ["external_hedge_policy"],
+                            "blocked_capabilities": [
+                                "hedge_policy_approval",
+                                "treasury_instruction",
+                                "counterparty_selection",
+                                "oms_acknowledgement",
+                            ],
+                            "reason_codes": ["EXTERNAL_HEDGE_POLICY_FAIL_CLOSED"],
+                        }
+                    },
                     "method_plan": {
                         "reason_codes": ["TARGET_METHOD_COMPARISON_AVAILABLE"],
                     },

--- a/tests/unit/test_dpm_construction_service.py
+++ b/tests/unit/test_dpm_construction_service.py
@@ -70,9 +70,23 @@ async def test_dpm_construction_preserves_manage_alternative_set_payload() -> No
     assert response.supportability.authority == "lotus-manage:RFC-0039"
     assert response.supportability.state == "READY"
     assert response.supportability.reason_codes == [
+        "EXTERNAL_HEDGE_POLICY_FAIL_CLOSED",
         "REGIME_SCENARIO_PACK_READY",
         "TARGET_METHOD_COMPARISON_AVAILABLE",
     ]
+    currency_context = response.data["alternatives"][0]["diagnostics"]["authority_context"][
+        "currency_overlay_context"
+    ]
+    assert currency_context["external_hedge_policy_source_product_name"] == ("ExternalHedgePolicy")
+    assert currency_context["external_hedge_policy_source_product_version"] == "v1"
+    assert currency_context["external_hedge_policy_source_id"] == ("sha256:external-hedge-policy")
+    assert currency_context["external_hedge_policy_content_hash"] == (
+        "sha256:external-hedge-policy-content"
+    )
+    assert currency_context["external_hedge_policy_rule_count"] == 0
+    assert currency_context["external_hedge_policy_rules"] == []
+    assert currency_context["missing_data_families"] == ["external_hedge_policy"]
+    assert "hedge_policy_approval" in currency_context["blocked_capabilities"]
     assert response.data == manage_payload
     assert client.calls == [
         {
@@ -184,6 +198,28 @@ def _construction_alternative_set() -> dict[str, object]:
                 "constraint_trace": [],
                 "comparison_metrics": {"turnover_weight": "0.05"},
                 "diagnostics": {
+                    "authority_context": {
+                        "currency_overlay_context": {
+                            "supportability_status": "BLOCKED",
+                            "source_system": "lotus-core",
+                            "external_hedge_policy_source_product_name": ("ExternalHedgePolicy"),
+                            "external_hedge_policy_source_product_version": "v1",
+                            "external_hedge_policy_source_id": ("sha256:external-hedge-policy"),
+                            "external_hedge_policy_content_hash": (
+                                "sha256:external-hedge-policy-content"
+                            ),
+                            "external_hedge_policy_rule_count": 0,
+                            "external_hedge_policy_rules": [],
+                            "missing_data_families": ["external_hedge_policy"],
+                            "blocked_capabilities": [
+                                "hedge_policy_approval",
+                                "treasury_instruction",
+                                "counterparty_selection",
+                                "oms_acknowledgement",
+                            ],
+                            "reason_codes": ["EXTERNAL_HEDGE_POLICY_FAIL_CLOSED"],
+                        }
+                    },
                     "method_plan": {
                         "reason_codes": ["TARGET_METHOD_COMPARISON_AVAILABLE"],
                     },


### PR DESCRIPTION
## Summary
- Preserve Manage-owned external hedge policy diagnostics in Gateway construction responses.
- Include currency-overlay reason codes in normalized construction supportability.
- Extend construction contract examples and tests for hedge-policy source, rule count, missing data, blocked capabilities, and reason codes.

## Boundaries
- No hedge-policy calculation, approval, treasury instruction, counterparty selection, order generation, OMS acknowledgement, fills, settlement, or autonomous treasury action.
- Gateway keeps lotus-manage as construction authority and only passes through Manage truth.

## Validation
- python -m pytest tests/unit/test_dpm_construction_service.py tests/integration/test_dpm_construction_router.py tests/contract/test_dpm_construction_contract.py
- make lint
- make typecheck
- git diff --check
- make check