### PR TITLE
Preserve outcome client communication boundary

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -57,8 +57,9 @@ Current repository posture:
 9. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
 10. RFC-0042 outcome-review AI narrative handoff now reads manage-owned
     `DpmOutcomeAiEvidenceInput` and executes `lotus-ai` `outcome_review_narrative.pack@v1` as
-    `lotus-gateway`; manage remains outcome evidence and workflow authority, and Gateway does not
-    generate narrative locally,
+    `lotus-gateway`; manage remains outcome evidence and workflow authority, Gateway preserves
+    Manage-owned `client_communication_boundary` posture when present, and Gateway does not
+    generate narrative or client communication truth locally,
 11. RFC-0038 DPM exception-summary AI handoff now reads manage-owned monitoring-exception evidence
     from the command-center exception queue and executes `lotus-ai`
     `dpm_exception_summary.pack@v1` as `lotus-gateway`; manage remains exception evidence
@@ -216,8 +217,8 @@ Most relevant current governance:
     `/api/v1/dpm/command-center/runs/{rebalance_run_id}/outcome-review`, and
     `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`. Gateway composes a BFF envelope
     and supportability summary over manage truth, but it must not recompute outcome dimensions,
-    generate reports, generate AI narrative, infer PM quality, or let Workbench call manage
-    directly.
+    synthesize `client_communication_boundary`, generate reports, generate AI narrative, infer PM
+    quality, or let Workbench call manage directly.
 11. RFC-0038 mandate command-center Gateway routes are active under
     `/api/v1/dpm/command-center`, `/api/v1/dpm/command-center/monitoring/*`,
     `/api/v1/dpm/command-center/exceptions*`, and

--- a/src/app/contracts/dpm_command_center.py
+++ b/src/app/contracts/dpm_command_center.py
@@ -480,7 +480,8 @@ class DpmOutcomeReviewGatewayResponse(BaseModel):
     data: dict[str, object] = Field(
         description=(
             "Authoritative manage outcome-review payload preserved for Workbench composition. "
-            "Gateway does not alter manage-owned calculations, hashes, lineage, state, or evidence."
+            "Gateway does not alter manage-owned calculations, hashes, lineage, state, evidence, "
+            "or client_communication_boundary posture."
         ),
         examples=[
             {
@@ -496,6 +497,13 @@ class DpmOutcomeReviewGatewayResponse(BaseModel):
                         "state": "WITHIN_TOLERANCE",
                     }
                 ],
+                "client_communication_boundary": {
+                    "boundary_id": "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY",
+                    "supportability_state": "BLOCKED",
+                    "client_communication_projected": False,
+                    "client_approval_projected": False,
+                    "required_source_product": "ClientCommunicationRecord:v1",
+                },
             }
         ],
     )
@@ -688,7 +696,8 @@ class DpmOutcomeReviewNarrativeGatewayResponse(BaseModel):
     ai_evidence_input: dict[str, object] = Field(
         description=(
             "Manage-owned DpmOutcomeAiEvidenceInput used as the sole source for narrative "
-            "generation. Gateway preserves it without adding facts or removing guardrails."
+            "generation. Gateway preserves it without adding facts, removing guardrails, or "
+            "rewriting client_communication_boundary posture."
         ),
     )
     narrative_request: dict[str, object] = Field(

--- a/tests/contract/test_dpm_command_center_contract.py
+++ b/tests/contract/test_dpm_command_center_contract.py
@@ -26,12 +26,27 @@ def test_dpm_outcome_review_gateway_response_contract_shape() -> None:
             "state": "READY",
             "portfolio_id": "PB_SG_GLOBAL_BAL_001",
             "expected_snapshot_hash": "sha256:expected",
+            "client_communication_boundary": {
+                "boundary_id": "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY",
+                "supportability_state": "BLOCKED",
+                "client_communication_projected": False,
+                "client_approval_projected": False,
+                "required_source_product": "ClientCommunicationRecord:v1",
+            },
         },
     )
 
     assert response.source_service == "lotus-manage"
     assert response.supportability.authority == "lotus-manage:RFC-0042"
     assert response.data["outcome_review_id"] == "or_1"
+    assert response.data["client_communication_boundary"]["boundary_id"] == (
+        "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY"
+    )
+    assert response.data["client_communication_boundary"]["client_communication_projected"] is False
+    assert response.data["client_communication_boundary"]["client_approval_projected"] is False
+    assert response.data["client_communication_boundary"]["required_source_product"] == (
+        "ClientCommunicationRecord:v1"
+    )
 
 
 def test_dpm_command_center_gateway_response_contract_shape() -> None:
