### PR TITLE
Enable advisory shell workspace capability

### DIFF
--- a/src/app/services/platform_capabilities_service.py
+++ b/src/app/services/platform_capabilities_service.py
@@ -350,8 +350,8 @@ class PlatformCapabilitiesService:
             ),
             "performance_workspace": feature_enabled["lotus_performance_analytics"],
             "risk_workspace": feature_enabled["lotus_risk_analytics"],
-            "proposal_workspace": False,
-            "advisory_workspace": False,
+            "proposal_workspace": feature_enabled["lotus_advise_lifecycle"],
+            "advisory_workspace": feature_enabled["lotus_advise_lifecycle"],
         }
         workflow_flags = {
             "proposal_lifecycle": self._any_workflow_enabled(

--- a/tests/integration/test_platform_capabilities_router.py
+++ b/tests/integration/test_platform_capabilities_router.py
@@ -107,8 +107,8 @@ def test_platform_capabilities_router_success(monkeypatch):
     assert body["normalized"]["navigation"]["portfolio_workspace"] is True
     assert body["normalized"]["navigation"]["performance_workspace"] is True
     assert body["normalized"]["navigation"]["risk_workspace"] is True
-    assert body["normalized"]["navigation"]["proposal_workspace"] is False
-    assert body["normalized"]["navigation"]["advisory_workspace"] is False
+    assert body["normalized"]["navigation"]["proposal_workspace"] is True
+    assert body["normalized"]["navigation"]["advisory_workspace"] is True
     assert body["normalized"]["workflowFlags"]["proposal_lifecycle"] is True
     assert body["normalized"]["workflowFlags"]["portfolio_reporting"] is True
     assert body["normalized"]["policyVersionsBySource"] == {
@@ -163,8 +163,8 @@ def test_platform_capabilities_router_success(monkeypatch):
     proposal_workspace = next(
         workspace for workspace in shell_bootstrap["workspaces"] if workspace["id"] == "proposal"
     )
-    assert proposal_workspace["enabled"] is False
-    assert proposal_workspace["supportability"]["state"] == "unavailable"
+    assert proposal_workspace["enabled"] is True
+    assert proposal_workspace["supportability"]["state"] == "ready"
     assert proposal_workspace["caching"]["correctnessCritical"] is True
 
 

--- a/tests/unit/test_platform_capabilities_service.py
+++ b/tests/unit/test_platform_capabilities_service.py
@@ -249,8 +249,8 @@ async def test_platform_capabilities_all_sources_success():
     assert response.data.normalized.navigation["portfolio_workspace"] is True
     assert response.data.normalized.navigation["performance_workspace"] is True
     assert response.data.normalized.navigation["risk_workspace"] is True
-    assert response.data.normalized.navigation["proposal_workspace"] is False
-    assert response.data.normalized.navigation["advisory_workspace"] is False
+    assert response.data.normalized.navigation["proposal_workspace"] is True
+    assert response.data.normalized.navigation["advisory_workspace"] is True
     assert response.data.normalized.workflow_flags["proposal_lifecycle"] is True
     assert response.data.normalized.workflow_flags["portfolio_reporting"] is True
     assert "inline_bundle" in response.data.normalized.input_modes_union
@@ -307,7 +307,7 @@ async def test_platform_capabilities_all_sources_success():
     proposal_workspace = next(
         workspace for workspace in shell_bootstrap.workspaces if workspace.id == "proposal"
     )
-    assert proposal_workspace.enabled is False
+    assert proposal_workspace.enabled is True
     assert proposal_workspace.supportability.state == "ready"
     assert proposal_workspace.supportability.reasons == ["advisory_ready"]
     assert proposal_workspace.caching.correctness_critical is True
@@ -623,8 +623,10 @@ async def test_platform_capabilities_preserves_advise_supportability_without_loc
     )
     assert proposal_workspace.supportability.state == "degraded"
     assert proposal_workspace.supportability.reasons == ["dependency_degraded"]
+    assert proposal_workspace.enabled is True
     assert advisory_workspace.supportability.state == "degraded"
     assert advisory_workspace.supportability.reasons == ["dependency_degraded"]
+    assert advisory_workspace.enabled is True
 
 
 def test_platform_capabilities_module_health_marks_unknown_sources():


### PR DESCRIPTION
## Summary
- enables proposal and advisory workspace navigation when lotus-advise lifecycle capability is ready
- preserves degraded advisory supportability while still exposing the workspace as enabled when the dependency is configured but degraded
- updates platform-capabilities service/router tests for the promoted shell posture

## Validation
- python -m pytest tests/unit/test_platform_capabilities_service.py tests/integration/test_platform_capabilities_router.py -q
- make lint
- make typecheck

## Boundaries
- no advisory narrative generation or client communication claims
- no direct Workbench-to-Advise contract changes
- no OMS, order routing, fills, settlement, PM ranking, HR/conduct, prompt storage, or generated-summary retention claims