### PR TITLE
feat: route RFC-0024 proposal memo APIs through Advise

### DIFF
--- a/src/app/clients/advise_client.py
+++ b/src/app/clients/advise_client.py
@@ -254,6 +254,130 @@ class AdviseClient:
             operation="advise.advisory.proposals.delivery-events",
         )
 
+    async def create_proposal_memo(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo",
+            body=body,
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="advise.advisory.proposals.memo.create",
+        )
+
+    async def get_proposal_memo(
+        self,
+        proposal_id: str,
+        version_no: int,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.memo.get",
+        )
+
+    async def get_proposal_memo_projection(
+        self,
+        proposal_id: str,
+        version_no: int,
+        audience: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        params: dict[str, Any] = {}
+        if audience:
+            params["audience"] = audience
+        return await self._get(
+            f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo/projection",
+            params=params,
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.memo.projection",
+        )
+
+    async def review_proposal_memo(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        headers = self._headers(correlation_id)
+        if idempotency_key is not None:
+            headers["Idempotency-Key"] = idempotency_key
+        return await self._post(
+            f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo/review",
+            body=body,
+            headers=headers,
+            operation="advise.advisory.proposals.memo.review",
+        )
+
+    async def request_proposal_memo_report_package(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        headers = self._headers(correlation_id)
+        if idempotency_key is not None:
+            headers["Idempotency-Key"] = idempotency_key
+        return await self._post(
+            f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo/report-packages",
+            body=body,
+            headers=headers,
+            operation="advise.advisory.proposals.memo.report-packages",
+        )
+
+    async def request_proposal_memo_ai_commentary(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        headers = self._headers(correlation_id)
+        if idempotency_key is not None:
+            headers["Idempotency-Key"] = idempotency_key
+        return await self._post(
+            f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo/ai-commentary",
+            body=body,
+            headers=headers,
+            operation="advise.advisory.proposals.memo.ai-commentary",
+        )
+
+    async def get_proposal_memo_lineage(
+        self,
+        proposal_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/{proposal_id}/memos/lineage",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.memo.lineage",
+        )
+
+    async def get_proposal_memo_replay_evidence(
+        self,
+        proposal_id: str,
+        version_no: int,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo/replay-evidence",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.memo.replay-evidence",
+        )
+
     def _headers(
         self,
         correlation_id: str,

--- a/src/app/contracts/proposals.py
+++ b/src/app/contracts/proposals.py
@@ -265,6 +265,104 @@ class ProposalReportRequest(BaseModel):
     )
 
 
+class ProposalMemoCreateRequest(BaseModel):
+    created_by: str = Field(
+        description="Actor creating or replaying the advisor proposal memo in lotus-advise.",
+        examples=["advisor_1"],
+    )
+    lifecycle_status: str = Field(
+        default="DRAFT",
+        description=(
+            "Requested durable memo lifecycle status. Gateway forwards the value to "
+            "lotus-advise and does not decide memo finalization locally."
+        ),
+        examples=["DRAFT"],
+    )
+    reason: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Structured memo creation reason forwarded unchanged to lotus-advise.",
+        examples=[{"purpose": "advisor review pack for client meeting"}],
+    )
+
+
+class ProposalMemoReviewRequest(BaseModel):
+    action: Literal["APPROVE_FOR_ADVISOR_USE", "REJECT", "REQUEST_CHANGES"] = Field(
+        description=(
+            "Bounded memo review action. Gateway forwards the action to lotus-advise and "
+            "does not alter memo evidence, readiness, or publication state."
+        ),
+        examples=["APPROVE_FOR_ADVISOR_USE"],
+    )
+    reviewed_by: str = Field(
+        description="Reviewer actor identifier.",
+        examples=["compliance_1"],
+    )
+    reason: str = Field(
+        description="Business reason for the memo review decision.",
+        examples=["Memo is ready for advisor discussion; client-ready release remains blocked."],
+    )
+    source_memo_hash: str = Field(
+        description="Memo hash inspected by the reviewer; stale hashes are rejected upstream.",
+        examples=["sha256:memo-001"],
+    )
+    client_ready_release_requested: bool = Field(
+        default=False,
+        description="Whether client-ready release is requested. RFC-0024 keeps this blocked.",
+        examples=[False],
+    )
+
+
+class ProposalMemoReportPackageRequest(BaseModel):
+    requested_by: str = Field(
+        description="Actor requesting memo report/render/archive materialization.",
+        examples=["advisor_1"],
+    )
+    source_memo_hash: str = Field(
+        description="Memo hash inspected by the requester; stale hashes are rejected upstream.",
+        examples=["sha256:memo-001"],
+    )
+    requested_output_formats: list[str] = Field(
+        default_factory=lambda: ["pdf"],
+        description="Output formats requested from lotus-report through lotus-advise.",
+        examples=[["pdf"]],
+    )
+    client_ready_document_requested: bool = Field(
+        default=False,
+        description=(
+            "Whether client-ready document release is requested. RFC-0024 keeps this blocked."
+        ),
+        examples=[False],
+    )
+    reason: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Structured report-package request reason forwarded unchanged to lotus-advise.",
+        examples=[{"purpose": "advisor-use memo report package"}],
+    )
+
+
+class ProposalMemoAiCommentaryRequest(BaseModel):
+    requested_by: str = Field(
+        description="Actor requesting review-gated advisor-use AI commentary.",
+        examples=["advisor_1"],
+    )
+    source_memo_hash: str = Field(
+        description="Memo hash inspected by the requester; stale hashes are rejected upstream.",
+        examples=["sha256:memo-001"],
+    )
+    requested_sections: list[str] = Field(
+        default_factory=lambda: ["EXECUTIVE_SUMMARY", "LIMITATIONS_AND_DISCLOSURES"],
+        description=(
+            "Bounded advisor-use commentary sections requested from lotus-ai through Advise."
+        ),
+        examples=[["EXECUTIVE_SUMMARY", "LIMITATIONS_AND_DISCLOSURES"]],
+    )
+    reason: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Structured AI commentary request reason forwarded unchanged to lotus-advise.",
+        examples=[{"purpose": "advisor-use commentary draft"}],
+    )
+
+
 class ProposalEnvelopeBase(BaseModel):
     correlation_id: str = Field(
         description="Correlation identifier propagated through the gateway request.",
@@ -706,6 +804,82 @@ class ProposalDeliveryEventsEnvelopeResponse(ProposalEnvelopeBase):
         description=(
             "Delivery-only proposal workflow history from lotus-advise, preserving append-only "
             "report, archive, and execution posture without gateway recomputation."
+        ),
+    )
+
+
+class ProposalMemoEnvelopeResponse(ProposalEnvelopeBase):
+    data: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Memo payload returned by lotus-advise. Gateway preserves memo evidence, projection, "
+            "review, report/render/archive, archive refs, AI commentary, supportability, and "
+            "lineage posture without recomputing or inferring memo facts."
+        ),
+        examples=[
+            {
+                "memo_id": "memo_001",
+                "memo_status": "PENDING_REVIEW",
+                "memo_hash": "sha256:memo-001",
+                "projection": {"client_ready_publication": "BLOCKED"},
+            }
+        ],
+    )
+
+
+class ProposalMemoProjectionEnvelopeResponse(ProposalEnvelopeBase):
+    data: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Audience-filtered memo projection returned by lotus-advise. Gateway does not "
+            "redact, rank, or construct memo sections locally."
+        ),
+    )
+
+
+class ProposalMemoReviewEnvelopeResponse(ProposalEnvelopeBase):
+    data: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Memo review response returned by lotus-advise with append-only event posture.",
+    )
+
+
+class ProposalMemoReportPackageEnvelopeResponse(ProposalEnvelopeBase):
+    data: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Memo report/render/archive request response returned by lotus-advise, including "
+            "report, render, archive, and memo lineage refs when available."
+        ),
+    )
+
+
+class ProposalMemoAiCommentaryEnvelopeResponse(ProposalEnvelopeBase):
+    data: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Review-gated advisor-use AI commentary response returned by lotus-advise. The "
+            "commentary is non-authoritative and cannot alter memo evidence or approval posture."
+        ),
+    )
+
+
+class ProposalMemoLineageEnvelopeResponse(ProposalEnvelopeBase):
+    data: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Proposal memo lineage returned by lotus-advise, including memo hashes, event counts, "
+            "report-package posture, archive refs, and AI commentary posture."
+        ),
+    )
+
+
+class ProposalMemoReplayEvidenceEnvelopeResponse(ProposalEnvelopeBase):
+    data: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Memo replay evidence returned by lotus-advise, preserving source hashes, audit "
+            "events, supportability, and blocked client-ready posture."
         ),
     )
 