@@ -171,6 +186,13 @@ def test_dpm_outcome_review_narrative_gateway_response_contract_shape() -> None:
         ai_evidence_input={
             "outcome_review_id": "or_1",
             "content_hash": "sha256:ai-evidence",
+            "client_communication_boundary": {
+                "boundary_id": "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY",
+                "supportability_state": "BLOCKED",
+                "client_communication_projected": False,
+                "client_approval_projected": False,
+                "required_source_product": "ClientCommunicationRecord:v1",
+            },
         },
         narrative_request={"requested_outputs": ["pm_summary"], "audience": ["pm"]},
         data={
@@ -182,6 +204,9 @@ def test_dpm_outcome_review_narrative_gateway_response_contract_shape() -> None:
     assert response.source_service == "lotus-ai"
     assert response.evidence_source_service == "lotus-manage"
     assert response.supportability.authority == "lotus-manage:RFC-0042"
+    assert response.ai_evidence_input["client_communication_boundary"]["boundary_id"] == (
+        "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY"
+    )
     assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
 
 
@@ -404,7 +429,12 @@ def test_dpm_command_center_openapi_models_are_described() -> None:
     assert pm_quality_summary_request_schema["properties"]["requested_outputs"]["examples"]
     assert pm_quality_summary_response_schema["properties"]["data"]["description"]
     assert response_schema["properties"]["data"]["description"]
+    assert "client_communication_boundary" in response_schema["properties"]["data"]["description"]
     assert narrative_response_schema["properties"]["data"]["description"]
+    assert (
+        "client_communication_boundary"
+        in narrative_response_schema["properties"]["ai_evidence_input"]["description"]
+    )
     assert exception_summary_request_schema["properties"]["requested_outputs"]["examples"]
     assert exception_summary_response_schema["properties"]["data"]["description"]
     assert supportability_schema["properties"]["state"]["examples"]

--- a/tests/integration/test_dpm_command_center_router.py
+++ b/tests/integration/test_dpm_command_center_router.py
@@ -544,6 +544,127 @@ def test_dpm_command_center_outcome_review_list_passes_filters(monkeypatch) -> N
     assert response.json()["data"]["items"][0]["outcome_review_id"] == "or_1"
 
 
+def test_dpm_command_center_outcome_review_boundary_is_preserved_in_handoffs(
+    monkeypatch,
+) -> None:
+    boundary = _client_communication_boundary()
+    captured: dict[str, object] = {}
+
+    async def _fake_get_outcome_review_supportability(
+        self,
+        outcome_review_id,
+        correlation_id,
+    ):  # noqa: ANN001
+        _ = self
+        captured["supportability"] = {
+            "outcome_review_id": outcome_review_id,
+            "correlation_id": correlation_id,
+        }
+        return 200, {
+            "outcome_review_id": outcome_review_id,
+            "state": "SUPPORTED",
+            "client_communication_boundary": boundary,
+            "supportability": {
+                "state": "SUPPORTED",
+                "reason_codes": ["READY_FOR_REPORT_INPUT"],
+                "blocked_actions": [],
+            },
+        }
+
+    async def _fake_get_outcome_review_report_input(
+        self,
+        outcome_review_id,
+        correlation_id,
+    ):  # noqa: ANN001
+        _ = self
+        captured["report_input"] = {
+            "outcome_review_id": outcome_review_id,
+            "correlation_id": correlation_id,
+        }
+        return 200, {
+            "outcome_review_id": outcome_review_id,
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "content_hash": "sha256:report-input",
+            "client_communication_boundary": boundary,
+        }
+
+    async def _fake_get_outcome_review_ai_evidence_input(
+        self,
+        outcome_review_id,
+        correlation_id,
+    ):  # noqa: ANN001
+        _ = self
+        captured["ai_evidence_input"] = {
+            "outcome_review_id": outcome_review_id,
+            "correlation_id": correlation_id,
+        }
+        payload = _outcome_ai_evidence(outcome_review_id)
+        payload["client_communication_boundary"] = boundary
+        return 200, payload
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_outcome_review_supportability",
+        _fake_get_outcome_review_supportability,
+    )
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_outcome_review_report_input",
+        _fake_get_outcome_review_report_input,
+    )
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_outcome_review_ai_evidence_input",
+        _fake_get_outcome_review_ai_evidence_input,
+    )
+
+    client = TestClient(app)
+    supportability_response = client.get(
+        "/api/v1/dpm/command-center/outcome-reviews/or_1/supportability",
+        headers={"X-Correlation-Id": "corr-boundary-supportability"},
+    )
+    report_response = client.get(
+        "/api/v1/dpm/command-center/outcome-reviews/or_1/report-input",
+        headers={"X-Correlation-Id": "corr-boundary-report"},
+    )
+    ai_response = client.get(
+        "/api/v1/dpm/command-center/outcome-reviews/or_1/ai-evidence-input",
+        headers={"X-Correlation-Id": "corr-boundary-ai"},
+    )
+
+    assert supportability_response.status_code == 200
+    assert report_response.status_code == 200
+    assert ai_response.status_code == 200
+    assert captured == {
+        "supportability": {
+            "outcome_review_id": "or_1",
+            "correlation_id": "corr-boundary-supportability",
+        },
+        "report_input": {
+            "outcome_review_id": "or_1",
+            "correlation_id": "corr-boundary-report",
+        },
+        "ai_evidence_input": {
+            "outcome_review_id": "or_1",
+            "correlation_id": "corr-boundary-ai",
+        },
+    }
+
+    for payload in (
+        supportability_response.json()["data"],
+        report_response.json()["data"],
+        ai_response.json()["data"],
+    ):
+        assert payload["client_communication_boundary"] == boundary
+        assert (
+            payload["client_communication_boundary"]["boundary_id"]
+            == "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY"
+        )
+        assert payload["client_communication_boundary"]["client_communication_projected"] is False
+        assert payload["client_communication_boundary"]["client_approval_projected"] is False
+        assert (
+            payload["client_communication_boundary"]["required_source_product"]
+            == "ClientCommunicationRecord:v1"
+        )
+
+
 def test_dpm_command_center_outcome_review_error_is_not_marked_supported(monkeypatch) -> None:
     async def _fake_get_outcome_review(self, outcome_review_id, correlation_id):  # noqa: ANN001
         _ = self, outcome_review_id, correlation_id
