### PR TITLE
Certify campaign assignment memory pass-through

### DIFF
--- a/tests/contract/test_dpm_command_center_contract.py
+++ b/tests/contract/test_dpm_command_center_contract.py
@@ -77,8 +77,12 @@ def test_dpm_portfolio_memory_gateway_response_contract_shape() -> None:
         upstream_status=200,
         supportability={
             "state": "READY",
-            "event_count": 2,
-            "event_type_counts": {"PROOF_PACK_CREATED": 1, "OUTCOME_REVIEW_CREATED": 1},
+            "event_count": 3,
+            "event_type_counts": {
+                "PROOF_PACK_CREATED": 1,
+                "OUTCOME_REVIEW_CREATED": 1,
+                "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION": 1,
+            },
             "source_systems": ["lotus-manage", "lotus-core"],
             "reason_codes": ["SOURCE_READY"],
             "content_hash": "sha256:portfolio-memory",
@@ -96,6 +100,7 @@ def test_dpm_portfolio_memory_gateway_response_contract_shape() -> None:
     assert response.supportability.event_type_counts == {
         "PROOF_PACK_CREATED": 1,
         "OUTCOME_REVIEW_CREATED": 1,
+        "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION": 1,
     }
     assert response.data["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
 

--- a/tests/integration/test_dpm_command_center_router.py
+++ b/tests/integration/test_dpm_command_center_router.py
@@ -187,15 +187,36 @@ def test_dpm_command_center_portfolio_memory_passes_limit_and_preserves_events(m
         captured["correlation_id"] = correlation_id
         return 200, {
             "portfolio_id": portfolio_id,
-            "event_count": 2,
+            "event_count": 3,
             "supportability_state": "READY",
-            "event_type_counts": {"PROOF_PACK_CREATED": 1, "OUTCOME_REVIEW_CREATED": 1},
+            "event_type_counts": {
+                "PROOF_PACK_CREATED": 1,
+                "OUTCOME_REVIEW_CREATED": 1,
+                "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION": 1,
+            },
             "source_systems": ["lotus-manage", "lotus-core"],
             "reason_codes": ["SOURCE_READY"],
             "content_hash": "sha256:portfolio-memory",
             "events": [
                 {"event_id": "memory:proof-pack:dpp_1", "event_type": "PROOF_PACK_CREATED"},
                 {"event_id": "memory:outcome-review:or_1", "event_type": "OUTCOME_REVIEW_CREATED"},
+                {
+                    "event_id": "memory:campaign-assignment-task-transition:transition_001",
+                    "event_type": "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION",
+                    "source_refs": [
+                        {"source_system": "lotus-manage", "source_id": "campaign_001:v1"}
+                    ],
+                    "artifact_refs": [{"source_system": "lotus-manage", "source_id": "task_001"}],
+                    "content_hash": "sha256:assignment-task-transition",
+                    "reason_codes": ["BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_RECORDED"],
+                    "metadata": {
+                        "task_ref": "task-ref-001",
+                        "transition_type": "ACKNOWLEDGE",
+                        "from_status": "OPEN",
+                        "to_status": "IN_PROGRESS",
+                        "sla_posture": "ON_TRACK",
+                    },
+                },
             ],
         }
 
@@ -218,12 +239,24 @@ def test_dpm_command_center_portfolio_memory_passes_limit_and_preserves_events(m
     }
     payload = response.json()
     assert payload["supportability"]["state"] == "READY"
-    assert payload["supportability"]["event_count"] == 2
+    assert payload["supportability"]["event_count"] == 3
+    assert (
+        payload["supportability"]["event_type_counts"][
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION"
+        ]
+        == 1
+    )
     assert payload["supportability"]["content_hash"] == "sha256:portfolio-memory"
-    assert payload["data"]["events"] == [
-        {"event_id": "memory:proof-pack:dpp_1", "event_type": "PROOF_PACK_CREATED"},
-        {"event_id": "memory:outcome-review:or_1", "event_type": "OUTCOME_REVIEW_CREATED"},
+    transition_event = payload["data"]["events"][2]
+    assert transition_event["event_type"] == "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION"
+    assert transition_event["source_refs"] == [
+        {"source_system": "lotus-manage", "source_id": "campaign_001:v1"}
     ]
+    assert transition_event["artifact_refs"] == [
+        {"source_system": "lotus-manage", "source_id": "task_001"}
+    ]
+    assert transition_event["content_hash"] == "sha256:assignment-task-transition"
+    assert transition_event["metadata"]["transition_type"] == "ACKNOWLEDGE"
 
 
 def test_dpm_command_center_pm_quality_fairness_preview_forwards_segment_refs(

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -421,13 +421,14 @@ async def test_dpm_command_center_mandate_supportability_uses_manage_field_gaps(
 async def test_dpm_portfolio_memory_preserves_manage_timeline_and_supportability() -> None:
     manage_payload = {
         "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-        "event_count": 4,
+        "event_count": 5,
         "supportability_state": "READY",
         "event_type_counts": {
             "PROOF_PACK_CREATED": 1,
             "WAVE_HANDOFF_READY": 1,
             "OUTCOME_REVIEW_CREATED": 1,
             "OUTCOME_REVIEW_EVENT": 1,
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION": 1,
         },
         "source_systems": ["lotus-manage", "lotus-core", "lotus-risk"],
         "reason_codes": ["SOURCE_READY", "OUTCOME_REVIEW_READY"],
@@ -455,8 +456,12 @@ async def test_dpm_portfolio_memory_preserves_manage_timeline_and_supportability
     assert response.upstream_status == 200
     assert response.supportability.authority == "lotus-manage:RFC-0040/RFC-0041/RFC-0042"
     assert response.supportability.state == "READY"
-    assert response.supportability.event_count == 4
+    assert response.supportability.event_count == 5
     assert response.supportability.event_type_counts["WAVE_HANDOFF_READY"] == 1
+    assert (
+        response.supportability.event_type_counts["BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION"]
+        == 1
+    )
     assert response.supportability.source_systems == ["lotus-manage", "lotus-core", "lotus-risk"]
     assert response.supportability.reason_codes == ["SOURCE_READY", "OUTCOME_REVIEW_READY"]
     assert response.supportability.content_hash == "sha256:portfolio-memory"
@@ -467,6 +472,106 @@ async def test_dpm_portfolio_memory_preserves_manage_timeline_and_supportability
             "portfolio_id": "PB_SG_GLOBAL_BAL_001",
             "params": {"limit": 50},
             "correlation_id": "corr-portfolio-memory",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dpm_portfolio_memory_preserves_campaign_assignment_transition_event() -> None:
+    transition_event = {
+        "event_id": (
+            "memory:campaign_definition:campaign_001:v1:"
+            "assignment-task:task_001:transition:transition_001"
+        ),
+        "event_type": "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION",
+        "event_time": "2026-05-21T08:15:00Z",
+        "actor": "ops_lead",
+        "source_system": "lotus-manage",
+        "source_type": "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION",
+        "source_id": "transition_001",
+        "status": "IN_PROGRESS",
+        "supportability_state": "PENDING_REVIEW",
+        "summary": "Bounded Manage transition summary from source truth.",
+        "reason_codes": [
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_RECORDED",
+            "ACKNOWLEDGE",
+            "IN_PROGRESS",
+            "ON_TRACK",
+        ],
+        "source_refs": [
+            {
+                "source_system": "lotus-manage",
+                "source_type": "BulkReviewCampaignDefinition",
+                "source_id": "campaign_001:v1",
+                "content_hash": "sha256:campaign-definition",
+            }
+        ],
+        "artifact_refs": [
+            {
+                "source_system": "lotus-manage",
+                "source_type": "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK",
+                "source_id": "task_001",
+                "content_hash": "sha256:assignment-task",
+            }
+        ],
+        "content_hash": "sha256:assignment-task-transition",
+        "metadata": {
+            "task_ref": "task-ref-001",
+            "assignment_task_id": "task_001",
+            "transition_type": "ACKNOWLEDGE",
+            "from_status": "OPEN",
+            "to_status": "IN_PROGRESS",
+            "sla_posture": "ON_TRACK",
+            "supportability_state": "PENDING_REVIEW",
+            "transition_reason_projected": False,
+            "external_workflow_orchestration_claimed": False,
+            "client_contact_claimed": False,
+            "external_execution_claimed": False,
+            "transition_reason": "unsafe upstream rationale stays source-owned",
+            "raw_rationale": "unsafe raw rationale stays source-owned",
+            "client_contact": "message client",
+            "oms_action": "route order",
+            "order_instruction": "buy security",
+        },
+    }
+    manage_payload = {
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "event_count": 1,
+        "supportability_state": "READY",
+        "event_type_counts": {
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION": 1,
+        },
+        "source_systems": ["lotus-manage"],
+        "reason_codes": ["BULK_REVIEW_CAMPAIGN_WORKFLOW_SOURCE_EVENTS_SUPPORTED"],
+        "content_hash": "sha256:portfolio-memory",
+        "events": [transition_event],
+    }
+    client = _FakeDpmClient((200, manage_payload))
+    service = DpmCommandCenterService(dpm_client=client)  # type: ignore[arg-type]
+
+    response = await service.get_portfolio_memory(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        filters={"limit": 25},
+        correlation_id="corr-campaign-assignment-task-transition",
+    )
+
+    assert (
+        response.supportability.event_type_counts["BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION"]
+        == 1
+    )
+    assert response.data["events"][0] == transition_event
+    assert response.data["events"][0]["source_refs"] == transition_event["source_refs"]
+    assert response.data["events"][0]["artifact_refs"] == transition_event["artifact_refs"]
+    assert response.data["events"][0]["content_hash"] == "sha256:assignment-task-transition"
+    assert response.data["events"][0]["metadata"]["transition_reason_projected"] is False
+    assert response.data["events"][0]["metadata"]["client_contact_claimed"] is False
+    assert response.data["events"][0]["metadata"]["external_execution_claimed"] is False
+    assert client.calls == [
+        {
+            "method": "portfolio_memory",
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "params": {"limit": 25},
+            "correlation_id": "corr-campaign-assignment-task-transition",
         }
     ]
 


### PR DESCRIPTION
## Summary
- certify the DPM portfolio-memory BFF preserves Manage's new BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION event family
- add unit, router integration, and contract fixtures for event_type_counts plus event id/type, source refs, artifact refs, content hash, reason codes, and safe transition metadata
- keep Gateway as a pass-through/source-consumer with no campaign readiness, assignment state, OMS, execution, order, or client communication computation

## Validation
- make lint
- make typecheck
- python -m pytest tests/unit/test_dpm_command_center_service.py tests/integration/test_dpm_command_center_router.py tests/contract/test_dpm_command_center_contract.py -q
- git diff --check

## Docs
No Gateway contract or wiki source changed; this is coverage/certification for an existing pass-through contract.