### PR TITLE
Align Advise capability query context

### DIFF
--- a/src/app/clients/advise_client.py
+++ b/src/app/clients/advise_client.py
@@ -25,6 +25,8 @@ class AdviseClient:
     async def get_platform_capabilities(
         self,
         *,
+        consumer_system: str = "lotus-gateway",
+        tenant_id: str = "default",
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         return await request_observed_fanout(
@@ -36,6 +38,7 @@ class AdviseClient:
             timeout_seconds=self._timeout,
             max_retries=self._max_retries,
             backoff_seconds=self._retry_backoff_seconds,
+            params={"consumer_system": consumer_system, "tenant_id": tenant_id},
             headers=propagation_headers(correlation_id),
         )
 
@@ -45,8 +48,12 @@ class AdviseClient:
         tenant_id: str,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        _ = consumer_system, tenant_id
-        return await self.get_platform_capabilities(correlation_id=correlation_id)
+        _ = consumer_system
+        return await self.get_platform_capabilities(
+            consumer_system="lotus-gateway",
+            tenant_id=tenant_id,
+            correlation_id=correlation_id,
+        )
 
     async def simulate_proposal(
         self,

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -2764,6 +2764,26 @@ async def test_advise_client_proposal_routes(method_name, kwargs, expected_url):
 
 
 @pytest.mark.asyncio
+async def test_advise_client_capabilities_uses_gateway_consumer_and_tenant_context():
+    client = AdviseClient(base_url="http://advise", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"ok": True})
+
+    status_code, payload = await client.get_capabilities(
+        consumer_system="lotus-workbench",
+        tenant_id="tenant-sg",
+        correlation_id="corr-workbench",
+    )
+
+    assert status_code == 200
+    assert payload["ok"] is True
+    assert _FakeAsyncClient.calls[0]["url"] == "http://advise/platform/capabilities"
+    assert _FakeAsyncClient.calls[0]["params"] == {
+        "consumer_system": "lotus-gateway",
+        "tenant_id": "tenant-sg",
+    }
+
+
+@pytest.mark.asyncio
 async def test_dpm_client_has_no_stale_proposal_routes():
     client = DpmClient(base_url="http://dpm", timeout_seconds=2.0)
 


### PR DESCRIPTION
## Summary
- call lotus-advise GET /platform/capabilities with canonical snake_case query params
- preserve Gateway as the consumer_system while forwarding caller tenant_id
- add focused upstream-client coverage for the Advise capability query context

## Validation
- python -m pytest tests/unit/test_upstream_clients.py::test_advise_client_capabilities_uses_gateway_consumer_and_tenant_context tests/unit/test_router_upstream_selection.py tests/integration/test_platform_capabilities_router.py::test_platform_capabilities_router_preserves_correlation_and_query_context -q
- python -m ruff check src/app/clients/advise_client.py tests/unit/test_upstream_clients.py
- make lint
- make typecheck
- git diff --check

## WTBD-004
Preserves source-backed Advise supportability by ensuring Gateway queries Advise capabilities with the correct Gateway consumer identity and tenant context.