### PR TITLE
Guard PM quality summary requests

### DIFF
--- a/src/app/contracts/dpm_command_center.py
+++ b/src/app/contracts/dpm_command_center.py
@@ -1,4 +1,17 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+PM_QUALITY_SUMMARY_ALLOWED_OUTPUTS = {
+    "score_run_summary",
+    "governance_summary",
+    "fairness_review_posture",
+    "support_references",
+    "evidence_gaps",
+}
+PM_QUALITY_SUMMARY_ALLOWED_AUDIENCES = {
+    "portfolio_manager",
+    "investment_control",
+    "cio_office",
+}
 
 
 class DpmCommandCenterForwardRequest(BaseModel):
@@ -204,6 +217,34 @@ class DpmPmOperatingQualitySummaryRequest(BaseModel):
         description="Intended internal audience labels for the support-only PM quality summary.",
         examples=[["portfolio_manager", "investment_control", "cio_office"]],
     )
+
+    @field_validator("requested_outputs")
+    @classmethod
+    def validate_requested_outputs(cls, value: list[str]) -> list[str]:
+        forbidden = sorted(
+            output for output in value if output not in PM_QUALITY_SUMMARY_ALLOWED_OUTPUTS
+        )
+        if forbidden:
+            raise ValueError(
+                "Unsupported PM quality summary outputs requested: "
+                f"{', '.join(forbidden)}. Allowed outputs are: "
+                f"{', '.join(sorted(PM_QUALITY_SUMMARY_ALLOWED_OUTPUTS))}."
+            )
+        return value
+
+    @field_validator("audience")
+    @classmethod
+    def validate_audience(cls, value: list[str]) -> list[str]:
+        forbidden = sorted(
+            audience for audience in value if audience not in PM_QUALITY_SUMMARY_ALLOWED_AUDIENCES
+        )
+        if forbidden:
+            raise ValueError(
+                "Unsupported PM quality summary audiences requested: "
+                f"{', '.join(forbidden)}. Allowed audiences are: "
+                f"{', '.join(sorted(PM_QUALITY_SUMMARY_ALLOWED_AUDIENCES))}."
+            )
+        return value
 
 
 class DpmOutcomeReviewNarrativeRequest(BaseModel):

--- a/tests/integration/test_dpm_command_center_router.py
+++ b/tests/integration/test_dpm_command_center_router.py
@@ -794,6 +794,49 @@ def test_dpm_command_center_pm_quality_summary_executes_lotus_ai(monkeypatch) ->
     assert payload["data"]["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
 
 
+def test_dpm_command_center_pm_quality_summary_rejects_unsupported_outputs(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {"manage_called": False, "ai_called": False}
+
+    async def _fake_get_pm_operating_quality_score_run(
+        self,
+        score_run_id,
+        correlation_id,
+    ):  # noqa: ANN001
+        _ = self, score_run_id, correlation_id
+        captured["manage_called"] = True
+        return 200, {"score_run": _pm_quality_score_run("pmq_run_001")}
+
+    async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN003
+        _ = self, kwargs
+        captured["ai_called"] = True
+        return 200, {}
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_pm_operating_quality_score_run",
+        _fake_get_pm_operating_quality_score_run,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_ai_client.LotusAiClient.execute_workflow_pack",
+        _fake_execute_workflow_pack,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/pm-operating-quality/score-runs/pmq_run_001/ai-summary",
+        json={
+            "requested_outputs": ["score_run_summary", "pm_ranking"],
+            "audience": ["portfolio_manager"],
+        },
+        headers={"X-Correlation-Id": "corr-pmq-summary-router"},
+    )
+
+    assert response.status_code == 422
+    assert "Unsupported PM quality summary outputs requested" in response.text
+    assert captured == {"manage_called": False, "ai_called": False}
+
+
 def _outcome_ai_evidence(outcome_review_id: str) -> dict[str, object]:
     return {
         "contract_version": "1.0",

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -1007,6 +1007,20 @@ async def test_dpm_pm_operating_quality_summary_preserves_lotus_ai_errors() -> N
     }
 
 
+def test_dpm_pm_operating_quality_summary_rejects_unsupported_request_labels() -> None:
+    with pytest.raises(ValueError, match="Unsupported PM quality summary outputs requested"):
+        DpmPmOperatingQualitySummaryRequest(
+            requested_outputs=["score_run_summary", "pm_ranking"],
+            audience=["portfolio_manager"],
+        )
+
+    with pytest.raises(ValueError, match="Unsupported PM quality summary audiences requested"):
+        DpmPmOperatingQualitySummaryRequest(
+            requested_outputs=["score_run_summary"],
+            audience=["portfolio_manager", "hr_committee"],
+        )
+
+
 @pytest.mark.asyncio
 async def test_dpm_command_center_requests_ai_narrative_from_manage_evidence_only() -> None:
     ai_evidence = _outcome_ai_evidence()


### PR DESCRIPTION
## Summary
- add a Gateway allowlist for governed PM-quality summary requested outputs and audience labels
- reject unsupported labels such as PM ranking or HR committee use before any Manage or lotus-ai client call
- add unit and router tests covering the fail-closed boundary

## Boundaries
- preserves Manage-owned score-run truth and existing lotus-ai pack invocation path
- no PM score calculation, PM ranking, policy administration, fairness calculation, HR/compensation/conduct/client-contact/execution/OMS decisioning, or invented facts
- no Workbench direct calls to Manage or lotus-ai

## Validation
- python -m pytest tests/unit/test_dpm_command_center_service.py::test_dpm_pm_operating_quality_summary_uses_manage_score_run_and_lotus_ai tests/unit/test_dpm_command_center_service.py::test_dpm_pm_operating_quality_summary_rejects_unsupported_request_labels tests/integration/test_dpm_command_center_router.py::test_dpm_command_center_pm_quality_summary_executes_lotus_ai tests/integration/test_dpm_command_center_router.py::test_dpm_command_center_pm_quality_summary_rejects_unsupported_outputs tests/contract/test_dpm_command_center_contract.py::test_dpm_command_center_openapi_models_are_described
- make lint
- make typecheck
- git diff --check

## Docs/Wiki
- No repo-local docs or wiki source changed; no wiki publication expected for this guardrail-only slice.