### PR TITLE
Expose advisory workspace gateway surface

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -31,13 +31,17 @@ Current repository posture:
 
 1. `lotus-gateway` is the primary backend contract for `lotus-workbench`,
 2. the repository is moving from thin pass-through behavior to a cleaner experience-API posture,
-3. performance, proposal, foundation, reporting, and capability aggregation routes are active,
-   with proposal simulation/lifecycle/workflow/approval/lineage, reviewed narrative posture,
-   report-request, and delivery-posture routes routed to `lotus-advise`
-   `/advisory/proposals/*`; Gateway preserves source-hash, review, report-package, and delivery
-   event posture without generating narrative, inferring client-ready publication, rendering
-   reports, archiving documents, or recomputing advisory delivery truth; `lotus-manage`
-   consumption is through versioned `/api/v1` APIs for
+3. performance, proposal, advisory-workspace, foundation, reporting, and capability aggregation
+   routes are active, with proposal simulation/lifecycle/workflow/approval/lineage, async
+   operation support, idempotency lookup, replay evidence, reviewed narrative posture, execution
+   handoff/status/update posture, memo report-package events, report-request, and delivery-posture
+   routes routed to `lotus-advise` `/advisory/proposals/*`; advisory workspace create/draft/save,
+   saved-version replay, resume, compare, rationale request/review, and handoff routes are routed
+   to `lotus-advise` `/advisory/workspaces/*`. Gateway preserves source-hash, review,
+   report-package, workspace replay, execution handoff, and delivery event posture without
+   generating narrative, inferring client-ready publication, rendering reports, archiving
+   documents, sourcing portfolio positions locally, or recomputing advisory delivery truth;
+   `lotus-manage` consumption is through versioned `/api/v1` APIs for
    run lookup, supportability summary, capability posture, RFC-0038 mandate command-center
    summary/monitoring/exception/mandate drill-down route families, RFC-0040 proof-pack
    generate/read/Markdown/report-input/AI-evidence/AI PM memo route families,

--- a/src/app/clients/advise_client.py
+++ b/src/app/clients/advise_client.py
@@ -68,6 +68,85 @@ class AdviseClient:
             operation="advise.advisory.proposals.simulate",
         )
 
