### PR TITLE
Expose execution acknowledgement source product

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/platform/*`
 - `domain-products`
   `/api/v1/domain-products/*`
+- `source-products`
+  `/api/v1/source-products/portfolios/{portfolio_id}/external-order-execution-acknowledgement`
 - `proposals`
   `/api/v1/proposals/*`
 - `intake` and `lookups`

--- a/src/app/clients/lotus_core_query_client.py
+++ b/src/app/clients/lotus_core_query_client.py
@@ -400,6 +400,29 @@ class LotusCoreQueryClient:
             headers=headers,
         )
 
+    async def get_external_order_execution_acknowledgement(
+        self,
+        *,
+        portfolio_id: str,
+        payload: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        url = (
+            f"{self._control_plane_base_url}/integration/portfolios/"
+            f"{portfolio_id}/external-order-execution-acknowledgement"
+        )
+        headers = propagation_headers(correlation_id)
+        return await self._request(
+            operation="core.integration.portfolios.external-order-execution-acknowledgement.get",
+            method="POST",
+            url=url,
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            json_body=payload,
+            headers=headers,
+        )
+
     async def get_support_overview(
         self,
         portfolio_id: str,

--- a/src/app/contracts/source_products.py
+++ b/src/app/contracts/source_products.py
@@ -1,0 +1,129 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ExternalOrderExecutionAcknowledgementRequest(BaseModel):
+    as_of_date: str = Field(
+        description=(
+            "Portfolio as-of date for source-owned ExternalOrderExecutionAcknowledgement:v1 "
+            "posture lookup."
+        ),
+        examples=["2026-05-18"],
+    )
+    tenant_id: str | None = Field(
+        default=None,
+        description="Optional tenant scope forwarded unchanged to lotus-core.",
+        examples=["default"],
+    )
+    mandate_id: str | None = Field(
+        default=None,
+        description="Optional mandate identifier forwarded unchanged to lotus-core.",
+        examples=["MANDATE_SG_001"],
+    )
+    execution_intent_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional execution intent identifier forwarded unchanged. Gateway does not create "
+            "or certify execution intent."
+        ),
+        examples=["exec-intent-001"],
+    )
+    order_reference_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional upstream order reference identifiers forwarded unchanged. Gateway does not "
+            "generate orders or infer acknowledgement state from these identifiers."
+        ),
+        examples=[["order-ref-001"]],
+    )
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ExternalOrderExecutionAcknowledgementSupportability(BaseModel):
+    state: Literal["UNAVAILABLE"] = Field(
+        description=(
+            "Core-owned supportability state. This source product is fail-closed until bank-owned "
+            "external OMS acknowledgement feeds are ingested and certified."
+        ),
+        examples=["UNAVAILABLE"],
+    )
+    reason: str = Field(
+        description="Core-owned reason code for the fail-closed acknowledgement posture.",
+        examples=["EXTERNAL_OMS_SOURCE_NOT_INGESTED"],
+    )
+    acknowledgement_count: int = Field(
+        description=(
+            "Core-owned count of available acknowledgements; fail-closed posture returns 0."
+        ),
+        examples=[0],
+    )
+    missing_data_families: list[str] = Field(
+        description="Core-owned missing data families preserved unchanged by Gateway.",
+        examples=[["external_oms_order_execution_acknowledgement"]],
+    )
+    blocked_capabilities: list[str] = Field(
+        description=(
+            "Core-owned blocked capabilities preserved unchanged. These are supportability "
+            "blockers, not Gateway-generated workflow decisions."
+        ),
+        examples=[
+            [
+                "order_generation",
+                "venue_routing",
+                "best_execution",
+                "oms_acknowledgement",
+                "fills",
+                "settlement",
+                "execution_status_certification",
+                "autonomous_execution",
+            ]
+        ],
+    )
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ExternalOrderExecutionAcknowledgementResponse(BaseModel):
+    product_name: Literal["ExternalOrderExecutionAcknowledgement"] = Field(
+        description="Core source product name preserved by Gateway.",
+        examples=["ExternalOrderExecutionAcknowledgement"],
+    )
+    product_version: Literal["v1"] = Field(
+        description="Core source product version preserved by Gateway.",
+        examples=["v1"],
+    )
+    portfolio_id: str = Field(description="Portfolio identifier from the Core source product.")
+    client_id: str | None = Field(
+        default=None,
+        description="Client identifier from the Core source product when supplied.",
+    )
+    mandate_id: str | None = Field(
+        default=None,
+        description="Mandate identifier from the Core source product when supplied.",
+    )
+    execution_intent_id: str | None = Field(
+        default=None,
+        description="Execution intent identifier echoed from Core when supplied.",
+    )
+    order_reference_ids: list[str] = Field(
+        default_factory=list,
+        description="Order reference identifiers echoed from Core.",
+    )
+    acknowledgements: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Core-owned acknowledgement evidence. Gateway does not synthesize OMS "
+            "acknowledgements, fills, settlement, or execution status."
+        ),
+    )
+    supportability: ExternalOrderExecutionAcknowledgementSupportability = Field(
+        description="Core-owned fail-closed supportability posture preserved by Gateway."
+    )
+    lineage: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Core-owned lineage and non-claims preserved unchanged by Gateway.",
+    )
+
+    model_config = ConfigDict(extra="allow")

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -27,6 +27,7 @@ from app.routers.reporting import batches_router as reporting_batches_router
 from app.routers.reporting import jobs_router as reporting_jobs_router
 from app.routers.reporting import router as reporting_router
 from app.routers.reporting import schedules_router as reporting_schedules_router
+from app.routers.source_products import router as source_products_router
 from app.routers.workbench import router as workbench_router
 
 
@@ -87,6 +88,13 @@ app = FastAPI(
                 "lotus-manage authority."
             ),
         },
+        {
+            "name": "Source Products",
+            "description": (
+                "Gateway source-consumer routes for source-owned products that Workbench may "
+                "display as evidence or supportability posture without recalculating source truth."
+            ),
+        },
     ],
 )
 setup_logging()
@@ -97,6 +105,7 @@ Instrumentator().instrument(app).expose(app)
 app.include_router(proposals_router)
 app.include_router(platform_router)
 app.include_router(domain_products_router)
+app.include_router(source_products_router)
 app.include_router(intake_router)
 app.include_router(foundation_router)
 app.include_router(portfolio_router)

--- a/src/app/routers/source_products.py
+++ b/src/app/routers/source_products.py
@@ -1,0 +1,75 @@
+from fastapi import APIRouter, Header, HTTPException, Path, status
+
+from app.clients.lotus_core_query_client import LotusCoreQueryClient
+from app.config import settings
+from app.contracts.source_products import (
+    ExternalOrderExecutionAcknowledgementRequest,
+    ExternalOrderExecutionAcknowledgementResponse,
+)
+from app.middleware.correlation import correlation_id_var
+
+router = APIRouter(prefix="/api/v1/source-products", tags=["Source Products"])
+
+
+def _source_product_core_client() -> LotusCoreQueryClient:
+    return LotusCoreQueryClient(
+        base_url=settings.portfolio_data_query_base_url,
+        control_plane_base_url=settings.portfolio_data_control_plane_base_url,
+        timeout_seconds=settings.upstream_timeout_seconds,
+        max_retries=settings.upstream_max_retries,
+        retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+    )
+
+
+def _raise_core_error(*, upstream_status: int, payload: dict[str, object]) -> None:
+    if upstream_status < 400:
+        return
+    detail = {
+        "source_service": "lotus-core",
+        "upstream_status": upstream_status,
+        "error": payload,
+    }
+    if upstream_status == status.HTTP_404_NOT_FOUND:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+    if upstream_status in {status.HTTP_400_BAD_REQUEST, 422}:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+    raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=detail)
+
+
+@router.post(
+    "/portfolios/{portfolio_id}/external-order-execution-acknowledgement",
+    response_model=ExternalOrderExecutionAcknowledgementResponse,
+    summary="Get External Order Execution Acknowledgement Supportability",
+    description=(
+        "Pass-through source-consumer route for lotus-core "
+        "ExternalOrderExecutionAcknowledgement:v1. Gateway forwards the request to Core and "
+        "preserves the response shape, UNAVAILABLE state, lineage, missing_data_families, and "
+        "blocked_capabilities. Gateway does not generate orders, route venues, claim best "
+        "execution, ingest OMS acknowledgements, certify fills or settlement, or create "
+        "autonomous execution state."
+    ),
+)
+async def get_external_order_execution_acknowledgement(
+    request: ExternalOrderExecutionAcknowledgementRequest,
+    portfolio_id: str = Path(
+        description="Portfolio identifier for the Core source-product lookup.",
+        examples=["PB_SG_GLOBAL_BAL_001"],
+    ),
+    x_correlation_id: str | None = Header(
+        default=None,
+        alias="X-Correlation-Id",
+        description="Optional caller-supplied correlation identifier propagated to lotus-core.",
+    ),
+) -> ExternalOrderExecutionAcknowledgementResponse:
+    correlation_id = x_correlation_id or correlation_id_var.get() or ""
+    payload = request.model_dump(exclude_none=True)
+    (
+        upstream_status,
+        upstream_payload,
+    ) = await _source_product_core_client().get_external_order_execution_acknowledgement(
+        portfolio_id=portfolio_id,
+        payload=payload,
+        correlation_id=correlation_id,
+    )
+    _raise_core_error(upstream_status=upstream_status, payload=upstream_payload)
+    return ExternalOrderExecutionAcknowledgementResponse.model_validate(upstream_payload)

--- a/tests/contract/test_source_products_contract.py
+++ b/tests/contract/test_source_products_contract.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_external_execution_acknowledgement_source_product_openapi_contract() -> None:
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+
+    path = (
+        "/api/v1/source-products/portfolios/{portfolio_id}/external-order-execution-acknowledgement"
+    )
+    assert path in spec["paths"]
+    operation = spec["paths"][path]["post"]
+    assert operation["summary"] == "Get External Order Execution Acknowledgement Supportability"
+    assert "ExternalOrderExecutionAcknowledgement:v1" in operation["description"]
+    assert "preserves the response shape" in operation["description"]
+    assert "does not generate orders" in operation["description"]
+    assert "fills or settlement" in operation["description"]
+
+    parameters = {parameter["name"]: parameter for parameter in operation["parameters"]}
+    assert parameters["portfolio_id"]["schema"]["examples"] == ["PB_SG_GLOBAL_BAL_001"]
+    assert parameters["X-Correlation-Id"]["description"]
+
+
+def test_external_execution_acknowledgement_source_product_schemas_are_documented() -> None:
+    client = TestClient(app)
+    schemas = client.get("/openapi.json").json()["components"]["schemas"]
+
+    request_schema = schemas["ExternalOrderExecutionAcknowledgementRequest"]
+    response_schema = schemas["ExternalOrderExecutionAcknowledgementResponse"]
+    supportability_schema = schemas["ExternalOrderExecutionAcknowledgementSupportability"]
+
+    assert request_schema["properties"]["as_of_date"]["description"]
+    assert request_schema["properties"]["order_reference_ids"]["description"]
+    assert response_schema["properties"]["product_name"]["examples"] == [
+        "ExternalOrderExecutionAcknowledgement"
+    ]
+    assert response_schema["properties"]["acknowledgements"]["description"]
+    assert response_schema["properties"]["lineage"]["description"]
+    assert supportability_schema["properties"]["state"]["examples"] == ["UNAVAILABLE"]
+    assert supportability_schema["properties"]["missing_data_families"]["description"]
+    assert supportability_schema["properties"]["blocked_capabilities"]["description"]

--- a/tests/integration/test_source_products_router.py
+++ b/tests/integration/test_source_products_router.py
@@ -1,0 +1,148 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+class _FakeCoreSourceProductClient:
+    calls: list[dict[str, object]] = []
+
+    async def get_external_order_execution_acknowledgement(
+        self,
+        *,
+        portfolio_id: str,
+        payload: dict[str, object],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        self.calls.append(
+            {
+                "portfolio_id": portfolio_id,
+                "payload": payload,
+                "correlation_id": correlation_id,
+            }
+        )
+        return 200, {
+            "product_name": "ExternalOrderExecutionAcknowledgement",
+            "product_version": "v1",
+            "portfolio_id": portfolio_id,
+            "client_id": "CIF_SG_000184",
+            "mandate_id": "MANDATE_SG_001",
+            "execution_intent_id": payload.get("execution_intent_id"),
+            "order_reference_ids": payload.get("order_reference_ids", []),
+            "acknowledgements": [],
+            "data_quality_status": "MISSING",
+            "supportability": {
+                "state": "UNAVAILABLE",
+                "reason": "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+                "acknowledgement_count": 0,
+                "missing_data_families": ["external_oms_order_execution_acknowledgement"],
+                "blocked_capabilities": [
+                    "order_generation",
+                    "venue_routing",
+                    "best_execution",
+                    "oms_acknowledgement",
+                    "fills",
+                    "settlement",
+                    "execution_status_certification",
+                    "autonomous_execution",
+                ],
+            },
+            "lineage": {
+                "source_system": "external-bank-oms",
+                "source_table": "not_ingested",
+                "contract_version": ("rfc_042_external_order_execution_acknowledgement_v1"),
+                "integration_status": "not_ingested",
+                "runtime_posture": "fail_closed",
+                "non_claims": (
+                    "order_generation,venue_routing,best_execution,"
+                    "oms_acknowledgement,fills,settlement,"
+                    "execution_status_certification,autonomous_execution_action"
+                ),
+            },
+        }
+
+
+def test_source_product_router_preserves_core_execution_acknowledgement_payload(monkeypatch):
+    fake_client = _FakeCoreSourceProductClient()
+    monkeypatch.setattr(
+        "app.routers.source_products._source_product_core_client",
+        lambda: fake_client,
+    )
+    client = TestClient(app)
+
+    response = client.post(
+        (
+            "/api/v1/source-products/portfolios/PB_SG_GLOBAL_BAL_001/"
+            "external-order-execution-acknowledgement"
+        ),
+        json={
+            "as_of_date": "2026-05-18",
+            "tenant_id": "default",
+            "mandate_id": "MANDATE_SG_001",
+            "execution_intent_id": "exec-intent-001",
+            "order_reference_ids": ["order-ref-001"],
+        },
+        headers={"X-Correlation-Id": "corr-source-product"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["product_name"] == "ExternalOrderExecutionAcknowledgement"
+    assert payload["product_version"] == "v1"
+    assert payload["supportability"]["state"] == "UNAVAILABLE"
+    assert payload["supportability"]["reason"] == "EXTERNAL_OMS_SOURCE_NOT_INGESTED"
+    assert payload["supportability"]["missing_data_families"] == [
+        "external_oms_order_execution_acknowledgement"
+    ]
+    assert payload["supportability"]["blocked_capabilities"] == [
+        "order_generation",
+        "venue_routing",
+        "best_execution",
+        "oms_acknowledgement",
+        "fills",
+        "settlement",
+        "execution_status_certification",
+        "autonomous_execution",
+    ]
+    assert payload["acknowledgements"] == []
+    assert payload["data_quality_status"] == "MISSING"
+    assert payload["lineage"]["runtime_posture"] == "fail_closed"
+    assert payload["lineage"]["integration_status"] == "not_ingested"
+
+    assert fake_client.calls == [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "payload": {
+                "as_of_date": "2026-05-18",
+                "tenant_id": "default",
+                "mandate_id": "MANDATE_SG_001",
+                "execution_intent_id": "exec-intent-001",
+                "order_reference_ids": ["order-ref-001"],
+            },
+            "correlation_id": "corr-source-product",
+        }
+    ]
+
+
+def test_source_product_router_maps_core_validation_error_without_local_execution_truth(
+    monkeypatch,
+):
+    class _ValidationErrorClient:
+        async def get_external_order_execution_acknowledgement(self, **_: object):
+            return 422, {"detail": "invalid as_of_date"}
+
+    monkeypatch.setattr(
+        "app.routers.source_products._source_product_core_client",
+        lambda: _ValidationErrorClient(),
+    )
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/source-products/portfolios/P1/external-order-execution-acknowledgement",
+        json={"as_of_date": "not-a-date", "order_reference_ids": []},
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["source_service"] == "lotus-core"
+    assert detail["upstream_status"] == 422
+    assert detail["error"] == {"detail": "invalid as_of_date"}

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -3250,6 +3250,52 @@ async def test_lotus_core_query_client_support_routes_use_control_plane_contract
 
 
 @pytest.mark.asyncio
+async def test_lotus_core_query_client_external_execution_acknowledgement_uses_control_plane():
+    client = LotusCoreQueryClient(
+        base_url="http://core-query",
+        control_plane_base_url="http://core-control",
+        timeout_seconds=2.0,
+    )
+    core_payload = {
+        "product_name": "ExternalOrderExecutionAcknowledgement",
+        "product_version": "v1",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "acknowledgements": [],
+        "supportability": {
+            "state": "UNAVAILABLE",
+            "reason": "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+            "acknowledgement_count": 0,
+            "missing_data_families": ["external_oms_order_execution_acknowledgement"],
+            "blocked_capabilities": ["oms_acknowledgement", "fills", "settlement"],
+        },
+        "lineage": {"runtime_posture": "fail_closed"},
+    }
+    request_payload = {
+        "as_of_date": "2026-05-18",
+        "tenant_id": "default",
+        "order_reference_ids": ["ord-001"],
+    }
+    _FakeAsyncClient.queue_json(200, core_payload)
+
+    status_code, payload = await client.get_external_order_execution_acknowledgement(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        payload=request_payload,
+        correlation_id="corr-exec-ack",
+    )
+
+    assert status_code == 200
+    assert payload == core_payload
+    request = _FakeAsyncClient.calls[0]
+    assert request["method"] == "POST"
+    assert request["url"] == (
+        "http://core-control/integration/portfolios/"
+        "PB_SG_GLOBAL_BAL_001/external-order-execution-acknowledgement"
+    )
+    assert request["json"] == request_payload
+    assert request["headers"]["X-Correlation-Id"] == "corr-exec-ack"
+
+
+@pytest.mark.asyncio
 async def test_lotus_core_query_client_emits_safe_fanout_metrics_without_runtime_ids(caplog):
     caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
     client = LotusCoreQueryClient(

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -9,6 +9,7 @@
 - `GET /api/v1/domain-products/products/{producer_repository}/{product_name}/{product_version}`
 - `GET /api/v1/domain-products/dependency-graph`
 - `GET /api/v1/domain-products/trust-certification`
+- `POST /api/v1/source-products/portfolios/{portfolio_id}/external-order-execution-acknowledgement`
 - `POST /api/v1/proposals/*` and `GET /api/v1/proposals/*`
 - `POST /api/v1/intake/*`
 - `GET /api/v1/lookups/*`
@@ -51,6 +52,10 @@
   `producer_repository`, `product_name`, and `product_version`
 - domain-product trust certification returns certified platform trust posture when the RFC-0087
   artifact exists and an explicit unavailable posture when it has not been generated
+- source-product external order execution acknowledgement is a lotus-core pass-through that
+  preserves fail-closed `UNAVAILABLE` supportability, missing data, blocked capabilities, and
+  lineage without creating execution, OMS acknowledgement, fills, settlement, or best-execution
+  truth
 - reporting snapshot and reporting request payloads use `asOfDate`; portfolio review requests also
   support `benchmarkCode` for RFC-0002 performance and risk context
 - reporting review preserves `client_sections`, `advisor_sections`, readiness, evidence, and


### PR DESCRIPTION
## Summary
- add Gateway source-product route for Core ExternalOrderExecutionAcknowledgement:v1
- preserve Core fail-closed UNAVAILABLE payload shape, missing data, blocked capabilities, and lineage
- document the API surface and add client/router/OpenAPI contract tests

## Boundaries
- no OMS acknowledgement, execution, venue routing, best-execution, fills, settlement, or autonomous execution truth is created in Gateway
- Gateway remains a pass-through/source-consumer route for Core-owned posture

## Validation
- python -m pytest tests/unit/test_upstream_clients.py::test_lotus_core_query_client_external_execution_acknowledgement_uses_control_plane tests/integration/test_source_products_router.py tests/contract/test_source_products_contract.py
- python -m pytest tests/contract/test_source_products_contract.py tests/integration/test_source_products_router.py -q
- python -m ruff check .
- python -m ruff format --check .
- python -m mypy src
- git diff --check
- wiki check run: expected drift in API-Surface.md until PR merge/publish