### PR TITLE
Forward RFC 25 policy queue portfolio scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "lotus-gateway for Advisor Workbench"
 requires-python = ">=3.11"
 dependencies = [
-  "fastapi>=0.129.0",
+  "fastapi>=0.129.0,<0.136.3",
   "uvicorn>=0.35.0",
   "pydantic>=2.11.0",
   "pydantic-settings>=2.10.0",
@@ -54,5 +54,4 @@ python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
-
 

--- a/requirements-audit.txt
+++ b/requirements-audit.txt
@@ -1,5 +1,5 @@
 # Production dependency audit only. Test and lint tooling are verified separately in CI.
-fastapi>=0.129.0
+fastapi>=0.129.0,<0.136.3
 uvicorn>=0.35.0
 pydantic>=2.11.0
 pydantic-settings>=2.10.0

--- a/src/app/clients/advise_client.py
+++ b/src/app/clients/advise_client.py
@@ -310,11 +310,14 @@ class AdviseClient:
     async def get_policy_review_queue(
         self,
         evaluation_status: str | None,
+        portfolio_id: str | None,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         params: dict[str, Any] = {}
         if evaluation_status is not None:
             params["evaluation_status"] = evaluation_status
+        if portfolio_id is not None:
+            params["portfolio_id"] = portfolio_id
         return await self._get(
             "/advisory/policy-evaluations/review-queue",
             params=params,

--- a/src/app/routers/advisory_policy.py
+++ b/src/app/routers/advisory_policy.py
@@ -335,8 +335,8 @@ async def record_policy_sign_off_decision(
     response_model=AdvisoryPolicyEnvelopeResponse,
     summary="Request Advisory Policy Report Package",
     description=(
-        "Requests a source-owned supervisory or client-draft report package through lotus-advise. "
-        "Gateway does not promote blocked or degraded evaluations to client-ready output."
+        "Requests a source-owned advisor/compliance policy sign-off package through lotus-advise. "
+        "Gateway does not promote blocked or degraded evaluations to client-ready publication."
     ),
 )
 async def request_policy_report_package(

--- a/src/app/routers/advisory_policy.py
+++ b/src/app/routers/advisory_policy.py
@@ -180,9 +180,15 @@ async def get_policy_review_queue(
         description="Optional policy evaluation status filter owned by lotus-advise.",
         examples=["PENDING_REVIEW"],
     ),
+    portfolio_id: str | None = Query(
+        default=None,
+        description="Optional portfolio identifier filter owned by lotus-advise.",
+        examples=["PB_SG_GLOBAL_BAL_001"],
+    ),
 ) -> AdvisoryPolicyEnvelopeResponse:
     return await _advisory_policy_service().get_policy_review_queue(
         evaluation_status=evaluation_status,
+        portfolio_id=portfolio_id,
         correlation_id=correlation_id_var.get(),
     )
 

--- a/src/app/services/advisory_policy_service.py
+++ b/src/app/services/advisory_policy_service.py
@@ -94,10 +94,12 @@ class AdvisoryPolicyService:
         self,
         *,
         evaluation_status: str | None,
+        portfolio_id: str | None,
         correlation_id: str,
     ) -> AdvisoryPolicyEnvelopeResponse:
         upstream_status, upstream_payload = await self._advise_client.get_policy_review_queue(
             evaluation_status=evaluation_status,
+            portfolio_id=portfolio_id,
             correlation_id=correlation_id,
         )
         self._raise_for_upstream_error(upstream_status, upstream_payload)

--- a/tests/contract/test_advise_gateway_route_coverage.py
+++ b/tests/contract/test_advise_gateway_route_coverage.py
@@ -122,3 +122,13 @@ def test_gateway_exposes_supported_lotus_advise_policy_surface() -> None:
     }
 
     assert expected - routes == set()
+
+
+def test_gateway_policy_report_package_openapi_stays_within_supported_boundary() -> None:
+    operation = app.openapi()["paths"][
+        "/api/v1/advisory-policy-evaluations/{evaluation_id}/report-packages"
+    ]["post"]
+
+    assert "client-draft" not in operation["description"].lower()
+    assert "advisor/compliance policy sign-off package" in operation["description"]
+    assert "client-ready publication" in operation["description"]

--- a/tests/integration/test_advisory_policy_router.py
+++ b/tests/integration/test_advisory_policy_router.py
@@ -153,10 +153,11 @@ def test_policy_evaluation_routes_preserve_advise_boundary_and_blockers(monkeypa
             },
         }
 