@@ -626,6 +747,9 @@ def test_dpm_command_center_outcome_review_ai_narrative_executes_lotus_ai(monkey
     assert payload["source_service"] == "lotus-ai"
     assert payload["evidence_source_service"] == "lotus-manage"
     assert payload["ai_evidence_input"]["content_hash"] == "sha256:or_1-ai-evidence"
+    assert payload["ai_evidence_input"]["client_communication_boundary"] == (
+        _client_communication_boundary()
+    )
     assert payload["data"]["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
 
 
@@ -861,7 +985,35 @@ def _outcome_ai_evidence(outcome_review_id: str) -> dict[str, object]:
             "source_id": f"{outcome_review_id}:dpm_outcome_ai_evidence_input",
             "content_hash": f"sha256:{outcome_review_id}-ai-evidence",
         },
+        "client_communication_boundary": _client_communication_boundary(),
         "content_hash": f"sha256:{outcome_review_id}-ai-evidence",
+    }
+
+
+def _client_communication_boundary() -> dict[str, object]:
+    return {
+        "boundary_id": "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY",
+        "supportability_state": "BLOCKED",
+        "source_system": "lotus-manage",
+        "source_product_name": "DpmPostTradeOutcomeReview",
+        "source_product_version": "v1",
+        "client_communication_projected": False,
+        "client_approval_projected": False,
+        "reason_code": "OUTCOME_CLIENT_COMMUNICATION_NOT_SUPPORTED",
+        "blocked_capabilities": [
+            "client_approval",
+            "client_contact",
+            "client_message_generation",
+            "communication_audit",
+            "delivery_confirmation",
+        ],
+        "required_owner": "future client-communication owner",
+        "required_source_product": "ClientCommunicationRecord:v1",
+        "summary": (
+            "Outcome review is internal-only until a client-communication owner publishes "
+            "governed source events."
+        ),
+        "content_hash": "sha256:client-communication-boundary",
     }
 
 

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -1065,6 +1065,9 @@ async def test_dpm_command_center_requests_ai_narrative_from_manage_evidence_onl
     assert response.manage_upstream_status == 200
     assert response.ai_upstream_status == 200
     assert response.ai_evidence_input == ai_evidence
