### PR TITLE
Refactor gateway route ownership batch 7

### DIFF
--- a/src/app/routers/advisor_cockpit.py
+++ b/src/app/routers/advisor_cockpit.py
@@ -14,6 +14,26 @@ from app.services.advisory_service_provider import advisor_cockpit_service
 router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 
+async def _list_advisor_cockpit_actions(
+    *,
+    portfolio_id: str | None,
+    advisor_id: str | None,
+    role: AdvisorCockpitOwnerRole,
+    limit: int,
+    cursor: str | None,
+) -> AdvisorCockpitEnvelopeResponse:
+    return await advisor_cockpit_service().list_actions(
+        params=cockpit_params(
+            portfolio_id=portfolio_id,
+            advisor_id=advisor_id,
+            role=role,
+            limit=limit,
+            cursor=cursor,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/actions",
     response_model=AdvisorCockpitEnvelopeResponse,
@@ -54,13 +74,10 @@ async def list_advisor_cockpit_actions(
         examples=["cockpit_action_001"],
     ),
 ) -> AdvisorCockpitEnvelopeResponse:
-    return await advisor_cockpit_service().list_actions(
-        params=cockpit_params(
-            portfolio_id=portfolio_id,
-            advisor_id=advisor_id,
-            role=role,
-            limit=limit,
-            cursor=cursor,
-        ),
-        correlation_id=correlation_id_var.get(),
+    return await _list_advisor_cockpit_actions(
+        portfolio_id=portfolio_id,
+        advisor_id=advisor_id,
+        role=role,
+        limit=limit,
+        cursor=cursor,
     )

--- a/src/app/routers/advisor_cockpit_acknowledgements.py
+++ b/src/app/routers/advisor_cockpit_acknowledgements.py
@@ -15,6 +15,24 @@ from app.services.advisory_service_provider import advisor_cockpit_service
 router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 
+async def _acknowledge_advisor_cockpit_action(
+    *,
+    request: AdvisorCockpitAcknowledgeRequest,
+    action_item_id: str,
+    idempotency_key: str,
+    portfolio_id: str | None,
+    advisor_id: str | None,
+    role: AdvisorCockpitOwnerRole,
+) -> AdvisorCockpitEnvelopeResponse:
+    return await advisor_cockpit_service().acknowledge_action(
+        action_item_id=action_item_id,
+        body=request.model_dump(exclude_none=True),
+        params=cockpit_params(portfolio_id=portfolio_id, advisor_id=advisor_id, role=role),
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/actions/{action_item_id}/acknowledgements",
     response_model=AdvisorCockpitEnvelopeResponse,
@@ -55,10 +73,11 @@ async def acknowledge_advisor_cockpit_action(
         examples=["ADVISOR"],
     ),
 ) -> AdvisorCockpitEnvelopeResponse:
-    return await advisor_cockpit_service().acknowledge_action(
+    return await _acknowledge_advisor_cockpit_action(
+        request=request,
         action_item_id=action_item_id,
-        body=request.model_dump(exclude_none=True),
-        params=cockpit_params(portfolio_id=portfolio_id, advisor_id=advisor_id, role=role),
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id_var.get(),
+        portfolio_id=portfolio_id,
+        advisor_id=advisor_id,
+        role=role,
     )

--- a/src/app/routers/advisor_cockpit_action_lookup.py
+++ b/src/app/routers/advisor_cockpit_action_lookup.py
@@ -14,6 +14,20 @@ from app.services.advisory_service_provider import advisor_cockpit_service
 router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 
+async def _get_advisor_cockpit_action(
+    *,
+    action_item_id: str,
+    portfolio_id: str | None,
+    advisor_id: str | None,
+    role: AdvisorCockpitOwnerRole,
+) -> AdvisorCockpitEnvelopeResponse:
+    return await advisor_cockpit_service().get_action(
+        action_item_id=action_item_id,
+        params=cockpit_params(portfolio_id=portfolio_id, advisor_id=advisor_id, role=role),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/actions/{action_item_id}",
     response_model=AdvisorCockpitEnvelopeResponse,
@@ -46,8 +60,9 @@ async def get_advisor_cockpit_action(
         examples=["ADVISOR"],
     ),
 ) -> AdvisorCockpitEnvelopeResponse:
-    return await advisor_cockpit_service().get_action(
+    return await _get_advisor_cockpit_action(
         action_item_id=action_item_id,
-        params=cockpit_params(portfolio_id=portfolio_id, advisor_id=advisor_id, role=role),
-        correlation_id=correlation_id_var.get(),
+        portfolio_id=portfolio_id,
+        advisor_id=advisor_id,
+        role=role,
     )

--- a/src/app/routers/advisor_cockpit_house_view.py
+++ b/src/app/routers/advisor_cockpit_house_view.py
@@ -10,6 +10,15 @@ from app.services.advisory_service_provider import advisor_cockpit_service
 router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 
+async def _evaluate_advisor_cockpit_house_view_cohort(
+    request: AdvisorCockpitHouseViewCohortRequest,
+) -> AdvisorCockpitEnvelopeResponse:
+    return await advisor_cockpit_service().evaluate_house_view_cohort(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/house-view-cohorts/evaluate",
     response_model=AdvisorCockpitEnvelopeResponse,
@@ -25,7 +34,4 @@ router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 async def evaluate_advisor_cockpit_house_view_cohort(
     request: AdvisorCockpitHouseViewCohortRequest,
 ) -> AdvisorCockpitEnvelopeResponse:
-    return await advisor_cockpit_service().evaluate_house_view_cohort(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _evaluate_advisor_cockpit_house_view_cohort(request)

--- a/src/app/routers/advisor_cockpit_preparation_packets.py
+++ b/src/app/routers/advisor_cockpit_preparation_packets.py
@@ -14,6 +14,26 @@ from app.services.advisory_service_provider import advisor_cockpit_service
 router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 
+async def _list_advisor_cockpit_preparation_packets(
+    *,
+    portfolio_id: str | None,
+    advisor_id: str | None,
+    role: AdvisorCockpitOwnerRole,
+    limit: int,
+    cursor: str | None,
+) -> AdvisorCockpitEnvelopeResponse:
+    return await advisor_cockpit_service().list_preparation_packets(
+        params=cockpit_params(
+            portfolio_id=portfolio_id,
+            advisor_id=advisor_id,
+            role=role,
+            limit=limit,
+            cursor=cursor,
+        ),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/preparation-packets",
     response_model=AdvisorCockpitEnvelopeResponse,
@@ -55,13 +75,10 @@ async def list_advisor_cockpit_preparation_packets(
         examples=["prep_packet_001"],
     ),
 ) -> AdvisorCockpitEnvelopeResponse:
-    return await advisor_cockpit_service().list_preparation_packets(
-        params=cockpit_params(
-            portfolio_id=portfolio_id,
-            advisor_id=advisor_id,
-            role=role,
-            limit=limit,
-            cursor=cursor,
-        ),
-        correlation_id=correlation_id_var.get(),
+    return await _list_advisor_cockpit_preparation_packets(
+        portfolio_id=portfolio_id,
+        advisor_id=advisor_id,
+        role=role,
+        limit=limit,
+        cursor=cursor,
     )

--- a/src/app/routers/advisor_cockpit_snapshot.py
+++ b/src/app/routers/advisor_cockpit_snapshot.py
@@ -14,6 +14,18 @@ from app.services.advisory_service_provider import advisor_cockpit_service
 router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 
+async def _get_advisor_cockpit_snapshot(
+    *,
+    portfolio_id: str | None,
+    advisor_id: str | None,
+    role: AdvisorCockpitOwnerRole,
+) -> AdvisorCockpitEnvelopeResponse:
+    return await advisor_cockpit_service().get_snapshot(
+        params=cockpit_params(portfolio_id=portfolio_id, advisor_id=advisor_id, role=role),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/snapshot",
     response_model=AdvisorCockpitEnvelopeResponse,
@@ -42,7 +54,8 @@ async def get_advisor_cockpit_snapshot(
         examples=["ADVISOR"],
     ),
 ) -> AdvisorCockpitEnvelopeResponse:
-    return await advisor_cockpit_service().get_snapshot(
-        params=cockpit_params(portfolio_id=portfolio_id, advisor_id=advisor_id, role=role),
-        correlation_id=correlation_id_var.get(),
+    return await _get_advisor_cockpit_snapshot(
+        portfolio_id=portfolio_id,
+        advisor_id=advisor_id,
+        role=role,
     )

--- a/src/app/routers/advisor_cockpit_supportability.py
+++ b/src/app/routers/advisor_cockpit_supportability.py
@@ -14,6 +14,18 @@ from app.services.advisory_service_provider import advisor_cockpit_service
 router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 
+async def _get_advisor_cockpit_supportability(
+    *,
+    portfolio_id: str | None,
+    advisor_id: str | None,
+    role: AdvisorCockpitOwnerRole,
+) -> AdvisorCockpitEnvelopeResponse:
+    return await advisor_cockpit_service().get_supportability(
+        params=cockpit_params(portfolio_id=portfolio_id, advisor_id=advisor_id, role=role),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/supportability",
     response_model=AdvisorCockpitEnvelopeResponse,
@@ -42,7 +54,8 @@ async def get_advisor_cockpit_supportability(
         examples=["ADVISOR"],
     ),
 ) -> AdvisorCockpitEnvelopeResponse:
-    return await advisor_cockpit_service().get_supportability(
-        params=cockpit_params(portfolio_id=portfolio_id, advisor_id=advisor_id, role=role),
-        correlation_id=correlation_id_var.get(),
+    return await _get_advisor_cockpit_supportability(
+        portfolio_id=portfolio_id,
+        advisor_id=advisor_id,
+        role=role,
     )

--- a/src/app/routers/analytics_diagnostics.py
+++ b/src/app/routers/analytics_diagnostics.py
@@ -24,6 +24,67 @@ logger = logging.getLogger("analytics_ui.gateway")
 router = APIRouter(prefix="/api/v1/analytics-ui", tags=["Analytics Diagnostics"])
 
 
+def _validate_diagnostics_caller_context(
+    *,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> None:
+    try:
+        caller_context_headers(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        )
+    except HTTPException:
+        emit_gateway_protected_diagnostics_audit_log(
+            logger=logger,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            reason="missing_caller_context",
+        )
+        raise
+
+
+def _raise_for_unauthorized_diagnostics_role(role: str | None) -> None:
+    if is_authorized_operator_role(role):
+        return
+    emit_gateway_protected_diagnostics_audit_log(
+        logger=logger,
+        status_code=status.HTTP_403_FORBIDDEN,
+        reason="operator_role_required",
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": "operator_role_required",
+            "message": "Analytics diagnostics lookup requires an operator support role.",
+        },
+    )
+
+
+def _raise_for_unsafe_support_reference(support_reference: str) -> None:
+    if is_safe_support_reference(support_reference):
+        return
+    emit_gateway_protected_diagnostics_audit_log(
+        logger=logger,
+        status_code=status.HTTP_400_BAD_REQUEST,
+        reason="invalid_support_reference",
+    )
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail={
+            "code": "invalid_support_reference",
+            "message": "Support reference must be opaque and product-safe.",
+        },
+    )
+
+
 @router.get(
     "/diagnostics/{support_reference}",
     response_model=AnalyticsDiagnosticsResponse,
@@ -60,51 +121,16 @@ async def lookup_analytics_diagnostics(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> AnalyticsDiagnosticsResponse:
-    try:
-        caller_context_headers(
-            actor_id=actor_id,
-            caller_application=caller_application,
-            tenant_id=tenant_id,
-            region=region,
-            booking_center_code=booking_center_code,
-            role=role,
-        )
-    except HTTPException:
-        emit_gateway_protected_diagnostics_audit_log(
-            logger=logger,
-            status_code=status.HTTP_400_BAD_REQUEST,
-            reason="missing_caller_context",
-        )
-        raise
-
-    if not is_authorized_operator_role(role):
-        emit_gateway_protected_diagnostics_audit_log(
-            logger=logger,
-            status_code=status.HTTP_403_FORBIDDEN,
-            reason="operator_role_required",
-        )
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={
-                "code": "operator_role_required",
-                "message": "Analytics diagnostics lookup requires an operator support role.",
-            },
-        )
-
-    if not is_safe_support_reference(support_reference):
-        emit_gateway_protected_diagnostics_audit_log(
-            logger=logger,
-            status_code=status.HTTP_400_BAD_REQUEST,
-            reason="invalid_support_reference",
-        )
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail={
-                "code": "invalid_support_reference",
-                "message": "Support reference must be opaque and product-safe.",
-            },
-        )
-
+    _validate_diagnostics_caller_context(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+    _raise_for_unauthorized_diagnostics_role(role)
+    _raise_for_unsafe_support_reference(support_reference)
     response = resolve_support_reference(support_reference)
     emit_gateway_protected_diagnostics_audit_log(
         logger=logger,

--- a/src/app/routers/archive_document_downloads.py
+++ b/src/app/routers/archive_document_downloads.py
@@ -4,12 +4,30 @@ from fastapi import APIRouter, Header, Path, Response
 
 from app.middleware.correlation import correlation_id_var
 from app.routers.archive_documents_common import (
-    archive_caller_headers,
+    ArchiveDocumentCallerHeaders,
     archive_error_response,
 )
 from app.services.gateway_service_provider import archive_document_service
 
 router = APIRouter(prefix="/api/v1/documents", tags=["Archived Documents"])
+
+
+async def _download_archived_document(
+    *,
+    document_id: str,
+    caller_headers: ArchiveDocumentCallerHeaders,
+) -> Response:
+    download = await archive_document_service().download_document(
+        document_id=document_id,
+        caller_headers=caller_headers.as_archive_context(),
+        correlation_id=correlation_id_var.get(),
+    )
+
+    return Response(
+        content=download.content,
+        media_type=download.media_type,
+        headers=download.headers,
+    )
 
 
 @router.get(
@@ -67,9 +85,9 @@ async def download_archived_document(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> Response:
-    download = await archive_document_service().download_document(
+    return await _download_archived_document(
         document_id=document_id,
-        caller_headers=archive_caller_headers(
+        caller_headers=ArchiveDocumentCallerHeaders(
             actor_id=actor_id,
             caller_application=caller_application,
             tenant_id=tenant_id,
@@ -77,11 +95,4 @@ async def download_archived_document(
             booking_center_code=booking_center_code,
             role=role,
         ),
-        correlation_id=correlation_id_var.get(),
-    )
-
-    return Response(
-        content=download.content,
-        media_type=download.media_type,
-        headers=download.headers,
     )

--- a/src/app/routers/archive_documents.py
+++ b/src/app/routers/archive_documents.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Annotated
 
 from fastapi import APIRouter, Header, Path, Query
@@ -9,32 +8,12 @@ from app.contracts.archive_documents import (
 )
 from app.middleware.correlation import correlation_id_var
 from app.routers.archive_documents_common import (
-    archive_caller_headers,
+    ArchiveDocumentCallerHeaders,
     archive_error_response,
 )
 from app.services.gateway_service_provider import archive_document_service
 
 router = APIRouter(prefix="/api/v1/documents", tags=["Archived Documents"])
-
-
-@dataclass(frozen=True)
-class ArchiveDocumentCallerHeaders:
-    actor_id: str | None
-    caller_application: str | None
-    tenant_id: str | None
-    region: str | None
-    booking_center_code: str | None
-    role: str | None
-
-    def as_archive_context(self) -> dict[str, str]:
-        return archive_caller_headers(
-            actor_id=self.actor_id,
-            caller_application=self.caller_application,
-            tenant_id=self.tenant_id,
-            region=self.region,
-            booking_center_code=self.booking_center_code,
-            role=self.role,
-        )
 
 
 async def _get_archived_document_metadata(

--- a/src/app/routers/archive_documents.py
+++ b/src/app/routers/archive_documents.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Annotated
 
 from fastapi import APIRouter, Header, Path, Query
@@ -14,6 +15,41 @@ from app.routers.archive_documents_common import (
 from app.services.gateway_service_provider import archive_document_service
 
 router = APIRouter(prefix="/api/v1/documents", tags=["Archived Documents"])
+
+
+@dataclass(frozen=True)
+class ArchiveDocumentCallerHeaders:
+    actor_id: str | None
+    caller_application: str | None
+    tenant_id: str | None
+    region: str | None
+    booking_center_code: str | None
+    role: str | None
+
+    def as_archive_context(self) -> dict[str, str]:
+        return archive_caller_headers(
+            actor_id=self.actor_id,
+            caller_application=self.caller_application,
+            tenant_id=self.tenant_id,
+            region=self.region,
+            booking_center_code=self.booking_center_code,
+            role=self.role,
+        )
+
+
+async def _get_archived_document_metadata(
+    *,
+    document_id: str,
+    current: bool,
+    caller_headers: ArchiveDocumentCallerHeaders,
+) -> ArchivedDocumentMetadataResponse:
+    correlation_id = correlation_id_var.get()
+    return await archive_document_service().get_document_metadata(
+        document_id=document_id,
+        caller_headers=caller_headers.as_archive_context(),
+        correlation_id=correlation_id,
+        current=current,
+    )
 
 
 @router.get(
@@ -81,10 +117,10 @@ async def get_archived_document_metadata(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> ArchivedDocumentMetadataResponse:
-    correlation_id = correlation_id_var.get()
-    return await archive_document_service().get_document_metadata(
+    return await _get_archived_document_metadata(
         document_id=document_id,
-        caller_headers=archive_caller_headers(
+        current=current,
+        caller_headers=ArchiveDocumentCallerHeaders(
             actor_id=actor_id,
             caller_application=caller_application,
             tenant_id=tenant_id,
@@ -92,6 +128,4 @@ async def get_archived_document_metadata(
             booking_center_code=booking_center_code,
             role=role,
         ),
-        correlation_id=correlation_id,
-        current=current,
     )

--- a/src/app/routers/archive_documents_common.py
+++ b/src/app/routers/archive_documents_common.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any
 
 from app.contracts.archive_documents import (
@@ -5,6 +6,26 @@ from app.contracts.archive_documents import (
     ArchivedDocumentErrorResponse,
 )
 from app.services.caller_context import caller_context_headers
+
+
+@dataclass(frozen=True)
+class ArchiveDocumentCallerHeaders:
+    actor_id: str | None
+    caller_application: str | None
+    tenant_id: str | None
+    region: str | None
+    booking_center_code: str | None
+    role: str | None
+
+    def as_archive_context(self) -> dict[str, str]:
+        return archive_caller_headers(
+            actor_id=self.actor_id,
+            caller_application=self.caller_application,
+            tenant_id=self.tenant_id,
+            region=self.region,
+            booking_center_code=self.booking_center_code,
+            role=self.role,
+        )
 
 
 def archive_error_response(

--- a/src/app/routers/bank_demo_proof.py
+++ b/src/app/routers/bank_demo_proof.py
@@ -10,6 +10,14 @@ from app.services.advisory_service_provider import bank_demo_proof_service
 router = APIRouter(prefix="/api/v1/advisory/bank-demo-proof", tags=["bank-demo-proof"])
 
 
+async def _get_bank_demo_scenario_contract(
+    x_correlation_id: str | None,
+) -> BankDemoProofEnvelopeResponse:
+    return await bank_demo_proof_service().get_scenario_contract(
+        correlation_id=bank_demo_correlation_id(x_correlation_id),
+    )
+
+
 @router.get(
     "/scenario-contract",
     response_model=BankDemoProofEnvelopeResponse,
@@ -24,6 +32,4 @@ router = APIRouter(prefix="/api/v1/advisory/bank-demo-proof", tags=["bank-demo-p
 async def get_bank_demo_scenario_contract(
     x_correlation_id: str | None = Header(default=None, alias="X-Correlation-Id"),
 ) -> BankDemoProofEnvelopeResponse:
-    return await bank_demo_proof_service().get_scenario_contract(
-        correlation_id=bank_demo_correlation_id(x_correlation_id),
-    )
+    return await _get_bank_demo_scenario_contract(x_correlation_id)

--- a/src/app/routers/bank_demo_proof_packs.py
+++ b/src/app/routers/bank_demo_proof_packs.py
@@ -12,6 +12,17 @@ from app.services.advisory_service_provider import bank_demo_proof_service
 router = APIRouter(prefix="/api/v1/advisory/bank-demo-proof", tags=["bank-demo-proof"])
 
 
+async def _build_bank_demo_proof_pack(
+    *,
+    body: dict[str, Any],
+    x_correlation_id: str | None,
+) -> BankDemoProofEnvelopeResponse:
+    return await bank_demo_proof_service().build_proof_pack(
+        body=body,
+        correlation_id=bank_demo_correlation_id(x_correlation_id),
+    )
+
+
 @router.post(
     "/proof-packs",
     response_model=BankDemoProofEnvelopeResponse,
@@ -33,7 +44,7 @@ async def build_bank_demo_proof_pack(
     ),
     x_correlation_id: str | None = Header(default=None, alias="X-Correlation-Id"),
 ) -> BankDemoProofEnvelopeResponse:
-    return await bank_demo_proof_service().build_proof_pack(
+    return await _build_bank_demo_proof_pack(
         body=body,
-        correlation_id=bank_demo_correlation_id(x_correlation_id),
+        x_correlation_id=x_correlation_id,
     )

--- a/src/app/routers/bank_demo_supported_claims.py
+++ b/src/app/routers/bank_demo_supported_claims.py
@@ -10,6 +10,14 @@ from app.services.advisory_service_provider import bank_demo_proof_service
 router = APIRouter(prefix="/api/v1/advisory/bank-demo-proof", tags=["bank-demo-proof"])
 
 
+async def _get_bank_demo_supported_claim_register(
+    x_correlation_id: str | None,
+) -> BankDemoProofEnvelopeResponse:
+    return await bank_demo_proof_service().get_supported_claim_register(
+        correlation_id=bank_demo_correlation_id(x_correlation_id),
+    )
+
+
 @router.get(
     "/supported-claim-register",
     response_model=BankDemoProofEnvelopeResponse,
@@ -25,6 +33,4 @@ router = APIRouter(prefix="/api/v1/advisory/bank-demo-proof", tags=["bank-demo-p
 async def get_bank_demo_supported_claim_register(
     x_correlation_id: str | None = Header(default=None, alias="X-Correlation-Id"),
 ) -> BankDemoProofEnvelopeResponse:
-    return await bank_demo_proof_service().get_supported_claim_register(
-        correlation_id=bank_demo_correlation_id(x_correlation_id),
-    )
+    return await _get_bank_demo_supported_claim_register(x_correlation_id)

--- a/src/app/routers/composite_performance.py
+++ b/src/app/routers/composite_performance.py
@@ -13,6 +13,31 @@ from app.services.gateway_service_provider import composite_performance_service
 router = APIRouter(prefix="/api/v1/performance/composites", tags=["Composite Performance"])
 
 
+async def _calculate_composite_twr(
+    *,
+    request: CompositePerformanceTwrRequest,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> CompositePerformanceGatewayResponse:
+    correlation_id = correlation_id_var.get()
+    return await composite_performance_service().calculate_twr(
+        payload=request.model_dump(exclude_none=True),
+        correlation_id=correlation_id,
+        caller_context=composite_caller_context(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+    )
+
+
 @router.post(
     "/twr",
     response_model=CompositePerformanceGatewayResponse,
@@ -33,16 +58,12 @@ async def calculate_composite_twr(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> CompositePerformanceGatewayResponse:
-    correlation_id = correlation_id_var.get()
-    return await composite_performance_service().calculate_twr(
-        payload=request.model_dump(exclude_none=True),
-        correlation_id=correlation_id,
-        caller_context=composite_caller_context(
-            actor_id=actor_id,
-            caller_application=caller_application,
-            tenant_id=tenant_id,
-            region=region,
-            booking_center_code=booking_center_code,
-            role=role,
-        ),
+    return await _calculate_composite_twr(
+        request=request,
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
     )

--- a/src/app/routers/dpm_command_center_outcome_review_lookup.py
+++ b/src/app/routers/dpm_command_center_outcome_review_lookup.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+from typing import Any
+
 from fastapi import APIRouter, Query
 
 from app.contracts.dpm_command_center import DpmOutcomeReviewGatewayResponse
@@ -10,6 +13,43 @@ router = APIRouter(
     tags=["DPM Command Center"],
     responses=UPSTREAM_ERROR_RESPONSES,
 )
+
+
+@dataclass(frozen=True)
+class OutcomeReviewListFilters:
+    portfolio_id: str | None
+    rebalance_run_id: str | None
+    wave_id: str | None
+    state: str | None
+    source_system: str | None
+    source_type: str | None
+    limit: int
+    offset: int | None
+    source_scan_limit: int | None
+    cursor: str | None
+
+    def as_filters(self) -> dict[str, Any]:
+        return {
+            "portfolio_id": self.portfolio_id,
+            "rebalance_run_id": self.rebalance_run_id,
+            "wave_id": self.wave_id,
+            "state": self.state,
+            "source_system": self.source_system,
+            "source_type": self.source_type,
+            "limit": self.limit,
+            "offset": self.offset,
+            "source_scan_limit": self.source_scan_limit,
+            "cursor": self.cursor,
+        }
+
+
+async def _list_outcome_reviews(
+    filters: OutcomeReviewListFilters,
+) -> DpmOutcomeReviewGatewayResponse:
+    return await dpm_command_center_service().list_outcome_reviews(
+        filters=filters.as_filters(),
+        correlation_id=correlation_id_var.get(),
+    )
 
 
 @router.get(
@@ -80,19 +120,17 @@ async def list_outcome_reviews(
         examples=["or_cursor_0025"],
     ),
 ) -> DpmOutcomeReviewGatewayResponse:
-    filters = {
-        "portfolio_id": portfolio_id,
-        "rebalance_run_id": rebalance_run_id,
-        "wave_id": wave_id,
-        "state": state,
-        "source_system": source_system,
-        "source_type": source_type,
-        "limit": limit,
-        "offset": offset,
-        "source_scan_limit": source_scan_limit,
-        "cursor": cursor,
-    }
-    return await dpm_command_center_service().list_outcome_reviews(
-        filters=filters,
-        correlation_id=correlation_id_var.get(),
+    return await _list_outcome_reviews(
+        OutcomeReviewListFilters(
+            portfolio_id=portfolio_id,
+            rebalance_run_id=rebalance_run_id,
+            wave_id=wave_id,
+            state=state,
+            source_system=source_system,
+            source_type=source_type,
+            limit=limit,
+            offset=offset,
+            source_scan_limit=source_scan_limit,
+            cursor=cursor,
+        )
     )

--- a/src/app/routers/dpm_command_center_portfolio_memory_search.py
+++ b/src/app/routers/dpm_command_center_portfolio_memory_search.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+from typing import Any
+
 from fastapi import APIRouter, Query
 
 from app.contracts.dpm_command_center import (
@@ -21,6 +24,39 @@ router = APIRouter(
     tags=["DPM Command Center"],
     responses=_UPSTREAM_ERROR_RESPONSES,
 )
+
+
+@dataclass(frozen=True)
+class PortfolioMemorySearchFilters:
+    portfolio_ids: list[str] | None
+    event_type: str | None
+    supportability_state: str | None
+    source_system: str | None
+    source_type: str | None
+    limit: int
+    offset: int
+    source_scan_limit: int | None
+
+    def as_filters(self) -> dict[str, Any]:
+        return {
+            "portfolio_ids": self.portfolio_ids,
+            "event_type": self.event_type,
+            "supportability_state": self.supportability_state,
+            "source_system": self.source_system,
+            "source_type": self.source_type,
+            "limit": self.limit,
+            "offset": self.offset,
+            "source_scan_limit": self.source_scan_limit,
+        }
+
+
+async def _search_portfolio_memory(
+    filters: PortfolioMemorySearchFilters,
+) -> DpmPortfolioMemoryGatewayResponse:
+    return await dpm_command_center_service().search_portfolio_memory(
+        filters=filters.as_filters(),
+        correlation_id=correlation_id_var.get(),
+    )
 
 
 @router.get(
@@ -84,16 +120,15 @@ async def search_portfolio_memory(
         examples=[250],
     ),
 ) -> DpmPortfolioMemoryGatewayResponse:
-    return await dpm_command_center_service().search_portfolio_memory(
-        filters={
-            "portfolio_ids": portfolio_ids,
-            "event_type": event_type,
-            "supportability_state": supportability_state,
-            "source_system": source_system,
-            "source_type": source_type,
-            "limit": limit,
-            "offset": offset,
-            "source_scan_limit": source_scan_limit,
-        },
-        correlation_id=correlation_id_var.get(),
+    return await _search_portfolio_memory(
+        PortfolioMemorySearchFilters(
+            portfolio_ids=portfolio_ids,
+            event_type=event_type,
+            supportability_state=supportability_state,
+            source_system=source_system,
+            source_type=source_type,
+            limit=limit,
+            offset=offset,
+            source_scan_limit=source_scan_limit,
+        )
     )

--- a/src/app/routers/dpm_wave_campaign_discovery.py
+++ b/src/app/routers/dpm_wave_campaign_discovery.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+from typing import Any
+
 from fastapi import APIRouter, Query
 
 from app.contracts.dpm_waves import (
@@ -19,6 +22,37 @@ _UPSTREAM_ERROR_RESPONSES = manage_upstream_error_responses(
     invalid_payload_description="lotus-manage rejected the campaign discovery payload as invalid.",
     unavailable_description="lotus-manage campaign discovery authority is unavailable or degraded.",
 )
+
+
+@dataclass(frozen=True)
+class CampaignDiscoveryFilters:
+    campaign_id: str | None
+    campaign_status: str | None
+    as_of_date: str | None
+    active_on: str | None
+    include_expired: bool
+    limit: int
+    offset: int
+
+    def as_filters(self) -> dict[str, Any]:
+        return {
+            "campaign_id": self.campaign_id,
+            "campaign_status": self.campaign_status,
+            "as_of_date": self.as_of_date,
+            "active_on": self.active_on,
+            "include_expired": self.include_expired,
+            "limit": self.limit,
+            "offset": self.offset,
+        }
+
+
+async def _discover_campaigns(
+    filters: CampaignDiscoveryFilters,
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await dpm_wave_service().discover_campaigns(
+        filters=filters.as_filters(),
+        correlation_id=correlation_id_var.get(),
+    )
 
 
 @router.get(
@@ -59,15 +93,14 @@ async def discover_campaigns(
     limit: int = Query(default=50, ge=1, le=200, description="Maximum campaigns to return."),
     offset: int = Query(default=0, ge=0, description="Zero-based campaign-discovery offset."),
 ) -> DpmCampaignDefinitionGatewayResponse:
-    return await dpm_wave_service().discover_campaigns(
-        filters={
-            "campaign_id": campaign_id,
-            "campaign_status": campaign_status,
-            "as_of_date": as_of_date,
-            "active_on": active_on,
-            "include_expired": include_expired,
-            "limit": limit,
-            "offset": offset,
-        },
-        correlation_id=correlation_id_var.get(),
+    return await _discover_campaigns(
+        CampaignDiscoveryFilters(
+            campaign_id=campaign_id,
+            campaign_status=campaign_status,
+            as_of_date=as_of_date,
+            active_on=active_on,
+            include_expired=include_expired,
+            limit=limit,
+            offset=offset,
+        )
     )

--- a/src/app/routers/portfolio.py
+++ b/src/app/routers/portfolio.py
@@ -7,6 +7,10 @@ from app.services.portfolio_service_provider import portfolio_service
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
 
+async def _get_portfolios() -> PortfolioCatalogResponse:
+    return await portfolio_service().get_portfolio_catalog(correlation_id=correlation_id_var.get())
+
+
 @router.get(
     "/portfolios",
     response_model=PortfolioCatalogResponse,
@@ -20,4 +24,4 @@ router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
     ),
 )
 async def get_portfolios() -> PortfolioCatalogResponse:
-    return await portfolio_service().get_portfolio_catalog(correlation_id=correlation_id_var.get())
+    return await _get_portfolios()

--- a/src/app/routers/portfolio_activity.py
+++ b/src/app/routers/portfolio_activity.py
@@ -7,6 +7,24 @@ from app.services.portfolio_service_provider import portfolio_service
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
 
+async def _get_portfolio_activity_summary(
+    *,
+    portfolio_id: str,
+    as_of_date: str | None,
+    start_date: str | None,
+    end_date: str | None,
+    reporting_currency: str | None,
+) -> PortfolioActivitySummaryResponse:
+    return await portfolio_service().get_activity_summary(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
+        start_date=start_date,
+        end_date=end_date,
+        reporting_currency=reporting_currency,
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/activity-summary",
     response_model=PortfolioActivitySummaryResponse,
@@ -53,9 +71,8 @@ async def get_portfolio_activity_summary(
         examples=["USD"],
     ),
 ) -> PortfolioActivitySummaryResponse:
-    return await portfolio_service().get_activity_summary(
+    return await _get_portfolio_activity_summary(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
         start_date=start_date,
         end_date=end_date,

--- a/src/app/routers/portfolio_allocations.py
+++ b/src/app/routers/portfolio_allocations.py
@@ -7,6 +7,22 @@ from app.services.portfolio_service_provider import portfolio_service
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
 
+async def _get_portfolio_allocations(
+    *,
+    portfolio_id: str,
+    as_of_date: str | None,
+    reporting_currency: str | None,
+    look_through_mode: str,
+) -> PortfolioAllocationResponse:
+    return await portfolio_service().get_portfolio_allocations(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
+        reporting_currency=reporting_currency,
+        look_through_mode=look_through_mode,
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/allocations",
     response_model=PortfolioAllocationResponse,
@@ -47,9 +63,8 @@ async def get_portfolio_allocations(
         examples=["direct_only", "full"],
     ),
 ) -> PortfolioAllocationResponse:
-    return await portfolio_service().get_portfolio_allocations(
+    return await _get_portfolio_allocations(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
         reporting_currency=reporting_currency,
         look_through_mode=look_through_mode,

--- a/src/app/routers/portfolio_book.py
+++ b/src/app/routers/portfolio_book.py
@@ -9,6 +9,22 @@ from app.services.portfolio_service_provider import portfolio_service
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
 
+async def _get_portfolio_book(
+    *,
+    portfolio_id: str,
+    as_of_date: str | None,
+    include_projected: bool,
+    reporting_currency: str | None,
+) -> PortfolioBookResponse:
+    return await portfolio_service().get_portfolio_book(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
+        include_projected=include_projected,
+        reporting_currency=reporting_currency,
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/book",
     response_model=PortfolioBookResponse,
@@ -49,9 +65,8 @@ async def get_portfolio_book(
         examples=["USD"],
     ),
 ) -> PortfolioBookResponse:
-    return await portfolio_service().get_portfolio_book(
+    return await _get_portfolio_book(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
         include_projected=include_projected,
         reporting_currency=reporting_currency,

--- a/src/app/routers/portfolio_income_summary.py
+++ b/src/app/routers/portfolio_income_summary.py
@@ -7,6 +7,24 @@ from app.services.portfolio_service_provider import portfolio_service
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
 
+async def _get_portfolio_income_summary(
+    *,
+    portfolio_id: str,
+    as_of_date: str | None,
+    start_date: str | None,
+    end_date: str | None,
+    reporting_currency: str | None,
+) -> PortfolioIncomeSummaryResponse:
+    return await portfolio_service().get_income_summary(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
+        start_date=start_date,
+        end_date=end_date,
+        reporting_currency=reporting_currency,
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/income-summary",
     response_model=PortfolioIncomeSummaryResponse,
@@ -53,9 +71,8 @@ async def get_portfolio_income_summary(
         examples=["USD"],
     ),
 ) -> PortfolioIncomeSummaryResponse:
-    return await portfolio_service().get_income_summary(
+    return await _get_portfolio_income_summary(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
         start_date=start_date,
         end_date=end_date,

--- a/src/app/routers/portfolio_insights.py
+++ b/src/app/routers/portfolio_insights.py
@@ -7,6 +7,18 @@ from app.services.portfolio_service_provider import portfolio_service
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
 
+async def _get_portfolio_insights(
+    *,
+    portfolio_id: str,
+    as_of_date: str | None,
+) -> PortfolioInsightsResponse:
+    return await portfolio_service().get_portfolio_insights(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/insights",
     response_model=PortfolioInsightsResponse,
@@ -33,8 +45,7 @@ async def get_portfolio_insights(
         examples=["2026-03-27"],
     ),
 ) -> PortfolioInsightsResponse:
-    return await portfolio_service().get_portfolio_insights(
+    return await _get_portfolio_insights(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
     )

--- a/src/app/routers/portfolio_liquidity.py
+++ b/src/app/routers/portfolio_liquidity.py
@@ -7,6 +7,20 @@ from app.services.portfolio_service_provider import portfolio_service
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
 
+async def _get_portfolio_liquidity(
+    *,
+    portfolio_id: str,
+    as_of_date: str | None,
+    reporting_currency: str | None,
+) -> PortfolioLiquidityResponse:
+    return await portfolio_service().get_portfolio_liquidity(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
+        reporting_currency=reporting_currency,
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/liquidity",
     response_model=PortfolioLiquidityResponse,
@@ -38,9 +52,8 @@ async def get_portfolio_liquidity(
         examples=["USD"],
     ),
 ) -> PortfolioLiquidityResponse:
-    return await portfolio_service().get_portfolio_liquidity(
+    return await _get_portfolio_liquidity(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
         reporting_currency=reporting_currency,
     )

--- a/src/app/routers/portfolio_performance.py
+++ b/src/app/routers/portfolio_performance.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from fastapi import APIRouter, Query
 
 from app.contracts.portfolio import PortfolioPerformanceSnapshotResponse
@@ -5,6 +7,33 @@ from app.middleware.correlation import correlation_id_var
 from app.services.portfolio_service_provider import portfolio_performance_workspace_service
 
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
+
+
+@dataclass(frozen=True)
+class PortfolioPerformanceSnapshotQuery:
+    period: str
+    chart_frequency: str
+    detail_basis: str
+    benchmark_code: str | None
+    explicit_start_date: str | None
+    explicit_end_date: str | None
+
+
+async def _get_portfolio_performance_snapshot(
+    *,
+    portfolio_id: str,
+    query: PortfolioPerformanceSnapshotQuery,
+) -> PortfolioPerformanceSnapshotResponse:
+    return await portfolio_performance_workspace_service().get_portfolio_performance_snapshot(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        period=query.period,
+        chart_frequency=query.chart_frequency,
+        detail_basis=query.detail_basis,
+        benchmark_code=query.benchmark_code,
+        explicit_start_date=query.explicit_start_date,
+        explicit_end_date=query.explicit_end_date,
+    )
 
 
 @router.get(
@@ -87,13 +116,14 @@ async def get_portfolio_performance_snapshot(
         },
     ),
 ) -> PortfolioPerformanceSnapshotResponse:
-    return await portfolio_performance_workspace_service().get_portfolio_performance_snapshot(
+    return await _get_portfolio_performance_snapshot(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
-        period=period,
-        chart_frequency=chart_frequency,
-        detail_basis=detail_basis,
-        benchmark_code=benchmark_code,
-        explicit_start_date=explicit_start_date,
-        explicit_end_date=explicit_end_date,
+        query=PortfolioPerformanceSnapshotQuery(
+            period=period,
+            chart_frequency=chart_frequency,
+            detail_basis=detail_basis,
+            benchmark_code=benchmark_code,
+            explicit_start_date=explicit_start_date,
+            explicit_end_date=explicit_end_date,
+        ),
     )

--- a/src/app/routers/portfolio_positions.py
+++ b/src/app/routers/portfolio_positions.py
@@ -7,6 +7,22 @@ from app.services.portfolio_service_provider import portfolio_service
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
 
+async def _get_portfolio_positions(
+    *,
+    portfolio_id: str,
+    as_of_date: str | None,
+    include_projected: bool,
+    reporting_currency: str | None,
+) -> PortfolioPositionBookResponse:
+    return await portfolio_service().get_portfolio_positions(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
+        include_projected=include_projected,
+        reporting_currency=reporting_currency,
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/positions",
     response_model=PortfolioPositionBookResponse,
@@ -44,9 +60,8 @@ async def get_portfolio_positions(
         examples=["USD"],
     ),
 ) -> PortfolioPositionBookResponse:
-    return await portfolio_service().get_portfolio_positions(
+    return await _get_portfolio_positions(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
         include_projected=include_projected,
         reporting_currency=reporting_currency,

--- a/src/app/routers/portfolio_projected_cashflow.py
+++ b/src/app/routers/portfolio_projected_cashflow.py
@@ -7,6 +7,22 @@ from app.services.portfolio_service_provider import portfolio_service
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
 
+async def _get_portfolio_projected_cashflow(
+    *,
+    portfolio_id: str,
+    as_of_date: str | None,
+    horizon_days: int,
+    include_projected: bool,
+) -> PortfolioProjectedCashflowResponse:
+    return await portfolio_service().get_portfolio_projected_cashflow(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
+        horizon_days=horizon_days,
+        include_projected=include_projected,
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/projected-cashflow",
     response_model=PortfolioProjectedCashflowResponse,
@@ -43,9 +59,8 @@ async def get_portfolio_projected_cashflow(
         examples=[True],
     ),
 ) -> PortfolioProjectedCashflowResponse:
-    return await portfolio_service().get_portfolio_projected_cashflow(
+    return await _get_portfolio_projected_cashflow(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
         horizon_days=horizon_days,
         include_projected=include_projected,

--- a/src/app/routers/portfolio_readiness.py
+++ b/src/app/routers/portfolio_readiness.py
@@ -7,6 +7,18 @@ from app.services.portfolio_service_provider import portfolio_service
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
 
+async def _get_portfolio_readiness(
+    *,
+    portfolio_id: str,
+    as_of_date: str | None,
+) -> PortfolioReadinessResponse:
+    return await portfolio_service().get_portfolio_readiness(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/readiness",
     response_model=PortfolioReadinessResponse,
@@ -28,8 +40,7 @@ async def get_portfolio_readiness(
         examples=["2026-04-10"],
     ),
 ) -> PortfolioReadinessResponse:
-    return await portfolio_service().get_portfolio_readiness(
+    return await _get_portfolio_readiness(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
     )

--- a/src/app/routers/portfolio_workflow.py
+++ b/src/app/routers/portfolio_workflow.py
@@ -7,6 +7,18 @@ from app.services.portfolio_service_provider import portfolio_service
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
 
+async def _get_portfolio_workflow(
+    *,
+    portfolio_id: str,
+    as_of_date: str | None,
+) -> PortfolioWorkflowResponse:
+    return await portfolio_service().get_portfolio_workflow(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/workflow",
     response_model=PortfolioWorkflowResponse,
@@ -32,8 +44,7 @@ async def get_portfolio_workflow(
         examples=["2026-03-27"],
     ),
 ) -> PortfolioWorkflowResponse:
-    return await portfolio_service().get_portfolio_workflow(
+    return await _get_portfolio_workflow(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
     )

--- a/src/app/routers/portfolio_workspace.py
+++ b/src/app/routers/portfolio_workspace.py
@@ -7,6 +7,20 @@ from app.services.portfolio_service_provider import portfolio_service
 router = APIRouter(prefix="/api/v1/portfolio", tags=["portfolio"])
 
 
+async def _get_portfolio_workspace(
+    *,
+    portfolio_id: str,
+    as_of_date: str | None,
+    reporting_currency: str | None,
+) -> PortfolioWorkspaceResponse:
+    return await portfolio_service().get_portfolio_workspace(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+        as_of_date=as_of_date,
+        reporting_currency=reporting_currency,
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/workspace",
     response_model=PortfolioWorkspaceResponse,
@@ -38,9 +52,8 @@ async def get_portfolio_workspace(
         examples=["USD"],
     ),
 ) -> PortfolioWorkspaceResponse:
-    return await portfolio_service().get_portfolio_workspace(
+    return await _get_portfolio_workspace(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
         as_of_date=as_of_date,
         reporting_currency=reporting_currency,
     )

--- a/src/app/routers/reporting_batch_lease_recovery.py
+++ b/src/app/routers/reporting_batch_lease_recovery.py
@@ -10,6 +10,18 @@ from app.services.reporting_service_provider import reporting_batch_control_serv
 recovery_router = APIRouter(prefix="/api/v1/report-batches", tags=["Report Batches"])
 
 
+async def _recover_expired_report_batch_leases(
+    *,
+    batch_id: str,
+    caller_headers: dict[str, str],
+) -> BatchRecoveryResponse:
+    return await reporting_batch_control_service().recover_expired_leases(
+        batch_id=batch_id,
+        caller_headers=caller_headers,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @recovery_router.post(
     "/{batch_id}:recover-expired-leases",
     response_model=BatchRecoveryResponse,
@@ -28,8 +40,7 @@ async def recover_expired_report_batch_leases(
     batch_id: Annotated[str, Path(description="Opaque durable report batch identifier.")],
     caller_headers: ReportingCallerContext,
 ) -> BatchRecoveryResponse:
-    return await reporting_batch_control_service().recover_expired_leases(
+    return await _recover_expired_report_batch_leases(
         batch_id=batch_id,
         caller_headers=caller_headers,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/reporting_batch_run_once.py
+++ b/src/app/routers/reporting_batch_run_once.py
@@ -16,6 +16,22 @@ from app.services.reporting_service_provider import reporting_batch_control_serv
 worker_router = APIRouter(prefix="/api/v1/report-batches", tags=["Report Batches"])
 
 
+async def _run_report_batch_once(
+    *,
+    batch_id: str,
+    request: BatchWorkerRunRequest,
+    caller_headers: dict[str, str],
+) -> BatchWorkerRunResponse:
+    correlation_id = correlation_id_var.get()
+    return await reporting_batch_control_service().run_batch_once(
+        batch_id=batch_id,
+        request=request,
+        caller_headers=caller_headers,
+        correlation_id=correlation_id,
+        tenant_id=caller_headers.get("X-Tenant-Id"),
+    )
+
+
 @worker_router.post(
     "/{batch_id}:run-once",
     response_model=BatchWorkerRunResponse,
@@ -60,11 +76,8 @@ async def run_report_batch_once(
     batch_id: Annotated[str, Path(description="Opaque durable report batch identifier.")],
     caller_headers: ReportingCallerContext,
 ) -> BatchWorkerRunResponse:
-    correlation_id = correlation_id_var.get()
-    return await reporting_batch_control_service().run_batch_once(
+    return await _run_report_batch_once(
         batch_id=batch_id,
         request=request,
         caller_headers=caller_headers,
-        correlation_id=correlation_id,
-        tenant_id=caller_headers.get("X-Tenant-Id"),
     )

--- a/src/app/routers/reporting_batch_status.py
+++ b/src/app/routers/reporting_batch_status.py
@@ -11,6 +11,20 @@ from app.services.reporting_service_provider import reporting_batch_lifecycle_se
 status_router = APIRouter(prefix="/api/v1/report-batches", tags=["Report Batches"])
 
 
+async def _get_report_batch_status(
+    *,
+    batch_id: str,
+    caller_headers: dict[str, str],
+) -> BatchStatusResponse:
+    correlation_id = correlation_id_var.get()
+    return await reporting_batch_lifecycle_service().get_batch_status(
+        batch_id=batch_id,
+        caller_headers=caller_headers,
+        correlation_id=correlation_id,
+        tenant_id=caller_headers.get("X-Tenant-Id"),
+    )
+
+
 @status_router.get(
     "/{batch_id}",
     response_model=BatchStatusResponse,
@@ -42,10 +56,7 @@ async def get_report_batch_status(
     batch_id: Annotated[str, Path(description="Opaque durable report batch identifier.")],
     caller_headers: ReportingCallerContext,
 ) -> BatchStatusResponse:
-    correlation_id = correlation_id_var.get()
-    return await reporting_batch_lifecycle_service().get_batch_status(
+    return await _get_report_batch_status(
         batch_id=batch_id,
         caller_headers=caller_headers,
-        correlation_id=correlation_id,
-        tenant_id=caller_headers.get("X-Tenant-Id"),
     )

--- a/src/app/routers/reporting_batches.py
+++ b/src/app/routers/reporting_batches.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Header, status
@@ -14,6 +15,44 @@ from app.routers.reporting_errors import report_batch_error_response
 from app.services.reporting_service_provider import reporting_batch_lifecycle_service
 
 batches_router = APIRouter(prefix="/api/v1/report-batches", tags=["Report Batches"])
+
+
+@dataclass(frozen=True)
+class ReportBatchCallerHeaders:
+    actor_id: str | None
+    caller_application: str | None
+    tenant_id: str | None
+    region: str | None
+    booking_center_code: str | None
+    role: str | None
+
+    def as_reporting_context(self) -> dict[str, str]:
+        return reporting_context_headers(
+            actor_id=self.actor_id,
+            caller_application=self.caller_application,
+            tenant_id=self.tenant_id,
+            region=self.region,
+            booking_center_code=self.booking_center_code,
+            role=self.role,
+        )
+
+
+async def _create_report_batch(
+    *,
+    request: BatchCreateRequest,
+    idempotency_key: str | None,
+    caller_headers: ReportBatchCallerHeaders,
+) -> BatchHandleResponse:
+    correlation_id = correlation_id_var.get()
+    service = reporting_batch_lifecycle_service()
+    required_idempotency_key = service.require_idempotency_key(idempotency_key)
+    return await service.create_batch(
+        request=request,
+        idempotency_key=required_idempotency_key,
+        caller_headers=caller_headers.as_reporting_context(),
+        correlation_id=correlation_id,
+        tenant_id=caller_headers.tenant_id,
+    )
 
 
 @batches_router.post(
@@ -88,21 +127,15 @@ async def create_report_batch(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> BatchHandleResponse:
-    correlation_id = correlation_id_var.get()
-    service = reporting_batch_lifecycle_service()
-    required_idempotency_key = service.require_idempotency_key(idempotency_key)
-    caller_headers = reporting_context_headers(
-        actor_id=actor_id,
-        caller_application=caller_application,
-        tenant_id=tenant_id,
-        region=region,
-        booking_center_code=booking_center_code,
-        role=role,
-    )
-    return await service.create_batch(
+    return await _create_report_batch(
         request=request,
-        idempotency_key=required_idempotency_key,
-        caller_headers=caller_headers,
-        correlation_id=correlation_id,
-        tenant_id=tenant_id,
+        idempotency_key=idempotency_key,
+        caller_headers=ReportBatchCallerHeaders(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
     )

--- a/src/app/routers/reporting_batches.py
+++ b/src/app/routers/reporting_batches.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Header, status
@@ -10,38 +9,18 @@ from app.contracts.reporting import (
     BatchHandleResponse,
 )
 from app.middleware.correlation import correlation_id_var
-from app.routers.reporting_context import reporting_context_headers
+from app.routers.reporting_context import ReportingCallerHeaderInputs
 from app.routers.reporting_errors import report_batch_error_response
 from app.services.reporting_service_provider import reporting_batch_lifecycle_service
 
 batches_router = APIRouter(prefix="/api/v1/report-batches", tags=["Report Batches"])
 
 
-@dataclass(frozen=True)
-class ReportBatchCallerHeaders:
-    actor_id: str | None
-    caller_application: str | None
-    tenant_id: str | None
-    region: str | None
-    booking_center_code: str | None
-    role: str | None
-
-    def as_reporting_context(self) -> dict[str, str]:
-        return reporting_context_headers(
-            actor_id=self.actor_id,
-            caller_application=self.caller_application,
-            tenant_id=self.tenant_id,
-            region=self.region,
-            booking_center_code=self.booking_center_code,
-            role=self.role,
-        )
-
-
 async def _create_report_batch(
     *,
     request: BatchCreateRequest,
     idempotency_key: str | None,
-    caller_headers: ReportBatchCallerHeaders,
+    caller_headers: ReportingCallerHeaderInputs,
 ) -> BatchHandleResponse:
     correlation_id = correlation_id_var.get()
     service = reporting_batch_lifecycle_service()
@@ -49,7 +28,7 @@ async def _create_report_batch(
     return await service.create_batch(
         request=request,
         idempotency_key=required_idempotency_key,
-        caller_headers=caller_headers.as_reporting_context(),
+        caller_headers=caller_headers.as_headers(),
         correlation_id=correlation_id,
         tenant_id=caller_headers.tenant_id,
     )
@@ -130,7 +109,7 @@ async def create_report_batch(
     return await _create_report_batch(
         request=request,
         idempotency_key=idempotency_key,
-        caller_headers=ReportBatchCallerHeaders(
+        caller_headers=ReportingCallerHeaderInputs(
             actor_id=actor_id,
             caller_application=caller_application,
             tenant_id=tenant_id,

--- a/src/app/routers/reporting_context.py
+++ b/src/app/routers/reporting_context.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Annotated
 
 from fastapi import Depends, Header
@@ -22,6 +23,26 @@ def reporting_context_headers(
         booking_center_code=booking_center_code,
         role=role,
     )
+
+
+@dataclass(frozen=True)
+class ReportingCallerHeaderInputs:
+    actor_id: str | None
+    caller_application: str | None
+    tenant_id: str | None
+    region: str | None
+    booking_center_code: str | None
+    role: str | None
+
+    def as_headers(self) -> dict[str, str]:
+        return reporting_context_headers(
+            actor_id=self.actor_id,
+            caller_application=self.caller_application,
+            tenant_id=self.tenant_id,
+            region=self.region,
+            booking_center_code=self.booking_center_code,
+            role=self.role,
+        )
 
 
 def reporting_context_dependency(

--- a/src/app/routers/reporting_job_controls.py
+++ b/src/app/routers/reporting_job_controls.py
@@ -11,6 +11,18 @@ from app.services.reporting_service_provider import reporting_job_query_service
 controls_router = APIRouter(prefix="/api/v1/report-jobs", tags=["Report Jobs"])
 
 
+async def _cancel_report_job(
+    *,
+    job_id: str,
+    caller_headers: dict[str, str],
+) -> ReportJobStatusResponse:
+    return await reporting_job_query_service().cancel_report_job(
+        job_id=job_id,
+        caller_headers=caller_headers,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @controls_router.post(
     "/{job_id}/cancel",
     response_model=ReportJobStatusResponse,
@@ -42,8 +54,7 @@ async def cancel_report_job(
     job_id: Annotated[str, Path(description="Opaque report job identifier.")],
     caller_headers: ReportingCallerContext,
 ) -> ReportJobStatusResponse:
-    return await reporting_job_query_service().cancel_report_job(
+    return await _cancel_report_job(
         job_id=job_id,
         caller_headers=caller_headers,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/reporting_job_events.py
+++ b/src/app/routers/reporting_job_events.py
@@ -11,6 +11,18 @@ from app.services.reporting_service_provider import reporting_job_query_service
 events_router = APIRouter(prefix="/api/v1/report-jobs", tags=["Report Jobs"])
 
 
+async def _get_report_job_events(
+    *,
+    job_id: str,
+    caller_headers: dict[str, str],
+) -> ReportJobStatusEventsResponse:
+    return await reporting_job_query_service().get_report_job_events(
+        job_id=job_id,
+        caller_headers=caller_headers,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @events_router.get(
     "/{job_id}/events",
     response_model=ReportJobStatusEventsResponse,
@@ -36,8 +48,7 @@ async def get_report_job_events(
     job_id: Annotated[str, Path(description="Opaque report job identifier.")],
     caller_headers: ReportingCallerContext,
 ) -> ReportJobStatusEventsResponse:
-    return await reporting_job_query_service().get_report_job_events(
+    return await _get_report_job_events(
         job_id=job_id,
         caller_headers=caller_headers,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/reporting_job_lineage.py
+++ b/src/app/routers/reporting_job_lineage.py
@@ -11,6 +11,18 @@ from app.services.reporting_service_provider import reporting_job_query_service
 lineage_router = APIRouter(prefix="/api/v1/report-jobs", tags=["Report Jobs"])
 
 
+async def _get_report_job_lineage(
+    *,
+    job_id: str,
+    caller_headers: dict[str, str],
+) -> ReportSnapshotLineageResponse:
+    return await reporting_job_query_service().get_report_job_lineage(
+        job_id=job_id,
+        caller_headers=caller_headers,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @lineage_router.get(
     "/{job_id}/lineage",
     response_model=ReportSnapshotLineageResponse,
@@ -36,8 +48,7 @@ async def get_report_job_lineage(
     job_id: Annotated[str, Path(description="Opaque report job identifier.")],
     caller_headers: ReportingCallerContext,
 ) -> ReportSnapshotLineageResponse:
-    return await reporting_job_query_service().get_report_job_lineage(
+    return await _get_report_job_lineage(
         job_id=job_id,
         caller_headers=caller_headers,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/reporting_job_search.py
+++ b/src/app/routers/reporting_job_search.py
@@ -1,4 +1,5 @@
-from typing import Annotated
+from dataclasses import dataclass
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Query
 
@@ -12,6 +13,49 @@ from app.routers.reporting_errors import report_job_error_response
 from app.services.reporting_service_provider import reporting_job_query_service
 
 search_router = APIRouter(prefix="/api/v1/report-jobs", tags=["Report Jobs"])
+
+
+@dataclass(frozen=True)
+class ReportJobSearchFilters:
+    tenant_id: str | None
+    region: str | None
+    status: str | None
+    report_type: str | None
+    portfolio_id: str | None
+    as_of_date: str | None
+    idempotency_key: str | None
+    correlation_id: str | None
+    created_from: str | None
+    created_to: str | None
+    limit: int
+
+    def as_query_params(self) -> dict[str, Any]:
+        filters: dict[str, Any] = {
+            "tenantId": self.tenant_id,
+            "region": self.region,
+            "status": self.status,
+            "reportType": self.report_type,
+            "portfolioId": self.portfolio_id,
+            "asOfDate": self.as_of_date,
+            "idempotencyKey": self.idempotency_key,
+            "correlationId": self.correlation_id,
+            "createdFrom": self.created_from,
+            "createdTo": self.created_to,
+            "limit": self.limit,
+        }
+        return {key: value for key, value in filters.items() if value is not None}
+
+
+async def _list_report_jobs(
+    *,
+    caller_headers: dict[str, str],
+    filters: ReportJobSearchFilters,
+) -> ReportJobListResponse:
+    return await reporting_job_query_service().list_report_jobs(
+        filters=filters.as_query_params(),
+        caller_headers=caller_headers,
+        correlation_id=correlation_id_var.get(),
+    )
 
 
 @search_router.get(
@@ -106,22 +150,19 @@ async def list_report_jobs(
         ),
     ] = 25,
 ) -> ReportJobListResponse:
-    filters = {
-        "tenantId": tenant_id_filter,
-        "region": region_filter,
-        "status": status_filter,
-        "reportType": report_type_filter,
-        "portfolioId": portfolio_id_filter,
-        "asOfDate": as_of_date_filter,
-        "idempotencyKey": idempotency_key_filter,
-        "correlationId": correlation_id_filter,
-        "createdFrom": created_from,
-        "createdTo": created_to,
-        "limit": limit,
-    }
-    filters = {key: value for key, value in filters.items() if value is not None}
-    return await reporting_job_query_service().list_report_jobs(
-        filters=filters,
+    return await _list_report_jobs(
         caller_headers=caller_headers,
-        correlation_id=correlation_id_var.get(),
+        filters=ReportJobSearchFilters(
+            tenant_id=tenant_id_filter,
+            region=region_filter,
+            status=status_filter,
+            report_type=report_type_filter,
+            portfolio_id=portfolio_id_filter,
+            as_of_date=as_of_date_filter,
+            idempotency_key=idempotency_key_filter,
+            correlation_id=correlation_id_filter,
+            created_from=created_from,
+            created_to=created_to,
+            limit=limit,
+        ),
     )

--- a/src/app/routers/reporting_job_submissions.py
+++ b/src/app/routers/reporting_job_submissions.py
@@ -7,13 +7,33 @@ from app.contracts.reporting import (
     ReportJobHandleResponse,
 )
 from app.middleware.correlation import correlation_id_var
-from app.routers.reporting_context import reporting_context_headers
+from app.routers.reporting_context import ReportingCallerHeaderInputs
 from app.routers.reporting_errors import report_job_error_response
 from app.routers.reporting_examples import PORTFOLIO_REVIEW_JOB_REQUEST_EXAMPLES
 from app.services.reporting_links import gateway_report_job_status_url
 from app.services.reporting_service_provider import reporting_job_submission_service
 
 router = APIRouter(prefix="/api/v1/reports", tags=["Reports"])
+
+
+async def _submit_portfolio_review_report_job(
+    *,
+    request: PortfolioReviewJobRequest,
+    idempotency_key: str | None,
+    caller_headers: ReportingCallerHeaderInputs,
+) -> ReportJobHandleResponse:
+    correlation_id = correlation_id_var.get()
+    service = reporting_job_submission_service()
+    required_idempotency_key = service.require_idempotency_key(idempotency_key)
+    response = await service.submit_portfolio_review_job(
+        request=request,
+        idempotency_key=required_idempotency_key,
+        caller_headers=caller_headers.as_headers(),
+        correlation_id=correlation_id,
+    )
+    return response.model_copy(
+        update={"status_url": gateway_report_job_status_url(response.report_job_id)}
+    )
 
 
 @router.post(
@@ -67,13 +87,10 @@ async def submit_portfolio_review_report_job(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> ReportJobHandleResponse:
-    correlation_id = correlation_id_var.get()
-    service = reporting_job_submission_service()
-    required_idempotency_key = service.require_idempotency_key(idempotency_key)
-    response = await service.submit_portfolio_review_job(
+    return await _submit_portfolio_review_report_job(
         request=request,
-        idempotency_key=required_idempotency_key,
-        caller_headers=reporting_context_headers(
+        idempotency_key=idempotency_key,
+        caller_headers=ReportingCallerHeaderInputs(
             actor_id=actor_id,
             caller_application=caller_application,
             tenant_id=tenant_id,
@@ -81,8 +98,4 @@ async def submit_portfolio_review_report_job(
             booking_center_code=booking_center_code,
             role=role,
         ),
-        correlation_id=correlation_id,
-    )
-    return response.model_copy(
-        update={"status_url": gateway_report_job_status_url(response.report_job_id)}
     )

--- a/src/app/routers/reporting_jobs.py
+++ b/src/app/routers/reporting_jobs.py
@@ -11,6 +11,18 @@ from app.services.reporting_service_provider import reporting_job_query_service
 jobs_router = APIRouter(prefix="/api/v1/report-jobs", tags=["Report Jobs"])
 
 
+async def _get_report_job_status(
+    *,
+    job_id: str,
+    caller_headers: dict[str, str],
+) -> ReportJobStatusResponse:
+    return await reporting_job_query_service().get_report_job_status(
+        job_id=job_id,
+        caller_headers=caller_headers,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @jobs_router.get(
     "/{job_id}",
     response_model=ReportJobStatusResponse,
@@ -36,8 +48,7 @@ async def get_report_job_status(
     job_id: Annotated[str, Path(description="Opaque report job identifier.")],
     caller_headers: ReportingCallerContext,
 ) -> ReportJobStatusResponse:
-    return await reporting_job_query_service().get_report_job_status(
+    return await _get_report_job_status(
         job_id=job_id,
         caller_headers=caller_headers,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/reporting_outcome_review_submissions.py
+++ b/src/app/routers/reporting_outcome_review_submissions.py
@@ -7,13 +7,33 @@ from app.contracts.reporting import (
     ReportJobHandleResponse,
 )
 from app.middleware.correlation import correlation_id_var
-from app.routers.reporting_context import reporting_context_headers
+from app.routers.reporting_context import ReportingCallerHeaderInputs
 from app.routers.reporting_errors import report_job_error_response
 from app.routers.reporting_examples import OUTCOME_REVIEW_REPORT_JOB_REQUEST_EXAMPLES
 from app.services.reporting_links import gateway_report_job_status_url
 from app.services.reporting_service_provider import reporting_job_submission_service
 
 router = APIRouter(prefix="/api/v1/reports", tags=["Reports"])
+
+
+async def _submit_outcome_review_report_job(
+    *,
+    request: OutcomeReviewReportJobRequest,
+    idempotency_key: str | None,
+    caller_headers: ReportingCallerHeaderInputs,
+) -> ReportJobHandleResponse:
+    correlation_id = correlation_id_var.get()
+    service = reporting_job_submission_service()
+    required_idempotency_key = service.require_idempotency_key(idempotency_key)
+    response = await service.submit_outcome_review_report_job(
+        request=request,
+        idempotency_key=required_idempotency_key,
+        caller_headers=caller_headers.as_headers(),
+        correlation_id=correlation_id,
+    )
+    return response.model_copy(
+        update={"status_url": gateway_report_job_status_url(response.report_job_id)}
+    )
 
 
 @router.post(
@@ -67,13 +87,10 @@ async def submit_outcome_review_report_job(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> ReportJobHandleResponse:
-    correlation_id = correlation_id_var.get()
-    service = reporting_job_submission_service()
-    required_idempotency_key = service.require_idempotency_key(idempotency_key)
-    response = await service.submit_outcome_review_report_job(
+    return await _submit_outcome_review_report_job(
         request=request,
-        idempotency_key=required_idempotency_key,
-        caller_headers=reporting_context_headers(
+        idempotency_key=idempotency_key,
+        caller_headers=ReportingCallerHeaderInputs(
             actor_id=actor_id,
             caller_application=caller_application,
             tenant_id=tenant_id,
@@ -81,8 +98,4 @@ async def submit_outcome_review_report_job(
             booking_center_code=booking_center_code,
             role=role,
         ),
-        correlation_id=correlation_id,
-    )
-    return response.model_copy(
-        update={"status_url": gateway_report_job_status_url(response.report_job_id)}
     )

--- a/src/app/routers/reporting_portfolio_reviews.py
+++ b/src/app/routers/reporting_portfolio_reviews.py
@@ -10,6 +10,19 @@ from app.services.reporting_service_provider import reporting_portfolio_service
 router = APIRouter(prefix="/api/v1/reports", tags=["Reports"])
 
 
+async def _get_reporting_review(
+    *,
+    portfolio_id: str,
+    request: ReportingPortfolioRequest,
+) -> ReportingReviewResponse:
+    correlation_id = correlation_id_var.get()
+    return await reporting_portfolio_service().get_review(
+        portfolio_id=portfolio_id,
+        request=request,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{portfolio_id}/review",
     response_model=ReportingReviewResponse,
@@ -42,9 +55,7 @@ async def get_reporting_review(
         ),
     ],
 ) -> ReportingReviewResponse:
-    correlation_id = correlation_id_var.get()
-    return await reporting_portfolio_service().get_review(
+    return await _get_reporting_review(
         portfolio_id=portfolio_id,
         request=request,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/reporting_portfolio_snapshots.py
+++ b/src/app/routers/reporting_portfolio_snapshots.py
@@ -9,6 +9,19 @@ from app.services.reporting_service_provider import reporting_portfolio_service
 router = APIRouter(prefix="/api/v1/reports", tags=["Reports"])
 
 
+async def _get_reporting_snapshot(
+    *,
+    portfolio_id: str,
+    as_of_date: str,
+) -> ReportingSnapshotResponse:
+    correlation_id = correlation_id_var.get()
+    return await reporting_portfolio_service().get_snapshot(
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{portfolio_id}/snapshot",
     response_model=ReportingSnapshotResponse,
@@ -36,9 +49,7 @@ async def get_reporting_snapshot(
         ),
     ],
 ) -> ReportingSnapshotResponse:
-    correlation_id = correlation_id_var.get()
-    return await reporting_portfolio_service().get_snapshot(
+    return await _get_reporting_snapshot(
         portfolio_id=portfolio_id,
         as_of_date=as_of_date,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/reporting_portfolio_summary.py
+++ b/src/app/routers/reporting_portfolio_summary.py
@@ -15,6 +15,19 @@ from app.services.reporting_service_provider import (
 router = APIRouter(prefix="/api/v1/reports", tags=["Reports"])
 
 
+async def _get_reporting_summary(
+    *,
+    portfolio_id: str,
+    request: ReportingPortfolioRequest,
+) -> ReportingSummaryResponse:
+    correlation_id = correlation_id_var.get()
+    return await reporting_portfolio_service().get_summary(
+        portfolio_id=portfolio_id,
+        request=request,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{portfolio_id}/summary",
     response_model=ReportingSummaryResponse,
@@ -45,9 +58,7 @@ async def get_reporting_summary(
         ),
     ],
 ) -> ReportingSummaryResponse:
-    correlation_id = correlation_id_var.get()
-    return await reporting_portfolio_service().get_summary(
+    return await _get_reporting_summary(
         portfolio_id=portfolio_id,
         request=request,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/reporting_schedule_runs.py
+++ b/src/app/routers/reporting_schedule_runs.py
@@ -19,6 +19,18 @@ schedule_runs_router = APIRouter(
 )
 
 
+async def _run_due_report_batch_schedules(
+    *,
+    request: BatchSchedulerRunRequest,
+    caller_headers: dict[str, str],
+) -> BatchSchedulerRunResponse:
+    return await reporting_batch_scheduler_service().run_due_schedules(
+        request=request,
+        caller_headers=caller_headers,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @schedule_runs_router.post(
     ":run-due",
     response_model=BatchSchedulerRunResponse,
@@ -61,8 +73,7 @@ async def run_due_report_batch_schedules(
     ],
     caller_headers: ReportingCallerContext,
 ) -> BatchSchedulerRunResponse:
-    return await reporting_batch_scheduler_service().run_due_schedules(
+    return await _run_due_report_batch_schedules(
         request=request,
         caller_headers=caller_headers,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/reporting_schedules.py
+++ b/src/app/routers/reporting_schedules.py
@@ -15,6 +15,15 @@ schedules_router = APIRouter(
 )
 
 
+async def _list_report_batch_schedules(
+    caller_headers: dict[str, str],
+) -> BatchScheduleListResponse:
+    return await reporting_batch_scheduler_service().list_schedules(
+        caller_headers=caller_headers,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @schedules_router.get(
     "",
     response_model=BatchScheduleListResponse,
@@ -42,7 +51,4 @@ schedules_router = APIRouter(
 async def list_report_batch_schedules(
     caller_headers: ReportingCallerContext,
 ) -> BatchScheduleListResponse:
-    return await reporting_batch_scheduler_service().list_schedules(
-        caller_headers=caller_headers,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _list_report_batch_schedules(caller_headers=caller_headers)

--- a/src/app/routers/reporting_snapshot_lineage.py
+++ b/src/app/routers/reporting_snapshot_lineage.py
@@ -11,6 +11,18 @@ from app.services.reporting_service_provider import reporting_job_query_service
 router = APIRouter(prefix="/api/v1/reports/snapshots", tags=["Reports"])
 
 
+async def _get_report_snapshot_lineage(
+    *,
+    snapshot_id: str,
+    caller_headers: dict[str, str],
+) -> ReportSnapshotLineageResponse:
+    return await reporting_job_query_service().get_report_snapshot_lineage(
+        snapshot_id=snapshot_id,
+        caller_headers=caller_headers,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{snapshot_id}/lineage",
     response_model=ReportSnapshotLineageResponse,
@@ -35,8 +47,7 @@ async def get_report_snapshot_lineage(
     snapshot_id: Annotated[str, Path(description="Opaque report snapshot identifier.")],
     caller_headers: ReportingCallerContext,
 ) -> ReportSnapshotLineageResponse:
-    return await reporting_job_query_service().get_report_snapshot_lineage(
+    return await _get_report_snapshot_lineage(
         snapshot_id=snapshot_id,
         caller_headers=caller_headers,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/reporting_snapshot_records.py
+++ b/src/app/routers/reporting_snapshot_records.py
@@ -11,6 +11,18 @@ from app.services.reporting_service_provider import reporting_job_query_service
 router = APIRouter(prefix="/api/v1/reports/snapshots", tags=["Reports"])
 
 
+async def _get_report_snapshot(
+    *,
+    snapshot_id: str,
+    caller_headers: dict[str, str],
+) -> ReportInputSnapshotRecord:
+    return await reporting_job_query_service().get_report_snapshot(
+        snapshot_id=snapshot_id,
+        caller_headers=caller_headers,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{snapshot_id}",
     response_model=ReportInputSnapshotRecord,
@@ -36,8 +48,7 @@ async def get_report_snapshot(
     snapshot_id: Annotated[str, Path(description="Opaque report snapshot identifier.")],
     caller_headers: ReportingCallerContext,
 ) -> ReportInputSnapshotRecord:
-    return await reporting_job_query_service().get_report_snapshot(
+    return await _get_report_snapshot(
         snapshot_id=snapshot_id,
         caller_headers=caller_headers,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/workbench_risk_concentration.py
+++ b/src/app/routers/workbench_risk_concentration.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from fastapi import APIRouter, Path, Query
 
 from app.contracts.risk_workspace import WorkbenchRiskConcentrationResponse
@@ -6,6 +8,35 @@ from app.routers.workbench_risk_common import RISK_PERIOD_QUERY_DESCRIPTION
 from app.services.workbench_service_provider import risk_workspace_service
 
 router = APIRouter(prefix="/api/v1/workbench", tags=["workbench"])
+
+
+@dataclass(frozen=True)
+class RiskConcentrationQuery:
+    period: str
+    benchmark_code: str | None
+    as_of_date: str | None
+    report_start_date: str | None
+    report_end_date: str | None
+    reporting_currency: str
+
+
+async def _get_risk_concentration(
+    *,
+    portfolio_id: str,
+    query: RiskConcentrationQuery,
+) -> WorkbenchRiskConcentrationResponse:
+    service = risk_workspace_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_concentration(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+        period=query.period,
+        as_of_date=query.as_of_date,
+        report_start_date=query.report_start_date,
+        report_end_date=query.report_end_date,
+        reporting_currency=query.reporting_currency,
+        benchmark_code=query.benchmark_code,
+    )
 
 
 @router.get(
@@ -61,15 +92,14 @@ async def get_workbench_risk_concentration(
         examples=["USD"],
     ),
 ) -> WorkbenchRiskConcentrationResponse:
-    service = risk_workspace_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_concentration(
+    return await _get_risk_concentration(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id,
-        period=period,
-        as_of_date=as_of_date,
-        report_start_date=report_start_date,
-        report_end_date=report_end_date,
-        reporting_currency=reporting_currency,
-        benchmark_code=benchmark_code,
+        query=RiskConcentrationQuery(
+            period=period,
+            benchmark_code=benchmark_code,
+            as_of_date=as_of_date,
+            report_start_date=report_start_date,
+            report_end_date=report_end_date,
+            reporting_currency=reporting_currency,
+        ),
     )


### PR DESCRIPTION
## Summary
- Continue gateway route ownership hardening with a 50-commit batch of small, auditable router refactors.
- Extract typed filter/header/query forwarding helpers across reporting, archive, analytics diagnostics, Workbench risk concentration, DPM lookup, advisor cockpit, bank-demo proof, portfolio, and composite-performance routes.
- Preserve public paths, response models, upstream authority boundaries, idempotency handling, caller-context propagation, and Workbench/product-facing contracts.

## Validation
- Focused slices run during the batch:
  - `python -m pytest tests/unit/test_analytics_ui_observability_contract.py tests/unit/test_archive_document_service.py tests/contract/test_archive_documents_contract.py tests/unit/test_portfolio_service.py tests/contract/test_portfolio_contract.py tests/unit/test_reporting_job_query_service.py tests/unit/test_reporting_batch_lifecycle_service.py tests/contract/test_reporting_contract.py -q` passed: 86 passed
  - `python -m pytest tests/unit/test_reporting_job_submission_service.py tests/unit/test_reporting_batch_lifecycle_service.py tests/contract/test_reporting_contract.py tests/unit/test_archive_document_service.py tests/contract/test_archive_documents_contract.py tests/unit/test_risk_workspace_service.py tests/contract/test_workbench_contract.py -q` passed: 45 passed
  - `python -m pytest tests/unit/test_dpm_command_center_service.py tests/contract/test_dpm_command_center_contract.py tests/unit/test_dpm_wave_service.py tests/contract/test_dpm_wave_contract.py tests/unit/test_advisor_cockpit_service.py tests/contract/test_advise_gateway_route_coverage.py -q` passed: 77 passed
  - `python -m pytest tests/unit/test_reporting_job_query_service.py tests/unit/test_reporting_portfolio_service.py tests/unit/test_reporting_batch_scheduler_service.py tests/contract/test_reporting_contract.py -q` passed: 17 passed
  - `python -m pytest tests/unit/test_portfolio_service.py tests/contract/test_portfolio_contract.py -q` passed: 51 passed
  - `python -m pytest tests/unit/test_advisor_cockpit_service.py tests/unit/test_bank_demo_proof_service.py tests/unit/test_composite_performance_service.py tests/unit/test_portfolio_service.py tests/contract/test_advise_gateway_route_coverage.py tests/contract/test_portfolio_contract.py -q` passed: 68 passed
- Full `make check` passed at 10, 20, 30, 40, and 50 commits.
- Final `make check` evidence:
  - `python -m ruff check .` passed
  - `python -m ruff format --check .` passed
  - monetary float guard passed: `Findings=189, allowlisted=189`
  - `python -m mypy src` passed over 396 source files
  - `python -m pytest tests/contract/test_workbench_contract.py -q` passed: 3 passed
  - `python -m pytest tests/unit tests/contract` passed: 750 passed

## Cross-Repo Refactor Pulse
- Read-only pulse only, per integration guidance.
- `lotus-core`: `perf/api-query-index-optimization`, latest local head `98ce8814 perf: parallelize analytics performance horizon reads`; no gateway contract collision seen.
- `lotus-performance`: `feat/performance-modular-refactor`, latest local head `9f87ba0 Harden workspace summary nullable numerics`; no gateway contract collision seen.
- `lotus-manage`: `feat/manage-hardening-wave-2`, latest local head `0b7ab70 move run support config out of router`; no gateway contract collision seen.

## Documentation / Wiki
- No documentation, wiki, context, OpenAPI snapshot, migration, CI workflow, or durable governance-source files changed in this batch.
- No repo-local wiki source update is required for this code-only route ownership hardening batch.

## Merge Posture
- Branch intentionally contains roughly 50 small commits to preserve normal non-squash history.
- Use the standard merge strategy; do not squash.