### PR TITLE
Refactor gateway route ownership batch 8

### DIFF
--- a/src/app/routers/advisory_policy.py
+++ b/src/app/routers/advisory_policy.py
@@ -7,6 +7,12 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _list_policy_packs() -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().list_policy_packs(
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/advisory-policy-packs",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -17,6 +23,4 @@ router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
     ),
 )
 async def list_policy_packs() -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().list_policy_packs(
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _list_policy_packs()

--- a/src/app/routers/advisory_policy_actions.py
+++ b/src/app/routers/advisory_policy_actions.py
@@ -11,6 +11,22 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _activate_policy_pack_version(
+    *,
+    request: AdvisoryPolicyBodyRequest,
+    policy_pack_id: str,
+    policy_version: str,
+    idempotency_key: str,
+) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().activate_policy_pack_version(
+        policy_pack_id=policy_pack_id,
+        policy_version=policy_version,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/advisory-policy-packs/{policy_pack_id}/versions/{policy_version}/activate",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -31,10 +47,9 @@ async def activate_policy_pack_version(
         examples=["idem-policy-activate-1"],
     ),
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().activate_policy_pack_version(
+    return await _activate_policy_pack_version(
+        request=request,
         policy_pack_id=policy_pack_id,
         policy_version=policy_version,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_policy_ai_evidence.py
+++ b/src/app/routers/advisory_policy_ai_evidence.py
@@ -11,6 +11,20 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _request_policy_ai_evidence(
+    *,
+    request: AdvisoryPolicyBodyRequest,
+    evaluation_id: str,
+    idempotency_key: str | None,
+) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().request_policy_ai_evidence(
+        evaluation_id=evaluation_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/advisory-policy-evaluations/{evaluation_id}/ai-evidence",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -30,9 +44,8 @@ async def request_policy_ai_evidence(
         examples=["idem-policy-ai-evidence-1"],
     ),
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().request_policy_ai_evidence(
+    return await _request_policy_ai_evidence(
+        request=request,
         evaluation_id=evaluation_id,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_policy_evaluation_actions.py
+++ b/src/app/routers/advisory_policy_evaluation_actions.py
@@ -11,6 +11,18 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _replay_policy_evaluation(
+    *,
+    request: AdvisoryPolicyBodyRequest,
+    evaluation_id: str,
+) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().replay_policy_evaluation(
+        evaluation_id=evaluation_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/advisory-policy-evaluations/{evaluation_id}/replay",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -24,8 +36,7 @@ async def replay_policy_evaluation(
     request: AdvisoryPolicyBodyRequest,
     evaluation_id: str = POLICY_EVALUATION_PATH,
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().replay_policy_evaluation(
+    return await _replay_policy_evaluation(
+        request=request,
         evaluation_id=evaluation_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_policy_evaluation_detail.py
+++ b/src/app/routers/advisory_policy_evaluation_detail.py
@@ -8,6 +8,13 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _get_policy_evaluation(evaluation_id: str) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().get_policy_evaluation(
+        evaluation_id=evaluation_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/advisory-policy-evaluations/{evaluation_id}",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -17,7 +24,4 @@ router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 async def get_policy_evaluation(
     evaluation_id: str = POLICY_EVALUATION_PATH,
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().get_policy_evaluation(
-        evaluation_id=evaluation_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_policy_evaluation(evaluation_id)

--- a/src/app/routers/advisory_policy_evaluation_events.py
+++ b/src/app/routers/advisory_policy_evaluation_events.py
@@ -11,6 +11,20 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _record_policy_evaluation_event(
+    *,
+    request: AdvisoryPolicyBodyRequest,
+    evaluation_id: str,
+    idempotency_key: str | None,
+) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().record_policy_evaluation_event(
+        evaluation_id=evaluation_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/advisory-policy-evaluations/{evaluation_id}/events",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -30,9 +44,8 @@ async def record_policy_evaluation_event(
         examples=["idem-policy-event-1"],
     ),
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().record_policy_evaluation_event(
+    return await _record_policy_evaluation_event(
+        request=request,
         evaluation_id=evaluation_id,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_policy_evaluation_evidence.py
+++ b/src/app/routers/advisory_policy_evaluation_evidence.py
@@ -8,6 +8,13 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _get_policy_evaluation_lineage(evaluation_id: str) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().get_policy_evaluation_lineage(
+        evaluation_id=evaluation_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/advisory-policy-evaluations/{evaluation_id}/lineage",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -17,7 +24,4 @@ router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 async def get_policy_evaluation_lineage(
     evaluation_id: str = POLICY_EVALUATION_PATH,
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().get_policy_evaluation_lineage(
-        evaluation_id=evaluation_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_policy_evaluation_lineage(evaluation_id)

--- a/src/app/routers/advisory_policy_evaluation_support_actions.py
+++ b/src/app/routers/advisory_policy_evaluation_support_actions.py
@@ -11,6 +11,20 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _request_policy_report_package(
+    *,
+    request: AdvisoryPolicyBodyRequest,
+    evaluation_id: str,
+    idempotency_key: str | None,
+) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().request_policy_report_package(
+        evaluation_id=evaluation_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/advisory-policy-evaluations/{evaluation_id}/report-packages",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -30,9 +44,8 @@ async def request_policy_report_package(
         examples=["idem-policy-report-1"],
     ),
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().request_policy_report_package(
+    return await _request_policy_report_package(
+        request=request,
         evaluation_id=evaluation_id,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_policy_evaluation_workflow.py
+++ b/src/app/routers/advisory_policy_evaluation_workflow.py
@@ -8,6 +8,15 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _get_policy_evaluation_workflow(
+    evaluation_id: str,
+) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().get_policy_evaluation_workflow(
+        evaluation_id=evaluation_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/advisory-policy-evaluations/{evaluation_id}/workflow",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -17,7 +26,4 @@ router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 async def get_policy_evaluation_workflow(
     evaluation_id: str = POLICY_EVALUATION_PATH,
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().get_policy_evaluation_workflow(
-        evaluation_id=evaluation_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_policy_evaluation_workflow(evaluation_id)

--- a/src/app/routers/advisory_policy_evaluations.py
+++ b/src/app/routers/advisory_policy_evaluations.py
@@ -10,6 +10,22 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _create_policy_evaluation(
+    *,
+    request: AdvisoryPolicyBodyRequest,
+    proposal_id: str,
+    proposal_version_id: str,
+    idempotency_key: str,
+) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().create_policy_evaluation(
+        proposal_id=proposal_id,
+        proposal_version_id=proposal_version_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/proposals/{proposal_id}/versions/{proposal_version_id}/policy-evaluations",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -34,10 +50,9 @@ async def create_policy_evaluation(
         examples=["idem-policy-evaluation-1"],
     ),
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().create_policy_evaluation(
+    return await _create_policy_evaluation(
+        request=request,
         proposal_id=proposal_id,
         proposal_version_id=proposal_version_id,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_policy_pack_detail.py
+++ b/src/app/routers/advisory_policy_pack_detail.py
@@ -7,6 +7,18 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _get_policy_pack_version(
+    *,
+    policy_pack_id: str,
+    policy_version: str,
+) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().get_policy_pack_version(
+        policy_pack_id=policy_pack_id,
+        policy_version=policy_version,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/advisory-policy-packs/{policy_pack_id}/versions/{policy_version}",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -28,8 +40,7 @@ async def get_policy_pack_version(
         examples=["2026.05"],
     ),
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().get_policy_pack_version(
+    return await _get_policy_pack_version(
         policy_pack_id=policy_pack_id,
         policy_version=policy_version,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_policy_review_queue.py
+++ b/src/app/routers/advisory_policy_review_queue.py
@@ -7,6 +7,18 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _get_policy_review_queue(
+    *,
+    evaluation_status: str | None,
+    portfolio_id: str | None,
+) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().get_policy_review_queue(
+        evaluation_status=evaluation_status,
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/advisory-policy-evaluations/review-queue",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -28,8 +40,7 @@ async def get_policy_review_queue(
         examples=["PB_SG_GLOBAL_BAL_001"],
     ),
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().get_policy_review_queue(
+    return await _get_policy_review_queue(
         evaluation_status=evaluation_status,
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_policy_sign_off_decisions.py
+++ b/src/app/routers/advisory_policy_sign_off_decisions.py
@@ -11,6 +11,20 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _record_policy_sign_off_decision(
+    *,
+    request: AdvisoryPolicyBodyRequest,
+    evaluation_id: str,
+    idempotency_key: str | None,
+) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().record_policy_sign_off_decision(
+        evaluation_id=evaluation_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/advisory-policy-evaluations/{evaluation_id}/sign-off-decisions",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -30,9 +44,8 @@ async def record_policy_sign_off_decision(
         examples=["idem-policy-signoff-1"],
     ),
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().record_policy_sign_off_decision(
+    return await _record_policy_sign_off_decision(
+        request=request,
         evaluation_id=evaluation_id,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_policy_sign_off_package.py
+++ b/src/app/routers/advisory_policy_sign_off_package.py
@@ -8,6 +8,15 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _get_policy_sign_off_package(
+    evaluation_id: str,
+) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().get_policy_sign_off_package(
+        evaluation_id=evaluation_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/advisory-policy-evaluations/{evaluation_id}/sign-off-package",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -20,7 +29,4 @@ router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 async def get_policy_sign_off_package(
     evaluation_id: str = POLICY_EVALUATION_PATH,
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().get_policy_sign_off_package(
-        evaluation_id=evaluation_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_policy_sign_off_package(evaluation_id)

--- a/src/app/routers/advisory_policy_validation.py
+++ b/src/app/routers/advisory_policy_validation.py
@@ -11,6 +11,22 @@ from app.services.advisory_service_provider import advisory_policy_service
 router = APIRouter(prefix="/api/v1", tags=["advisory-policy"])
 
 
+async def _validate_policy_pack_version(
+    *,
+    request: AdvisoryPolicyBodyRequest,
+    policy_pack_id: str,
+    policy_version: str,
+    idempotency_key: str,
+) -> AdvisoryPolicyEnvelopeResponse:
+    return await advisory_policy_service().validate_policy_pack_version(
+        policy_pack_id=policy_pack_id,
+        policy_version=policy_version,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/advisory-policy-packs/{policy_pack_id}/versions/{policy_version}/validate",
     response_model=AdvisoryPolicyEnvelopeResponse,
@@ -31,10 +47,9 @@ async def validate_policy_pack_version(
         examples=["idem-policy-validate-1"],
     ),
 ) -> AdvisoryPolicyEnvelopeResponse:
-    return await advisory_policy_service().validate_policy_pack_version(
+    return await _validate_policy_pack_version(
+        request=request,
         policy_pack_id=policy_pack_id,
         policy_version=policy_version,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_workspace_actions.py
+++ b/src/app/routers/advisory_workspace_actions.py
@@ -10,6 +10,15 @@ from app.services.advisory_service_provider import advisory_workspace_service
 router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
 
 
+async def _create_workspace(
+    request: AdvisoryWorkspaceBodyRequest,
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await advisory_workspace_service().create_workspace(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "",
     response_model=AdvisoryWorkspaceEnvelopeResponse,
@@ -23,7 +32,4 @@ router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspa
 async def create_workspace(
     request: AdvisoryWorkspaceBodyRequest,
 ) -> AdvisoryWorkspaceEnvelopeResponse:
-    return await advisory_workspace_service().create_workspace(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _create_workspace(request)

--- a/src/app/routers/advisory_workspace_assistant.py
+++ b/src/app/routers/advisory_workspace_assistant.py
@@ -11,6 +11,18 @@ from app.services.advisory_service_provider import advisory_workspace_service
 router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
 
 
+async def _request_rationale(
+    *,
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str,
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await advisory_workspace_service().request_rationale(
+        workspace_id=workspace_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{workspace_id}/assistant/rationale",
     response_model=AdvisoryWorkspaceEnvelopeResponse,
@@ -24,8 +36,7 @@ async def request_rationale(
     request: AdvisoryWorkspaceBodyRequest,
     workspace_id: str = WORKSPACE_ID_PATH,
 ) -> AdvisoryWorkspaceEnvelopeResponse:
-    return await advisory_workspace_service().request_rationale(
+    return await _request_rationale(
+        request=request,
         workspace_id=workspace_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_workspace_compare.py
+++ b/src/app/routers/advisory_workspace_compare.py
@@ -11,6 +11,18 @@ from app.services.advisory_service_provider import advisory_workspace_service
 router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
 
 
+async def _compare_workspace(
+    *,
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str,
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await advisory_workspace_service().compare_workspace(
+        workspace_id=workspace_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{workspace_id}/compare",
     response_model=AdvisoryWorkspaceEnvelopeResponse,
@@ -24,8 +36,7 @@ async def compare_workspace(
     request: AdvisoryWorkspaceBodyRequest,
     workspace_id: str = WORKSPACE_ID_PATH,
 ) -> AdvisoryWorkspaceEnvelopeResponse:
-    return await advisory_workspace_service().compare_workspace(
+    return await _compare_workspace(
+        request=request,
         workspace_id=workspace_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_workspace_draft_actions.py
+++ b/src/app/routers/advisory_workspace_draft_actions.py
@@ -11,6 +11,18 @@ from app.services.advisory_service_provider import advisory_workspace_service
 router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
 
 
+async def _apply_draft_action(
+    *,
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str,
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await advisory_workspace_service().apply_draft_action(
+        workspace_id=workspace_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{workspace_id}/draft-actions",
     response_model=AdvisoryWorkspaceEnvelopeResponse,
@@ -24,8 +36,7 @@ async def apply_draft_action(
     request: AdvisoryWorkspaceBodyRequest,
     workspace_id: str = WORKSPACE_ID_PATH,
 ) -> AdvisoryWorkspaceEnvelopeResponse:
-    return await advisory_workspace_service().apply_draft_action(
+    return await _apply_draft_action(
+        request=request,
         workspace_id=workspace_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_workspace_evaluate.py
+++ b/src/app/routers/advisory_workspace_evaluate.py
@@ -8,6 +8,13 @@ from app.services.advisory_service_provider import advisory_workspace_service
 router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
 
 
+async def _evaluate_workspace(workspace_id: str) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await advisory_workspace_service().evaluate_workspace(
+        workspace_id=workspace_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{workspace_id}/evaluate",
     response_model=AdvisoryWorkspaceEnvelopeResponse,
@@ -17,7 +24,4 @@ router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspa
 async def evaluate_workspace(
     workspace_id: str = WORKSPACE_ID_PATH,
 ) -> AdvisoryWorkspaceEnvelopeResponse:
-    return await advisory_workspace_service().evaluate_workspace(
-        workspace_id=workspace_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _evaluate_workspace(workspace_id)

--- a/src/app/routers/advisory_workspace_handoff.py
+++ b/src/app/routers/advisory_workspace_handoff.py
@@ -11,6 +11,20 @@ from app.services.advisory_service_provider import advisory_workspace_service
 router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
 
 
+async def _handoff_workspace(
+    *,
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str,
+    idempotency_key: str | None,
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await advisory_workspace_service().handoff_workspace(
+        workspace_id=workspace_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{workspace_id}/handoff",
     response_model=AdvisoryWorkspaceEnvelopeResponse,
@@ -30,9 +44,8 @@ async def handoff_workspace(
         examples=["idem-workspace-handoff-1"],
     ),
 ) -> AdvisoryWorkspaceEnvelopeResponse:
-    return await advisory_workspace_service().handoff_workspace(
+    return await _handoff_workspace(
+        request=request,
         workspace_id=workspace_id,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_workspace_rationale_reviews.py
+++ b/src/app/routers/advisory_workspace_rationale_reviews.py
@@ -11,6 +11,18 @@ from app.services.advisory_service_provider import advisory_workspace_service
 router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
 
 
+async def _review_rationale(
+    *,
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str,
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await advisory_workspace_service().review_rationale(
+        workspace_id=workspace_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{workspace_id}/assistant/rationale/review-actions",
     response_model=AdvisoryWorkspaceEnvelopeResponse,
@@ -24,8 +36,7 @@ async def review_rationale(
     request: AdvisoryWorkspaceBodyRequest,
     workspace_id: str = WORKSPACE_ID_PATH,
 ) -> AdvisoryWorkspaceEnvelopeResponse:
-    return await advisory_workspace_service().review_rationale(
+    return await _review_rationale(
+        request=request,
         workspace_id=workspace_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_workspace_replay_evidence.py
+++ b/src/app/routers/advisory_workspace_replay_evidence.py
@@ -8,6 +8,18 @@ from app.services.advisory_service_provider import advisory_workspace_service
 router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
 
 
+async def _get_saved_version_replay_evidence(
+    *,
+    workspace_id: str,
+    workspace_version_id: str,
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await advisory_workspace_service().get_saved_version_replay_evidence(
+        workspace_id=workspace_id,
+        workspace_version_id=workspace_version_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{workspace_id}/saved-versions/{workspace_version_id}/replay-evidence",
     response_model=AdvisoryWorkspaceEnvelopeResponse,
@@ -25,8 +37,7 @@ async def get_saved_version_replay_evidence(
         examples=["awv_001"],
     ),
 ) -> AdvisoryWorkspaceEnvelopeResponse:
-    return await advisory_workspace_service().get_saved_version_replay_evidence(
+    return await _get_saved_version_replay_evidence(
         workspace_id=workspace_id,
         workspace_version_id=workspace_version_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_workspace_resume.py
+++ b/src/app/routers/advisory_workspace_resume.py
@@ -11,6 +11,18 @@ from app.services.advisory_service_provider import advisory_workspace_service
 router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
 
 
+async def _resume_workspace(
+    *,
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str,
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await advisory_workspace_service().resume_workspace(
+        workspace_id=workspace_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{workspace_id}/resume",
     response_model=AdvisoryWorkspaceEnvelopeResponse,
@@ -23,8 +35,7 @@ async def resume_workspace(
     request: AdvisoryWorkspaceBodyRequest,
     workspace_id: str = WORKSPACE_ID_PATH,
 ) -> AdvisoryWorkspaceEnvelopeResponse:
-    return await advisory_workspace_service().resume_workspace(
+    return await _resume_workspace(
+        request=request,
         workspace_id=workspace_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_workspace_version_lookups.py
+++ b/src/app/routers/advisory_workspace_version_lookups.py
@@ -8,6 +8,13 @@ from app.services.advisory_service_provider import advisory_workspace_service
 router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
 
 
+async def _list_saved_versions(workspace_id: str) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await advisory_workspace_service().list_saved_versions(
+        workspace_id=workspace_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{workspace_id}/saved-versions",
     response_model=AdvisoryWorkspaceEnvelopeResponse,
@@ -20,7 +27,4 @@ router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspa
 async def list_saved_versions(
     workspace_id: str = WORKSPACE_ID_PATH,
 ) -> AdvisoryWorkspaceEnvelopeResponse:
-    return await advisory_workspace_service().list_saved_versions(
-        workspace_id=workspace_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _list_saved_versions(workspace_id)

--- a/src/app/routers/advisory_workspace_versions.py
+++ b/src/app/routers/advisory_workspace_versions.py
@@ -11,6 +11,18 @@ from app.services.advisory_service_provider import advisory_workspace_service
 router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
 
 
+async def _save_workspace(
+    *,
+    request: AdvisoryWorkspaceBodyRequest,
+    workspace_id: str,
+) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await advisory_workspace_service().save_workspace(
+        workspace_id=workspace_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{workspace_id}/save",
     response_model=AdvisoryWorkspaceEnvelopeResponse,
@@ -21,8 +33,7 @@ async def save_workspace(
     request: AdvisoryWorkspaceBodyRequest,
     workspace_id: str = WORKSPACE_ID_PATH,
 ) -> AdvisoryWorkspaceEnvelopeResponse:
-    return await advisory_workspace_service().save_workspace(
+    return await _save_workspace(
+        request=request,
         workspace_id=workspace_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/advisory_workspaces.py
+++ b/src/app/routers/advisory_workspaces.py
@@ -8,6 +8,13 @@ from app.services.advisory_service_provider import advisory_workspace_service
 router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspaces"])
 
 
+async def _get_workspace(workspace_id: str) -> AdvisoryWorkspaceEnvelopeResponse:
+    return await advisory_workspace_service().get_workspace(
+        workspace_id=workspace_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{workspace_id}",
     response_model=AdvisoryWorkspaceEnvelopeResponse,
@@ -17,7 +24,4 @@ router = APIRouter(prefix="/api/v1/advisory-workspaces", tags=["advisory-workspa
 async def get_workspace(
     workspace_id: str = WORKSPACE_ID_PATH,
 ) -> AdvisoryWorkspaceEnvelopeResponse:
-    return await advisory_workspace_service().get_workspace(
-        workspace_id=workspace_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_workspace(workspace_id)

--- a/src/app/routers/proposal_approvals.py
+++ b/src/app/routers/proposal_approvals.py
@@ -7,6 +7,15 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_approvals(proposal_id: str) -> ProposalApprovalsEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_approvals(
+        proposal_id=proposal_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/approvals",
     response_model=ProposalApprovalsEnvelopeResponse,
@@ -20,9 +29,4 @@ async def get_approvals(
         examples=["pp_1"],
     ),
 ) -> ProposalApprovalsEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_approvals(
-        proposal_id=proposal_id,
-        correlation_id=correlation_id,
-    )
+    return await _get_approvals(proposal_id)

--- a/src/app/routers/proposal_client_consent.py
+++ b/src/app/routers/proposal_client_consent.py
@@ -10,6 +10,25 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _record_client_consent(
+    *,
+    request: ProposalApprovalActionRequest,
+    proposal_id: str,
+    idempotency_key: str,
+) -> ProposalStateTransitionEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.record_client_consent(
+        proposal_id=proposal_id,
+        actor_id=request.actor_id,
+        expected_state=request.expected_state,
+        details=request.details,
+        related_version_no=request.related_version_no,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/record-client-consent",
     response_model=ProposalStateTransitionEnvelopeResponse,
@@ -29,14 +48,8 @@ async def record_client_consent(
         examples=["idem-client-consent-1"],
     ),
 ) -> ProposalStateTransitionEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.record_client_consent(
+    return await _record_client_consent(
+        request=request,
         proposal_id=proposal_id,
-        actor_id=request.actor_id,
-        expected_state=request.expected_state,
-        details=request.details,
-        related_version_no=request.related_version_no,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_create.py
+++ b/src/app/routers/proposal_create.py
@@ -7,6 +7,20 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _create_proposal(
+    *,
+    request: ProposalCreateRequest,
+    idempotency_key: str,
+) -> ProposalCreateEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_proposal(
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "",
     response_model=ProposalCreateEnvelopeResponse,
@@ -24,10 +38,7 @@ async def create_proposal(
         examples=["idem-create-1"],
     ),
 ) -> ProposalCreateEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.create_proposal(
-        body=request.body,
+    return await _create_proposal(
+        request=request,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_delivery.py
+++ b/src/app/routers/proposal_delivery.py
@@ -7,6 +7,18 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_delivery_summary(
+    *,
+    proposal_id: str,
+) -> ProposalDeliverySummaryEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_delivery_summary(
+        proposal_id=proposal_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/delivery-summary",
     response_model=ProposalDeliverySummaryEnvelopeResponse,
@@ -24,9 +36,6 @@ async def get_delivery_summary(
         examples=["pp_1"],
     ),
 ) -> ProposalDeliverySummaryEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_delivery_summary(
+    return await _get_delivery_summary(
         proposal_id=proposal_id,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_detail.py
+++ b/src/app/routers/proposal_detail.py
@@ -7,6 +7,20 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal(
+    *,
+    proposal_id: str,
+    include_evidence: bool,
+) -> ProposalDetailEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal(
+        proposal_id=proposal_id,
+        include_evidence=include_evidence,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}",
     response_model=ProposalDetailEnvelopeResponse,
@@ -25,10 +39,7 @@ async def get_proposal(
         examples=[True],
     ),
 ) -> ProposalDetailEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal(
+    return await _get_proposal(
         proposal_id=proposal_id,
         include_evidence=include_evidence,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_execution.py
+++ b/src/app/routers/proposal_execution.py
@@ -7,6 +7,22 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _create_execution_handoff(
+    *,
+    request: ProposalBodyRequest,
+    proposal_id: str,
+    idempotency_key: str | None,
+) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_execution_handoff(
+        proposal_id=proposal_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/execution-handoffs",
     response_model=ProposalEnvelopeResponse,
@@ -30,11 +46,8 @@ async def create_execution_handoff(
         examples=["idem-execution-handoff-1"],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.create_execution_handoff(
+    return await _create_execution_handoff(
+        request=request,
         proposal_id=proposal_id,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_execution_status.py
+++ b/src/app/routers/proposal_execution_status.py
@@ -7,6 +7,15 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_execution_status(proposal_id: str) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_execution_status(
+        proposal_id=proposal_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/execution-status",
     response_model=ProposalEnvelopeResponse,
@@ -23,9 +32,4 @@ async def get_execution_status(
         examples=["pp_1"],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_execution_status(
-        proposal_id=proposal_id,
-        correlation_id=correlation_id,
-    )
+    return await _get_execution_status(proposal_id)

--- a/src/app/routers/proposal_generation.py
+++ b/src/app/routers/proposal_generation.py
@@ -10,6 +10,20 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _simulate_proposal(
+    *,
+    request: ProposalSimulateRequest,
+    idempotency_key: str,
+) -> ProposalSimulateResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.simulate_proposal(
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/simulate",
     response_model=ProposalSimulateResponse,
@@ -27,10 +41,7 @@ async def simulate_proposal(
         examples=["idem-simulate-1"],
     ),
 ) -> ProposalSimulateResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.simulate_proposal(
-        body=request.body,
+    return await _simulate_proposal(
+        request=request,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_lineage.py
+++ b/src/app/routers/proposal_lineage.py
@@ -7,6 +7,15 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal_lineage(proposal_id: str) -> ProposalLineageEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_lineage(
+        proposal_id=proposal_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/lineage",
     response_model=ProposalLineageEnvelopeResponse,
@@ -20,9 +29,4 @@ async def get_proposal_lineage(
         examples=["pp_1"],
     ),
 ) -> ProposalLineageEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal_lineage(
-        proposal_id=proposal_id,
-        correlation_id=correlation_id,
-    )
+    return await _get_proposal_lineage(proposal_id)

--- a/src/app/routers/proposal_memo_actions.py
+++ b/src/app/routers/proposal_memo_actions.py
@@ -11,6 +11,24 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _review_proposal_memo(
+    *,
+    request: ProposalMemoReviewRequest,
+    proposal_id: str,
+    version_no: int,
+    idempotency_key: str | None,
+) -> ProposalMemoReviewEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.review_proposal_memo(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.model_dump(exclude_none=True),
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/versions/{version_no}/memo/review",
     response_model=ProposalMemoReviewEnvelopeResponse,
@@ -32,12 +50,9 @@ async def review_proposal_memo(
         examples=["idem-memo-review-1"],
     ),
 ) -> ProposalMemoReviewEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.review_proposal_memo(
+    return await _review_proposal_memo(
+        request=request,
         proposal_id=proposal_id,
         version_no=version_no,
-        body=request.model_dump(exclude_none=True),
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_memo_ai_commentary.py
+++ b/src/app/routers/proposal_memo_ai_commentary.py
@@ -11,6 +11,24 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _request_proposal_memo_ai_commentary(
+    *,
+    request: ProposalMemoAiCommentaryRequest,
+    proposal_id: str,
+    version_no: int,
+    idempotency_key: str | None,
+) -> ProposalMemoAiCommentaryEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.request_proposal_memo_ai_commentary(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.model_dump(exclude_none=True),
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/versions/{version_no}/memo/ai-commentary",
     response_model=ProposalMemoAiCommentaryEnvelopeResponse,
@@ -31,12 +49,9 @@ async def request_proposal_memo_ai_commentary(
         examples=["idem-memo-ai-commentary-1"],
     ),
 ) -> ProposalMemoAiCommentaryEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.request_proposal_memo_ai_commentary(
+    return await _request_proposal_memo_ai_commentary(
+        request=request,
         proposal_id=proposal_id,
         version_no=version_no,
-        body=request.model_dump(exclude_none=True),
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_memo_evidence.py
+++ b/src/app/routers/proposal_memo_evidence.py
@@ -8,6 +8,22 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal_memo_projection(
+    *,
+    proposal_id: str,
+    version_no: int,
+    audience: str | None,
+) -> ProposalMemoProjectionEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_memo_projection(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        audience=audience,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/versions/{version_no}/memo/projection",
     response_model=ProposalMemoProjectionEnvelopeResponse,
@@ -27,11 +43,8 @@ async def get_proposal_memo_projection(
         examples=["COMPLIANCE"],
     ),
 ) -> ProposalMemoProjectionEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal_memo_projection(
+    return await _get_proposal_memo_projection(
         proposal_id=proposal_id,
         version_no=version_no,
         audience=audience,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_memo_lineage.py
+++ b/src/app/routers/proposal_memo_lineage.py
@@ -8,6 +8,18 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal_memo_lineage(
+    *,
+    proposal_id: str,
+) -> ProposalMemoLineageEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_memo_lineage(
+        proposal_id=proposal_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/memos/lineage",
     response_model=ProposalMemoLineageEnvelopeResponse,
@@ -21,9 +33,6 @@ router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 async def get_proposal_memo_lineage(
     proposal_id: str = PROPOSAL_ID_PATH,
 ) -> ProposalMemoLineageEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal_memo_lineage(
+    return await _get_proposal_memo_lineage(
         proposal_id=proposal_id,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_memo_replay_evidence.py
+++ b/src/app/routers/proposal_memo_replay_evidence.py
@@ -8,6 +8,20 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal_memo_replay_evidence(
+    *,
+    proposal_id: str,
+    version_no: int,
+) -> ProposalMemoReplayEvidenceEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_memo_replay_evidence(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/versions/{version_no}/memo/replay-evidence",
     response_model=ProposalMemoReplayEvidenceEnvelopeResponse,
@@ -22,10 +36,7 @@ async def get_proposal_memo_replay_evidence(
     proposal_id: str = PROPOSAL_ID_PATH,
     version_no: int = VERSION_NO_PATH,
 ) -> ProposalMemoReplayEvidenceEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal_memo_replay_evidence(
+    return await _get_proposal_memo_replay_evidence(
         proposal_id=proposal_id,
         version_no=version_no,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_memos.py
+++ b/src/app/routers/proposal_memos.py
@@ -11,6 +11,24 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _create_proposal_memo(
+    *,
+    request: ProposalMemoCreateRequest,
+    proposal_id: str,
+    version_no: int,
+    idempotency_key: str,
+) -> ProposalMemoEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_proposal_memo(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.model_dump(exclude_none=True),
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/versions/{version_no}/memo",
     response_model=ProposalMemoEnvelopeResponse,
@@ -31,12 +49,9 @@ async def create_proposal_memo(
         examples=["idem-memo-create-1"],
     ),
 ) -> ProposalMemoEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.create_proposal_memo(
+    return await _create_proposal_memo(
+        request=request,
         proposal_id=proposal_id,
         version_no=version_no,
-        body=request.model_dump(exclude_none=True),
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_operation_lookups.py
+++ b/src/app/routers/proposal_operation_lookups.py
@@ -7,6 +7,15 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal_operation(operation_id: str) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_operation(
+        operation_id=operation_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/operations/{operation_id}",
     response_model=ProposalEnvelopeResponse,
@@ -20,9 +29,4 @@ async def get_proposal_operation(
         examples=["apo_001"],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal_operation(
-        operation_id=operation_id,
-        correlation_id=correlation_id,
-    )
+    return await _get_proposal_operation(operation_id)

--- a/src/app/routers/proposal_operation_support_lookups.py
+++ b/src/app/routers/proposal_operation_support_lookups.py
@@ -7,6 +7,17 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal_operation_replay_evidence(
+    operation_id: str,
+) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_operation_replay_evidence(
+        operation_id=operation_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/operations/{operation_id}/replay-evidence",
     response_model=ProposalEnvelopeResponse,
@@ -22,9 +33,4 @@ async def get_proposal_operation_replay_evidence(
         examples=["apo_001"],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal_operation_replay_evidence(
-        operation_id=operation_id,
-        correlation_id=correlation_id,
-    )
+    return await _get_proposal_operation_replay_evidence(operation_id)

--- a/src/app/routers/proposal_operations.py
+++ b/src/app/routers/proposal_operations.py
@@ -7,6 +7,20 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _create_proposal_async(
+    *,
+    request: ProposalBodyRequest,
+    idempotency_key: str,
+) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_proposal_async(
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/async",
     response_model=ProposalEnvelopeResponse,
@@ -24,10 +38,7 @@ async def create_proposal_async(
         examples=["idem-proposal-async-1"],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.create_proposal_async(
-        body=request.body,
+    return await _create_proposal_async(
+        request=request,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_report_requests.py
+++ b/src/app/routers/proposal_report_requests.py
@@ -10,6 +10,20 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _create_report_request(
+    *,
+    request: ProposalReportRequest,
+    proposal_id: str,
+) -> ProposalReportRequestEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_report_request(
+        proposal_id=proposal_id,
+        body=request.model_dump(exclude_none=True),
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/report-requests",
     response_model=ProposalReportRequestEnvelopeResponse,
@@ -28,10 +42,7 @@ async def create_report_request(
         examples=["pp_1"],
     ),
 ) -> ProposalReportRequestEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.create_report_request(
+    return await _create_report_request(
+        request=request,
         proposal_id=proposal_id,
-        body=request.model_dump(exclude_none=True),
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_version_commands.py
+++ b/src/app/routers/proposal_version_commands.py
@@ -10,6 +10,22 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _create_proposal_version(
+    *,
+    request: ProposalVersionCreateRequest,
+    proposal_id: str,
+    idempotency_key: str,
+) -> ProposalCreateEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_proposal_version(
+        proposal_id=proposal_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/versions",
     response_model=ProposalCreateEnvelopeResponse,
@@ -29,11 +45,8 @@ async def create_proposal_version(
         examples=["idem-version-2"],
     ),
 ) -> ProposalCreateEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.create_proposal_version(
+    return await _create_proposal_version(
+        request=request,
         proposal_id=proposal_id,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_versions.py
+++ b/src/app/routers/proposal_versions.py
@@ -7,6 +7,22 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal_version(
+    *,
+    proposal_id: str,
+    version_no: int,
+    include_evidence: bool,
+) -> ProposalVersionEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_version(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        include_evidence=include_evidence,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/versions/{version_no}",
     response_model=ProposalVersionEnvelopeResponse,
@@ -32,11 +48,8 @@ async def get_proposal_version(
         examples=[True],
     ),
 ) -> ProposalVersionEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal_version(
+    return await _get_proposal_version(
         proposal_id=proposal_id,
         version_no=version_no,
         include_evidence=include_evidence,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_workflow.py
+++ b/src/app/routers/proposal_workflow.py
@@ -10,6 +10,26 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _submit_proposal(
+    *,
+    request: ProposalSubmitRequest,
+    proposal_id: str,
+    idempotency_key: str,
+) -> ProposalStateTransitionEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.submit_proposal(
+        proposal_id=proposal_id,
+        actor_id=request.actor_id,
+        expected_state=request.expected_state,
+        review_type=request.review_type,
+        reason=request.reason,
+        related_version_no=request.related_version_no,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/submit",
     response_model=ProposalStateTransitionEnvelopeResponse,
@@ -29,15 +49,8 @@ async def submit_proposal(
         examples=["idem-submit-1"],
     ),
 ) -> ProposalStateTransitionEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.submit_proposal(
+    return await _submit_proposal(
+        request=request,
         proposal_id=proposal_id,
-        actor_id=request.actor_id,
-        expected_state=request.expected_state,
-        review_type=request.review_type,
-        reason=request.reason,
-        related_version_no=request.related_version_no,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_workflow_evidence.py
+++ b/src/app/routers/proposal_workflow_evidence.py
@@ -7,6 +7,15 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_workflow_events(proposal_id: str) -> ProposalWorkflowEventsEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_workflow_events(
+        proposal_id=proposal_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/workflow-events",
     response_model=ProposalWorkflowEventsEnvelopeResponse,
@@ -20,9 +29,4 @@ async def get_workflow_events(
         examples=["pp_1"],
     ),
 ) -> ProposalWorkflowEventsEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_workflow_events(
-        proposal_id=proposal_id,
-        correlation_id=correlation_id,
-    )
+    return await _get_workflow_events(proposal_id)


### PR DESCRIPTION
## Summary
- Refactors another 50 gateway route handlers into private route-owned forwarding helpers across advisory policy, advisory workspace, proposal, and proposal memo routers.
- Preserves public FastAPI paths, response models, request serialization, idempotency-key forwarding, correlation-id propagation, and upstream lotus-advise authority.
- Keeps this as a code-only maintainability slice; no API contract, docs, wiki, context, or runtime behavior changes intended.

## Validation
- `python -m pytest tests/unit/test_advisory_policy_service.py tests/unit/test_advisory_service_provider.py tests/unit/test_proposal_service.py tests/contract/test_proposals_contract.py tests/contract/test_advise_gateway_route_coverage.py -q` -> 31 passed
- `make check` -> ruff check passed; ruff format check passed; monetary float guard passed (`Findings=189, allowlisted=189`); mypy passed over 396 source files; Workbench contract tests passed; unit/contract suite passed (`750 passed`)

## Sibling Refactor Pulse
- `lotus-core`: `perf/api-query-index-optimization` at `98ce8814 perf: parallelize analytics performance horizon reads`, clean working tree.
- `lotus-performance`: `feat/performance-modular-refactor` at `9f87ba0 Harden workspace summary nullable numerics`, clean working tree.
- `lotus-manage`: `feat/manage-hardening-wave-2` at `0b7ab70 move run support config out of router`, clean working tree.
- No gateway route contract collision observed for this code-only forwarding refactor.

## Governance
- Commit count over `origin/main`: 50, preserving normal commit history for non-squash merge.
- No wiki change required: repo-local wiki truth is unchanged.
- No durable docs/context/RFC truth changed in this PR.