--- a/src/app/routers/proposals.py
+++ b/src/app/routers/proposals.py
@@ -12,6 +12,17 @@ from app.contracts.proposals import (
     ProposalDetailEnvelopeResponse,
     ProposalLineageEnvelopeResponse,
     ProposalListEnvelopeResponse,
+    ProposalMemoAiCommentaryEnvelopeResponse,
+    ProposalMemoAiCommentaryRequest,
+    ProposalMemoCreateRequest,
+    ProposalMemoEnvelopeResponse,
+    ProposalMemoLineageEnvelopeResponse,
+    ProposalMemoProjectionEnvelopeResponse,
+    ProposalMemoReplayEvidenceEnvelopeResponse,
+    ProposalMemoReportPackageEnvelopeResponse,
+    ProposalMemoReportPackageRequest,
+    ProposalMemoReviewEnvelopeResponse,
+    ProposalMemoReviewRequest,
     ProposalNarrativeReviewEnvelopeResponse,
     ProposalNarrativeReviewRequest,
     ProposalReportRequest,
@@ -551,5 +562,286 @@ async def get_delivery_events(
     correlation_id = correlation_id_var.get()
     return await service.get_delivery_events(
         proposal_id=proposal_id,
+        correlation_id=correlation_id,
+    )
+
+
+@router.post(
+    "/{proposal_id}/versions/{version_no}/memo",
+    response_model=ProposalMemoEnvelopeResponse,
+    summary="Create Proposal Memo",
+    description=(
+        "Creates or replays the advisor proposal memo through lotus-advise. Gateway preserves "
+        "memo evidence, supportability, review posture, report/render/archive posture, and "
+        "client-ready blockers without local inference."
+    ),
+)
+async def create_proposal_memo(
+    request: ProposalMemoCreateRequest,
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    version_no: int = Path(
+        ...,
+        description="Immutable proposal version number used as the memo source.",
+        examples=[2],
+    ),
+    idempotency_key: str = Header(
+        alias="Idempotency-Key",
+        description="Caller-supplied idempotency key for memo creation or replay requests.",
+        examples=["idem-memo-create-1"],
+    ),
+) -> ProposalMemoEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_proposal_memo(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.model_dump(exclude_none=True),
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
+@router.get(
+    "/{proposal_id}/versions/{version_no}/memo",
+    response_model=ProposalMemoEnvelopeResponse,
+    summary="Get Proposal Memo",
+    description=(
+        "Returns the source-owned proposal memo from lotus-advise. Gateway does not recompute "
+        "suitability, readiness, supportability, archive refs, or memo sections locally."
+    ),
+)
+async def get_proposal_memo(
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    version_no: int = Path(
+        ...,
+        description="Immutable proposal version number used as the memo source.",
+        examples=[2],
+    ),
+) -> ProposalMemoEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_memo(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        correlation_id=correlation_id,
+    )
+
+
+@router.get(
+    "/{proposal_id}/versions/{version_no}/memo/projection",
+    response_model=ProposalMemoProjectionEnvelopeResponse,
+    summary="Get Proposal Memo Projection",
+    description=(
+        "Returns an audience-specific memo projection from lotus-advise for advisor, compliance, "
+        "operations, or client-draft review. Gateway forwards the requested audience and does not "
+        "redact, rank, or construct memo content locally."
+    ),
+)
+async def get_proposal_memo_projection(
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    version_no: int = Path(
+        ...,
+        description="Immutable proposal version number used as the memo source.",
+        examples=[2],
+    ),
+    audience: str | None = Query(
+        default=None,
+        description="Optional lotus-advise memo projection audience.",
+        examples=["COMPLIANCE"],
+    ),
+) -> ProposalMemoProjectionEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_memo_projection(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        audience=audience,
+        correlation_id=correlation_id,
+    )
+
+
+@router.post(
+    "/{proposal_id}/versions/{version_no}/memo/review",
+    response_model=ProposalMemoReviewEnvelopeResponse,
+    summary="Review Proposal Memo",
+    description=(
+        "Records an advisor-use memo review decision through lotus-advise. Gateway forwards the "
+        "source memo hash and does not promote client-ready release, mutate memo facts, or bypass "
+        "upstream stale-hash controls."
+    ),
+)
+async def review_proposal_memo(
+    request: ProposalMemoReviewRequest,
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    version_no: int = Path(
+        ...,
+        description="Immutable proposal version number used as the memo source.",
+        examples=[2],
+    ),
+    idempotency_key: str | None = Header(
+        default=None,
+        alias="Idempotency-Key",
+        description="Caller-supplied idempotency key for memo review requests.",
+        examples=["idem-memo-review-1"],
+    ),
+) -> ProposalMemoReviewEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.review_proposal_memo(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.model_dump(exclude_none=True),
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
+@router.post(
+    "/{proposal_id}/versions/{version_no}/memo/report-packages",
+    response_model=ProposalMemoReportPackageEnvelopeResponse,
+    summary="Request Proposal Memo Report Package",
+    description=(
+        "Requests memo report/render/archive materialization through lotus-advise. Gateway keeps "
+        "client-ready document requests governed by upstream blockers and does not synthesize "
+        "archive refs or render status locally."
+    ),
+)
+async def request_proposal_memo_report_package(
+    request: ProposalMemoReportPackageRequest,
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    version_no: int = Path(
+        ...,
+        description="Immutable proposal version number used as the memo source.",
+        examples=[2],
+    ),
+    idempotency_key: str | None = Header(
+        default=None,
+        alias="Idempotency-Key",
+        description="Caller-supplied idempotency key for memo report-package requests.",
+        examples=["idem-memo-report-package-1"],
+    ),
+) -> ProposalMemoReportPackageEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.request_proposal_memo_report_package(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.model_dump(exclude_none=True),
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
+@router.post(
+    "/{proposal_id}/versions/{version_no}/memo/ai-commentary",
+    response_model=ProposalMemoAiCommentaryEnvelopeResponse,
+    summary="Request Proposal Memo AI Commentary",
+    description=(
+        "Requests review-gated advisor-use AI commentary through lotus-advise. Gateway does not "
+        "treat commentary as memo evidence and does not alter memo approval or readiness posture."
+    ),
+)
+async def request_proposal_memo_ai_commentary(
+    request: ProposalMemoAiCommentaryRequest,
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    version_no: int = Path(
+        ...,
+        description="Immutable proposal version number used as the memo source.",
+        examples=[2],
+    ),
+    idempotency_key: str | None = Header(
+        default=None,
+        alias="Idempotency-Key",
+        description="Caller-supplied idempotency key for memo AI-commentary requests.",
+        examples=["idem-memo-ai-commentary-1"],
+    ),
+) -> ProposalMemoAiCommentaryEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.request_proposal_memo_ai_commentary(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.model_dump(exclude_none=True),
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
+@router.get(
+    "/{proposal_id}/memos/lineage",
+    response_model=ProposalMemoLineageEnvelopeResponse,
+    summary="Get Proposal Memo Lineage",
+    description=(
+        "Returns proposal memo lineage from lotus-advise, including memo hashes, review posture, "
+        "report-package posture, archive refs, replay evidence, and AI commentary posture without "
+        "gateway-side recomputation."
+    ),
+)
+async def get_proposal_memo_lineage(
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+) -> ProposalMemoLineageEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_memo_lineage(
+        proposal_id=proposal_id,
+        correlation_id=correlation_id,
+    )
+
+
+@router.get(
+    "/{proposal_id}/versions/{version_no}/memo/replay-evidence",
+    response_model=ProposalMemoReplayEvidenceEnvelopeResponse,
+    summary="Get Proposal Memo Replay Evidence",
+    description=(
+        "Returns memo replay evidence from lotus-advise so operations can inspect source hashes, "
+        "audit events, supportability, and blocked client-ready posture without local Gateway "
+        "interpretation."
+    ),
+)
+async def get_proposal_memo_replay_evidence(
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    version_no: int = Path(
+        ...,
+        description="Immutable proposal version number used as the memo source.",
+        examples=[2],
+    ),
+) -> ProposalMemoReplayEvidenceEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_memo_replay_evidence(
+        proposal_id=proposal_id,
+        version_no=version_no,
         correlation_id=correlation_id,
     )

--- a/src/app/services/proposal_service.py
+++ b/src/app/services/proposal_service.py
@@ -17,6 +17,13 @@ from app.contracts.proposals import (
     ProposalLineageEnvelopeResponse,
     ProposalListData,
     ProposalListEnvelopeResponse,
+    ProposalMemoAiCommentaryEnvelopeResponse,
+    ProposalMemoEnvelopeResponse,
+    ProposalMemoLineageEnvelopeResponse,
+    ProposalMemoProjectionEnvelopeResponse,
+    ProposalMemoReplayEvidenceEnvelopeResponse,
+    ProposalMemoReportPackageEnvelopeResponse,
+    ProposalMemoReviewEnvelopeResponse,
     ProposalNarrativeReviewEnvelopeResponse,
     ProposalReportRequestEnvelopeResponse,
     ProposalSimulateResponse,
@@ -396,6 +403,175 @@ class ProposalService:
         )
         self._raise_for_upstream_error(upstream_status, upstream_payload)
         return ProposalDeliveryEventsEnvelopeResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            data=upstream_payload,
+        )
+
+    async def create_proposal_memo(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> ProposalMemoEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.create_proposal_memo(
+            proposal_id=proposal_id,
+            version_no=version_no,
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return ProposalMemoEnvelopeResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            data=upstream_payload,
+        )
+
+    async def get_proposal_memo(
+        self,
+        proposal_id: str,
+        version_no: int,
+        correlation_id: str,
+    ) -> ProposalMemoEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.get_proposal_memo(
+            proposal_id=proposal_id,
+            version_no=version_no,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return ProposalMemoEnvelopeResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            data=upstream_payload,
+        )
+
+    async def get_proposal_memo_projection(
+        self,
+        proposal_id: str,
+        version_no: int,
+        audience: str | None,
+        correlation_id: str,
+    ) -> ProposalMemoProjectionEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.get_proposal_memo_projection(
+            proposal_id=proposal_id,
+            version_no=version_no,
+            audience=audience,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return ProposalMemoProjectionEnvelopeResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            data=upstream_payload,
+        )
+
+    async def review_proposal_memo(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> ProposalMemoReviewEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.review_proposal_memo(
+            proposal_id=proposal_id,
+            version_no=version_no,
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return ProposalMemoReviewEnvelopeResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            data=upstream_payload,
+        )
+
+    async def request_proposal_memo_report_package(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> ProposalMemoReportPackageEnvelopeResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.request_proposal_memo_report_package(
+            proposal_id=proposal_id,
+            version_no=version_no,
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return ProposalMemoReportPackageEnvelopeResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            data=upstream_payload,
+        )
+
+    async def request_proposal_memo_ai_commentary(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> ProposalMemoAiCommentaryEnvelopeResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.request_proposal_memo_ai_commentary(
+            proposal_id=proposal_id,
+            version_no=version_no,
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return ProposalMemoAiCommentaryEnvelopeResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            data=upstream_payload,
+        )
+
+    async def get_proposal_memo_lineage(
+        self,
+        proposal_id: str,
+        correlation_id: str,
+    ) -> ProposalMemoLineageEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.get_proposal_memo_lineage(
+            proposal_id=proposal_id,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return ProposalMemoLineageEnvelopeResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            data=upstream_payload,
+        )
+
+    async def get_proposal_memo_replay_evidence(
+        self,
+        proposal_id: str,
+        version_no: int,
+        correlation_id: str,
+    ) -> ProposalMemoReplayEvidenceEnvelopeResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.get_proposal_memo_replay_evidence(
+            proposal_id=proposal_id,
+            version_no=version_no,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return ProposalMemoReplayEvidenceEnvelopeResponse(
             correlation_id=correlation_id,
             contract_version=settings.contract_version,
             data=upstream_payload,

--- a/tests/contract/test_proposals_contract.py
+++ b/tests/contract/test_proposals_contract.py
@@ -10,6 +10,17 @@ from app.contracts.proposals import (
     ProposalEnvelopeResponse,
     ProposalLineageEnvelopeResponse,
     ProposalListEnvelopeResponse,
+    ProposalMemoAiCommentaryEnvelopeResponse,
+    ProposalMemoAiCommentaryRequest,
+    ProposalMemoCreateRequest,
+    ProposalMemoEnvelopeResponse,
+    ProposalMemoLineageEnvelopeResponse,
+    ProposalMemoProjectionEnvelopeResponse,
+    ProposalMemoReplayEvidenceEnvelopeResponse,
+    ProposalMemoReportPackageEnvelopeResponse,
+    ProposalMemoReportPackageRequest,
+    ProposalMemoReviewEnvelopeResponse,
+    ProposalMemoReviewRequest,
     ProposalNarrativeReviewEnvelopeResponse,
     ProposalNarrativeReviewRequest,
     ProposalReportRequest,
@@ -204,6 +215,71 @@ def test_proposal_reviewed_narrative_contract_shapes() -> None:
     assert events_payload.data["event_count"] == 1
 
 
+def test_proposal_memo_contract_shapes() -> None:
+    create_request = ProposalMemoCreateRequest(created_by="advisor_1")
+    review_request = ProposalMemoReviewRequest(
+        action="APPROVE_FOR_ADVISOR_USE",
+        reviewed_by="compliance_1",
+        reason="Evidence-backed advisor-use memo.",
+        source_memo_hash="sha256:memo-001",
+    )
+    report_request = ProposalMemoReportPackageRequest(
+        requested_by="advisor_1",
+        source_memo_hash="sha256:memo-001",
+    )
+    ai_request = ProposalMemoAiCommentaryRequest(
+        requested_by="advisor_1",
+        source_memo_hash="sha256:memo-001",
+    )
+    memo_payload = ProposalMemoEnvelopeResponse(
+        correlation_id="corr_memo_1",
+        contract_version="v1",
+        data={"memo_hash": "sha256:memo-001", "projection": {"client_ready": "BLOCKED"}},
+    )
+    projection_payload = ProposalMemoProjectionEnvelopeResponse(
+        correlation_id="corr_memo_2",
+        contract_version="v1",
+        data={"projection": {"audience": "COMPLIANCE"}, "sections": []},
+    )
+    review_payload = ProposalMemoReviewEnvelopeResponse(
+        correlation_id="corr_memo_3",
+        contract_version="v1",
+        data={"review_posture": {"advisor_use": "APPROVED_FOR_ADVISOR_USE"}},
+    )
+    report_payload = ProposalMemoReportPackageEnvelopeResponse(
+        correlation_id="corr_memo_4",
+        contract_version="v1",
+        data={"report": {"archive_refs": ["archive://memo/report/1"]}},
+    )
+    ai_payload = ProposalMemoAiCommentaryEnvelopeResponse(
+        correlation_id="corr_memo_5",
+        contract_version="v1",
+        data={"commentary": {"authority": "NON_AUTHORITATIVE"}},
+    )
+    lineage_payload = ProposalMemoLineageEnvelopeResponse(
+        correlation_id="corr_memo_6",
+        contract_version="v1",
+        data={"memos": [{"memo_hash": "sha256:memo-001"}]},
+    )
+    replay_payload = ProposalMemoReplayEvidenceEnvelopeResponse(
+        correlation_id="corr_memo_7",
+        contract_version="v1",
+        data={"hashes": {"memo_hash": "sha256:memo-001"}},
+    )
+
+    assert create_request.lifecycle_status == "DRAFT"
+    assert review_request.client_ready_release_requested is False
+    assert report_request.client_ready_document_requested is False
+    assert ai_request.requested_sections
+    assert memo_payload.data["memo_hash"] == "sha256:memo-001"
+    assert projection_payload.data["projection"]["audience"] == "COMPLIANCE"
+    assert review_payload.data["review_posture"]["advisor_use"] == "APPROVED_FOR_ADVISOR_USE"
+    assert report_payload.data["report"]["archive_refs"] == ["archive://memo/report/1"]
+    assert ai_payload.data["commentary"]["authority"] == "NON_AUTHORITATIVE"
+    assert lineage_payload.data["memos"][0]["memo_hash"] == "sha256:memo-001"
+    assert replay_payload.data["hashes"]["memo_hash"] == "sha256:memo-001"
+
+
 def test_proposal_submit_request_contract_shape() -> None:
     payload = ProposalSubmitRequest(actor_id="advisor_1")
     assert payload.review_type == "RISK"
@@ -234,6 +310,16 @@ def test_proposals_openapi_read_contract() -> None:
     delivery_events_operation = spec["paths"]["/api/v1/proposals/{proposal_id}/delivery-events"][
         "get"
     ]
+    memo_operation = spec["paths"]["/api/v1/proposals/{proposal_id}/versions/{version_no}/memo"][
+        "get"
+    ]
+    memo_projection_operation = spec["paths"][
+        "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo/projection"
+    ]["get"]
+    memo_lineage_operation = spec["paths"]["/api/v1/proposals/{proposal_id}/memos/lineage"]["get"]
+    memo_replay_operation = spec["paths"][
+        "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo/replay-evidence"
+    ]["get"]
 
     list_parameters = {parameter["name"]: parameter for parameter in list_operation["parameters"]}
     detail_parameters = {
@@ -256,6 +342,16 @@ def test_proposals_openapi_read_contract() -> None:
     }
     delivery_events_parameters = {
         parameter["name"]: parameter for parameter in delivery_events_operation["parameters"]
+    }
+    memo_parameters = {parameter["name"]: parameter for parameter in memo_operation["parameters"]}
+    memo_projection_parameters = {
+        parameter["name"]: parameter for parameter in memo_projection_operation["parameters"]
+    }
+    memo_lineage_parameters = {
+        parameter["name"]: parameter for parameter in memo_lineage_operation["parameters"]
+    }
+    memo_replay_parameters = {
+        parameter["name"]: parameter for parameter in memo_replay_operation["parameters"]
     }
 
     assert "portfolio" in list_operation["description"].lower()
@@ -299,6 +395,15 @@ def test_proposals_openapi_read_contract() -> None:
     assert delivery_events_parameters["proposal_id"]["schema"]["examples"] == ["pp_1"]
     assert "reviewed advisory narrative" in delivery_summary_operation["description"].lower()
     assert "without gateway-side inference" in delivery_events_operation["description"].lower()
+    assert memo_parameters["proposal_id"]["schema"]["examples"] == ["pp_1"]
+    assert memo_parameters["version_no"]["schema"]["examples"] == [2]
+    assert memo_projection_parameters["audience"]["schema"]["examples"] == ["COMPLIANCE"]
+    assert memo_lineage_parameters["proposal_id"]["schema"]["examples"] == ["pp_1"]
+    assert memo_replay_parameters["version_no"]["schema"]["examples"] == [2]
+    assert "does not recompute" in memo_operation["description"].lower()
+    assert "does not redact" in memo_projection_operation["description"].lower()
+    assert "without gateway-side recomputation" in memo_lineage_operation["description"].lower()
+    assert "without local gateway interpretation" in memo_replay_operation["description"].lower()
 
     list_response_ref = list_operation["responses"]["200"]["content"]["application/json"]["schema"][
         "$ref"
@@ -324,6 +429,18 @@ def test_proposals_openapi_read_contract() -> None:
     delivery_events_response_ref = delivery_events_operation["responses"]["200"]["content"][
         "application/json"
     ]["schema"]["$ref"]
+    memo_response_ref = memo_operation["responses"]["200"]["content"]["application/json"]["schema"][
+        "$ref"
+    ]
+    memo_projection_response_ref = memo_projection_operation["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
+    memo_lineage_response_ref = memo_lineage_operation["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
+    memo_replay_response_ref = memo_replay_operation["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
 
     assert list_response_ref.endswith("/ProposalListEnvelopeResponse")
     assert detail_response_ref.endswith("/ProposalDetailEnvelopeResponse")
@@ -333,6 +450,10 @@ def test_proposals_openapi_read_contract() -> None:
     assert lineage_response_ref.endswith("/ProposalLineageEnvelopeResponse")
     assert delivery_summary_response_ref.endswith("/ProposalDeliverySummaryEnvelopeResponse")
     assert delivery_events_response_ref.endswith("/ProposalDeliveryEventsEnvelopeResponse")
+    assert memo_response_ref.endswith("/ProposalMemoEnvelopeResponse")
+    assert memo_projection_response_ref.endswith("/ProposalMemoProjectionEnvelopeResponse")
+    assert memo_lineage_response_ref.endswith("/ProposalMemoLineageEnvelopeResponse")
+    assert memo_replay_response_ref.endswith("/ProposalMemoReplayEvidenceEnvelopeResponse")
 
 
 def test_proposals_openapi_write_contract() -> None:
@@ -356,6 +477,18 @@ def test_proposals_openapi_write_contract() -> None:
     report_request_operation = spec["paths"]["/api/v1/proposals/{proposal_id}/report-requests"][
         "post"
     ]
+    memo_create_operation = spec["paths"][
+        "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo"
+    ]["post"]
+    memo_review_operation = spec["paths"][
+        "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo/review"
+    ]["post"]
+    memo_report_package_operation = spec["paths"][
+        "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo/report-packages"
+    ]["post"]
+    memo_ai_commentary_operation = spec["paths"][
+        "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo/ai-commentary"
+    ]["post"]
 
     simulate_parameters = {
         parameter["name"]: parameter for parameter in simulate_operation["parameters"]
@@ -383,6 +516,18 @@ def test_proposals_openapi_write_contract() -> None:
     }
     report_request_parameters = {
         parameter["name"]: parameter for parameter in report_request_operation["parameters"]
+    }
+    memo_create_parameters = {
+        parameter["name"]: parameter for parameter in memo_create_operation["parameters"]
+    }
+    memo_review_parameters = {
+        parameter["name"]: parameter for parameter in memo_review_operation["parameters"]
+    }
+    memo_report_package_parameters = {
+        parameter["name"]: parameter for parameter in memo_report_package_operation["parameters"]
+    }
+    memo_ai_commentary_parameters = {
+        parameter["name"]: parameter for parameter in memo_ai_commentary_operation["parameters"]
     }
 
     assert "idempotency" in simulate_operation["description"].lower()
@@ -433,6 +578,21 @@ def test_proposals_openapi_write_contract() -> None:
     assert report_request_parameters["proposal_id"]["schema"]["examples"] == ["pp_1"]
     assert "never regenerates narrative locally" in narrative_review_operation["description"]
     assert "source-hash continuity" in report_request_operation["description"]
+    assert memo_create_parameters["proposal_id"]["schema"]["examples"] == ["pp_1"]
+    assert memo_create_parameters["version_no"]["schema"]["examples"] == [2]
+    assert memo_create_parameters["Idempotency-Key"]["schema"]["examples"] == ["idem-memo-create-1"]
+    assert memo_review_parameters["Idempotency-Key"]["schema"]["examples"] == ["idem-memo-review-1"]
+    assert memo_report_package_parameters["Idempotency-Key"]["schema"]["examples"] == [
+        "idem-memo-report-package-1"
+    ]
+    assert memo_ai_commentary_parameters["Idempotency-Key"]["schema"]["examples"] == [
+        "idem-memo-ai-commentary-1"
+    ]
+    assert "does not promote client-ready release" in memo_review_operation["description"]
+    assert "does not synthesize archive refs" in memo_report_package_operation["description"]
+    assert (
+        "does not treat commentary as memo evidence" in memo_ai_commentary_operation["description"]
+    )
 
     assert create_operation["responses"]["200"]["content"]["application/json"]["schema"][
         "$ref"
@@ -458,6 +618,18 @@ def test_proposals_openapi_write_contract() -> None:
     assert report_request_operation["responses"]["200"]["content"]["application/json"]["schema"][
         "$ref"
     ].endswith("/ProposalReportRequestEnvelopeResponse")
+    assert memo_create_operation["responses"]["200"]["content"]["application/json"]["schema"][
+        "$ref"
+    ].endswith("/ProposalMemoEnvelopeResponse")
+    assert memo_review_operation["responses"]["200"]["content"]["application/json"]["schema"][
+        "$ref"
+    ].endswith("/ProposalMemoReviewEnvelopeResponse")
+    assert memo_report_package_operation["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]["$ref"].endswith("/ProposalMemoReportPackageEnvelopeResponse")
+    assert memo_ai_commentary_operation["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]["$ref"].endswith("/ProposalMemoAiCommentaryEnvelopeResponse")
 
     simulate_request_schema = spec["components"]["schemas"]["ProposalSimulateRequest"]
     create_request_schema = spec["components"]["schemas"]["ProposalCreateRequest"]
@@ -468,6 +640,10 @@ def test_proposals_openapi_write_contract() -> None:
         "ProposalNarrativeReviewRequest"
     ]
     report_request_schema = spec["components"]["schemas"]["ProposalReportRequest"]
+    memo_create_request_schema = spec["components"]["schemas"]["ProposalMemoCreateRequest"]
+    memo_review_request_schema = spec["components"]["schemas"]["ProposalMemoReviewRequest"]
+    memo_report_request_schema = spec["components"]["schemas"]["ProposalMemoReportPackageRequest"]
+    memo_ai_request_schema = spec["components"]["schemas"]["ProposalMemoAiCommentaryRequest"]
     simulate_response_schema = spec["components"]["schemas"]["ProposalSimulateResponse"]
     simulate_data_schema = spec["components"]["schemas"]["ProposalSimulationData"]
     list_envelope_schema = spec["components"]["schemas"]["ProposalListEnvelopeResponse"]
@@ -489,6 +665,25 @@ def test_proposals_openapi_write_contract() -> None:
     ]
     delivery_events_envelope_schema = spec["components"]["schemas"][
         "ProposalDeliveryEventsEnvelopeResponse"
+    ]
+    memo_envelope_schema = spec["components"]["schemas"]["ProposalMemoEnvelopeResponse"]
+    memo_projection_envelope_schema = spec["components"]["schemas"][
+        "ProposalMemoProjectionEnvelopeResponse"
+    ]
+    memo_review_envelope_schema = spec["components"]["schemas"][
+        "ProposalMemoReviewEnvelopeResponse"
+    ]
+    memo_report_envelope_schema = spec["components"]["schemas"][
+        "ProposalMemoReportPackageEnvelopeResponse"
+    ]
+    memo_ai_envelope_schema = spec["components"]["schemas"][
+        "ProposalMemoAiCommentaryEnvelopeResponse"
+    ]
+    memo_lineage_envelope_schema = spec["components"]["schemas"][
+        "ProposalMemoLineageEnvelopeResponse"
+    ]
+    memo_replay_envelope_schema = spec["components"]["schemas"][
+        "ProposalMemoReplayEvidenceEnvelopeResponse"
     ]
     create_envelope_schema = spec["components"]["schemas"]["ProposalCreateEnvelopeResponse"]
     transition_envelope_schema = spec["components"]["schemas"][
@@ -544,6 +739,20 @@ def test_proposals_openapi_write_contract() -> None:
     assert report_request_schema["properties"]["report_type"]["examples"] == ["PORTFOLIO_REVIEW"]
     assert report_request_schema["properties"]["requested_by"]["description"]
     assert report_request_schema["properties"]["include_reviewed_narrative"]["examples"] == [True]
+    assert memo_create_request_schema["properties"]["created_by"]["examples"] == ["advisor_1"]
+    assert memo_create_request_schema["properties"]["lifecycle_status"]["default"] == "DRAFT"
+    assert memo_review_request_schema["properties"]["source_memo_hash"]["examples"] == [
+        "sha256:memo-001"
+    ]
+    assert (
+        memo_review_request_schema["properties"]["client_ready_release_requested"]["default"]
+        is False
+    )
+    assert (
+        memo_report_request_schema["properties"]["client_ready_document_requested"]["default"]
+        is False
+    )
+    assert memo_ai_request_schema["properties"]["requested_sections"]["description"]
 
     assert simulate_response_schema["properties"]["correlation_id"]["description"]
     assert simulate_response_schema["properties"]["correlation_id"]["examples"] == [
@@ -581,6 +790,13 @@ def test_proposals_openapi_write_contract() -> None:
         report_request_envelope_schema,
         delivery_summary_envelope_schema,
         delivery_events_envelope_schema,
+        memo_envelope_schema,
+        memo_projection_envelope_schema,
+        memo_review_envelope_schema,
+        memo_report_envelope_schema,
+        memo_ai_envelope_schema,
+        memo_lineage_envelope_schema,
+        memo_replay_envelope_schema,
         create_envelope_schema,
         transition_envelope_schema,
     ):

--- a/tests/unit/test_proposal_service.py
+++ b/tests/unit/test_proposal_service.py
@@ -413,6 +413,201 @@ class _FakeAdviseClient:
             "explanation": {"filter": "DELIVERY_ONLY"},
         }
 
+    async def create_proposal_memo(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict,
+        idempotency_key: str,
+        correlation_id: str,
+    ):
+        self.calls.append(
+            (
+                "create_proposal_memo",
+                {
+                    "proposal_id": proposal_id,
+                    "version_no": version_no,
+                    "body": body,
+                    "idempotency_key": idempotency_key,
+                    "correlation_id": correlation_id,
+                },
+            )
+        )
+        return 200, {
+            "proposal": {"proposal_id": proposal_id, "current_version_no": version_no},
+            "memo_id": "memo_1",
+            "memo_status": "PENDING_REVIEW",
+            "lifecycle_status": body["lifecycle_status"],
+            "memo_hash": "sha256:memo-1",
+            "projection": {"client_ready_publication": "BLOCKED"},
+            "review_posture": {"advisor_use": "PENDING_REVIEW"},
+            "report_package_posture": {"status": "NOT_REQUESTED"},
+        }
+
+    async def get_proposal_memo(self, proposal_id: str, version_no: int, correlation_id: str):
+        self.calls.append(
+            (
+                "get_proposal_memo",
+                {
+                    "proposal_id": proposal_id,
+                    "version_no": version_no,
+                    "correlation_id": correlation_id,
+                },
+            )
+        )
+        return 200, {
+            "proposal": {"proposal_id": proposal_id, "current_version_no": version_no},
+            "memo_id": "memo_1",
+            "memo_status": "APPROVED_FOR_ADVISOR_USE",
+            "memo_hash": "sha256:memo-1",
+            "read_posture": {"supportability": "SUPPORTED_ADVISOR_USE"},
+        }
+
+    async def get_proposal_memo_projection(
+        self,
+        proposal_id: str,
+        version_no: int,
+        audience: str | None,
+        correlation_id: str,
+    ):
+        self.calls.append(
+            (
+                "get_proposal_memo_projection",
+                {
+                    "proposal_id": proposal_id,
+                    "version_no": version_no,
+                    "audience": audience,
+                    "correlation_id": correlation_id,
+                },
+            )
+        )
+        return 200, {
+            "proposal": {"proposal_id": proposal_id, "current_version_no": version_no},
+            "projection": {"audience": audience, "client_ready_publication": "BLOCKED"},
+            "sections": [{"section_id": "DISCLOSURES", "supportability": "SOURCE_BACKED"}],
+            "projection_posture": {"supportability": "SUPPORTED_ADVISOR_USE"},
+        }
+
+    async def review_proposal_memo(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict,
+        idempotency_key: str | None,
+        correlation_id: str,
+    ):
+        self.calls.append(
+            (
+                "review_proposal_memo",
+                {
+                    "proposal_id": proposal_id,
+                    "version_no": version_no,
+                    "body": body,
+                    "idempotency_key": idempotency_key,
+                    "correlation_id": correlation_id,
+                },
+            )
+        )
+        return 200, {
+            "memo": {"memo_hash": body["source_memo_hash"]},
+            "review_event": {"action": body["action"], "reviewed_by": body["reviewed_by"]},
+            "review_posture": {"advisor_use": "APPROVED_FOR_ADVISOR_USE"},
+        }
+
+    async def request_proposal_memo_report_package(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict,
+        idempotency_key: str | None,
+        correlation_id: str,
+    ):
+        self.calls.append(
+            (
+                "request_proposal_memo_report_package",
+                {
+                    "proposal_id": proposal_id,
+                    "version_no": version_no,
+                    "body": body,
+                    "idempotency_key": idempotency_key,
+                    "correlation_id": correlation_id,
+                },
+            )
+        )
+        return 200, {
+            "memo": {"memo_hash": body["source_memo_hash"]},
+            "report_package_event": {"client_ready_document_requested": False},
+            "report": {"render_status": "READY", "archive_refs": ["archive://memo/report/1"]},
+        }
+
+    async def request_proposal_memo_ai_commentary(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict,
+        idempotency_key: str | None,
+        correlation_id: str,
+    ):
+        self.calls.append(
+            (
+                "request_proposal_memo_ai_commentary",
+                {
+                    "proposal_id": proposal_id,
+                    "version_no": version_no,
+                    "body": body,
+                    "idempotency_key": idempotency_key,
+                    "correlation_id": correlation_id,
+                },
+            )
+        )
+        return 200, {
+            "memo": {"memo_hash": body["source_memo_hash"]},
+            "ai_event": {"requested_sections": body["requested_sections"]},
+            "commentary": {"status": "AVAILABLE", "authority": "NON_AUTHORITATIVE"},
+        }
+
+    async def get_proposal_memo_lineage(self, proposal_id: str, correlation_id: str):
+        self.calls.append(
+            (
+                "get_proposal_memo_lineage",
+                {"proposal_id": proposal_id, "correlation_id": correlation_id},
+            )
+        )
+        return 200, {
+            "proposal": {"proposal_id": proposal_id},
+            "memos": [
+                {
+                    "memo_id": "memo_1",
+                    "memo_hash": "sha256:memo-1",
+                    "report_package_posture": {"archive_refs": ["archive://memo/report/1"]},
+                    "ai_commentary_posture": {"status": "AVAILABLE"},
+                }
+            ],
+        }
+
+    async def get_proposal_memo_replay_evidence(
+        self,
+        proposal_id: str,
+        version_no: int,
+        correlation_id: str,
+    ):
+        self.calls.append(
+            (
+                "get_proposal_memo_replay_evidence",
+                {
+                    "proposal_id": proposal_id,
+                    "version_no": version_no,
+                    "correlation_id": correlation_id,
+                },
+            )
+        )
+        return 200, {
+            "proposal": {"proposal_id": proposal_id, "current_version_no": version_no},
+            "hashes": {"memo_hash": "sha256:memo-1", "artifact_hash": "sha256:artifact-1"},
+            "audit_events": [{"event_type": "MEMO_CREATED"}],
+            "supportability": {"client_ready_publication": "BLOCKED"},
+        }
+
 
 class _FakeAdviseErrorClient(_FakeAdviseClient):
     async def record_approval(
@@ -752,6 +947,102 @@ async def test_reviewed_narrative_and_delivery_posture_routes_wrap_source_payloa
         "get_delivery_events",
     ]
     assert client.calls[-4][1]["idempotency_key"] == "idem-narrative-review-1"
+
+
+@pytest.mark.asyncio
+async def test_proposal_memo_routes_wrap_source_owned_payloads() -> None:
+    client = _FakeAdviseClient()
+    service = ProposalService(advise_client=client)
+
+    created = await service.create_proposal_memo(
+        proposal_id="pp_1",
+        version_no=2,
+        body={
+            "created_by": "advisor_1",
+            "lifecycle_status": "DRAFT",
+            "reason": {"purpose": "advisor-use memo pack"},
+        },
+        idempotency_key="idem-memo-create-1",
+        correlation_id="corr_memo_create",
+    )
+    memo = await service.get_proposal_memo(
+        proposal_id="pp_1",
+        version_no=2,
+        correlation_id="corr_memo_read",
+    )
+    projection = await service.get_proposal_memo_projection(
+        proposal_id="pp_1",
+        version_no=2,
+        audience="COMPLIANCE",
+        correlation_id="corr_memo_projection",
+    )
+    review = await service.review_proposal_memo(
+        proposal_id="pp_1",
+        version_no=2,
+        body={
+            "action": "APPROVE_FOR_ADVISOR_USE",
+            "reviewed_by": "compliance_1",
+            "reason": "Advisor-use memo is evidence backed.",
+            "source_memo_hash": "sha256:memo-1",
+        },
+        idempotency_key="idem-memo-review-1",
+        correlation_id="corr_memo_review",
+    )
+    report_package = await service.request_proposal_memo_report_package(
+        proposal_id="pp_1",
+        version_no=2,
+        body={
+            "requested_by": "advisor_1",
+            "source_memo_hash": "sha256:memo-1",
+            "requested_output_formats": ["pdf"],
+            "client_ready_document_requested": False,
+            "reason": {"purpose": "advisor-use memo report"},
+        },
+        idempotency_key="idem-memo-report-1",
+        correlation_id="corr_memo_report",
+    )
+    ai_commentary = await service.request_proposal_memo_ai_commentary(
+        proposal_id="pp_1",
+        version_no=2,
+        body={
+            "requested_by": "advisor_1",
+            "source_memo_hash": "sha256:memo-1",
+            "requested_sections": ["EXECUTIVE_SUMMARY"],
+            "reason": {"purpose": "advisor-use commentary"},
+        },
+        idempotency_key="idem-memo-ai-1",
+        correlation_id="corr_memo_ai",
+    )
+    lineage = await service.get_proposal_memo_lineage(
+        proposal_id="pp_1",
+        correlation_id="corr_memo_lineage",
+    )
+    replay = await service.get_proposal_memo_replay_evidence(
+        proposal_id="pp_1",
+        version_no=2,
+        correlation_id="corr_memo_replay",
+    )
+
+    assert created.data["memo_hash"] == "sha256:memo-1"
+    assert memo.data["read_posture"]["supportability"] == "SUPPORTED_ADVISOR_USE"
+    assert projection.data["projection"]["audience"] == "COMPLIANCE"
+    assert review.data["review_event"]["action"] == "APPROVE_FOR_ADVISOR_USE"
+    assert report_package.data["report"]["archive_refs"] == ["archive://memo/report/1"]
+    assert ai_commentary.data["commentary"]["authority"] == "NON_AUTHORITATIVE"
+    assert lineage.data["memos"][0]["ai_commentary_posture"]["status"] == "AVAILABLE"
+    assert replay.data["hashes"]["artifact_hash"] == "sha256:artifact-1"
+    assert [name for name, _ in client.calls[-8:]] == [
+        "create_proposal_memo",
+        "get_proposal_memo",
+        "get_proposal_memo_projection",
+        "review_proposal_memo",
+        "request_proposal_memo_report_package",
+        "request_proposal_memo_ai_commentary",
+        "get_proposal_memo_lineage",
+        "get_proposal_memo_replay_evidence",
+    ]
+    assert client.calls[-5][1]["idempotency_key"] == "idem-memo-review-1"
+    assert client.calls[-4][1]["body"]["client_ready_document_requested"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds Gateway proposal memo create/read/projection/review/report-package/AI-commentary, lineage, and replay-evidence routes.
- Preserves Advise-owned memo payloads without Gateway recomputation of memo facts, supportability, readiness, archive refs, or client-ready posture.
- Adds service and OpenAPI contract coverage for the new BFF surface.

## Local validation
- make check
- python -m pytest tests/unit/test_proposal_service.py tests/contract/test_proposals_contract.py -q
- python -m ruff check src/app/clients/advise_client.py src/app/contracts/proposals.py src/app/routers/proposals.py src/app/services/proposal_service.py tests/unit/test_proposal_service.py tests/contract/test_proposals_contract.py