### PR TITLE
Expose construction execution acknowledgement diagnostics

### DIFF
--- a/src/app/contracts/dpm_construction.py
+++ b/src/app/contracts/dpm_construction.py
@@ -160,7 +160,40 @@ class DpmConstructionGatewayResponse(BaseModel):
                                         "EXTERNAL_HEDGE_POLICY_FAIL_CLOSED",
                                         "EXTERNAL_ELIGIBLE_HEDGE_INSTRUMENTS_FAIL_CLOSED",
                                     ],
-                                }
+                                },
+                                "execution_acknowledgement_context": {
+                                    "supportability_status": "BLOCKED",
+                                    "source_system": "lotus-core",
+                                    "source_product_name": (
+                                        "ExternalOrderExecutionAcknowledgement"
+                                    ),
+                                    "source_product_version": "v1",
+                                    "source_id": (
+                                        "sha256:external-order-execution-acknowledgement"
+                                    ),
+                                    "content_hash": (
+                                        "sha256:external-order-execution-acknowledgement-content"
+                                    ),
+                                    "acknowledgement_count": 0,
+                                    "missing_data_families": [
+                                        "external_oms_order_execution_acknowledgement"
+                                    ],
+                                    "blocked_capabilities": [
+                                        "order_generation",
+                                        "venue_routing",
+                                        "best_execution",
+                                        "oms_acknowledgement",
+                                        "fills",
+                                        "settlement",
+                                        "execution_status_certification",
+                                        "autonomous_execution",
+                                    ],
+                                    "acknowledgements": [],
+                                    "reason_codes": [
+                                        "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+                                        ("EXTERNAL_ORDER_EXECUTION_ACKNOWLEDGEMENT_FAIL_CLOSED"),
+                                    ],
+                                },
                             }
                         },
                     }

--- a/src/app/services/dpm_construction_service.py
+++ b/src/app/services/dpm_construction_service.py
@@ -130,6 +130,17 @@ def _reason_codes_from_payload(payload: dict[str, Any]) -> list[str]:
                             or []
                         )
                     )
+                execution_acknowledgement_context = authority_context.get(
+                    "execution_acknowledgement_context"
+                )
+                if isinstance(execution_acknowledgement_context, dict):
+                    reason_codes.extend(
+                        _list_of_strings(
+                            execution_acknowledgement_context.get("reason_codes")
+                            or execution_acknowledgement_context.get("reasonCodes")
+                            or []
+                        )
+                    )
     return reason_codes
 
 

--- a/tests/integration/test_dpm_construction_router.py
+++ b/tests/integration/test_dpm_construction_router.py
@@ -46,6 +46,8 @@ def test_dpm_construction_generate_preserves_manage_truth(monkeypatch) -> None:
     assert payload["supportability"]["reason_codes"] == [
         "EXTERNAL_ELIGIBLE_HEDGE_INSTRUMENTS_FAIL_CLOSED",
         "EXTERNAL_HEDGE_POLICY_FAIL_CLOSED",
+        "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+        "EXTERNAL_ORDER_EXECUTION_ACKNOWLEDGEMENT_FAIL_CLOSED",
         "REGIME_SCENARIO_PACK_READY",
         "TARGET_METHOD_COMPARISON_AVAILABLE",
     ]
@@ -73,6 +75,21 @@ def test_dpm_construction_generate_preserves_manage_truth(monkeypatch) -> None:
     ]
     assert "hedge_policy_approval" in currency_context["blocked_capabilities"]
     assert "eligible_instrument_selection" in currency_context["blocked_capabilities"]
+    acknowledgement_context = payload["data"]["alternatives"][0]["diagnostics"][
+        "authority_context"
+    ]["execution_acknowledgement_context"]
+    assert acknowledgement_context["source_product_name"] == (
+        "ExternalOrderExecutionAcknowledgement"
+    )
+    assert acknowledgement_context["source_product_version"] == "v1"
+    assert acknowledgement_context["acknowledgement_count"] == 0
+    assert acknowledgement_context["acknowledgements"] == []
+    assert (
+        "external_oms_order_execution_acknowledgement"
+        in (acknowledgement_context["missing_data_families"])
+    )
+    assert "best_execution" in acknowledgement_context["blocked_capabilities"]
+    assert "oms_acknowledgement" in acknowledgement_context["blocked_capabilities"]
     assert payload["data"] == _construction_alternative_set()
 
 
@@ -221,7 +238,36 @@ def _construction_alternative_set() -> dict[str, object]:
                                 "EXTERNAL_HEDGE_POLICY_FAIL_CLOSED",
                                 "EXTERNAL_ELIGIBLE_HEDGE_INSTRUMENTS_FAIL_CLOSED",
                             ],
