### PR TITLE
feat: guard core campaign candidate source

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -262,6 +262,9 @@ Most relevant current governance:
     operating queue, approval inbox, workflow board, assignment plan, workflow automation,
     approval-decision, assignment-action, assignment-task, task-transition, and maker-checker
     evidence requests to `lotus-manage`;
+    preserves the bounded `campaign_candidate_source=CORE_DPM_PORTFOLIO_UNIVERSE` request shape
+    for Manage/Core `DpmPortfolioUniverseCandidate:v1` consumption while rejecting non-empty
+    caller-supplied candidate portfolio fields at the BFF boundary;
     preserves manage-owned `wave_id`, lifecycle state, item states, reason codes, aggregate
     metrics, selected alternative refs, proof-pack refs, handoff refs, campaign definition payloads,
     campaign workflow/audit payloads, count/page metadata, supportability issues, source refs,

--- a/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
+++ b/docs/rfcs/RFC-0098-dpm-command-center-composition-contract.md
@@ -426,19 +426,22 @@ Gateway responsibility:
 3. preserve manage `wave_id`, `wave_version`, optimistic `version`, `state`, item states,
    reason codes, aggregate metrics, selected alternative refs, proof-pack refs, handoff refs,
    retention policy, event refs, and supportability refs,
-4. compose module posture using the common command-center states `ready`, `degraded`, `blocked`,
+4. preserve `campaign_candidate_source=CORE_DPM_PORTFOLIO_UNIVERSE` and related lotus-core
+   `DpmPortfolioUniverseCandidate:v1` filters for lotus-manage while rejecting non-empty
+   caller-supplied candidate portfolio fields in that source-discovery mode,
+5. compose module posture using the common command-center states `ready`, `degraded`, `blocked`,
    `not_supported`, `unavailable`, and `error`,
-5. compose risk, performance, report, archive, and AI posture only from owning services and only
+6. compose risk, performance, report, archive, and AI posture only from owning services and only
    as adjacent modules; Gateway must not infer missing domain readiness from manage wave state,
-6. expose action eligibility as a Gateway view over manage-supported actions, entitlement posture,
+7. expose action eligibility as a Gateway view over manage-supported actions, entitlement posture,
    upstream availability, and supportability state, with disabled reasons when actions are blocked.
 
 Gateway must not:
 
 1. calculate affected portfolios, source readiness, aggregate metrics, item readiness,
    construction alternatives, proof-pack state, or handoff state,
-2. create implicit PM-book or CIO model-change cohort discovery until `lotus-core` or another
-   owning app exposes a certified cohort product,
+2. create implicit PM-book, CIO model-change, or campaign candidate discovery beyond forwarding
+   source-discovery requests to `lotus-manage`,
 3. mark handoff as external execution; manage handoff refs explicitly use
    `external_execution_claimed=false`,
 4. expose a Workbench route that bypasses manage supportability diagnostics for operator

--- a/src/app/contracts/dpm_waves.py
+++ b/src/app/contracts/dpm_waves.py
@@ -1,4 +1,17 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+_CORE_DPM_PORTFOLIO_UNIVERSE = "CORE_DPM_PORTFOLIO_UNIVERSE"
+_CORE_DISCOVERY_CALLER_SUPPLIED_FIELDS = ("portfolios", "portfolio_ids", "source_candidates")
+
+
+def _has_supplied_value(value: object) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) > 0
+    return True
 
 
 class DpmWaveForwardRequest(BaseModel):
@@ -7,7 +20,11 @@ class DpmWaveForwardRequest(BaseModel):
             "Request payload forwarded unchanged to the lotus-manage RFC-0041 rebalance-wave "
             "authority. Gateway does not discover PM books, infer affected portfolios, classify "
             "source readiness, simulate construction alternatives, approve items, stage items, "
