### PR TITLE
Fix Gateway benchmark assignment cache during canonical seed

### DIFF
--- a/src/app/services/async_ttl_cache.py
+++ b/src/app/services/async_ttl_cache.py
@@ -56,3 +56,10 @@ class AsyncTtlCache(Generic[T]):
     def clear(self) -> None:
         self._entries.clear()
         self._inflight.clear()
+
+    def discard(self, key: tuple[object, ...]) -> None:
+        self._entries.pop(key, None)
+        self._inflight.pop(key, None)
+
+    def set(self, key: tuple[object, ...], value: T) -> None:
+        self._entries[key] = (monotonic() + self._ttl_seconds, value)

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -1679,23 +1679,37 @@ class PerformanceWorkspaceService:
     ) -> str | None:
         if benchmark_code:
             return benchmark_code
-        return cast(
-            str | None,
-            await self._get_cached_upstream_result(
-                (
-                    "benchmark_assignment",
-                    portfolio_id,
-                    as_of_date,
-                    portfolio_currency,
-                ),
-                lambda: self._fetch_assigned_benchmark_code(
-                    portfolio_id=portfolio_id,
-                    as_of_date=as_of_date,
-                    portfolio_currency=portfolio_currency,
-                    correlation_id=correlation_id,
-                ),
+        cache_key = (
+            "benchmark_assignment",
+            portfolio_id,
+            as_of_date,
+            portfolio_currency,
+        )
+        resolved_benchmark_code, cache_hit = await self._upstream_cache.get_or_set_with_status(
+            key=cache_key,
+            factory=lambda: self._fetch_assigned_benchmark_code(
+                portfolio_id=portfolio_id,
+                as_of_date=as_of_date,
+                portfolio_currency=portfolio_currency,
+                correlation_id=correlation_id,
             ),
         )
+        if resolved_benchmark_code:
+            return cast(str, resolved_benchmark_code)
+
+        self._upstream_cache.discard(cache_key)
+        if not cache_hit:
+            return None
+
+        refreshed_benchmark_code = await self._fetch_assigned_benchmark_code(
+            portfolio_id=portfolio_id,
+            as_of_date=as_of_date,
+            portfolio_currency=portfolio_currency,
+            correlation_id=correlation_id,
+        )
+        if refreshed_benchmark_code:
+            self._upstream_cache.set(cache_key, refreshed_benchmark_code)
+        return refreshed_benchmark_code
 
     async def _fetch_assigned_benchmark_code(
         self,

--- a/tests/unit/test_performance_workspace_service.py
+++ b/tests/unit/test_performance_workspace_service.py
@@ -1529,6 +1529,55 @@ async def test_performance_workspace_service_resolves_linked_benchmark_when_code
 
 
 @pytest.mark.asyncio
+async def test_performance_workspace_service_does_not_negative_cache_missing_benchmark_assignment():
+    class _LaggedBenchmarkAssignmentClient(_StubLotusCoreQueryClient):
+        async def get_benchmark_assignment(self, **kwargs):
+            self.benchmark_assignment_calls.append(kwargs)
+            if len(self.benchmark_assignment_calls) == 1:
+                return 200, {"benchmark_id": None, "assignment_status": "not_found"}
+            return 200, {
+                "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+                "assignment_status": "active",
+            }
+
+    analytics_client = _StubAnalyticsClient()
+    query_client = _LaggedBenchmarkAssignmentClient()
+    service = PerformanceWorkspaceService(
+        workbench_service=_StubWorkbenchService(),
+        analytics_client=analytics_client,
+        lotus_core_query_client=query_client,
+    )
+
+    await service.get_performance_workspace_summary(
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-performance-first",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code=None,
+    )
+    second_response = await service.get_performance_workspace_summary(
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-performance-second",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code=None,
+    )
+
+    assert analytics_client.workspace_summary_calls[0]["benchmark_id"] is None
+    assert second_response.benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert analytics_client.workspace_summary_calls[1]["benchmark_id"] == (
+        "BMK_PB_GLOBAL_BALANCED_60_40"
+    )
+    assert len(query_client.benchmark_assignment_calls) == 2
+
+
+@pytest.mark.asyncio
 async def test_performance_workspace_service_builds_horizon_comparison_contract():
     analytics_client = _StubAnalyticsClient()
     query_client = _StubLotusCoreQueryClient()


### PR DESCRIPTION
## Summary
- Avoid negative-caching missing Core benchmark assignments in the Gateway performance workspace path.
- Add cache discard/set support so seed-time source lag cannot strand no-benchmark summaries after Core publishes the assignment.
- Add a focused regression for the canonical seed-lag scenario.

## Evidence
Local Gateway gates:
- `make lint` passed.
- `make typecheck` passed.
- `python -m pytest tests\unit\test_performance_workspace_service.py -q` passed: 41 passed.
- `make check` passed: lint, typecheck, OpenAPI workbench contract, unit+contract pack: 593 passed.

Canonical front-office evidence:
- Rebuilt/restarted only `lotus-gateway` with `powershell -ExecutionPolicy Bypass -File automation\Service-Refresh.ps1 -ProjectPath C:\Users\Sandeep\projects\lotus-gateway -ChangedOnly -BaseRef origin/main`.
- Verified no-explicit-benchmark live Gateway summary now resolves `BMK_PB_GLOBAL_BALANCED_60_40`, returns report_end_date `2026-04-10`, and has no warnings/partial_failures.
- `npm run live:stack:up` passed after the Gateway refresh; seed verified `PB_SG_GLOBAL_BAL_001` with 11 valued positions, 31 transactions, 2 cash accounts, fresh analytics/performance/return-path dates, and canonical benchmark resolution.
- `npm run live:validate` passed and wrote screenshots to `C:\Users\Sandeep\projects\lotus-workbench-rfc36-43-evidence\output\playwright\live-canonical`.
- Platform QA wrapper passed: `powershell -ExecutionPolicy Bypass -File automation\Invoke-Canonical-FrontOffice-QA.ps1 -ScreenshotDirectory C:\Users\Sandeep\projects\lotus-platform\output\front-office-qa\rfc36-43-gold-pass-20260524`.
- Platform evidence: `C:\Users\Sandeep\projects\lotus-platform\output\front-office-qa\canonical-front-office-qa-20260524-185940.md` and screenshot pack `C:\Users\Sandeep\projects\lotus-platform\output\front-office-qa\rfc36-43-gold-pass-20260524`.

## Boundary
- This fixes Gateway source-consumer cache behavior only.
- No new product capability, OMS execution, client communication, PM ranking, or global universe ownership is claimed.
- No public API shape changed.
