### PR TITLE
fix: normalize canonical proposal and foundation readiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,10 @@ migration-apply:
 	python scripts/migration_contract_check.py --mode no-schema
 
 security-audit:
-	python -m pip_audit -r requirements-audit.txt
+	# PYSEC-2026-161 is tracked as a governed temporary exception: FastAPI still
+	# constrains Starlette below the fixed 1.0.1 line, so no compatible upgrade is
+	# available for this service yet. Remove this ignore when FastAPI supports it.
+	python -m pip_audit --ignore-vuln PYSEC-2026-161 -r requirements-audit.txt
 
 test:
 	$(MAKE) test-unit

--- a/docs/documentation/experience-api-foundation-blueprint.md
+++ b/docs/documentation/experience-api-foundation-blueprint.md
@@ -43,6 +43,24 @@ The gateway should not own:
 2. permanent workarounds for upstream contract defects,
 3. business semantics that belong in domain apps.
 
+## Implemented Foundation Workspace Behavior
+
+The `GET /api/v1/foundation/portfolios/{portfolio_id}/workspace` contract composes the first-paint
+front-office workspace from source-owned services:
+
+1. `lotus-core` portfolio identity and `core-snapshot` sections provide the portfolio summary,
+   allocation, and top-position view.
+2. `lotus-core` `PortfolioAnalyticsReference.performance_end_date` provides the source-owned
+   performance horizon for the Foundation YTD return request. Gateway must not send a future or
+   non-overlapping calendar date to `lotus-performance` when Core has already resolved the latest
+   complete calculable performance horizon.
+3. `lotus-performance` remains the authority for TWR calculations. Gateway reshapes the returned
+   `results_by_period` payload into the Foundation summary and preserves degraded or unavailable
+   upstream results through warnings and partial failures.
+4. If the analytics reference lookup is unavailable, Gateway falls back to the snapshot as-of date
+   and lets the performance supportability response determine whether the Foundation workspace is
+   ready or degraded.
+
 ## Product Areas
 
 The long-term gateway direction should support:

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,13 +1,13 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-05-10T23:37:28Z",
+  "generated_at": "2026-05-23T02:36:19Z",
   "allowlist": [
     {
-      "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
+      "finding": "scripts/check_monetary_float_usage.py:115:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-08-24"
+      "review_by": "2026-11-19"
     },
     {
       "finding": "src/app/contracts/foundation.py:105:cash_weight_pct: float = Field(",
@@ -688,268 +688,310 @@
       "review_by": "2026-11-02"
     },
     {
-      "finding": "src/app/services/foundation_service.py:245:market_value_base = float(",
+      "finding": "src/app/services/foundation_service.py:275:market_value_base = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/foundation_service.py:251:cash_weight_pct = float(",
+      "finding": "src/app/services/foundation_service.py:281:cash_weight_pct = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/foundation_service.py:291:bucket.market_value_base = float(",
+      "finding": "src/app/services/foundation_service.py:321:bucket.market_value_base = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/foundation_service.py:305:market_value_base=float(quantize_money(market_value))",
+      "finding": "src/app/services/foundation_service.py:335:market_value_base=float(quantize_money(market_value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/foundation_service.py:308:weight_pct=float(",
+      "finding": "src/app/services/foundation_service.py:338:weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/foundation_service.py:323:bucket.weight_pct = float(",
+      "finding": "src/app/services/foundation_service.py:353:bucket.weight_pct = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/foundation_service.py:513:def _extract_market_value(self, item: dict[str, Any]) -> float | None:",
+      "finding": "src/app/services/foundation_service.py:431:def _extract_performance_return_pct(self, period_payload: dict[str, Any]) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/foundation_service.py:521:return float(quantize_money(value))",
+      "finding": "src/app/services/foundation_service.py:433:if isinstance(legacy_return, int | float):",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/foundation_service.py:536:return float(quantize_money(value))",
+      "finding": "src/app/services/foundation_service.py:434:return float(legacy_return)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1289:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/foundation_service.py:445:if isinstance(base_return, int | float):",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1313:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/foundation_service.py:446:return float(base_return)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1389:float(quantize_performance(period_return)) if period_return is not None else None",
+      "finding": "src/app/services/foundation_service.py:450:if isinstance(base_return, int | float):",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1521:market_price=float(quantize_price(item.get(\"valuation\", {}).get(\"market_price\", 0)))",
+      "finding": "src/app/services/foundation_service.py:451:return float(base_return)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1524:cost_basis_base=float(quantize_money(item.get(\"cost_basis\", 0)))",
+      "finding": "src/app/services/foundation_service.py:566:def _extract_market_value(self, item: dict[str, Any]) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1527:cost_basis_local=float(quantize_money(item.get(\"cost_basis_local\", 0)))",
+      "finding": "src/app/services/foundation_service.py:574:return float(quantize_money(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1530:market_value_base=float(",
+      "finding": "src/app/services/foundation_service.py:589:return float(quantize_money(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1542:market_value_local=float(",
+      "finding": "src/app/services/portfolio_service.py:1290:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1580:weight_pct=float(quantize_performance(float(item.get(\"weight\", 0)) * 100))",
+      "finding": "src/app/services/portfolio_service.py:1314:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1597:market_value_base=float(",
+      "finding": "src/app/services/portfolio_service.py:1390:float(quantize_performance(period_return)) if period_return is not None else None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1600:weight_pct=float(",
+      "finding": "src/app/services/portfolio_service.py:1522:market_price=float(quantize_price(item.get(\"valuation\", {}).get(\"market_price\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1601:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
+      "finding": "src/app/services/portfolio_service.py:1525:cost_basis_base=float(quantize_money(item.get(\"cost_basis\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1658:cash_total += float(quantize_money(market_value or 0))",
+      "finding": "src/app/services/portfolio_service.py:1528:cost_basis_local=float(quantize_money(item.get(\"cost_basis_local\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1660:return float(quantize_money(cash_total)), cash_count",
+      "finding": "src/app/services/portfolio_service.py:1531:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1678:price=float(quantize_price(item.get(\"price\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1543:market_value_local=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1681:gross_amount=float(quantize_money(item.get(\"gross_transaction_amount\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1581:weight_pct=float(quantize_performance(float(item.get(\"weight\", 0)) * 100))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1685:net_cost_base=float(quantize_money(item.get(\"net_cost\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:1598:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1827:accumulator[\"gross_amount_portfolio_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:1601:weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1830:accumulator[\"gross_amount_reporting_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:1602:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1857:accumulator[\"net_amount_portfolio_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:1659:cash_total += float(quantize_money(market_value or 0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1860:accumulator[\"net_amount_reporting_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:1661:return float(quantize_money(cash_total)), cash_count",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1868:portfolio_amount: float,",
+      "finding": "src/app/services/portfolio_service.py:1679:price=float(quantize_price(item.get(\"price\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1869:reporting_amount: float,",
+      "finding": "src/app/services/portfolio_service.py:1682:gross_amount=float(quantize_money(item.get(\"gross_transaction_amount\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1873:float(accumulator[\"amount_portfolio_currency\"]) + portfolio_amount",
+      "finding": "src/app/services/portfolio_service.py:1686:net_cost_base=float(quantize_money(item.get(\"net_cost\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1876:float(accumulator[\"amount_reporting_currency\"]) + reporting_amount",
+      "finding": "src/app/services/portfolio_service.py:1828:accumulator[\"gross_amount_portfolio_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1899:def _activity_portfolio_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1831:accumulator[\"gross_amount_reporting_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1906:def _activity_reporting_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1858:accumulator[\"net_amount_portfolio_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1923:def _income_net_portfolio_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1861:accumulator[\"net_amount_reporting_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1933:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
+      "finding": "src/app/services/portfolio_service.py:1869:portfolio_amount: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1935:def _income_net_reporting_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1870:reporting_amount: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1961:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
+      "finding": "src/app/services/portfolio_service.py:1874:float(accumulator[\"amount_portfolio_currency\"]) + portfolio_amount",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1974:def _absolute_money(self, value: Any) -> float:",
+      "finding": "src/app/services/portfolio_service.py:1877:float(accumulator[\"amount_reporting_currency\"]) + reporting_amount",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1977:return float(quantize_money(abs(float(value))))",
+      "finding": "src/app/services/portfolio_service.py:1900:def _activity_portfolio_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2039:reporting_currency_amount=float(quantize_money(payload.get(reporting_key, 0))),",
+      "finding": "src/app/services/portfolio_service.py:1907:def _activity_reporting_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2562:return float(",
+      "finding": "src/app/services/portfolio_service.py:1924:def _income_net_portfolio_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-19"
+    },
+    {
+      "finding": "src/app/services/portfolio_service.py:1934:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-19"
+    },
+    {
+      "finding": "src/app/services/portfolio_service.py:1936:def _income_net_reporting_amount(self, row: dict[str, Any]) -> float:",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-19"
+    },
+    {
+      "finding": "src/app/services/portfolio_service.py:1962:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-19"
+    },
+    {
+      "finding": "src/app/services/portfolio_service.py:1975:def _absolute_money(self, value: Any) -> float:",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-19"
+    },
+    {
+      "finding": "src/app/services/portfolio_service.py:1978:return float(quantize_money(abs(float(value))))",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-19"
+    },
+    {
+      "finding": "src/app/services/portfolio_service.py:2040:reporting_currency_amount=float(quantize_money(payload.get(reporting_key, 0))),",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-19"
+    },
+    {
+      "finding": "src/app/services/portfolio_service.py:2563:return float(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-11-19"
     },
     {
       "finding": "src/app/services/risk_workspace_service.py:1756:def _safe_float(value: Any) -> float | None:",

--- a/scripts/check_monetary_float_usage.py
+++ b/scripts/check_monetary_float_usage.py
@@ -17,7 +17,8 @@ KEYWORDS = (
     "notional",
     "weight",
 )
-IGNORE_DIRS = {"tests", ".venv", "venv", "docs", "rfcs", "output", "build", "dist", "__pycache__"}
+IGNORE_DIRS = {"tests", "venv", "docs", "rfcs", "output", "build", "dist", "__pycache__"}
+IGNORE_DIR_PREFIXES = (".venv",)
 
 FLOAT_ANNOTATION = re.compile(r"\bfloat\b")
 
@@ -25,6 +26,8 @@ FLOAT_ANNOTATION = re.compile(r"\bfloat\b")
 def is_candidate(path: Path) -> bool:
     parts = set(path.parts)
     if any(p in parts for p in IGNORE_DIRS):
+        return False
+    if any(part.startswith(IGNORE_DIR_PREFIXES) for part in path.parts):
         return False
     return path.suffix == ".py"
 

--- a/src/app/routers/foundation.py
+++ b/src/app/routers/foundation.py
@@ -71,7 +71,10 @@ async def get_foundation_portfolios() -> FoundationPortfolioCatalogResponse:
         "Returns the first-paint Foundation workspace payload for a single portfolio. "
         "Use this route when the UI needs portfolio identity, valuation summary, "
         "allocation shape, top positions, readiness posture, workflow launch cues, "
-        "and advisor-facing evidence of degraded upstream dependencies in one response."
+        "and advisor-facing evidence of degraded upstream dependencies in one response. "
+        "Gateway resolves the Core analytics reference before requesting performance so "
+        "Foundation YTD return evidence is aligned to the latest complete calculable "
+        "performance horizon."
     ),
 )
 async def get_foundation_workspace(

--- a/src/app/services/foundation_service.py
+++ b/src/app/services/foundation_service.py
@@ -189,13 +189,14 @@ class FoundationService:
         as_of_date: str,
     ) -> str:
         try:
-            reference_status, reference_payload = (
-                await self._lotus_core_query_client.get_portfolio_analytics_reference(
-                    portfolio_id=portfolio_id,
-                    as_of_date=as_of_date,
-                    consumer_system="lotus-gateway",
-                    correlation_id=correlation_id,
-                )
+            (
+                reference_status,
+                reference_payload,
+            ) = await self._lotus_core_query_client.get_portfolio_analytics_reference(
+                portfolio_id=portfolio_id,
+                as_of_date=as_of_date,
+                consumer_system="lotus-gateway",
+                correlation_id=correlation_id,
             )
         except Exception:
             return as_of_date

--- a/src/app/services/foundation_service.py
+++ b/src/app/services/foundation_service.py
@@ -109,10 +109,15 @@ class FoundationService:
             payload=pas_payload,
             fallback_as_of_date=as_of_date,
         )
+        performance_report_end_date = await self._resolve_performance_report_end_date(
+            portfolio_id=portfolio_id,
+            correlation_id=correlation_id,
+            as_of_date=as_of_date,
+        )
 
         performance_task = self._analytics_client.get_stateful_twr(
             portfolio_id=portfolio_id,
-            report_end_date=as_of_date,
+            report_end_date=performance_report_end_date,
             period="YTD",
             correlation_id=correlation_id,
         )
@@ -176,6 +181,30 @@ class FoundationService:
             warnings=warnings,
             partial_failures=partial_failures,
         )
+
+    async def _resolve_performance_report_end_date(
+        self,
+        portfolio_id: str,
+        correlation_id: str,
+        as_of_date: str,
+    ) -> str:
+        try:
+            reference_status, reference_payload = (
+                await self._lotus_core_query_client.get_portfolio_analytics_reference(
+                    portfolio_id=portfolio_id,
+                    as_of_date=as_of_date,
+                    consumer_system="lotus-gateway",
+                    correlation_id=correlation_id,
+                )
+            )
+        except Exception:
+            return as_of_date
+
+        if reference_status >= status.HTTP_400_BAD_REQUEST:
+            return as_of_date
+        if not isinstance(reference_payload, dict):
+            return as_of_date
+        return self._optional_str(reference_payload.get("performance_end_date")) or as_of_date
 
     def _parse_catalog_item(self, item: dict[str, Any]) -> FoundationPortfolioCatalogItem:
         portfolio_id = str(item.get("portfolio_id", item.get("id", ""))).strip()
@@ -381,7 +410,7 @@ class FoundationService:
         if payload is None:
             return None
 
-        results_by_period = payload.get("resultsByPeriod", {})
+        results_by_period = payload.get("results_by_period", payload.get("resultsByPeriod", {}))
         if not isinstance(results_by_period, dict):
             warnings.append("FOUNDATION_PERFORMANCE_INVALID")
             return None
@@ -395,8 +424,31 @@ class FoundationService:
             return None
         return FoundationPerformanceSummary(
             period=period_key,
-            return_pct=period_payload.get("net_cumulative_return"),
+            return_pct=self._extract_performance_return_pct(period_payload),
         )
+
+    def _extract_performance_return_pct(self, period_payload: dict[str, Any]) -> float | None:
+        legacy_return = period_payload.get("net_cumulative_return")
+        if isinstance(legacy_return, int | float):
+            return float(legacy_return)
+
+        portfolio_payload = period_payload.get("portfolio")
+        if not isinstance(portfolio_payload, dict):
+            return None
+        summary = portfolio_payload.get("summary")
+        if not isinstance(summary, dict):
+            return None
+        period_return = summary.get("period_return")
+        if isinstance(period_return, dict):
+            base_return = period_return.get("base")
+            if isinstance(base_return, int | float):
+                return float(base_return)
+        cumulative_return = summary.get("cumulative_return")
+        if isinstance(cumulative_return, dict):
+            base_return = cumulative_return.get("base")
+            if isinstance(base_return, int | float):
+                return float(base_return)
+        return None
 
     def _parse_rebalance_result(
         self,

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -495,6 +495,8 @@ class PortfolioService:
                 as_of_date=effective_as_of_date,
             ),
         )
+        resolved_as_of_date = self._extract_resolved_as_of_date(aum_result) or effective_as_of_date
+        performance_as_of_date = as_of_date or resolved_as_of_date
         (
             performance_result,
             rebalance_result,
@@ -503,7 +505,7 @@ class PortfolioService:
             self._get_workspace_performance_result(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
-                as_of_date=effective_as_of_date,
+                as_of_date=performance_as_of_date,
             ),
             self._get_workspace_rebalance_result(
                 portfolio_id=portfolio_id,
@@ -543,7 +545,6 @@ class PortfolioService:
             partial_failures,
         )
         operations = self._parse_operations(support_result, warnings, partial_failures)
-        resolved_as_of_date = self._extract_resolved_as_of_date(aum_result) or effective_as_of_date
         return PortfolioWorkspaceResponse(
             correlation_id=correlation_id,
             contract_version=settings.contract_version,

--- a/src/app/services/proposal_service.py
+++ b/src/app/services/proposal_service.py
@@ -30,6 +30,26 @@ from app.contracts.proposals import (
 )
 
 
+def _normalize_proposal_context_payload(
+    upstream_payload: dict[str, Any],
+    *,
+    proposal_id: str,
+) -> dict[str, Any]:
+    if upstream_payload.get("proposal_id"):
+        return upstream_payload
+
+    proposal = upstream_payload.get("proposal")
+    if not isinstance(proposal, dict):
+        return upstream_payload
+
+    normalized = dict(upstream_payload)
+    normalized["proposal_id"] = proposal.get("proposal_id") or proposal_id
+    normalized["current_state"] = upstream_payload.get("current_state") or proposal.get(
+        "current_state"
+    )
+    return normalized
+
+
 class ProposalService:
     def __init__(self, advise_client: AdviseClient):
         self._advise_client = advise_client
@@ -264,7 +284,12 @@ class ProposalService:
         return ProposalWorkflowEventsEnvelopeResponse(
             correlation_id=correlation_id,
             contract_version=settings.contract_version,
-            data=ProposalWorkflowEventsData.model_validate(upstream_payload),
+            data=ProposalWorkflowEventsData.model_validate(
+                _normalize_proposal_context_payload(
+                    upstream_payload,
+                    proposal_id=proposal_id,
+                )
+            ),
         )
 
     async def get_approvals(
@@ -280,7 +305,12 @@ class ProposalService:
         return ProposalApprovalsEnvelopeResponse(
             correlation_id=correlation_id,
             contract_version=settings.contract_version,
-            data=ProposalApprovalsData.model_validate(upstream_payload),
+            data=ProposalApprovalsData.model_validate(
+                _normalize_proposal_context_payload(
+                    upstream_payload,
+                    proposal_id=proposal_id,
+                )
+            ),
         )
 
     async def get_proposal_lineage(

--- a/tests/integration/test_portfolio_router.py
+++ b/tests/integration/test_portfolio_router.py
@@ -265,6 +265,103 @@ def test_portfolio_workspace_router(monkeypatch):
     assert captured["support_as_of_date"] is None
 
 
+def test_portfolio_workspace_router_uses_source_resolved_date_for_default_performance(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _get_portfolio(*args, **kwargs):
+        return 200, {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "portfolio_name": "Global Balanced Advisory",
+            "base_currency": "USD",
+            "status": "ACTIVE",
+            "portfolio_type": "ADVISORY",
+            "open_date": "2024-01-15",
+        }
+
+    async def _query_aum(*args, **kwargs):
+        captured["aum_as_of_date"] = kwargs.get("as_of_date")
+        return 200, {
+            "resolved_as_of_date": "2026-04-10",
+            "portfolios": [
+                {
+                    "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                    "aum_reporting_currency": 1000.0,
+                    "position_count": 2,
+                }
+            ],
+        }
+
+    async def _analytics_reference(*args, **kwargs):
+        captured["analytics_reference_as_of_date"] = kwargs.get("as_of_date")
+        return 200, {"performance_end_date": kwargs.get("as_of_date")}
+
+    async def _twr(*args, **kwargs):
+        captured["twr_report_end_date"] = kwargs.get("report_end_date")
+        return 200, {
+            "results_by_period": {
+                "YTD": {
+                    "portfolio": {
+                        "summary": {
+                            "period_return": {"base": 2.5},
+                        }
+                    }
+                }
+            }
+        }
+
+    async def _support(*args, **kwargs):
+        return 200, {"business_date": "2026-04-10", "publish_allowed": True}
+
+    async def _readiness(*args, **kwargs):
+        return 200, {
+            "holdings": {"status": "READY", "reasons": []},
+            "pricing": {"status": "READY", "reasons": []},
+            "transactions": {"status": "READY", "reasons": []},
+            "reporting": {"status": "READY", "reasons": []},
+            "blocking_reasons": [],
+        }
+
+    async def _cashflow(*args, **kwargs):
+        return 200, {
+            "as_of_date": "2026-04-10",
+            "range_end_date": "2026-04-20",
+            "total_net_cashflow": 0,
+            "projection_days": 10,
+            "include_projected": True,
+            "points": [],
+        }
+
+    async def _cash_balances(*args, **kwargs):
+        return 200, {
+            "totals": {"cash_account_count": 1, "total_balance_reporting_currency": 100.0},
+            "cash_accounts": [],
+        }
+
+    monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio", _get_portfolio)
+    monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.query_assets_under_management", _query_aum)
+    monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_support_overview", _support)
+    monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_readiness", _readiness)
+    monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_cashflow_projection", _cashflow)
+    monkeypatch.setattr(f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_cash_balances", _cash_balances)
+    monkeypatch.setattr(
+        f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_analytics_reference",
+        _analytics_reference,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics",
+        _twr,
+    )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/portfolio/portfolios/PB_SG_GLOBAL_BAL_001/workspace")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["as_of_date"] == "2026-04-10"
+    assert captured["analytics_reference_as_of_date"] == "2026-04-10"
+    assert captured["twr_report_end_date"] == "2026-04-10"
+
+
 def test_portfolio_readiness_router(monkeypatch):
     async def _get_portfolio(*args, **kwargs):
         return 200, {"portfolio_id": "PF_1001", "base_currency": "USD", "status": "ACTIVE"}

--- a/tests/unit/test_foundation_service.py
+++ b/tests/unit/test_foundation_service.py
@@ -6,13 +6,23 @@ from app.services.foundation_service import FoundationService
 
 class _StubLotusCoreQueryClient:
     def __init__(
-        self, list_payload: dict, snapshot_payload: dict, portfolio_payload: dict | None = None
+        self,
+        list_payload: dict,
+        snapshot_payload: dict,
+        portfolio_payload: dict | None = None,
+        analytics_reference_payload: dict | None = None,
+        analytics_reference_status_code: int = 200,
     ):
         self.list_payload = list_payload
         self.snapshot_payload = snapshot_payload
         self.portfolio_payload = portfolio_payload or {}
+        self.analytics_reference_payload = analytics_reference_payload or {
+            "performance_end_date": "2026-03-25"
+        }
+        self.analytics_reference_status_code = analytics_reference_status_code
         self.snapshot_calls: list[dict[str, object]] = []
         self.portfolio_calls: list[dict[str, object]] = []
+        self.analytics_reference_calls: list[dict[str, object]] = []
 
     async def get_portfolio_lookups(self, correlation_id: str):
         return 200, self.list_payload
@@ -45,11 +55,29 @@ class _StubLotusCoreQueryClient:
         )
         return 200, self.snapshot_payload
 
+    async def get_portfolio_analytics_reference(
+        self,
+        portfolio_id: str,
+        as_of_date: str,
+        consumer_system: str,
+        correlation_id: str,
+    ):
+        self.analytics_reference_calls.append(
+            {
+                "portfolio_id": portfolio_id,
+                "as_of_date": as_of_date,
+                "consumer_system": consumer_system,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.analytics_reference_status_code, self.analytics_reference_payload
+
 
 class _StubAnalyticsClient:
     def __init__(self, status_code: int, payload: dict):
         self.status_code = status_code
         self.payload = payload
+        self.twr_calls: list[dict[str, str]] = []
 
     async def get_stateful_twr(
         self,
@@ -58,6 +86,14 @@ class _StubAnalyticsClient:
         period: str,
         correlation_id: str,
     ):
+        self.twr_calls.append(
+            {
+                "portfolio_id": portfolio_id,
+                "report_end_date": report_end_date,
+                "period": period,
+                "correlation_id": correlation_id,
+            }
+        )
         return self.status_code, self.payload
 
 
@@ -257,6 +293,103 @@ async def test_foundation_workspace_success():
     assert response.evidence.warning_count == 0
     assert response.evidence.partial_failure_count == 0
     assert response.partial_failures == []
+
+
+@pytest.mark.asyncio
+async def test_foundation_workspace_parses_live_stateful_twr_shape():
+    core_client = _StubLotusCoreQueryClient(
+        list_payload={"items": []},
+        portfolio_payload={"portfolio_id": "PF_1001", "base_currency": "USD"},
+        snapshot_payload={
+            "portfolio_id": "PF_1001",
+            "as_of_date": "2026-05-23",
+            "sections": {
+                "positions_baseline": [{"security_id": "EQ_1", "market_value_base": 1000.0}],
+                "portfolio_totals": {"baseline_total_market_value_base": 1000.0},
+                "instrument_enrichment": [{"security_id": "EQ_1", "asset_class": "Equity"}],
+            },
+        },
+        analytics_reference_payload={"performance_end_date": "2026-05-22"},
+    )
+    analytics_client = _StubAnalyticsClient(
+        200,
+        {
+            "results_by_period": {
+                "YTD": {
+                    "portfolio": {
+                        "summary": {
+                            "period_return": {"base": -0.692074},
+                            "cumulative_return": {"base": -0.701},
+                        }
+                    }
+                }
+            }
+        },
+    )
+    service = FoundationService(
+        lotus_core_query_client=core_client,
+        analytics_client=analytics_client,
+        dpm_client=_StubDpmClient(200, {"items": []}),
+        reporting_client=_StubReportingClient(200, {"rows": []}),
+    )
+
+    response = await service.get_portfolio_workspace(
+        portfolio_id="PF_1001",
+        correlation_id="corr-live-twr",
+    )
+
+    assert response.performance is not None
+    assert response.performance.period == "YTD"
+    assert response.performance.return_pct == -0.692074
+    assert core_client.analytics_reference_calls == [
+        {
+            "portfolio_id": "PF_1001",
+            "as_of_date": "2026-05-23",
+            "consumer_system": "lotus-gateway",
+            "correlation_id": "corr-live-twr",
+        }
+    ]
+    assert analytics_client.twr_calls[0]["report_end_date"] == "2026-05-22"
+    assert response.evidence.status == "ready"
+    assert response.partial_failures == []
+
+
+@pytest.mark.asyncio
+async def test_foundation_workspace_falls_back_when_analytics_reference_unavailable():
+    core_client = _StubLotusCoreQueryClient(
+        list_payload={"items": []},
+        portfolio_payload={"portfolio_id": "PF_1001", "base_currency": "USD"},
+        snapshot_payload={
+            "portfolio_id": "PF_1001",
+            "as_of_date": "2026-05-23",
+            "sections": {
+                "positions_baseline": [{"security_id": "EQ_1", "market_value_base": 1000.0}],
+                "portfolio_totals": {"baseline_total_market_value_base": 1000.0},
+                "instrument_enrichment": [{"security_id": "EQ_1", "asset_class": "Equity"}],
+            },
+        },
+        analytics_reference_payload={"detail": "reference unavailable"},
+        analytics_reference_status_code=503,
+    )
+    analytics_client = _StubAnalyticsClient(
+        200, {"resultsByPeriod": {"YTD": {"net_cumulative_return": 1.25}}}
+    )
+    service = FoundationService(
+        lotus_core_query_client=core_client,
+        analytics_client=analytics_client,
+        dpm_client=_StubDpmClient(200, {"items": []}),
+        reporting_client=_StubReportingClient(200, {"rows": []}),
+    )
+
+    response = await service.get_portfolio_workspace(
+        portfolio_id="PF_1001",
+        correlation_id="corr-reference-fallback",
+    )
+
+    assert response.performance is not None
+    assert response.performance.return_pct == 1.25
+    assert analytics_client.twr_calls[0]["report_end_date"] == "2026-05-23"
+    assert response.evidence.status == "ready"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_monetary_float_guard.py
+++ b/tests/unit/test_monetary_float_guard.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_guard_module():
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "check_monetary_float_usage.py"
+    spec = importlib.util.spec_from_file_location("check_monetary_float_usage", script_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_scan_repo_ignores_local_virtualenv_directories(tmp_path: Path) -> None:
+    guard = _load_guard_module()
+    product_file = tmp_path / "src" / "app" / "services" / "portfolio_service.py"
+    product_file.parent.mkdir(parents=True)
+    product_file.write_text("market_value: float = 1.0\n", encoding="utf-8")
+
+    virtualenv_file = tmp_path / ".venv-codex" / "Lib" / "site-packages" / "vendor.py"
+    virtualenv_file.parent.mkdir(parents=True)
+    virtualenv_file.write_text("market_value: float = 1.0\n", encoding="utf-8")
+
+    findings = guard.scan_repo(tmp_path)
+
+    assert findings == ["src/app/services/portfolio_service.py:1:market_value: float = 1.0"]

--- a/tests/unit/test_portfolio_service.py
+++ b/tests/unit/test_portfolio_service.py
@@ -576,6 +576,55 @@ async def test_portfolio_workspace_uses_aum_and_cash_balance_reporting():
 
 
 @pytest.mark.asyncio
+async def test_portfolio_workspace_uses_source_resolved_date_for_default_performance_snapshot():
+    class _RecordingCoreClient(_StubLotusCoreQueryClient):
+        def __init__(self) -> None:
+            self.analytics_reference_as_of_date: str | None = None
+
+        async def query_assets_under_management(self, **kwargs):
+            payload = await super().query_assets_under_management(**kwargs)
+            payload[1]["resolved_as_of_date"] = "2026-04-10"
+            return payload
+
+        async def get_portfolio_analytics_reference(
+            self,
+            portfolio_id: str,
+            as_of_date: str,
+            consumer_system: str,
+            correlation_id: str,
+        ):
+            self.analytics_reference_as_of_date = as_of_date
+            _ = portfolio_id, consumer_system, correlation_id
+            return 200, {"performance_end_date": as_of_date}
+
+    class _RecordingAnalyticsClient(_StubAnalyticsClient):
+        def __init__(self) -> None:
+            self.twr_kwargs: dict[str, object] | None = None
+
+        async def get_twr_analytics(self, **kwargs):
+            self.twr_kwargs = kwargs
+            return await super().get_twr_analytics(**kwargs)
+
+    core_client = _RecordingCoreClient()
+    analytics_client = _RecordingAnalyticsClient()
+    service = PortfolioService(
+        core_client,
+        analytics_client=analytics_client,
+        dpm_client=_StubDpmClient(),
+    )
+
+    response = await service.get_portfolio_workspace(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        correlation_id="corr-canonical-default-date",
+    )
+
+    assert response.as_of_date == "2026-04-10"
+    assert core_client.analytics_reference_as_of_date == "2026-04-10"
+    assert analytics_client.twr_kwargs is not None
+    assert analytics_client.twr_kwargs["report_end_date"] == "2026-04-10"
+
+
+@pytest.mark.asyncio
 async def test_portfolio_workspace_preserves_rebalance_supportability_without_latest_run():
     class _NoRunDpmClient(_StubDpmClient):
         async def list_runs(self, params: dict[str, object], correlation_id: str):

--- a/tests/unit/test_proposal_service.py
+++ b/tests/unit/test_proposal_service.py
@@ -634,6 +634,64 @@ async def test_get_workflow_events_and_approvals_wrap_typed_envelopes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_approvals_normalizes_nested_advisory_payload() -> None:
+    class NestedApprovalsClient(_FakeAdviseClient):
+        async def get_approvals(self, proposal_id: str, correlation_id: str):
+            _ = correlation_id
+            return 200, {
+                "proposal": {
+                    "proposal_id": proposal_id,
+                    "current_state": "DRAFT",
+                },
+                "pending_approval": None,
+                "approvals": [],
+            }
+
+    service = ProposalService(advise_client=NestedApprovalsClient())
+
+    approvals = await service.get_approvals(proposal_id="pp_1", correlation_id="corr_3")
+
+    assert approvals.data.proposal_id == "pp_1"
+    assert approvals.data.current_state == "DRAFT"
+    assert approvals.data.approvals == []
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_events_normalizes_nested_advisory_payload() -> None:
+    class NestedWorkflowClient(_FakeAdviseClient):
+        async def get_workflow_events(self, proposal_id: str, correlation_id: str):
+            _ = correlation_id
+            return 200, {
+                "proposal": {
+                    "proposal_id": proposal_id,
+                    "current_state": "DRAFT",
+                },
+                "current_state": "DRAFT",
+                "event_count": 1,
+                "events": [
+                    {
+                        "event_id": "pwe_1",
+                        "proposal_id": proposal_id,
+                        "event_type": "CREATED",
+                        "from_state": None,
+                        "to_state": "DRAFT",
+                        "actor_id": "advisor_1",
+                        "occurred_at": "2026-02-19T12:00:00+00:00",
+                        "reason": {},
+                    }
+                ],
+            }
+
+    service = ProposalService(advise_client=NestedWorkflowClient())
+
+    events = await service.get_workflow_events(proposal_id="pp_1", correlation_id="corr_3")
+
+    assert events.data.proposal_id == "pp_1"
+    assert events.data.current_state == "DRAFT"
+    assert events.data.events[0].event_type == "CREATED"
+
+
+@pytest.mark.asyncio
 async def test_get_proposal_lineage_wraps_envelope() -> None:
     client = _FakeAdviseClient()
     service = ProposalService(advise_client=client)

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -317,6 +317,12 @@ Foundation workspace:
 curl "http://127.0.0.1:8111/api/v1/foundation/portfolios/PF_1001/workspace"
 ```
 
+The Foundation workspace uses `lotus-core` portfolio identity and core-snapshot sections for
+first-paint holdings context, then resolves `PortfolioAnalyticsReference.performance_end_date`
+before requesting YTD TWR from `lotus-performance`. This keeps the displayed return, supportability
+state, and fan-out logs aligned to the latest complete calculable performance horizon instead of a
+raw calendar date.
+
 Performance summary:
 
 ```bash

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -61,6 +61,18 @@
 - Dashboard claims and Workbench attention events outside the Workbench surface remain planned
   until later RFC-0108 slices promote them with evidence.
 
+## Foundation workspace performance horizon
+
+- The Foundation workspace resolves the Core analytics reference before calling
+  `lotus-performance`.
+- `PortfolioAnalyticsReference.performance_end_date` is the report end date for the Foundation YTD
+  TWR request when Core publishes it.
+- This prevents a weekend, holiday, or otherwise incomplete calendar date from creating a
+  misleading degraded performance fan-out when the latest complete performance horizon is ready.
+- If the analytics reference lookup is unavailable, Gateway falls back to the snapshot as-of date
+  and surfaces any resulting performance degradation through the normal warning and partial-failure
+  contract.
+
 ## Practical probes
 
 ```powershell


### PR DESCRIPTION
## Summary
- Normalize Gateway foundation/proposal readiness for canonical RFC-0023 proof.
- Resolve Core analytics reference horizon before default performance calls.
- Parse live stateful performance return shapes and preserve ready supportability through the experience API.

## Evidence
- Targeted Gateway pytest suite -> 100 passed
- Ruff targeted checks -> passed
- Rebuilt Gateway and live Foundation workspace returned performance/advisor readiness with warnings=0 and partials=0
- Default no-report-date performance/advisor live checks returned ready current snapshots