-            "create handoff evidence, or cancel wave state locally."
+            "create handoff evidence, or cancel wave state locally. For BULK_REVIEW_CAMPAIGN, "
+            "`campaign_candidate_source=CORE_DPM_PORTFOLIO_UNIVERSE` asks lotus-manage to resolve "
+            "bounded source-owned candidates from lotus-core `DpmPortfolioUniverseCandidate:v1`; "
+            "Gateway preserves the request shape and rejects caller-supplied candidate portfolios "
+            "in that mode so Workbench cannot mix source discovery with explicit-list input."
         ),
         examples=[
             {
@@ -17,9 +34,38 @@ class DpmWaveForwardRequest(BaseModel):
                 "as_of_date": "2026-05-03",
                 "actor_id": "pm_sg_1",
                 "portfolios": [{"portfolio_id": "PB_SG_GLOBAL_BAL_001"}],
-            }
+            },
+            {
+                "trigger_type": "BULK_REVIEW_CAMPAIGN",
+                "trigger_id": "campaign-core-universe-20260524",
+                "rationale": "Review bounded Core-owned DPM mandate candidates.",
+                "as_of_date": "2026-05-24",
+                "actor_id": "pm_sg_1",
+                "campaign_candidate_source": "CORE_DPM_PORTFOLIO_UNIVERSE",
+                "model_portfolio_ids": ["MODEL_PB_SG_GLOBAL_BAL_DPM"],
+                "include_inactive_mandates": False,
+                "campaign_candidate_page_size": 500,
+            },
         ],
     )
+
+    @model_validator(mode="after")
+    def reject_caller_portfolios_for_core_candidate_source(self) -> "DpmWaveForwardRequest":
+        if self.body.get("campaign_candidate_source") != _CORE_DPM_PORTFOLIO_UNIVERSE:
+            return self
+        supplied_fields = [
+            field
+            for field in _CORE_DISCOVERY_CALLER_SUPPLIED_FIELDS
+            if _has_supplied_value(self.body.get(field))
+        ]
+        if supplied_fields:
+            supplied = ", ".join(supplied_fields)
+            raise ValueError(
+                "CORE_DPM_PORTFOLIO_UNIVERSE candidate discovery supplies the portfolio set from "
+                "lotus-core DpmPortfolioUniverseCandidate:v1; omit caller-supplied candidate "
+                f"fields: {supplied}."
+            )
+        return self
 
 
 class DpmWaveCreateRequest(DpmWaveForwardRequest):

--- a/tests/contract/test_dpm_wave_contract.py
+++ b/tests/contract/test_dpm_wave_contract.py
@@ -246,3 +246,7 @@ def test_dpm_wave_openapi_models_are_described() -> None:
 
     assert schemas["DpmWaveSupportability"]["properties"]["state"]["examples"]
     assert schemas["DpmWaveGatewayResponse"]["properties"]["data"]["description"]
+    wave_forward_body = schemas["DpmWaveForwardRequest"]["properties"]["body"]
+    assert "DpmPortfolioUniverseCandidate:v1" in wave_forward_body["description"]
+    assert "CORE_DPM_PORTFOLIO_UNIVERSE" in str(wave_forward_body["examples"])
+    assert "caller-supplied candidate portfolios" in wave_forward_body["description"]

--- a/tests/integration/test_dpm_wave_router.py
+++ b/tests/integration/test_dpm_wave_router.py
@@ -39,6 +39,92 @@ def test_dpm_wave_preview_preserves_manage_supportability(monkeypatch) -> None:
     assert payload["data"]["supportability"]["supportability_state"] == "ready"
 
 