+    async def create_advisory_workspace(
+        self,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/advisory/workspaces",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.workspaces.create",
+        )
+
+    async def get_advisory_workspace(
+        self,
+        workspace_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/workspaces/{workspace_id}",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.workspaces.get",
+        )
+
+    async def apply_advisory_workspace_draft_action(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/workspaces/{workspace_id}/draft-actions",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.workspaces.draft-action",
+        )
+
+    async def evaluate_advisory_workspace(
+        self,
+        workspace_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/workspaces/{workspace_id}/evaluate",
+            body={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.workspaces.evaluate",
+        )
+
+    async def save_advisory_workspace(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/workspaces/{workspace_id}/save",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.workspaces.save",
+        )
+
+    async def handoff_advisory_workspace(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        headers = self._headers(correlation_id)
+        if idempotency_key is not None:
+            headers["Idempotency-Key"] = idempotency_key
+        return await self._post(
+            f"/advisory/workspaces/{workspace_id}/handoff",
+            body=body,
+            headers=headers,
+            operation="advise.advisory.workspaces.handoff",
+        )
+
     async def create_proposal(
         self,
         body: dict[str, Any],

--- a/src/app/clients/advise_client.py
+++ b/src/app/clients/advise_client.py
@@ -68,6 +68,19 @@ class AdviseClient:
             operation="advise.advisory.proposals.simulate",
         )
 
+    async def create_proposal_artifact(
+        self,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/advisory/proposals/artifact",
+            body=body,
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="advise.advisory.proposals.artifact",
+        )
+
     async def create_advisory_workspace(
         self,
         body: dict[str, Any],
@@ -128,6 +141,84 @@ class AdviseClient:
             body=body,
             headers=self._headers(correlation_id),
             operation="advise.advisory.workspaces.save",
+        )
+
+    async def list_advisory_workspace_saved_versions(
+        self,
+        workspace_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/workspaces/{workspace_id}/saved-versions",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.workspaces.saved-versions.list",
+        )
+
+    async def get_advisory_workspace_saved_version_replay_evidence(
+        self,
+        workspace_id: str,
+        workspace_version_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/workspaces/{workspace_id}/saved-versions/"
+            f"{workspace_version_id}/replay-evidence",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.workspaces.saved-versions.replay-evidence",
+        )
+
+    async def resume_advisory_workspace(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/workspaces/{workspace_id}/resume",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.workspaces.resume",
+        )
+
+    async def compare_advisory_workspace(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/workspaces/{workspace_id}/compare",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.workspaces.compare",
+        )
+
+    async def request_advisory_workspace_rationale(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/workspaces/{workspace_id}/assistant/rationale",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.workspaces.assistant.rationale",
+        )
+
+    async def review_advisory_workspace_rationale(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/workspaces/{workspace_id}/assistant/rationale/review-actions",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.workspaces.assistant.rationale.review-actions",
         )
 
     async def handoff_advisory_workspace(
@@ -214,6 +305,69 @@ class AdviseClient:
             operation="advise.advisory.proposals.versions.create",
         )
 
+    async def create_proposal_async(
+        self,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            "/advisory/proposals/async",
+            body=body,
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="advise.advisory.proposals.async.create",
+        )
+
+    async def create_proposal_version_async(
+        self,
+        proposal_id: str,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/proposals/{proposal_id}/versions/async",
+            body=body,
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            operation="advise.advisory.proposals.versions.async.create",
+        )
+
+    async def get_proposal_operation(
+        self,
+        operation_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/operations/{operation_id}",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.operations.get",
+        )
+
+    async def get_proposal_operation_by_correlation(
+        self,
+        operation_correlation_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/operations/by-correlation/{operation_correlation_id}",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.operations.by-correlation",
+        )
+
+    async def get_proposal_operation_replay_evidence(
+        self,
+        operation_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/operations/{operation_id}/replay-evidence",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.operations.replay-evidence",
+        )
+
     async def transition_proposal(
         self,
         proposal_id: str,
@@ -278,6 +432,58 @@ class AdviseClient:
             operation="advise.advisory.proposals.lineage",
         )
 
+    async def get_proposal_version_replay_evidence(
+        self,
+        proposal_id: str,
+        version_no: int,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/{proposal_id}/versions/{version_no}/replay-evidence",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.versions.replay-evidence",
+        )
+
+    async def get_proposal_idempotency_record(
+        self,
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/idempotency/{idempotency_key}",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.idempotency.get",
+        )
+
+    async def regenerate_proposal_narrative(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._post(
+            f"/advisory/proposals/{proposal_id}/versions/{version_no}/narrative/regenerate",
+            body=body,
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.narrative.regenerate",
+        )
+
+    async def get_proposal_narrative(
+        self,
+        proposal_id: str,
+        version_no: int,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/{proposal_id}/versions/{version_no}/narrative",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.narrative.get",
+        )
+
     async def review_proposal_narrative(
         self,
         proposal_id: str,
@@ -309,6 +515,23 @@ class AdviseClient:
             operation="advise.advisory.proposals.report-requests.create",
         )
 
+    async def create_execution_handoff(
+        self,
+        proposal_id: str,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        headers = self._headers(correlation_id)
+        if idempotency_key is not None:
+            headers["Idempotency-Key"] = idempotency_key
+        return await self._post(
+            f"/advisory/proposals/{proposal_id}/execution-handoffs",
+            body=body,
+            headers=headers,
+            operation="advise.advisory.proposals.execution-handoffs.create",
+        )
+
     async def get_delivery_summary(
         self,
         proposal_id: str,
@@ -331,6 +554,35 @@ class AdviseClient:
             params={},
             headers=self._headers(correlation_id),
             operation="advise.advisory.proposals.delivery-events",
+        )
+
+    async def get_execution_status(
+        self,
+        proposal_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._get(
+            f"/advisory/proposals/{proposal_id}/execution-status",
+            params={},
+            headers=self._headers(correlation_id),
+            operation="advise.advisory.proposals.execution-status",
+        )
+
+    async def record_execution_update(
+        self,
+        proposal_id: str,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        headers = self._headers(correlation_id)
+        if idempotency_key is not None:
+            headers["Idempotency-Key"] = idempotency_key
+        return await self._post(
+            f"/advisory/proposals/{proposal_id}/execution-updates",
+            body=body,
+            headers=headers,
+            operation="advise.advisory.proposals.execution-updates.record",
         )
 
     async def create_proposal_memo(
@@ -394,6 +646,24 @@ class AdviseClient:
             body=body,
             headers=headers,
             operation="advise.advisory.proposals.memo.review",
+        )
+
+    async def record_proposal_memo_report_package_event(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        headers = self._headers(correlation_id)
+        if idempotency_key is not None:
+            headers["Idempotency-Key"] = idempotency_key
+        return await self._post(
+            f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo/report-package-events",
+            body=body,
+            headers=headers,
+            operation="advise.advisory.proposals.memo.report-package-events",
         )
 
     async def request_proposal_memo_report_package(

--- a/src/app/contracts/advisory_workspaces.py
+++ b/src/app/contracts/advisory_workspaces.py
@@ -1,0 +1,41 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class AdvisoryWorkspaceBodyRequest(BaseModel):
+    body: dict[str, Any] = Field(
+        description="Opaque advisory workspace payload forwarded unchanged to lotus-advise.",
+        examples=[
+            {
+                "workspace_name": "Smith Family Trust tactical rebalance draft",
+                "created_by": "advisor_1",
+                "input_mode": "stateful",
+                "stateful_input": {
+                    "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                    "as_of": "2026-05-24",
+                    "mandate_id": "mandate_growth_01",
+                },
+            }
+        ],
+    )
+
+
+class AdvisoryWorkspaceEnvelopeResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Correlation identifier propagated through the gateway request.",
+        examples=["corr-advisory-workspace-1"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Gateway contract version for advisory workspace envelopes.",
+        examples=["v1"],
+    )
+    data: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Advisory workspace payload returned by lotus-advise. Gateway preserves workspace "
+            "draft state, evaluation summary, replay evidence, and lifecycle handoff posture "
+            "without recomputing proposal facts."
+        ),
+    )

--- a/src/app/contracts/proposals.py
+++ b/src/app/contracts/proposals.py
@@ -151,6 +151,22 @@ class ProposalVersionCreateRequest(BaseModel):
     )
 
 
+class ProposalBodyRequest(BaseModel):
+    body: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Opaque advisory proposal payload forwarded unchanged to lotus-advise for "
+            "source-owned support, execution, memo, narrative, async, or artifact workflows."
+        ),
+        examples=[
+            {
+                "actor_id": "advisor_1",
+                "reason": {"summary": "Advisor workflow action requested from Workbench."},
+            }
+        ],
+    )
+
+
 class ProposalSubmitRequest(BaseModel):
     actor_id: str = Field(
         description="Actor identifier requesting the submit transition.",

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -10,6 +10,7 @@ from app.enterprise_readiness import (
     validate_enterprise_runtime_config,
 )
 from app.middleware.correlation import correlation_id_var, correlation_middleware, setup_logging
+from app.routers.advisory_workspaces import router as advisory_workspaces_router
 from app.routers.analytics_diagnostics import router as analytics_diagnostics_router
 from app.routers.archive_documents import router as archive_documents_router
 from app.routers.composite_performance import router as composite_performance_router
@@ -102,6 +103,7 @@ validate_enterprise_runtime_config()
 app.middleware("http")(correlation_middleware)
 app.middleware("http")(build_enterprise_audit_middleware("lotus-gateway"))
 Instrumentator().instrument(app).expose(app)
+app.include_router(advisory_workspaces_router)
 app.include_router(proposals_router)
 app.include_router(platform_router)
 app.include_router(domain_products_router)

--- a/src/app/routers/advisory_workspaces.py
+++ b/src/app/routers/advisory_workspaces.py
@@ -125,6 +125,151 @@ async def save_workspace(
     )
 
 
+@router.get(
+    "/{workspace_id}/saved-versions",
+    response_model=AdvisoryWorkspaceEnvelopeResponse,
+    summary="List Saved Advisory Workspace Versions",
+    description=(
+        "Returns saved advisory workspace versions from lotus-advise for resume, compare, "
+        "and support evidence workflows. Gateway does not reconstruct workspace history locally."
+    ),
+)
+async def list_saved_versions(
+    workspace_id: str = Path(
+        ...,
+        description="Advisory workspace identifier returned by lotus-advise.",
+        examples=["aws_001"],
+    ),
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await _advisory_workspace_service().list_saved_versions(
+        workspace_id=workspace_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/{workspace_id}/saved-versions/{workspace_version_id}/replay-evidence",
+    response_model=AdvisoryWorkspaceEnvelopeResponse,
+    summary="Get Saved Advisory Workspace Replay Evidence",
+    description=(
+        "Returns replay evidence for a saved advisory workspace version from lotus-advise, "
+        "preserving source hashes and lifecycle continuity without Gateway-side inference."
+    ),
+)
+async def get_saved_version_replay_evidence(
+    workspace_id: str = Path(
+        ...,
+        description="Advisory workspace identifier returned by lotus-advise.",
+        examples=["aws_001"],
+    ),
+    workspace_version_id: str = Path(
+        ...,
+        description="Saved advisory workspace version identifier returned by lotus-advise.",
+        examples=["awv_001"],
+    ),
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await _advisory_workspace_service().get_saved_version_replay_evidence(
+        workspace_id=workspace_id,
+        workspace_version_id=workspace_version_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{workspace_id}/resume",
+    response_model=AdvisoryWorkspaceEnvelopeResponse,
+    summary="Resume Saved Advisory Workspace Version",
+    description=(
+        "Restores a saved advisory workspace version into the editable draft through lotus-advise."
+    ),
+)
+async def resume_workspace(
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str = Path(
+        ...,
+        description="Advisory workspace identifier returned by lotus-advise.",
+        examples=["aws_001"],
+    ),
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await _advisory_workspace_service().resume_workspace(
+        workspace_id=workspace_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{workspace_id}/compare",
+    response_model=AdvisoryWorkspaceEnvelopeResponse,
+    summary="Compare Advisory Workspace Draft",
+    description=(
+        "Compares the current workspace draft against a saved version through lotus-advise. "
+        "Gateway preserves the returned comparison evidence unchanged."
+    ),
+)
+async def compare_workspace(
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str = Path(
+        ...,
+        description="Advisory workspace identifier returned by lotus-advise.",
+        examples=["aws_001"],
+    ),
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await _advisory_workspace_service().compare_workspace(
+        workspace_id=workspace_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{workspace_id}/assistant/rationale",
+    response_model=AdvisoryWorkspaceEnvelopeResponse,
+    summary="Request Advisory Workspace Rationale",
+    description=(
+        "Requests an evidence-grounded workspace rationale through lotus-advise and its "
+        "Lotus AI seam. Gateway does not generate advisory rationale or prompts locally."
+    ),
+)
+async def request_rationale(
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str = Path(
+        ...,
+        description="Advisory workspace identifier returned by lotus-advise.",
+        examples=["aws_001"],
+    ),
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await _advisory_workspace_service().request_rationale(
+        workspace_id=workspace_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{workspace_id}/assistant/rationale/review-actions",
+    response_model=AdvisoryWorkspaceEnvelopeResponse,
+    summary="Review Advisory Workspace Rationale Run",
+    description=(
+        "Applies a bounded review action to the Lotus AI rationale run through lotus-advise, "
+        "preserving run-ledger and replacement-lineage posture without Gateway rewriting."
+    ),
+)
+async def review_rationale(
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str = Path(
+        ...,
+        description="Advisory workspace identifier returned by lotus-advise.",
+        examples=["aws_001"],
+    ),
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await _advisory_workspace_service().review_rationale(
+        workspace_id=workspace_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{workspace_id}/handoff",
     response_model=AdvisoryWorkspaceEnvelopeResponse,

--- a/src/app/routers/advisory_workspaces.py
+++ b/src/app/routers/advisory_workspaces.py
@@ -1,0 +1,156 @@
+from fastapi import APIRouter, Header, Path
+
+from app.clients.advise_client import AdviseClient
+from app.config import settings
+from app.contracts.advisory_workspaces import (
+    AdvisoryWorkspaceBodyRequest,
+    AdvisoryWorkspaceEnvelopeResponse,
+)
+from app.middleware.correlation import correlation_id_var
+from app.services.advisory_workspace_service import AdvisoryWorkspaceService
+
+router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
+
+
+def _advisory_workspace_service() -> AdvisoryWorkspaceService:
+    return AdvisoryWorkspaceService(
+        advise_client=AdviseClient(
+            base_url=settings.decisioning_service_base_url,
+            timeout_seconds=settings.upstream_timeout_seconds,
+            max_retries=settings.upstream_max_retries,
+            retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+        )
+    )
+
+
+@router.post(
+    "",
+    response_model=AdvisoryWorkspaceEnvelopeResponse,
+    summary="Create Advisory Workspace",
+    description=(
+        "Creates a stateful or stateless advisory workspace through lotus-advise. Use this "
+        "for interactive proposal drafting where Advise owns context resolution, evaluation, "
+        "replay evidence, save versions, and lifecycle handoff."
+    ),
+)
+async def create_workspace(
+    request: AdvisoryWorkspaceBodyRequest,
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await _advisory_workspace_service().create_workspace(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/{workspace_id}",
+    response_model=AdvisoryWorkspaceEnvelopeResponse,
+    summary="Get Advisory Workspace",
+    description="Returns the current advisory workspace session from lotus-advise.",
+)
+async def get_workspace(
+    workspace_id: str = Path(
+        ...,
+        description="Advisory workspace identifier returned by lotus-advise.",
+        examples=["aws_001"],
+    ),
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await _advisory_workspace_service().get_workspace(
+        workspace_id=workspace_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{workspace_id}/draft-actions",
+    response_model=AdvisoryWorkspaceEnvelopeResponse,
+    summary="Apply Advisory Workspace Draft Action",
+    description=(
+        "Applies a draft trade, cash-flow, or option action through lotus-advise and returns "
+        "the re-evaluated workspace posture."
+    ),
+)
+async def apply_draft_action(
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str = Path(
+        ...,
+        description="Advisory workspace identifier returned by lotus-advise.",
+        examples=["aws_001"],
+    ),
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await _advisory_workspace_service().apply_draft_action(
+        workspace_id=workspace_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{workspace_id}/evaluate",
+    response_model=AdvisoryWorkspaceEnvelopeResponse,
+    summary="Evaluate Advisory Workspace",
+    description="Re-evaluates the current advisory workspace draft through lotus-advise.",
+)
+async def evaluate_workspace(
+    workspace_id: str = Path(
+        ...,
+        description="Advisory workspace identifier returned by lotus-advise.",
+        examples=["aws_001"],
+    ),
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await _advisory_workspace_service().evaluate_workspace(
+        workspace_id=workspace_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{workspace_id}/save",
+    response_model=AdvisoryWorkspaceEnvelopeResponse,
+    summary="Save Advisory Workspace Version",
+    description="Saves the current advisory workspace draft version in lotus-advise.",
+)
+async def save_workspace(
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str = Path(
+        ...,
+        description="Advisory workspace identifier returned by lotus-advise.",
+        examples=["aws_001"],
+    ),
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await _advisory_workspace_service().save_workspace(
+        workspace_id=workspace_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.post(
+    "/{workspace_id}/handoff",
+    response_model=AdvisoryWorkspaceEnvelopeResponse,
+    summary="Handoff Advisory Workspace to Proposal Lifecycle",
+    description=(
+        "Persists the evaluated workspace draft into the lotus-advise proposal lifecycle. "
+        "Gateway forwards the request and does not synthesize proposal evidence locally."
+    ),
+)
+async def handoff_workspace(
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str = Path(
+        ...,
+        description="Advisory workspace identifier returned by lotus-advise.",
+        examples=["aws_001"],
+    ),
+    idempotency_key: str | None = Header(
+        default=None,
+        alias="Idempotency-Key",
+        description="Optional idempotency key for workspace-to-proposal handoff.",
+        examples=["idem-workspace-handoff-1"],
+    ),
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await _advisory_workspace_service().handoff_workspace(
+        workspace_id=workspace_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )

--- a/src/app/routers/proposals.py
+++ b/src/app/routers/proposals.py
@@ -5,11 +5,13 @@ from app.config import settings
 from app.contracts.proposals import (
     ProposalApprovalActionRequest,
     ProposalApprovalsEnvelopeResponse,
+    ProposalBodyRequest,
     ProposalCreateEnvelopeResponse,
     ProposalCreateRequest,
     ProposalDeliveryEventsEnvelopeResponse,
     ProposalDeliverySummaryEnvelopeResponse,
     ProposalDetailEnvelopeResponse,
+    ProposalEnvelopeResponse,
     ProposalLineageEnvelopeResponse,
     ProposalListEnvelopeResponse,
     ProposalMemoAiCommentaryEnvelopeResponse,
@@ -72,6 +74,33 @@ async def simulate_proposal(
     service = _proposal_service()
     correlation_id = correlation_id_var.get()
     return await service.simulate_proposal(
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
+@router.post(
+    "/artifact",
+    response_model=ProposalEnvelopeResponse,
+    summary="Create Proposal Artifact",
+    description=(
+        "Creates a deterministic advisory proposal artifact through lotus-advise. Gateway "
+        "preserves decision summary, alternatives, evidence bundle, and hashes without "
+        "constructing artifact content locally."
+    ),
+)
+async def create_proposal_artifact(
+    request: ProposalBodyRequest,
+    idempotency_key: str = Header(
+        alias="Idempotency-Key",
+        description="Caller-supplied idempotency key for proposal artifact generation.",
+        examples=["idem-artifact-1"],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_proposal_artifact(
         body=request.body,
         idempotency_key=idempotency_key,
         correlation_id=correlation_id,
@@ -166,6 +195,121 @@ async def list_proposals(
     return await service.list_proposals(filters=filters, correlation_id=correlation_id)
 
 
+@router.post(
+    "/async",
+    response_model=ProposalEnvelopeResponse,
+    summary="Create Proposal Asynchronously",
+    description=(
+        "Starts an asynchronous proposal create operation in lotus-advise. Gateway returns the "
+        "source-owned operation reference and does not manage advisory operation state locally."
+    ),
+)
+async def create_proposal_async(
+    request: ProposalBodyRequest,
+    idempotency_key: str = Header(
+        alias="Idempotency-Key",
+        description="Caller-supplied idempotency key for async proposal creation.",
+        examples=["idem-proposal-async-1"],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_proposal_async(
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
+@router.get(
+    "/operations/{operation_id}",
+    response_model=ProposalEnvelopeResponse,
+    summary="Get Proposal Operation",
+    description="Returns async proposal operation state from lotus-advise.",
+)
+async def get_proposal_operation(
+    operation_id: str = Path(
+        ...,
+        description="lotus-advise async proposal operation identifier.",
+        examples=["apo_001"],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_operation(
+        operation_id=operation_id,
+        correlation_id=correlation_id,
+    )
+
+
+@router.get(
+    "/operations/by-correlation/{operation_correlation_id}",
+    response_model=ProposalEnvelopeResponse,
+    summary="Get Proposal Operation by Correlation",
+    description="Looks up a source-owned async proposal operation by its operation correlation id.",
+)
+async def get_proposal_operation_by_correlation(
+    operation_correlation_id: str = Path(
+        ...,
+        description="Operation correlation identifier recorded by lotus-advise.",
+        examples=["corr-operation-001"],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_operation_by_correlation(
+        operation_correlation_id=operation_correlation_id,
+        correlation_id=correlation_id,
+    )
+
+
+@router.get(
+    "/operations/{operation_id}/replay-evidence",
+    response_model=ProposalEnvelopeResponse,
+    summary="Get Proposal Operation Replay Evidence",
+    description=(
+        "Returns source-owned replay evidence for an async proposal operation from lotus-advise."
+    ),
+)
+async def get_proposal_operation_replay_evidence(
+    operation_id: str = Path(
+        ...,
+        description="lotus-advise async proposal operation identifier.",
+        examples=["apo_001"],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_operation_replay_evidence(
+        operation_id=operation_id,
+        correlation_id=correlation_id,
+    )
+
+
+@router.get(
+    "/idempotency/{idempotency_key}",
+    response_model=ProposalEnvelopeResponse,
+    summary="Get Proposal Idempotency Record",
+    description=(
+        "Returns the source-owned idempotency record from lotus-advise for support and replay "
+        "diagnosis. Gateway does not interpret or mutate idempotency state."
+    ),
+)
+async def get_proposal_idempotency_record(
+    idempotency_key: str = Path(
+        ...,
+        description="Idempotency key recorded by lotus-advise.",
+        examples=["idem-create-1"],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_idempotency_record(
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}",
     response_model=ProposalDetailEnvelopeResponse,
@@ -228,6 +372,35 @@ async def get_proposal_version(
     )
 
 
+@router.get(
+    "/{proposal_id}/versions/{version_no}/replay-evidence",
+    response_model=ProposalEnvelopeResponse,
+    summary="Get Proposal Version Replay Evidence",
+    description=(
+        "Returns source-owned replay evidence for one immutable proposal version from lotus-advise."
+    ),
+)
+async def get_proposal_version_replay_evidence(
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    version_no: int = Path(
+        ...,
+        description="Persisted proposal version number to retrieve replay evidence for.",
+        examples=[2],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_version_replay_evidence(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/versions",
     response_model=ProposalCreateEnvelopeResponse,
@@ -250,6 +423,38 @@ async def create_proposal_version(
     service = _proposal_service()
     correlation_id = correlation_id_var.get()
     return await service.create_proposal_version(
+        proposal_id=proposal_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
+@router.post(
+    "/{proposal_id}/versions/async",
+    response_model=ProposalEnvelopeResponse,
+    summary="Create Proposal Version Asynchronously",
+    description=(
+        "Starts an asynchronous version-create operation in lotus-advise for an existing "
+        "proposal. Gateway returns source-owned operation posture only."
+    ),
+)
+async def create_proposal_version_async(
+    request: ProposalBodyRequest,
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    idempotency_key: str = Header(
+        alias="Idempotency-Key",
+        description="Caller-supplied idempotency key for async proposal-version creation.",
+        examples=["idem-version-async-1"],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_proposal_version_async(
         proposal_id=proposal_id,
         body=request.body,
         idempotency_key=idempotency_key,
@@ -450,6 +655,70 @@ async def get_proposal_lineage(
 
 
 @router.post(
+    "/{proposal_id}/versions/{version_no}/narrative/regenerate",
+    response_model=ProposalEnvelopeResponse,
+    summary="Regenerate Proposal Narrative Candidate",
+    description=(
+        "Requests a non-persistent advisor-review narrative candidate from lotus-advise for a "
+        "persisted proposal version. Gateway does not generate or edit narrative text locally."
+    ),
+)
+async def regenerate_proposal_narrative(
+    request: ProposalBodyRequest,
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    version_no: int = Path(
+        ...,
+        ge=1,
+        description="Immutable proposal version number containing narrative evidence.",
+        examples=[2],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.regenerate_proposal_narrative(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.body,
+        correlation_id=correlation_id,
+    )
+
+
+@router.get(
+    "/{proposal_id}/versions/{version_no}/narrative",
+    response_model=ProposalEnvelopeResponse,
+    summary="Get Proposal Narrative",
+    description=(
+        "Returns the persisted proposal narrative and review posture from lotus-advise. Gateway "
+        "does not regenerate narrative text on read."
+    ),
+)
+async def get_proposal_narrative(
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    version_no: int = Path(
+        ...,
+        ge=1,
+        description="Immutable proposal version number containing narrative evidence.",
+        examples=[2],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_narrative(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        correlation_id=correlation_id,
+    )
+
+
+@router.post(
     "/{proposal_id}/versions/{version_no}/narrative/review",
     response_model=ProposalNarrativeReviewEnvelopeResponse,
     summary="Review Proposal Narrative",
@@ -517,6 +786,39 @@ async def create_report_request(
     )
 
 
+@router.post(
+    "/{proposal_id}/execution-handoffs",
+    response_model=ProposalEnvelopeResponse,
+    summary="Create Proposal Execution Handoff",
+    description=(
+        "Records a source-owned advisory execution handoff in lotus-advise. Gateway preserves "
+        "the boundary that downstream systems remain execution authorities."
+    ),
+)
+async def create_execution_handoff(
+    request: ProposalBodyRequest,
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    idempotency_key: str | None = Header(
+        default=None,
+        alias="Idempotency-Key",
+        description="Optional idempotency key for execution handoff requests.",
+        examples=["idem-execution-handoff-1"],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_execution_handoff(
+        proposal_id=proposal_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/delivery-summary",
     response_model=ProposalDeliverySummaryEnvelopeResponse,
@@ -562,6 +864,63 @@ async def get_delivery_events(
     correlation_id = correlation_id_var.get()
     return await service.get_delivery_events(
         proposal_id=proposal_id,
+        correlation_id=correlation_id,
+    )
+
+
+@router.get(
+    "/{proposal_id}/execution-status",
+    response_model=ProposalEnvelopeResponse,
+    summary="Get Proposal Execution Status",
+    description=(
+        "Returns advisory execution status projection from lotus-advise without Gateway claiming "
+        "OMS, fill, or settlement authority."
+    ),
+)
+async def get_execution_status(
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_execution_status(
+        proposal_id=proposal_id,
+        correlation_id=correlation_id,
+    )
+
+
+@router.post(
+    "/{proposal_id}/execution-updates",
+    response_model=ProposalEnvelopeResponse,
+    summary="Record Proposal Execution Update",
+    description=(
+        "Records a downstream execution-status update in lotus-advise while preserving external "
+        "execution-system ownership."
+    ),
+)
+async def record_execution_update(
+    request: ProposalBodyRequest,
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    idempotency_key: str | None = Header(
+        default=None,
+        alias="Idempotency-Key",
+        description="Optional idempotency key for execution update requests.",
+        examples=["idem-execution-update-1"],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.record_execution_update(
+        proposal_id=proposal_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
         correlation_id=correlation_id,
     )
 
@@ -707,6 +1066,45 @@ async def review_proposal_memo(
         proposal_id=proposal_id,
         version_no=version_no,
         body=request.model_dump(exclude_none=True),
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
+@router.post(
+    "/{proposal_id}/versions/{version_no}/memo/report-package-events",
+    response_model=ProposalEnvelopeResponse,
+    summary="Record Proposal Memo Report Package Event",
+    description=(
+        "Records report/render/archive package event posture through lotus-advise. Gateway does "
+        "not synthesize archive refs, render state, or memo lineage locally."
+    ),
+)
+async def record_proposal_memo_report_package_event(
+    request: ProposalBodyRequest,
+    proposal_id: str = Path(
+        ...,
+        description="Gateway-visible proposal identifier returned by lotus-advise.",
+        examples=["pp_1"],
+    ),
+    version_no: int = Path(
+        ...,
+        description="Immutable proposal version number used as the memo source.",
+        examples=[2],
+    ),
+    idempotency_key: str | None = Header(
+        default=None,
+        alias="Idempotency-Key",
+        description="Caller-supplied idempotency key for memo report-package events.",
+        examples=["idem-memo-report-package-event-1"],
+    ),
+) -> ProposalEnvelopeResponse:
+    service = _proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.record_proposal_memo_report_package_event(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.body,
         idempotency_key=idempotency_key,
         correlation_id=correlation_id,
     )

--- a/src/app/services/advisory_workspace_service.py
+++ b/src/app/services/advisory_workspace_service.py
@@ -1,0 +1,116 @@
+from typing import Any
+
+from fastapi import HTTPException, status
+
+from app.clients.advise_client import AdviseClient
+from app.config import settings
+from app.contracts.advisory_workspaces import AdvisoryWorkspaceEnvelopeResponse
+
+
+class AdvisoryWorkspaceService:
+    def __init__(self, advise_client: AdviseClient):
+        self._advise_client = advise_client
+
+    async def create_workspace(
+        self,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.create_advisory_workspace(
+            body=body,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._envelope(correlation_id, upstream_payload)
+
+    async def get_workspace(
+        self,
+        workspace_id: str,
+        correlation_id: str,
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.get_advisory_workspace(
+            workspace_id=workspace_id,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._envelope(correlation_id, upstream_payload)
+
+    async def apply_draft_action(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        upstream_status, upstream_payload = (
+            await self._advise_client.apply_advisory_workspace_draft_action(
+                workspace_id=workspace_id,
+                body=body,
+                correlation_id=correlation_id,
+            )
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._envelope(correlation_id, upstream_payload)
+
+    async def evaluate_workspace(
+        self,
+        workspace_id: str,
+        correlation_id: str,
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.evaluate_advisory_workspace(
+            workspace_id=workspace_id,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._envelope(correlation_id, upstream_payload)
+
+    async def save_workspace(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.save_advisory_workspace(
+            workspace_id=workspace_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._envelope(correlation_id, upstream_payload)
+
+    async def handoff_workspace(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.handoff_advisory_workspace(
+            workspace_id=workspace_id,
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._envelope(correlation_id, upstream_payload)
+
+    def _envelope(
+        self,
+        correlation_id: str,
+        upstream_payload: dict[str, Any],
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        return AdvisoryWorkspaceEnvelopeResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            data=upstream_payload,
+        )
+
+    def _raise_for_upstream_error(
+        self,
+        upstream_status: int,
+        upstream_payload: dict[str, Any],
+    ) -> None:
+        if upstream_status >= status.HTTP_400_BAD_REQUEST:
+            detail: str | dict[str, Any] = upstream_payload
+            if not isinstance(detail, str):
+                detail = str(detail)
+            raise HTTPException(status_code=upstream_status, detail=detail)

--- a/src/app/services/advisory_workspace_service.py
+++ b/src/app/services/advisory_workspace_service.py
@@ -41,12 +41,13 @@ class AdvisoryWorkspaceService:
         body: dict[str, Any],
         correlation_id: str,
     ) -> AdvisoryWorkspaceEnvelopeResponse:
-        upstream_status, upstream_payload = (
-            await self._advise_client.apply_advisory_workspace_draft_action(
-                workspace_id=workspace_id,
-                body=body,
-                correlation_id=correlation_id,
-            )
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.apply_advisory_workspace_draft_action(
+            workspace_id=workspace_id,
+            body=body,
+            correlation_id=correlation_id,
         )
         self._raise_for_upstream_error(upstream_status, upstream_payload)
         return self._envelope(correlation_id, upstream_payload)
@@ -70,6 +71,100 @@ class AdvisoryWorkspaceService:
         correlation_id: str,
     ) -> AdvisoryWorkspaceEnvelopeResponse:
         upstream_status, upstream_payload = await self._advise_client.save_advisory_workspace(
+            workspace_id=workspace_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._envelope(correlation_id, upstream_payload)
+
+    async def list_saved_versions(
+        self,
+        workspace_id: str,
+        correlation_id: str,
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.list_advisory_workspace_saved_versions(
+            workspace_id=workspace_id,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._envelope(correlation_id, upstream_payload)
+
+    async def get_saved_version_replay_evidence(
+        self,
+        workspace_id: str,
+        workspace_version_id: str,
+        correlation_id: str,
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.get_advisory_workspace_saved_version_replay_evidence(
+            workspace_id=workspace_id,
+            workspace_version_id=workspace_version_id,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._envelope(correlation_id, upstream_payload)
+
+    async def resume_workspace(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.resume_advisory_workspace(
+            workspace_id=workspace_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._envelope(correlation_id, upstream_payload)
+
+    async def compare_workspace(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.compare_advisory_workspace(
+            workspace_id=workspace_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._envelope(correlation_id, upstream_payload)
+
+    async def request_rationale(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.request_advisory_workspace_rationale(
+            workspace_id=workspace_id,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._envelope(correlation_id, upstream_payload)
+
+    async def review_rationale(
+        self,
+        workspace_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> AdvisoryWorkspaceEnvelopeResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.review_advisory_workspace_rationale(
             workspace_id=workspace_id,
             body=body,
             correlation_id=correlation_id,

--- a/src/app/services/platform_capabilities_service.py
+++ b/src/app/services/platform_capabilities_service.py
@@ -257,6 +257,8 @@ class PlatformCapabilitiesService:
                 source_name="lotus_core",
                 feature_keys=(
                     "lotus_core.integration.core_snapshot",
+                    "lotus_core.support.overview_api",
+                    "lotus_core.ingestion.portfolio_bundle_adapter",
                     "pas.integration.core_snapshot",
                 ),
             ),
@@ -265,6 +267,8 @@ class PlatformCapabilitiesService:
                 source_name="lotus_core",
                 feature_keys=(
                     "lotus_core.ingestion.bulk_upload",
+                    "lotus_core.ingestion.bulk_upload_adapter",
+                    "lotus_core.ingestion.portfolio_bundle_adapter",
                     "pas.ingestion.bulk_upload",
                 ),
             ),

--- a/src/app/services/proposal_service.py
+++ b/src/app/services/proposal_service.py
@@ -13,6 +13,7 @@ from app.contracts.proposals import (
     ProposalDeliverySummaryEnvelopeResponse,
     ProposalDetailData,
     ProposalDetailEnvelopeResponse,
+    ProposalEnvelopeResponse,
     ProposalLineageData,
     ProposalLineageEnvelopeResponse,
     ProposalListData,
@@ -84,6 +85,20 @@ class ProposalService:
             contract_version=settings.contract_version,
             data=ProposalSimulationData.model_validate(upstream_payload),
         )
+
+    async def create_proposal_artifact(
+        self,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.create_proposal_artifact(
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
 
     async def create_proposal(
         self,
@@ -176,6 +191,78 @@ class ProposalService:
             contract_version=settings.contract_version,
             data=ProposalCreateData.model_validate(upstream_payload),
         )
+
+    async def create_proposal_async(
+        self,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.create_proposal_async(
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
+
+    async def create_proposal_version_async(
+        self,
+        proposal_id: str,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.create_proposal_version_async(
+            proposal_id=proposal_id,
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
+
+    async def get_proposal_operation(
+        self,
+        operation_id: str,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.get_proposal_operation(
+            operation_id=operation_id,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
+
+    async def get_proposal_operation_by_correlation(
+        self,
+        operation_correlation_id: str,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.get_proposal_operation_by_correlation(
+            operation_correlation_id=operation_correlation_id,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
+
+    async def get_proposal_operation_replay_evidence(
+        self,
+        operation_id: str,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.get_proposal_operation_replay_evidence(
+            operation_id=operation_id,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
 
     async def submit_proposal(
         self,
@@ -336,6 +423,68 @@ class ProposalService:
             data=ProposalLineageData.model_validate(upstream_payload),
         )
 
+    async def get_proposal_version_replay_evidence(
+        self,
+        proposal_id: str,
+        version_no: int,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.get_proposal_version_replay_evidence(
+            proposal_id=proposal_id,
+            version_no=version_no,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
+
+    async def get_proposal_idempotency_record(
+        self,
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.get_proposal_idempotency_record(
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
+
+    async def regenerate_proposal_narrative(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.regenerate_proposal_narrative(
+            proposal_id=proposal_id,
+            version_no=version_no,
+            body=body,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
+
+    async def get_proposal_narrative(
+        self,
+        proposal_id: str,
+        version_no: int,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.get_proposal_narrative(
+            proposal_id=proposal_id,
+            version_no=version_no,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
+
     async def review_proposal_narrative(
         self,
         proposal_id: str,
@@ -376,6 +525,22 @@ class ProposalService:
             data=upstream_payload,
         )
 
+    async def create_execution_handoff(
+        self,
+        proposal_id: str,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.create_execution_handoff(
+            proposal_id=proposal_id,
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
+
     async def get_delivery_summary(
         self,
         proposal_id: str,
@@ -407,6 +572,34 @@ class ProposalService:
             contract_version=settings.contract_version,
             data=upstream_payload,
         )
+
+    async def get_execution_status(
+        self,
+        proposal_id: str,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.get_execution_status(
+            proposal_id=proposal_id,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
+
+    async def record_execution_update(
+        self,
+        proposal_id: str,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        upstream_status, upstream_payload = await self._advise_client.record_execution_update(
+            proposal_id=proposal_id,
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
 
     async def create_proposal_memo(
         self,
@@ -489,6 +682,27 @@ class ProposalService:
             contract_version=settings.contract_version,
             data=upstream_payload,
         )
+
+    async def record_proposal_memo_report_package_event(
+        self,
+        proposal_id: str,
+        version_no: int,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> ProposalEnvelopeResponse:
+        (
+            upstream_status,
+            upstream_payload,
+        ) = await self._advise_client.record_proposal_memo_report_package_event(
+            proposal_id=proposal_id,
+            version_no=version_no,
+            body=body,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+        )
+        self._raise_for_upstream_error(upstream_status, upstream_payload)
+        return self._opaque_envelope(correlation_id, upstream_payload)
 
     async def request_proposal_memo_report_package(
         self,
@@ -609,6 +823,17 @@ class ProposalService:
             correlation_id=correlation_id,
             contract_version=settings.contract_version,
             data=ProposalStateTransitionData.model_validate(upstream_payload),
+        )
+
+    def _opaque_envelope(
+        self,
+        correlation_id: str,
+        upstream_payload: dict[str, Any],
+    ) -> ProposalEnvelopeResponse:
+        return ProposalEnvelopeResponse(
+            correlation_id=correlation_id,
+            contract_version=settings.contract_version,
+            data=upstream_payload,
         )
 
     def _raise_for_upstream_error(

--- a/tests/contract/test_advise_gateway_route_coverage.py
+++ b/tests/contract/test_advise_gateway_route_coverage.py
@@ -1,0 +1,92 @@
+from fastapi.routing import APIRoute
+
+from app.main import app
+
+
+def _route_keys() -> set[tuple[str, str]]:
+    keys: set[tuple[str, str]] = set()
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        for method in route.methods or set():
+            if method in {"HEAD", "OPTIONS"}:
+                continue
+            keys.add((method, route.path))
+    return keys
+
+
+def test_gateway_exposes_supported_lotus_advise_proposal_surface() -> None:
+    routes = _route_keys()
+    expected = {
+        ("POST", "/api/v1/proposals/simulate"),
+        ("POST", "/api/v1/proposals/artifact"),
+        ("POST", "/api/v1/proposals"),
+        ("GET", "/api/v1/proposals"),
+        ("POST", "/api/v1/proposals/async"),
+        ("GET", "/api/v1/proposals/operations/{operation_id}"),
+        ("GET", "/api/v1/proposals/operations/by-correlation/{operation_correlation_id}"),
+        ("GET", "/api/v1/proposals/operations/{operation_id}/replay-evidence"),
+        ("GET", "/api/v1/proposals/idempotency/{idempotency_key}"),
+        ("GET", "/api/v1/proposals/{proposal_id}"),
+        ("GET", "/api/v1/proposals/{proposal_id}/versions/{version_no}"),
+        ("GET", "/api/v1/proposals/{proposal_id}/versions/{version_no}/replay-evidence"),
+        ("POST", "/api/v1/proposals/{proposal_id}/versions"),
+        ("POST", "/api/v1/proposals/{proposal_id}/versions/async"),
+        ("POST", "/api/v1/proposals/{proposal_id}/submit"),
+        ("POST", "/api/v1/proposals/{proposal_id}/approve-risk"),
+        ("POST", "/api/v1/proposals/{proposal_id}/approve-compliance"),
+        ("POST", "/api/v1/proposals/{proposal_id}/record-client-consent"),
+        ("GET", "/api/v1/proposals/{proposal_id}/workflow-events"),
+        ("GET", "/api/v1/proposals/{proposal_id}/approvals"),
+        ("GET", "/api/v1/proposals/{proposal_id}/lineage"),
+        ("POST", "/api/v1/proposals/{proposal_id}/versions/{version_no}/narrative/regenerate"),
+        ("GET", "/api/v1/proposals/{proposal_id}/versions/{version_no}/narrative"),
+        ("POST", "/api/v1/proposals/{proposal_id}/versions/{version_no}/narrative/review"),
+        ("POST", "/api/v1/proposals/{proposal_id}/report-requests"),
+        ("POST", "/api/v1/proposals/{proposal_id}/execution-handoffs"),
+        ("GET", "/api/v1/proposals/{proposal_id}/delivery-summary"),
+        ("GET", "/api/v1/proposals/{proposal_id}/delivery-events"),
+        ("GET", "/api/v1/proposals/{proposal_id}/execution-status"),
+        ("POST", "/api/v1/proposals/{proposal_id}/execution-updates"),
+        ("POST", "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo"),
+        ("GET", "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo"),
+        ("GET", "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo/projection"),
+        ("POST", "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo/review"),
+        (
+            "POST",
+            "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo/report-package-events",
+        ),
+        ("POST", "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo/report-packages"),
+        ("POST", "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo/ai-commentary"),
+        ("GET", "/api/v1/proposals/{proposal_id}/memos/lineage"),
+        ("GET", "/api/v1/proposals/{proposal_id}/versions/{version_no}/memo/replay-evidence"),
+    }
+
+    assert expected - routes == set()
+
+
+def test_gateway_exposes_supported_lotus_advise_workspace_surface() -> None:
+    routes = _route_keys()
+    expected = {
+        ("POST", "/api/v1/advisory-workspaces"),
+        ("GET", "/api/v1/advisory-workspaces/{workspace_id}"),
+        ("POST", "/api/v1/advisory-workspaces/{workspace_id}/draft-actions"),
+        ("POST", "/api/v1/advisory-workspaces/{workspace_id}/evaluate"),
+        ("POST", "/api/v1/advisory-workspaces/{workspace_id}/save"),
+        ("GET", "/api/v1/advisory-workspaces/{workspace_id}/saved-versions"),
+        (
+            "GET",
+            "/api/v1/advisory-workspaces/{workspace_id}/saved-versions/"
+            "{workspace_version_id}/replay-evidence",
+        ),
+        ("POST", "/api/v1/advisory-workspaces/{workspace_id}/resume"),
+        ("POST", "/api/v1/advisory-workspaces/{workspace_id}/compare"),
+        ("POST", "/api/v1/advisory-workspaces/{workspace_id}/assistant/rationale"),
+        (
+            "POST",
+            "/api/v1/advisory-workspaces/{workspace_id}/assistant/rationale/review-actions",
+        ),
+        ("POST", "/api/v1/advisory-workspaces/{workspace_id}/handoff"),
+    }
+
+    assert expected - routes == set()

--- a/tests/integration/test_advisory_workspaces_router.py
+++ b/tests/integration/test_advisory_workspaces_router.py
@@ -1,0 +1,175 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_create_advisory_workspace_preserves_stateful_contract(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_create_workspace(self, body, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["body"] = body
+        captured["correlation_id"] = correlation_id
+        return 201, {
+            "workspace": {
+                "workspace_id": "aws_001",
+                "workspace_name": body["workspace_name"],
+                "input_mode": "stateful",
+                "created_by": body["created_by"],
+                "created_at": "2026-05-24T09:00:00+00:00",
+                "lifecycle_state": "ACTIVE",
+                "stateful_input": body["stateful_input"],
+                "draft_state": {"trade_drafts": [], "cash_flow_drafts": []},
+                "resolved_context": {
+                    "portfolio_id": body["stateful_input"]["portfolio_id"],
+                    "as_of": body["stateful_input"]["as_of"],
+                    "portfolio_snapshot_id": "lotus-core:portfolio:PB_SG_GLOBAL_BAL_001:2026-05-24",
+                },
+            }
+        }
+
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.create_advisory_workspace",
+        _fake_create_workspace,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/advisory-workspaces",
+        json={
+            "body": {
+                "workspace_name": "Smith Family Trust tactical rebalance draft",
+                "created_by": "advisor_1",
+                "input_mode": "stateful",
+                "stateful_input": {
+                    "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                    "as_of": "2026-05-24",
+                    "mandate_id": "mandate_growth_01",
+                },
+            }
+        },
+        headers={"X-Correlation-Id": "corr-workspace-create"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["correlation_id"] == "corr-workspace-create"
+    assert payload["data"]["workspace"]["workspace_id"] == "aws_001"
+    assert captured["body"] == {
+        "workspace_name": "Smith Family Trust tactical rebalance draft",
+        "created_by": "advisor_1",
+        "input_mode": "stateful",
+        "stateful_input": {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "as_of": "2026-05-24",
+            "mandate_id": "mandate_growth_01",
+        },
+    }
+
+
+def test_advisory_workspace_draft_action_and_handoff_preserve_advise_boundary(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_apply_action(self, workspace_id, body, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["draft_action"] = {
+            "workspace_id": workspace_id,
+            "body": body,
+            "correlation_id": correlation_id,
+        }
+        return 200, {
+            "workspace": {
+                "workspace_id": workspace_id,
+                "evaluation_summary": {
+                    "status": "PENDING_REVIEW",
+                    "blocking_issue_count": 0,
+                    "review_issue_count": 1,
+                    "impact_summary": {
+                        "portfolio_value_delta_base_ccy": "1250.00",
+                        "trade_count": 1,
+                        "cash_flow_count": 0,
+                    },
+                },
+            }
+        }
+
+    async def _fake_handoff(self, workspace_id, body, idempotency_key, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["handoff"] = {
+            "workspace_id": workspace_id,
+            "body": body,
+            "idempotency_key": idempotency_key,
+            "correlation_id": correlation_id,
+        }
+        return 200, {
+            "handoff_action": "CREATED_PROPOSAL",
+            "proposal": {"proposal": {"proposal_id": "pp_001", "current_state": "DRAFT"}},
+            "workspace": {"workspace_id": workspace_id},
+        }
+
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.apply_advisory_workspace_draft_action",
+        _fake_apply_action,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.handoff_advisory_workspace",
+        _fake_handoff,
+    )
+
+    client = TestClient(app)
+    action = client.post(
+        "/api/v1/advisory-workspaces/aws_001/draft-actions",
+        json={
+            "body": {
+                "actor_id": "advisor_1",
+                "action_type": "ADD_TRADE",
+                "trade": {
+                    "intent_type": "SECURITY_TRADE",
+                    "side": "BUY",
+                    "instrument_id": "AAPL",
+                    "quantity": "25.0000",
+                },
+            }
+        },
+        headers={"X-Correlation-Id": "corr-workspace-action"},
+    )
+    handoff = client.post(
+        "/api/v1/advisory-workspaces/aws_001/handoff",
+        json={
+            "body": {
+                "handoff_by": "advisor_1",
+                "metadata": {"title": "Smith Family Trust tactical rebalance"},
+            }
+        },
+        headers={
+            "Idempotency-Key": "idem-workspace-handoff",
+            "X-Correlation-Id": "corr-workspace-handoff",
+        },
+    )
+
+    assert action.status_code == 200
+    assert handoff.status_code == 200
+    assert captured["draft_action"] == {
+        "workspace_id": "aws_001",
+        "body": {
+            "actor_id": "advisor_1",
+            "action_type": "ADD_TRADE",
+            "trade": {
+                "intent_type": "SECURITY_TRADE",
+                "side": "BUY",
+                "instrument_id": "AAPL",
+                "quantity": "25.0000",
+            },
+        },
+        "correlation_id": "corr-workspace-action",
+    }
+    assert captured["handoff"] == {
+        "workspace_id": "aws_001",
+        "body": {
+            "handoff_by": "advisor_1",
+            "metadata": {"title": "Smith Family Trust tactical rebalance"},
+        },
+        "idempotency_key": "idem-workspace-handoff",
+        "correlation_id": "corr-workspace-handoff",
+    }
+    assert handoff.json()["data"]["handoff_action"] == "CREATED_PROPOSAL"

--- a/tests/integration/test_advisory_workspaces_router.py
+++ b/tests/integration/test_advisory_workspaces_router.py
@@ -173,3 +173,177 @@ def test_advisory_workspace_draft_action_and_handoff_preserve_advise_boundary(mo
         "correlation_id": "corr-workspace-handoff",
     }
     assert handoff.json()["data"]["handoff_action"] == "CREATED_PROPOSAL"
+
+
+def test_advisory_workspace_saved_version_compare_and_ai_routes_preserve_advise_boundary(
+    monkeypatch,
+):
+    captured: dict[str, object] = {}
+
+    async def _fake_list_saved_versions(self, workspace_id, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["saved_versions"] = {
+            "workspace_id": workspace_id,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"items": [{"workspace_version_id": "awv_001", "version_label": "baseline"}]}
+
+    async def _fake_replay(
+        self,
+        workspace_id,
+        workspace_version_id,
+        correlation_id,  # noqa: ANN001
+    ):
+        _ = self
+        captured["replay"] = {
+            "workspace_id": workspace_id,
+            "workspace_version_id": workspace_version_id,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"workspace_version_id": workspace_version_id, "replayable": True}
+
+    async def _fake_resume(self, workspace_id, body, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["resume"] = {
+            "workspace_id": workspace_id,
+            "body": body,
+            "correlation_id": correlation_id,
+        }
+        return 200, {
+            "workspace_id": workspace_id,
+            "resumed_version_id": body["workspace_version_id"],
+        }
+
+    async def _fake_compare(self, workspace_id, body, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["compare"] = {
+            "workspace_id": workspace_id,
+            "body": body,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"workspace_id": workspace_id, "comparison": {"trade_delta_count": 2}}
+
+    async def _fake_rationale(self, workspace_id, body, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["rationale"] = {
+            "workspace_id": workspace_id,
+            "body": body,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"run_id": "packrun_workspace_001", "status": "REVIEW_REQUIRED"}
+
+    async def _fake_review_rationale(self, workspace_id, body, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["review_rationale"] = {
+            "workspace_id": workspace_id,
+            "body": body,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"run_id": body["run_id"], "review_action": {"action_type": "APPROVE"}}
+
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.list_advisory_workspace_saved_versions",
+        _fake_list_saved_versions,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient."
+        "get_advisory_workspace_saved_version_replay_evidence",
+        _fake_replay,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.resume_advisory_workspace",
+        _fake_resume,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.compare_advisory_workspace",
+        _fake_compare,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.request_advisory_workspace_rationale",
+        _fake_rationale,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.review_advisory_workspace_rationale",
+        _fake_review_rationale,
+    )
+
+    client = TestClient(app)
+    saved_versions = client.get(
+        "/api/v1/advisory-workspaces/aws_001/saved-versions",
+        headers={"X-Correlation-Id": "corr-saved"},
+    )
+    replay = client.get(
+        "/api/v1/advisory-workspaces/aws_001/saved-versions/awv_001/replay-evidence",
+        headers={"X-Correlation-Id": "corr-replay"},
+    )
+    resume = client.post(
+        "/api/v1/advisory-workspaces/aws_001/resume",
+        json={"body": {"workspace_version_id": "awv_001", "actor_id": "advisor_1"}},
+        headers={"X-Correlation-Id": "corr-resume"},
+    )
+    compare = client.post(
+        "/api/v1/advisory-workspaces/aws_001/compare",
+        json={"body": {"workspace_version_id": "awv_001"}},
+        headers={"X-Correlation-Id": "corr-compare"},
+    )
+    rationale = client.post(
+        "/api/v1/advisory-workspaces/aws_001/assistant/rationale",
+        json={"body": {"requested_by": "advisor_1", "instruction": "Summarize impact."}},
+        headers={"X-Correlation-Id": "corr-rationale"},
+    )
+    review_rationale = client.post(
+        "/api/v1/advisory-workspaces/aws_001/assistant/rationale/review-actions",
+        json={
+            "body": {
+                "run_id": "packrun_workspace_001",
+                "action_type": "APPROVE",
+                "reviewed_by": "advisor_1",
+            }
+        },
+        headers={"X-Correlation-Id": "corr-review-rationale"},
+    )
+
+    assert saved_versions.status_code == 200
+    assert replay.status_code == 200
+    assert resume.status_code == 200
+    assert compare.status_code == 200
+    assert rationale.status_code == 200
+    assert review_rationale.status_code == 200
+    assert captured == {
+        "saved_versions": {
+            "workspace_id": "aws_001",
+            "correlation_id": "corr-saved",
+        },
+        "replay": {
+            "workspace_id": "aws_001",
+            "workspace_version_id": "awv_001",
+            "correlation_id": "corr-replay",
+        },
+        "resume": {
+            "workspace_id": "aws_001",
+            "body": {"workspace_version_id": "awv_001", "actor_id": "advisor_1"},
+            "correlation_id": "corr-resume",
+        },
+        "compare": {
+            "workspace_id": "aws_001",
+            "body": {"workspace_version_id": "awv_001"},
+            "correlation_id": "corr-compare",
+        },
+        "rationale": {
+            "workspace_id": "aws_001",
+            "body": {"requested_by": "advisor_1", "instruction": "Summarize impact."},
+            "correlation_id": "corr-rationale",
+        },
+        "review_rationale": {
+            "workspace_id": "aws_001",
+            "body": {
+                "run_id": "packrun_workspace_001",
+                "action_type": "APPROVE",
+                "reviewed_by": "advisor_1",
+            },
+            "correlation_id": "corr-review-rationale",
+        },
+    }
+    assert saved_versions.json()["data"]["items"][0]["workspace_version_id"] == "awv_001"
+    assert compare.json()["data"]["comparison"]["trade_delta_count"] == 2
+    assert rationale.json()["data"]["run_id"] == "packrun_workspace_001"

--- a/tests/integration/test_proposals_router.py
+++ b/tests/integration/test_proposals_router.py
@@ -160,6 +160,271 @@ def test_proposal_create_requires_idempotency_header():
     assert response.status_code == 422
 
 
+def test_proposal_artifact_async_and_support_routes_preserve_advise_contract(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_artifact(self, body, idempotency_key, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["artifact"] = {
+            "body": body,
+            "idempotency_key": idempotency_key,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"artifact_id": "artifact_001", "artifact_hash": "sha256:artifact"}
+
+    async def _fake_async(self, body, idempotency_key, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["async"] = {
+            "body": body,
+            "idempotency_key": idempotency_key,
+            "correlation_id": correlation_id,
+        }
+        return 202, {"operation_id": "apo_001", "status": "ACCEPTED"}
+
+    async def _fake_operation(self, operation_id, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["operation"] = {
+            "operation_id": operation_id,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"operation_id": operation_id, "status": "SUCCEEDED"}
+
+    async def _fake_version_replay(self, proposal_id, version_no, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["version_replay"] = {
+            "proposal_id": proposal_id,
+            "version_no": version_no,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"proposal_id": proposal_id, "version_no": version_no, "replayable": True}
+
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.create_proposal_artifact",
+        _fake_artifact,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.create_proposal_async",
+        _fake_async,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.get_proposal_operation",
+        _fake_operation,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.get_proposal_version_replay_evidence",
+        _fake_version_replay,
+    )
+
+    client = TestClient(app)
+    artifact = client.post(
+        "/api/v1/proposals/artifact",
+        json={"body": {"proposal_run_id": "pr_001"}},
+        headers={"Idempotency-Key": "idem-artifact", "X-Correlation-Id": "corr-artifact"},
+    )
+    async_create = client.post(
+        "/api/v1/proposals/async",
+        json={"body": {"created_by": "advisor_1"}},
+        headers={"Idempotency-Key": "idem-async", "X-Correlation-Id": "corr-async"},
+    )
+    operation = client.get(
+        "/api/v1/proposals/operations/apo_001",
+        headers={"X-Correlation-Id": "corr-operation"},
+    )
+    replay = client.get(
+        "/api/v1/proposals/pp_001/versions/2/replay-evidence",
+        headers={"X-Correlation-Id": "corr-replay"},
+    )
+
+    assert artifact.status_code == 200
+    assert async_create.status_code == 200
+    assert operation.status_code == 200
+    assert replay.status_code == 200
+    assert captured == {
+        "artifact": {
+            "body": {"proposal_run_id": "pr_001"},
+            "idempotency_key": "idem-artifact",
+            "correlation_id": "corr-artifact",
+        },
+        "async": {
+            "body": {"created_by": "advisor_1"},
+            "idempotency_key": "idem-async",
+            "correlation_id": "corr-async",
+        },
+        "operation": {"operation_id": "apo_001", "correlation_id": "corr-operation"},
+        "version_replay": {
+            "proposal_id": "pp_001",
+            "version_no": 2,
+            "correlation_id": "corr-replay",
+        },
+    }
+    assert artifact.json()["data"]["artifact_hash"] == "sha256:artifact"
+    assert async_create.json()["data"]["operation_id"] == "apo_001"
+    assert operation.json()["data"]["status"] == "SUCCEEDED"
+    assert replay.json()["data"]["replayable"] is True
+
+
+def test_proposal_narrative_execution_and_memo_support_routes_forward_to_advise(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_regenerate_narrative(
+        self,
+        proposal_id,
+        version_no,
+        body,
+        correlation_id,  # noqa: ANN001
+    ):
+        _ = self
+        captured["regenerate_narrative"] = {
+            "proposal_id": proposal_id,
+            "version_no": version_no,
+            "body": body,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"narrative_id": "pn_candidate", "status": "READY_FOR_ADVISOR_REVIEW"}
+
+    async def _fake_get_narrative(self, proposal_id, version_no, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["get_narrative"] = {
+            "proposal_id": proposal_id,
+            "version_no": version_no,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"narrative_id": "pn_persisted", "review_state": "DRAFT"}
+
+    async def _fake_handoff(
+        self,
+        proposal_id,
+        body,
+        idempotency_key,
+        correlation_id,  # noqa: ANN001
+    ):
+        _ = self
+        captured["execution_handoff"] = {
+            "proposal_id": proposal_id,
+            "body": body,
+            "idempotency_key": idempotency_key,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"execution_request_id": "pex_001", "handoff_status": "REQUESTED"}
+
+    async def _fake_execution_status(self, proposal_id, correlation_id):  # noqa: ANN001
+        _ = self
+        captured["execution_status"] = {
+            "proposal_id": proposal_id,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"proposal_id": proposal_id, "handoff_status": "REQUESTED"}
+
+    async def _fake_memo_report_event(
+        self,
+        proposal_id,
+        version_no,
+        body,
+        idempotency_key,
+        correlation_id,  # noqa: ANN001
+    ):
+        _ = self
+        captured["memo_report_event"] = {
+            "proposal_id": proposal_id,
+            "version_no": version_no,
+            "body": body,
+            "idempotency_key": idempotency_key,
+            "correlation_id": correlation_id,
+        }
+        return 200, {"event_id": "memo_report_event_001", "event_type": "ARCHIVED"}
+
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.regenerate_proposal_narrative",
+        _fake_regenerate_narrative,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.get_proposal_narrative",
+        _fake_get_narrative,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.create_execution_handoff",
+        _fake_handoff,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.get_execution_status",
+        _fake_execution_status,
+    )
+    monkeypatch.setattr(
+        "app.clients.advise_client.AdviseClient.record_proposal_memo_report_package_event",
+        _fake_memo_report_event,
+    )
+
+    client = TestClient(app)
+    regenerated = client.post(
+        "/api/v1/proposals/pp_001/versions/2/narrative/regenerate",
+        json={"body": {"requested_by": "advisor_1"}},
+        headers={"X-Correlation-Id": "corr-narrative-regenerate"},
+    )
+    narrative = client.get(
+        "/api/v1/proposals/pp_001/versions/2/narrative",
+        headers={"X-Correlation-Id": "corr-narrative-read"},
+    )
+    handoff = client.post(
+        "/api/v1/proposals/pp_001/execution-handoffs",
+        json={"body": {"requested_by": "advisor_1", "execution_provider": "lotus-manage"}},
+        headers={
+            "Idempotency-Key": "idem-exec-handoff",
+            "X-Correlation-Id": "corr-exec-handoff",
+        },
+    )
+    execution_status = client.get(
+        "/api/v1/proposals/pp_001/execution-status",
+        headers={"X-Correlation-Id": "corr-exec-status"},
+    )
+    memo_event = client.post(
+        "/api/v1/proposals/pp_001/versions/2/memo/report-package-events",
+        json={"body": {"event_type": "ARCHIVED", "archive_ref": "archive_001"}},
+        headers={
+            "Idempotency-Key": "idem-memo-report-event",
+            "X-Correlation-Id": "corr-memo-report-event",
+        },
+    )
+
+    assert regenerated.status_code == 200
+    assert narrative.status_code == 200
+    assert handoff.status_code == 200
+    assert execution_status.status_code == 200
+    assert memo_event.status_code == 200
+    assert captured == {
+        "regenerate_narrative": {
+            "proposal_id": "pp_001",
+            "version_no": 2,
+            "body": {"requested_by": "advisor_1"},
+            "correlation_id": "corr-narrative-regenerate",
+        },
+        "get_narrative": {
+            "proposal_id": "pp_001",
+            "version_no": 2,
+            "correlation_id": "corr-narrative-read",
+        },
+        "execution_handoff": {
+            "proposal_id": "pp_001",
+            "body": {"requested_by": "advisor_1", "execution_provider": "lotus-manage"},
+            "idempotency_key": "idem-exec-handoff",
+            "correlation_id": "corr-exec-handoff",
+        },
+        "execution_status": {
+            "proposal_id": "pp_001",
+            "correlation_id": "corr-exec-status",
+        },
+        "memo_report_event": {
+            "proposal_id": "pp_001",
+            "version_no": 2,
+            "body": {"event_type": "ARCHIVED", "archive_ref": "archive_001"},
+            "idempotency_key": "idem-memo-report-event",
+            "correlation_id": "corr-memo-report-event",
+        },
+    }
+    assert regenerated.json()["data"]["status"] == "READY_FOR_ADVISOR_REVIEW"
+    assert handoff.json()["data"]["execution_request_id"] == "pex_001"
+    assert memo_event.json()["data"]["event_type"] == "ARCHIVED"
+
+
 def test_proposal_list_success(monkeypatch):
     async def _fake_list_proposals(self, params, correlation_id):  # noqa: ANN001
         _ = self, correlation_id

--- a/tests/unit/test_platform_capabilities_service.py
+++ b/tests/unit/test_platform_capabilities_service.py
@@ -924,7 +924,11 @@ async def test_platform_capabilities_normalizes_live_snake_case_capability_metad
                 "source_service": "lotus-core",
                 "policy_version": "tenant-default-v1",
                 "supported_input_modes": ["lotus_core_ref"],
-                "features": [],
+                "features": [
+                    {"key": "lotus_core.support.overview_api", "enabled": True},
+                    {"key": "lotus_core.ingestion.bulk_upload_adapter", "enabled": True},
+                    {"key": "lotus_core.ingestion.portfolio_bundle_adapter", "enabled": True},
+                ],
                 "workflows": [],
             },
         ),
@@ -984,6 +988,8 @@ async def test_platform_capabilities_normalizes_live_snake_case_capability_metad
         "inline_bundle",
         "simulation",
     ]
+    assert normalized.navigation["portfolio_intake"] is True
+    assert normalized.navigation["portfolio_workspace"] is True
     assert normalized.policy_versions_by_source == {
         "lotus_core": "tenant-default-v1",
         "lotus_performance": "tenant-default-v1",


### PR DESCRIPTION
## Summary
- Exposes the full advisory workspace and proposal route surface through Gateway to lotus-advise.
- Adds route coverage so Workbench can consume advisor workspace, proposal lifecycle, memo, delivery, and execution posture through the BFF boundary.
- Documents the advisory Gateway route surface in repository context.

## Validation
- `make check` passed: lint, format check, monetary float guard, mypy, OpenAPI workbench contract, and 595 unit/contract tests.
- `make ci` passed: lint/typecheck/OpenAPI/migration smoke, 200 integration tests, 795 coverage tests at 87.65%, and security audit with the governed PYSEC-2026-161 exception.

## Governance
- UI-facing advisory features remain Gateway-first and route to lotus-advise authority; Gateway does not synthesize portfolio positions, suitability, risk, report, archive, or client-ready truth locally.
- No direct Workbench-to-advise dependency is introduced.