-    async def _fake_queue(self, evaluation_status, correlation_id):  # noqa: ANN001
+    async def _fake_queue(self, evaluation_status, portfolio_id, correlation_id):  # noqa: ANN001
         _ = self
         captured["queue"] = {
             "evaluation_status": evaluation_status,
+            "portfolio_id": portfolio_id,
             "correlation_id": correlation_id,
         }
         return 200, {"items": [{"evaluation_id": "pev_001", "queue": "Compliance"}]}
@@ -231,7 +232,8 @@ def test_policy_evaluation_routes_preserve_advise_boundary_and_blockers(monkeypa
         },
     )
     queue_response = client.get(
-        "/api/v1/advisory-policy-evaluations/review-queue?evaluation_status=PENDING_REVIEW",
+        "/api/v1/advisory-policy-evaluations/review-queue"
+        "?evaluation_status=PENDING_REVIEW&portfolio_id=PB_SG_GLOBAL_BAL_001",
         headers={"X-Correlation-Id": "corr-policy-queue"},
     )
     workflow_response = client.get(
@@ -272,6 +274,7 @@ def test_policy_evaluation_routes_preserve_advise_boundary_and_blockers(monkeypa
         },
         "queue": {
             "evaluation_status": "PENDING_REVIEW",
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
             "correlation_id": "corr-policy-queue",
         },
         "workflow": {"evaluation_id": "pev_001", "correlation_id": "corr-policy-workflow"},

--- a/tests/integration/test_advisory_policy_router.py
+++ b/tests/integration/test_advisory_policy_router.py
@@ -400,7 +400,7 @@ def test_policy_decision_report_event_lineage_and_replay_routes_forward_unchange
     )
     report_response = client.post(
         "/api/v1/advisory-policy-evaluations/pev_001/report-packages",
-        json={"body": {"audience": "CLIENT_DRAFT", "requested_by": "advisor_1"}},
+        json={"body": {"audience": "ADVISOR_COMPLIANCE", "requested_by": "advisor_1"}},
         headers={
             "Idempotency-Key": "idem-policy-report",
             "X-Correlation-Id": "corr-policy-report",
@@ -435,7 +435,7 @@ def test_policy_decision_report_event_lineage_and_replay_routes_forward_unchange
         },
         "report": {
             "evaluation_id": "pev_001",
-            "body": {"audience": "CLIENT_DRAFT", "requested_by": "advisor_1"},
+            "body": {"audience": "ADVISOR_COMPLIANCE", "requested_by": "advisor_1"},
             "idempotency_key": "idem-policy-report",
             "correlation_id": "corr-policy-report",
         },

--- a/tests/unit/test_dependency_policy.py
+++ b/tests/unit/test_dependency_policy.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_fastapi_resolution_excludes_blocked_security_audit_release() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+    dependencies = pyproject["project"]["dependencies"]
+    audit_requirements = Path("requirements-audit.txt").read_text(encoding="utf-8").splitlines()
+
+    assert "fastapi>=0.129.0,<0.136.3" in dependencies
+    assert "fastapi>=0.129.0,<0.136.3" in audit_requirements

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -3126,6 +3126,7 @@ async def test_advise_client_policy_review_queue_omits_empty_filters() -> None:
 
     status_code, _ = await client.get_policy_review_queue(
         evaluation_status=None,
+        portfolio_id=None,
         correlation_id="corr-policy-queue",
     )
 
@@ -3135,6 +3136,27 @@ async def test_advise_client_policy_review_queue_omits_empty_filters() -> None:
     )
     assert _FakeAsyncClient.calls[0]["params"] == {}
     assert _FakeAsyncClient.calls[0]["headers"]["X-Correlation-Id"] == "corr-policy-queue"
+
+
+@pytest.mark.asyncio
+async def test_advise_client_policy_review_queue_forwards_portfolio_filter() -> None:
+    client = AdviseClient(base_url="http://advise", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"ok": True})
+
+    status_code, _ = await client.get_policy_review_queue(
+        evaluation_status="PENDING_REVIEW",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        correlation_id="corr-policy-queue",
+    )
+
+    assert status_code == 200
+    assert _FakeAsyncClient.calls[0]["url"] == (
+        "http://advise/advisory/policy-evaluations/review-queue"
+    )
+    assert _FakeAsyncClient.calls[0]["params"] == {
+        "evaluation_status": "PENDING_REVIEW",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- forward portfolio_id on the advisory policy review queue through Gateway
- tighten policy report package OpenAPI wording to advisor/compliance sign-off boundaries
- cover queue filtering and boundary wording with contract, integration, and upstream-client tests

## Validation
- make check
- python -m pytest tests/contract/test_advise_gateway_route_coverage.py tests/integration/test_advisory_policy_router.py tests/unit/test_upstream_clients.py -q