+def test_dpm_wave_preview_forwards_core_candidate_source_without_portfolios(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_preview_wave(self, body, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["body"] = body
+        captured["correlation_id"] = correlation_id
+        return 200, {
+            "wave": {
+                "wave_id": "dwv_core_candidates_preview",
+                "state": "PREVIEWED",
+                "trigger_type": "BULK_REVIEW_CAMPAIGN",
+            },
+            "durable": False,
+            "supportability": {
+                "supportability_state": "ready",
+                "reason": "core_portfolio_universe_candidates_ready",
+            },
+            "source_refs": [
+                {
+                    "source_system": "lotus-core",
+                    "source_type": "DpmPortfolioUniverseCandidate",
+                    "source_id": "core-dpm-universe:2026-05-24",
+                    "source_version": "v1",
+                    "content_hash": "sha256:core-candidates",
+                }
+            ],
+        }
+
+    monkeypatch.setattr("app.clients.dpm_client.DpmClient.preview_wave", _fake_preview_wave)
+
+    client = TestClient(app)
+    body = {
+        "trigger_type": "BULK_REVIEW_CAMPAIGN",
+        "trigger_id": "campaign-core-universe-20260524",
+        "rationale": "Review bounded Core-owned DPM mandate candidates.",
+        "as_of_date": "2026-05-24",
+        "actor_id": "pm_sg_1",
+        "campaign_candidate_source": "CORE_DPM_PORTFOLIO_UNIVERSE",
+        "model_portfolio_ids": ["MODEL_PB_SG_GLOBAL_BAL_DPM"],
+        "include_inactive_mandates": False,
+        "campaign_candidate_page_size": 500,
+    }
+    response = client.post(
+        "/api/v1/dpm/command-center/waves/preview",
+        json={"body": body},
+        headers={"X-Correlation-Id": "corr-wave-router-core-candidates"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "body": body,
+        "correlation_id": "corr-wave-router-core-candidates",
+    }
+    payload = response.json()
+    assert payload["supportability"]["state"] == "ready"
+    assert payload["data"]["source_refs"][0]["source_type"] == "DpmPortfolioUniverseCandidate"
+
+
+def test_dpm_wave_preview_rejects_core_candidate_source_with_caller_portfolios() -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/dpm/command-center/waves/preview",
+        json={
+            "body": {
+                "trigger_type": "BULK_REVIEW_CAMPAIGN",
+                "trigger_id": "campaign-core-universe-20260524",
+                "rationale": "Review bounded Core-owned DPM mandate candidates.",
+                "as_of_date": "2026-05-24",
+                "actor_id": "pm_sg_1",
+                "campaign_candidate_source": "CORE_DPM_PORTFOLIO_UNIVERSE",
+                "model_portfolio_ids": ["MODEL_PB_SG_GLOBAL_BAL_DPM"],
+                "portfolios": [{"portfolio_id": "PB_SG_GLOBAL_BAL_001"}],
+            }
+        },
+        headers={"X-Correlation-Id": "corr-wave-router-core-candidates-rejected"},
+    )
+
+    assert response.status_code == 422
+    error_text = str(response.json())
+    expected_error = "CORE_DPM_PORTFOLIO_UNIVERSE candidate discovery supplies the portfolio set"
+    assert expected_error in error_text
+    assert "portfolios" in error_text
+    assert "DpmPortfolioUniverseCandidate:v1" in error_text
+
+
 def test_dpm_wave_create_forwards_body_and_idempotency_key(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -52,5 +52,9 @@ def test_rfc0098_ownership_matches_manage_rfc0040_rfc0041_and_rfc0042() -> None:
     assert "portfolio memory remains `lotus-manage` truth" in integrations
     assert "must not calculate affected portfolios" in api_surface
     assert "calculate campaign membership" in api_surface
+    assert "DpmPortfolioUniverseCandidate:v1" in rfc
+    assert "DpmPortfolioUniverseCandidate:v1" in api_surface
+    assert "campaign_candidate_source=CORE_DPM_PORTFOLIO_UNIVERSE" in api_surface
+    assert "non-empty caller-supplied" in api_surface
     assert "`/api/v1/dpm/command-center/waves*`" in api_surface
     assert "Gateway does not generate proof packs. That belongs to `lotus-report`." not in rfc

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -183,6 +183,12 @@
   `BulkReviewCampaignDefinitionPreviewReadiness:v1`, paged append-only
   `BulkReviewCampaignDefinitionLaunchHistory:v1` audit history, ready-only launch posture, and
   bounded campaign workflow/audit evidence.
+  For bounded Core-owned campaign candidate discovery, Gateway preserves
+  `campaign_candidate_source=CORE_DPM_PORTFOLIO_UNIVERSE`,
+  `model_portfolio_ids`, `include_inactive_mandates`, and `campaign_candidate_page_size` for
+  lotus-manage, which consumes lotus-core `DpmPortfolioUniverseCandidate:v1`; Gateway rejects
+  non-empty caller-supplied `portfolios`, `portfolio_ids`, or `source_candidates` in that mode and
+  does not discover or rank a global portfolio universe.
   Gateway preserves preview-readiness supportability state, reason codes, blocked actions, source
   refs, requested as-of date, actor id, and operating boundaries exactly. Gateway also preserves
   launch-history campaign id/version, launch records, count, total count, limit, offset, and


### PR DESCRIPTION
## Summary
- document and expose the bounded Core-backed campaign candidate source mode in the Gateway DPM wave BFF contract
- reject mixed caller-supplied candidate portfolio fields when campaign_candidate_source=CORE_DPM_PORTFOLIO_UNIVERSE
- update RFC-0098, repo context, and wiki API surface truth for the Gateway boundary

## Validation
- python -m pytest tests\\integration\\test_dpm_wave_router.py tests\\contract\\test_dpm_wave_contract.py tests\\unit\\test_rfc0098_documentation.py -q
- make lint
- make typecheck
- make check

## Wiki
- wiki/API-Surface.md changed; pre-merge check shows expected drift for API-Surface.md and will be published after merge.