+    assert response.ai_evidence_input["client_communication_boundary"] == (
+        _client_communication_boundary()
+    )
     assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
     assert dpm_client.calls == [
         {
@@ -1080,6 +1083,10 @@ async def test_dpm_command_center_requests_ai_narrative_from_manage_evidence_onl
     task_request = ai_call["task_request"]
     assert task_request["caller"]["caller_app"] == "lotus-gateway"
     assert task_request["context"]["payload"]["ai_evidence_input"] == ai_evidence
+    assert (
+        task_request["context"]["payload"]["ai_evidence_input"]["client_communication_boundary"]
+        == _client_communication_boundary()
+    )
     assert task_request["context"]["payload"]["narrative_request"] == {
         "requested_outputs": ["pm_summary", "evidence_gaps"],
         "audience": ["pm"],
@@ -1290,7 +1297,35 @@ def _outcome_ai_evidence() -> dict[str, object]:
             "source_id": "or_1:dpm_outcome_ai_evidence_input",
             "content_hash": "sha256:outcome-ai-evidence-001",
         },
+        "client_communication_boundary": _client_communication_boundary(),
         "content_hash": "sha256:outcome-ai-evidence-001",
+    }
+
+
+def _client_communication_boundary() -> dict[str, object]:
+    return {
+        "boundary_id": "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY",
+        "supportability_state": "BLOCKED",
+        "source_system": "lotus-manage",
+        "source_product_name": "DpmPostTradeOutcomeReview",
+        "source_product_version": "v1",
+        "client_communication_projected": False,
+        "client_approval_projected": False,
+        "reason_code": "OUTCOME_CLIENT_COMMUNICATION_NOT_SUPPORTED",
+        "blocked_capabilities": [
+            "client_approval",
+            "client_contact",
+            "client_message_generation",
+            "communication_audit",
+            "delivery_confirmation",
+        ],
+        "required_owner": "future client-communication owner",
+        "required_source_product": "ClientCommunicationRecord:v1",
+        "summary": (
+            "Outcome review is internal-only until a client-communication owner publishes "
+            "governed source events."
+        ),
+        "content_hash": "sha256:client-communication-boundary",
     }
 
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -175,10 +175,12 @@
   `/api/v1/dpm/command-center/waves/{wave_id}/outcome-reviews`. These routes preserve manage
   `outcome_review_id`, state, dimension outcomes, expected values, realized values, variance,
   tolerances, source refs, source hashes, freshness, report-input posture, AI-evidence posture,
-  remediation routes, and supportability. Gateway also exposes a governed AI narrative handoff
-  action that reads manage-owned `DpmOutcomeAiEvidenceInput` and calls `lotus-ai`
+  remediation routes, supportability, and Manage-owned `client_communication_boundary` posture
+  when present. Gateway also exposes a governed AI narrative handoff action that reads
+  manage-owned `DpmOutcomeAiEvidenceInput` and calls `lotus-ai`
   `outcome_review_narrative.pack@v1` as `lotus-gateway`; Gateway must not recompute outcome
-  truth, generate reports, generate AI narrative locally, infer PM quality, approve trades, contact
+  truth, synthesize client communication truth, generate reports, generate AI narrative locally,
+  infer PM quality, approve trades, contact
   clients, or let Workbench bypass Gateway.
   In short: Gateway must not recompute outcome truth.
 - report batch schedule list and run-due actions are gateway-first under

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -434,8 +434,11 @@ Status: implementation-backed in Gateway for RFC42-WTBD-001 and RFC42-WTBD-005.
 
 Gateway exposes outcome-review preview/create/search/detail/source-refresh/supportability,
 report-input, AI-evidence, run lookup, wave lookup, and governed AI narrative handoff routes under
-`/api/v1/dpm/command-center/outcome-reviews*`. `lotus-manage` remains outcome-review authority and
-`lotus-ai` remains AI workflow execution authority.
+`/api/v1/dpm/command-center/outcome-reviews*`. The supportability, report-input, and AI-evidence
+payloads preserve Manage-owned `client_communication_boundary` posture when Manage publishes it,
+including fail-closed no-client-communication and no-client-approval projection flags.
+`lotus-manage` remains outcome-review authority and `lotus-ai` remains AI workflow execution
+authority; Gateway does not synthesize client communication truth.
 
 ## DPM Command Center Exception Summary
 


### PR DESCRIPTION
## Summary
- align outcome-review BFF contract descriptions/examples for Manage-owned client_communication_boundary posture
- preserve boundary through supportability, report-input, AI-evidence, and AI narrative handoff payload tests
- update Gateway context/wiki source to state Gateway passes through, but does not synthesize, client communication truth

## Validation
- python -m pytest tests/integration/test_dpm_command_center_router.py -q
- python -m pytest tests/unit/test_dpm_command_center_service.py::test_dpm_command_center_requests_ai_narrative_from_manage_evidence_only tests/contract/test_dpm_command_center_contract.py -q
- make lint
- make typecheck
- make openapi-gate
- git diff --check
- make ci

## Wiki
- Repo-authored wiki source changed: wiki/API-Surface.md, wiki/Supported-Features.md
- Pre-merge CheckOnly reports expected drift until this PR is merged and published