### PR TITLE
Align Advise capability supportability mapping

### DIFF
--- a/src/app/services/platform_capabilities_service.py
+++ b/src/app/services/platform_capabilities_service.py
@@ -289,6 +289,7 @@ class PlatformCapabilitiesService:
                 sources=sources,
                 source_name="lotus_advise",
                 feature_keys=(
+                    "advisory.proposals.lifecycle",
                     "lotus_advise.proposals.lifecycle",
                     "advise.proposals.lifecycle",
                     "dpm.proposals.lifecycle",
@@ -353,15 +354,21 @@ class PlatformCapabilitiesService:
             "advisory_workspace": False,
         }
         workflow_flags = {
-            "proposal_lifecycle": self._workflow_enabled(
+            "proposal_lifecycle": self._any_workflow_enabled(
                 sources=sources,
                 source_name="lotus_advise",
-                workflow_key="proposal_lifecycle",
+                workflow_keys=(
+                    "advisory_proposal_lifecycle",
+                    "proposal_lifecycle",
+                ),
             ),
-            "proposal_approval_flow": self._workflow_enabled(
+            "proposal_approval_flow": self._any_workflow_enabled(
                 sources=sources,
                 source_name="lotus_advise",
-                workflow_key="proposal_approval_flow",
+                workflow_keys=(
+                    "advisory_proposal_approval_flow",
+                    "proposal_approval_flow",
+                ),
             ),
             "portfolio_bulk_onboarding": self._workflow_enabled(
                 sources=sources,
@@ -384,6 +391,7 @@ class PlatformCapabilitiesService:
             errors=errors,
         )
         shell_bootstrap = self._build_shell_bootstrap(
+            sources=sources,
             navigation=navigation,
             module_health=module_health,
             policy_versions_by_source=policy_versions_by_source,
@@ -404,6 +412,7 @@ class PlatformCapabilitiesService:
     def _build_shell_bootstrap(
         self,
         *,
+        sources: dict[str, dict[str, Any]],
         navigation: dict[str, bool],
         module_health: dict[str, str],
         policy_versions_by_source: dict[str, str],
@@ -452,6 +461,7 @@ class PlatformCapabilitiesService:
                     href="/portfolio",
                     enabled=navigation["portfolio_workspace"],
                     dependency_source="lotus_core",
+                    source_supportability=None,
                     module_health=module_health,
                     policy_versions_by_source=policy_versions_by_source,
                     error_services=error_services,
@@ -467,6 +477,7 @@ class PlatformCapabilitiesService:
                     href="/performance",
                     enabled=navigation["performance_workspace"],
                     dependency_source="lotus_performance",
+                    source_supportability=None,
                     module_health=module_health,
                     policy_versions_by_source=policy_versions_by_source,
                     error_services=error_services,
@@ -482,6 +493,7 @@ class PlatformCapabilitiesService:
                     href="/performance?mode=risk",
                     enabled=navigation["risk_workspace"],
                     dependency_source="lotus_risk",
+                    source_supportability=None,
                     module_health=module_health,
                     policy_versions_by_source=policy_versions_by_source,
                     error_services=error_services,
@@ -497,6 +509,10 @@ class PlatformCapabilitiesService:
                     href="/proposals",
                     enabled=navigation["proposal_workspace"],
                     dependency_source="lotus_advise",
+                    source_supportability=self._source_supportability(
+                        sources=sources,
+                        source_name="lotus_advise",
+                    ),
                     module_health=module_health,
                     policy_versions_by_source=policy_versions_by_source,
                     error_services=error_services,
@@ -512,6 +528,10 @@ class PlatformCapabilitiesService:
                     href="/recommendations",
                     enabled=navigation["advisory_workspace"],
                     dependency_source="lotus_advise",
+                    source_supportability=self._source_supportability(
+                        sources=sources,
+                        source_name="lotus_advise",
+                    ),
                     module_health=module_health,
                     policy_versions_by_source=policy_versions_by_source,
                     error_services=error_services,
@@ -532,6 +552,7 @@ class PlatformCapabilitiesService:
         href: str,
         enabled: bool,
         dependency_source: str,
+        source_supportability: dict[str, Any] | None,
         module_health: dict[str, str],
         policy_versions_by_source: dict[str, str],
         error_services: list[str],
@@ -559,6 +580,10 @@ class PlatformCapabilitiesService:
             reasons = (
                 [f"{workspace_id}_disabled"] if not enabled else [f"{dependency_source}_unknown"]
             )
+        if source_supportability is not None and source_health == "available":
+            supportability_state = str(source_supportability.get("state") or supportability_state)
+            source_reason = source_supportability.get("reason")
+            reasons = [str(source_reason)] if source_reason else reasons
 
         return PlatformShellWorkspaceDescriptor(
             id=workspace_id,
@@ -646,6 +671,33 @@ class PlatformCapabilitiesService:
             if str(workflow.get("workflow_key")) == workflow_key:
                 return bool(workflow.get("enabled"))
         return False
+
+    def _any_workflow_enabled(
+        self,
+        *,
+        sources: dict[str, dict[str, Any]],
+        source_name: str,
+        workflow_keys: tuple[str, ...],
+    ) -> bool:
+        return any(
+            self._workflow_enabled(
+                sources=sources,
+                source_name=source_name,
+                workflow_key=workflow_key,
+            )
+            for workflow_key in workflow_keys
+        )
+
+    def _source_supportability(
+        self,
+        *,
+        sources: dict[str, dict[str, Any]],
+        source_name: str,
+    ) -> dict[str, Any] | None:
+        supportability = sources.get(source_name, {}).get("supportability")
+        if not isinstance(supportability, dict):
+            return None
+        return supportability
 
     def _module_health(
         self,

--- a/tests/unit/test_platform_capabilities_service.py
+++ b/tests/unit/test_platform_capabilities_service.py
@@ -147,9 +147,14 @@ async def test_platform_capabilities_all_sources_success():
                 "policyVersion": "advise-tenant-a-v2",
                 "supportedInputModes": ["pas_ref", "inline_bundle"],
                 "features": [
-                    {"key": "advise.proposals.lifecycle", "enabled": True},
+                    {"key": "advisory.proposals.lifecycle", "enabled": True},
                 ],
-                "workflows": [{"workflow_key": "proposal_lifecycle", "enabled": True}],
+                "workflows": [{"workflow_key": "advisory_proposal_lifecycle", "enabled": True}],
+                "supportability": {
+                    "state": "ready",
+                    "reason": "advisory_ready",
+                    "freshness_bucket": "current",
+                },
             },
         ),
         manage_client=_StubClient(
@@ -303,7 +308,8 @@ async def test_platform_capabilities_all_sources_success():
         workspace for workspace in shell_bootstrap.workspaces if workspace.id == "proposal"
     )
     assert proposal_workspace.enabled is False
-    assert proposal_workspace.supportability.state == "unavailable"
+    assert proposal_workspace.supportability.state == "ready"
+    assert proposal_workspace.supportability.reasons == ["advisory_ready"]
     assert proposal_workspace.caching.correctness_critical is True
 
 
@@ -535,6 +541,90 @@ def test_platform_capabilities_feature_and_workflow_skip_non_dict_entries():
         )
         is True
     )
+
+
+@pytest.mark.asyncio
+async def test_platform_capabilities_preserves_advise_supportability_without_local_inference():
+    service = PlatformCapabilitiesService(
+        advise_client=_StubClient(
+            200,
+            {
+                "source_service": "lotus-advise",
+                "policy_version": "advisory.v1",
+                "features": [
+                    {
+                        "key": "advisory.proposals.lifecycle",
+                        "enabled": True,
+                        "operational_ready": True,
+                    },
+                    {
+                        "key": "advise.observability.advisory_supportability",
+                        "enabled": True,
+                        "operational_ready": True,
+                    },
+                ],
+                "workflows": [
+                    {"workflow_key": "advisory_proposal_lifecycle", "enabled": True},
+                ],
+                "supportability": {
+                    "state": "degraded",
+                    "reason": "dependency_degraded",
+                    "freshness_bucket": "unknown",
+                    "dependency_count": 5,
+                    "ready_dependency_count": 4,
+                    "degraded_dependency_count": 1,
+                    "enabled_feature_count": 9,
+                    "ready_feature_count": 8,
+                },
+            },
+        ),
+        manage_client=_StubClient(
+            200,
+            {"source_service": "lotus-manage", "features": [], "workflows": []},
+        ),
+        lotus_core_query_client=_StubClient(
+            200,
+            {
+                "source_service": "lotus-core",
+                "features": [{"key": "pas.integration.core_snapshot", "enabled": True}],
+                "workflows": [],
+            },
+        ),
+        analytics_client=_StubClient(
+            200,
+            {"source_service": "lotus-performance", "features": [], "workflows": []},
+        ),
+        reporting_client=_StubClient(
+            200,
+            {"source_service": "lotus-report", "features": [], "workflows": []},
+        ),
+        contract_version="v1",
+    )
+
+    response = await service.get_platform_capabilities(
+        consumer_system="lotus-workbench",
+        tenant_id="default",
+        correlation_id="corr-wtbd-004",
+    )
+
+    normalized = response.data.normalized
+    assert normalized.navigation["advisory_pipeline"] is True
+    assert normalized.workflow_flags["proposal_lifecycle"] is True
+    assert response.data.sources["lotus_advise"]["supportability"]["state"] == "degraded"
+    proposal_workspace = next(
+        workspace
+        for workspace in normalized.shell_bootstrap.workspaces
+        if workspace.id == "proposal"
+    )
+    advisory_workspace = next(
+        workspace
+        for workspace in normalized.shell_bootstrap.workspaces
+        if workspace.id == "advisory"
+    )
+    assert proposal_workspace.supportability.state == "degraded"
+    assert proposal_workspace.supportability.reasons == ["dependency_degraded"]
+    assert advisory_workspace.supportability.state == "degraded"
+    assert advisory_workspace.supportability.reasons == ["dependency_degraded"]
 
 
 def test_platform_capabilities_module_health_marks_unknown_sources():


### PR DESCRIPTION
## Summary
- consume current lotus-advise capability keys for advisory proposal lifecycle
- carry source-provided Advise supportability state/reason into proposal/advisory shell workspace descriptors
- add focused tests proving Gateway preserves Advise supportability without local inference

## Validation
- make lint
- make typecheck
- python -m pytest tests/unit/test_platform_capabilities_service.py tests/integration/test_platform_capabilities_router.py tests/contract/test_platform_capabilities_contract.py -q
- git diff --check

## WTBD-004
Advances lotus-advise WTBD-004 by aligning Gateway as a capability consumer. Gateway does not compute advisory supportability locally; it preserves and surfaces the backend-provided capability contract fields.