-                        }
+                        },
+                        "execution_acknowledgement_context": {
+                            "supportability_status": "BLOCKED",
+                            "source_system": "lotus-core",
+                            "source_product_name": "ExternalOrderExecutionAcknowledgement",
+                            "source_product_version": "v1",
+                            "source_id": "sha256:external-order-execution-acknowledgement",
+                            "content_hash": (
+                                "sha256:external-order-execution-acknowledgement-content"
+                            ),
+                            "acknowledgement_count": 0,
+                            "missing_data_families": [
+                                "external_oms_order_execution_acknowledgement"
+                            ],
+                            "blocked_capabilities": [
+                                "order_generation",
+                                "venue_routing",
+                                "best_execution",
+                                "oms_acknowledgement",
+                                "fills",
+                                "settlement",
+                                "execution_status_certification",
+                                "autonomous_execution",
+                            ],
+                            "acknowledgements": [],
+                            "reason_codes": [
+                                "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+                                "EXTERNAL_ORDER_EXECUTION_ACKNOWLEDGEMENT_FAIL_CLOSED",
+                            ],
+                        },
                     },
                     "method_plan": {
                         "reason_codes": ["TARGET_METHOD_COMPARISON_AVAILABLE"],

--- a/tests/unit/test_dpm_construction_service.py
+++ b/tests/unit/test_dpm_construction_service.py
@@ -72,6 +72,8 @@ async def test_dpm_construction_preserves_manage_alternative_set_payload() -> No
     assert response.supportability.reason_codes == [
         "EXTERNAL_ELIGIBLE_HEDGE_INSTRUMENTS_FAIL_CLOSED",
         "EXTERNAL_HEDGE_POLICY_FAIL_CLOSED",
+        "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+        "EXTERNAL_ORDER_EXECUTION_ACKNOWLEDGEMENT_FAIL_CLOSED",
         "REGIME_SCENARIO_PACK_READY",
         "TARGET_METHOD_COMPARISON_AVAILABLE",
     ]
@@ -104,6 +106,28 @@ async def test_dpm_construction_preserves_manage_alternative_set_payload() -> No
     ]
     assert "hedge_policy_approval" in currency_context["blocked_capabilities"]
     assert "eligible_instrument_selection" in currency_context["blocked_capabilities"]
+    acknowledgement_context = response.data["alternatives"][0]["diagnostics"]["authority_context"][
+        "execution_acknowledgement_context"
+    ]
+    assert acknowledgement_context["source_product_name"] == (
+        "ExternalOrderExecutionAcknowledgement"
+    )
+    assert acknowledgement_context["source_product_version"] == "v1"
+    assert acknowledgement_context["source_id"] == (
+        "sha256:external-order-execution-acknowledgement"
+    )
+    assert acknowledgement_context["content_hash"] == (
+        "sha256:external-order-execution-acknowledgement-content"
+    )
+    assert acknowledgement_context["acknowledgement_count"] == 0
+    assert acknowledgement_context["acknowledgements"] == []
+    assert (
+        "external_oms_order_execution_acknowledgement"
+        in (acknowledgement_context["missing_data_families"])
+    )
+    assert "oms_acknowledgement" in acknowledgement_context["blocked_capabilities"]
+    assert "fills" in acknowledgement_context["blocked_capabilities"]
+    assert "settlement" in acknowledgement_context["blocked_capabilities"]
     assert response.data == manage_payload
     assert client.calls == [
         {
@@ -260,7 +284,36 @@ def _construction_alternative_set() -> dict[str, object]:
                                 "EXTERNAL_HEDGE_POLICY_FAIL_CLOSED",
                                 "EXTERNAL_ELIGIBLE_HEDGE_INSTRUMENTS_FAIL_CLOSED",
                             ],
-                        }
+                        },
+                        "execution_acknowledgement_context": {
+                            "supportability_status": "BLOCKED",
+                            "source_system": "lotus-core",
+                            "source_product_name": "ExternalOrderExecutionAcknowledgement",
+                            "source_product_version": "v1",
+                            "source_id": "sha256:external-order-execution-acknowledgement",
+                            "content_hash": (
+                                "sha256:external-order-execution-acknowledgement-content"
+                            ),
+                            "acknowledgement_count": 0,
+                            "missing_data_families": [
+                                "external_oms_order_execution_acknowledgement"
+                            ],
+                            "blocked_capabilities": [
+                                "order_generation",
+                                "venue_routing",
+                                "best_execution",
+                                "oms_acknowledgement",
+                                "fills",
+                                "settlement",
+                                "execution_status_certification",
+                                "autonomous_execution",
+                            ],
+                            "acknowledgements": [],
+                            "reason_codes": [
+                                "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+                                "EXTERNAL_ORDER_EXECUTION_ACKNOWLEDGEMENT_FAIL_CLOSED",
+                            ],
+                        },
                     },
                     "method_plan": {
                         "reason_codes": ["TARGET_METHOD_COMPARISON_AVAILABLE"],


### PR DESCRIPTION
## Summary
- preserve Manage construction execution_acknowledgement_context in the existing construction BFF response example
- include Manage-published execution acknowledgement reason codes in the existing supportability summary
- prove pass-through for ExternalOrderExecutionAcknowledgement:v1 fail-closed evidence without execution claims

## Validation
- python -m pytest tests/unit/test_dpm_construction_service.py tests/integration/test_dpm_construction_router.py tests/contract/test_dpm_construction_contract.py
- python -m ruff check src/app/services/dpm_construction_service.py src/app/contracts/dpm_construction.py tests/unit/test_dpm_construction_service.py tests/integration/test_dpm_construction_router.py
- python -m mypy src
- make openapi-gate
- git diff --check

## Boundaries
- no order generation, venue routing, best execution, OMS acknowledgement ingestion, fills, settlement, execution-status certification, or autonomous execution
- Gateway preserves Manage/Core diagnostic posture only