### PR TITLE
Refactor gateway route ownership batch 9

### DIFF
--- a/src/app/routers/composite_performance_inspection.py
+++ b/src/app/routers/composite_performance_inspection.py
@@ -13,6 +13,31 @@ from app.services.gateway_service_provider import composite_performance_service
 router = APIRouter(prefix="/api/v1/performance/composites", tags=["Composite Performance"])
 
 
+async def _inspect_composite_performance(
+    *,
+    request: CompositePerformanceInspectionRequest,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> CompositePerformanceGatewayResponse:
+    correlation_id = correlation_id_var.get()
+    return await composite_performance_service().inspect(
+        payload=request.model_dump(exclude_none=True),
+        correlation_id=correlation_id,
+        caller_context=composite_caller_context(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+        ),
+    )
+
+
 @router.post(
     "/inspect",
     response_model=CompositePerformanceGatewayResponse,
@@ -33,16 +58,12 @@ async def inspect_composite_performance(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> CompositePerformanceGatewayResponse:
-    correlation_id = correlation_id_var.get()
-    return await composite_performance_service().inspect(
-        payload=request.model_dump(exclude_none=True),
-        correlation_id=correlation_id,
-        caller_context=composite_caller_context(
-            actor_id=actor_id,
-            caller_application=caller_application,
-            tenant_id=tenant_id,
-            region=region,
-            booking_center_code=booking_center_code,
-            role=role,
-        ),
+    return await _inspect_composite_performance(
+        request=request,
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
     )

--- a/src/app/routers/domain_product_catalog.py
+++ b/src/app/routers/domain_product_catalog.py
@@ -12,6 +12,17 @@ def _correlation_id(header_value: str | None) -> str:
     return header_value or correlation_id_var.get() or ""
 
 
+async def _get_domain_product_catalog(
+    *,
+    consumer_system: str,
+    x_correlation_id: str | None,
+) -> DomainProductCatalogResponse:
+    return await domain_product_catalog_service().get_catalog(
+        consumer_system=consumer_system,
+        correlation_id=_correlation_id(x_correlation_id),
+    )
+
+
 @router.get(
     "/catalog",
     response_model=DomainProductCatalogResponse,
@@ -37,9 +48,9 @@ async def get_domain_product_catalog(
     ),
 ) -> DomainProductCatalogResponse:
     try:
-        return await domain_product_catalog_service().get_catalog(
+        return await _get_domain_product_catalog(
             consumer_system=consumer_system,
-            correlation_id=_correlation_id(x_correlation_id),
+            x_correlation_id=x_correlation_id,
         )
     except DomainProductCatalogUnavailable as exc:
         raise HTTPException(

--- a/src/app/routers/domain_product_detail.py
+++ b/src/app/routers/domain_product_detail.py
@@ -15,6 +15,23 @@ def _correlation_id(header_value: str | None) -> str:
     return header_value or correlation_id_var.get() or ""
 
 
+async def _get_domain_product_detail(
+    *,
+    producer_repository: str,
+    product_name: str,
+    product_version: str,
+    consumer_system: str,
+    x_correlation_id: str | None,
+) -> DomainProductDetailResponse:
+    return await domain_product_catalog_service().get_product(
+        producer_repository=producer_repository,
+        product_name=product_name,
+        product_version=product_version,
+        consumer_system=consumer_system,
+        correlation_id=_correlation_id(x_correlation_id),
+    )
+
+
 @router.get(
     "/products/{producer_repository}/{product_name}/{product_version}",
     response_model=DomainProductDetailResponse,
@@ -43,12 +60,12 @@ async def get_domain_product_detail(
     ),
 ) -> DomainProductDetailResponse:
     try:
-        return await domain_product_catalog_service().get_product(
+        return await _get_domain_product_detail(
             producer_repository=producer_repository,
             product_name=product_name,
             product_version=product_version,
             consumer_system=consumer_system,
-            correlation_id=_correlation_id(x_correlation_id),
+            x_correlation_id=x_correlation_id,
         )
     except DomainProductNotFound as exc:
         raise HTTPException(

--- a/src/app/routers/domain_product_graph.py
+++ b/src/app/routers/domain_product_graph.py
@@ -12,6 +12,17 @@ def _correlation_id(header_value: str | None) -> str:
     return header_value or correlation_id_var.get() or ""
 
 
+async def _get_domain_product_dependency_graph(
+    *,
+    consumer_system: str,
+    x_correlation_id: str | None,
+) -> DomainProductGraphResponse:
+    return await domain_product_catalog_service().get_dependency_graph(
+        consumer_system=consumer_system,
+        correlation_id=_correlation_id(x_correlation_id),
+    )
+
+
 @router.get(
     "/dependency-graph",
     response_model=DomainProductGraphResponse,
@@ -37,9 +48,9 @@ async def get_domain_product_dependency_graph(
     ),
 ) -> DomainProductGraphResponse:
     try:
-        return await domain_product_catalog_service().get_dependency_graph(
+        return await _get_domain_product_dependency_graph(
             consumer_system=consumer_system,
-            correlation_id=_correlation_id(x_correlation_id),
+            x_correlation_id=x_correlation_id,
         )
     except DomainProductCatalogUnavailable as exc:
         raise HTTPException(

--- a/src/app/routers/domain_product_trust.py
+++ b/src/app/routers/domain_product_trust.py
@@ -12,6 +12,17 @@ def _correlation_id(header_value: str | None) -> str:
     return header_value or correlation_id_var.get() or ""
 
 
+async def _get_domain_product_trust_certification(
+    *,
+    consumer_system: str,
+    x_correlation_id: str | None,
+) -> DomainProductTrustCertificationResponse:
+    return await domain_product_catalog_service().get_trust_certification(
+        consumer_system=consumer_system,
+        correlation_id=_correlation_id(x_correlation_id),
+    )
+
+
 @router.get(
     "/trust-certification",
     response_model=DomainProductTrustCertificationResponse,
@@ -37,9 +48,9 @@ async def get_domain_product_trust_certification(
     ),
 ) -> DomainProductTrustCertificationResponse:
     try:
-        return await domain_product_catalog_service().get_trust_certification(
+        return await _get_domain_product_trust_certification(
             consumer_system=consumer_system,
-            correlation_id=_correlation_id(x_correlation_id),
+            x_correlation_id=x_correlation_id,
         )
     except DomainProductCatalogUnavailable as exc:
         raise HTTPException(

--- a/src/app/routers/dpm_command_center.py
+++ b/src/app/routers/dpm_command_center.py
@@ -12,6 +12,28 @@ router = APIRouter(
 )
 
 
+async def _get_command_center(
+    *,
+    portfolio_manager_id: str | None,
+    tenant_id: str | None,
+    as_of_date: str | None,
+    book_id: str | None,
+    health_state: str | None,
+    limit: int,
+) -> DpmCommandCenterGatewayResponse:
+    return await dpm_command_center_service().get_command_center(
+        filters={
+            "portfolio_manager_id": portfolio_manager_id,
+            "tenant_id": tenant_id,
+            "as_of_date": as_of_date,
+            "book_id": book_id,
+            "health_state": health_state,
+            "limit": limit,
+        },
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "",
     response_model=DpmCommandCenterGatewayResponse,
@@ -57,14 +79,11 @@ async def get_command_center(
         description="Maximum active exceptions to consider for attention buckets.",
     ),
 ) -> DpmCommandCenterGatewayResponse:
-    return await dpm_command_center_service().get_command_center(
-        filters={
-            "portfolio_manager_id": portfolio_manager_id,
-            "tenant_id": tenant_id,
-            "as_of_date": as_of_date,
-            "book_id": book_id,
-            "health_state": health_state,
-            "limit": limit,
-        },
-        correlation_id=correlation_id_var.get(),
+    return await _get_command_center(
+        portfolio_manager_id=portfolio_manager_id,
+        tenant_id=tenant_id,
+        as_of_date=as_of_date,
+        book_id=book_id,
+        health_state=health_state,
+        limit=limit,
     )

--- a/src/app/routers/dpm_command_center_exception_ai.py
+++ b/src/app/routers/dpm_command_center_exception_ai.py
@@ -17,6 +17,18 @@ router = APIRouter(
 )
 
 
+async def _request_exception_summary(
+    *,
+    request: DpmExceptionSummaryRequest,
+    exception_id: str,
+) -> DpmExceptionSummaryGatewayResponse:
+    return await dpm_command_center_service().request_exception_summary(
+        exception_id=exception_id,
+        request=request,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/exceptions/{exception_id}/ai-summary",
     response_model=DpmExceptionSummaryGatewayResponse,
@@ -39,8 +51,7 @@ async def request_exception_summary(
         examples=["me_source_readiness_001"],
     ),
 ) -> DpmExceptionSummaryGatewayResponse:
-    return await dpm_command_center_service().request_exception_summary(
-        exception_id=exception_id,
+    return await _request_exception_summary(
         request=request,
-        correlation_id=correlation_id_var.get(),
+        exception_id=exception_id,
     )

--- a/src/app/routers/dpm_command_center_exception_resolution.py
+++ b/src/app/routers/dpm_command_center_exception_resolution.py
@@ -17,6 +17,18 @@ router = APIRouter(
 )
 
 
+async def _resolve_monitoring_exception(
+    *,
+    request: DpmCommandCenterResolveExceptionRequest,
+    exception_id: str,
+) -> DpmCommandCenterGatewayResponse:
+    return await dpm_command_center_service().resolve_monitoring_exception(
+        exception_id=exception_id,
+        body={"resolution_reason": request.resolution_reason},
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/exceptions/{exception_id}/resolve",
     response_model=DpmCommandCenterGatewayResponse,
@@ -35,8 +47,7 @@ async def resolve_monitoring_exception(
         examples=["me_source_readiness_001"],
     ),
 ) -> DpmCommandCenterGatewayResponse:
-    return await dpm_command_center_service().resolve_monitoring_exception(
+    return await _resolve_monitoring_exception(
+        request=request,
         exception_id=exception_id,
-        body={"resolution_reason": request.resolution_reason},
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_exceptions.py
+++ b/src/app/routers/dpm_command_center_exceptions.py
@@ -14,6 +14,26 @@ router = APIRouter(
 )
 
 
+async def _list_monitoring_exceptions(
+    *,
+    mandate_id: str | None,
+    portfolio_id: str | None,
+    state: str | None,
+    limit: int,
+    cursor: str | None,
+) -> DpmCommandCenterGatewayResponse:
+    return await dpm_command_center_service().list_monitoring_exceptions(
+        filters={
+            "mandate_id": mandate_id,
+            "portfolio_id": portfolio_id,
+            "state": state,
+            "limit": limit,
+            "cursor": cursor,
+        },
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/exceptions",
     response_model=DpmCommandCenterGatewayResponse,
@@ -35,13 +55,10 @@ async def list_monitoring_exceptions(
     limit: int = Query(default=50, ge=1, le=200, description="Maximum exceptions to return."),
     cursor: str | None = Query(default=None, description="Cursor from a previous page."),
 ) -> DpmCommandCenterGatewayResponse:
-    return await dpm_command_center_service().list_monitoring_exceptions(
-        filters={
-            "mandate_id": mandate_id,
-            "portfolio_id": portfolio_id,
-            "state": state,
-            "limit": limit,
-            "cursor": cursor,
-        },
-        correlation_id=correlation_id_var.get(),
+    return await _list_monitoring_exceptions(
+        mandate_id=mandate_id,
+        portfolio_id=portfolio_id,
+        state=state,
+        limit=limit,
+        cursor=cursor,
     )

--- a/src/app/routers/dpm_command_center_mandate_analysis.py
+++ b/src/app/routers/dpm_command_center_mandate_analysis.py
@@ -12,6 +12,16 @@ router = APIRouter(
 )
 
 
+async def _get_mandate_health(
+    *,
+    mandate_id: str,
+) -> DpmCommandCenterGatewayResponse:
+    return await dpm_command_center_service().get_mandate_health(
+        mandate_id=mandate_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/mandates/{mandate_id}/health",
     response_model=DpmCommandCenterGatewayResponse,
@@ -29,7 +39,6 @@ async def get_mandate_health(
         examples=["MANDATE_PB_SG_GLOBAL_BAL_001"],
     ),
 ) -> DpmCommandCenterGatewayResponse:
-    return await dpm_command_center_service().get_mandate_health(
+    return await _get_mandate_health(
         mandate_id=mandate_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_mandate_detail.py
+++ b/src/app/routers/dpm_command_center_mandate_detail.py
@@ -12,6 +12,16 @@ router = APIRouter(
 )
 
 
+async def _get_mandate(
+    *,
+    mandate_id: str,
+) -> DpmCommandCenterGatewayResponse:
+    return await dpm_command_center_service().get_mandate(
+        mandate_id=mandate_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/mandates/{mandate_id}",
     response_model=DpmCommandCenterGatewayResponse,
@@ -29,7 +39,6 @@ async def get_mandate(
         examples=["MANDATE_PB_SG_GLOBAL_BAL_001"],
     ),
 ) -> DpmCommandCenterGatewayResponse:
-    return await dpm_command_center_service().get_mandate(
+    return await _get_mandate(
         mandate_id=mandate_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_mandate_diff.py
+++ b/src/app/routers/dpm_command_center_mandate_diff.py
@@ -12,6 +12,19 @@ router = APIRouter(
 )
 
 
+async def _get_mandate_diff(
+    *,
+    mandate_id: str,
+    from_version: str | None,
+    to_version: str | None,
+) -> DpmCommandCenterGatewayResponse:
+    return await dpm_command_center_service().get_mandate_diff(
+        mandate_id=mandate_id,
+        filters={"from_version": from_version, "to_version": to_version},
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/mandates/{mandate_id}/diff",
     response_model=DpmCommandCenterGatewayResponse,
@@ -39,8 +52,8 @@ async def get_mandate_diff(
         examples=["3"],
     ),
 ) -> DpmCommandCenterGatewayResponse:
-    return await dpm_command_center_service().get_mandate_diff(
+    return await _get_mandate_diff(
         mandate_id=mandate_id,
-        filters={"from_version": from_version, "to_version": to_version},
-        correlation_id=correlation_id_var.get(),
+        from_version=from_version,
+        to_version=to_version,
     )

--- a/src/app/routers/dpm_command_center_mandates.py
+++ b/src/app/routers/dpm_command_center_mandates.py
@@ -12,6 +12,16 @@ router = APIRouter(
 )
 
 
+async def _get_mandate_by_portfolio(
+    *,
+    portfolio_id: str,
+) -> DpmCommandCenterGatewayResponse:
+    return await dpm_command_center_service().get_mandate_by_portfolio(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/mandates/by-portfolio/{portfolio_id}",
     response_model=DpmCommandCenterGatewayResponse,
@@ -29,7 +39,6 @@ async def get_mandate_by_portfolio(
         examples=["PB_SG_GLOBAL_BAL_001"],
     ),
 ) -> DpmCommandCenterGatewayResponse:
-    return await dpm_command_center_service().get_mandate_by_portfolio(
+    return await _get_mandate_by_portfolio(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_monitoring.py
+++ b/src/app/routers/dpm_command_center_monitoring.py
@@ -14,6 +14,18 @@ router = APIRouter(
 )
 
 
+async def _list_monitoring_runs(
+    *,
+    status_filter: str | None,
+    limit: int,
+    cursor: str | None,
+) -> DpmCommandCenterGatewayResponse:
+    return await dpm_command_center_service().list_monitoring_runs(
+        filters={"status_filter": status_filter, "limit": limit, "cursor": cursor},
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/monitoring/runs",
     response_model=DpmCommandCenterGatewayResponse,
@@ -33,7 +45,8 @@ async def list_monitoring_runs(
     limit: int = Query(default=50, ge=1, le=200, description="Maximum runs to return."),
     cursor: str | None = Query(default=None, description="Cursor from a previous page."),
 ) -> DpmCommandCenterGatewayResponse:
-    return await dpm_command_center_service().list_monitoring_runs(
-        filters={"status_filter": status_filter, "limit": limit, "cursor": cursor},
-        correlation_id=correlation_id_var.get(),
+    return await _list_monitoring_runs(
+        status_filter=status_filter,
+        limit=limit,
+        cursor=cursor,
     )

--- a/src/app/routers/dpm_command_center_monitoring_commands.py
+++ b/src/app/routers/dpm_command_center_monitoring_commands.py
@@ -17,6 +17,16 @@ router = APIRouter(
 )
 
 
+async def _run_monitoring_once(
+    *,
+    request: DpmCommandCenterForwardRequest,
+) -> DpmCommandCenterGatewayResponse:
+    return await dpm_command_center_service().run_monitoring_once(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/monitoring/run-once",
     response_model=DpmCommandCenterGatewayResponse,
@@ -31,7 +41,6 @@ router = APIRouter(
 async def run_monitoring_once(
     request: DpmCommandCenterForwardRequest,
 ) -> DpmCommandCenterGatewayResponse:
-    return await dpm_command_center_service().run_monitoring_once(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+    return await _run_monitoring_once(
+        request=request,
     )

--- a/src/app/routers/dpm_command_center_monitoring_detail.py
+++ b/src/app/routers/dpm_command_center_monitoring_detail.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _get_monitoring_run(
+    *,
+    monitoring_run_id: str,
+) -> DpmCommandCenterGatewayResponse:
+    return await dpm_command_center_service().get_monitoring_run(
+        monitoring_run_id=monitoring_run_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/monitoring/runs/{monitoring_run_id}",
     response_model=DpmCommandCenterGatewayResponse,
@@ -31,7 +41,6 @@ async def get_monitoring_run(
         examples=["dmr_20260503_083000"],
     ),
 ) -> DpmCommandCenterGatewayResponse:
-    return await dpm_command_center_service().get_monitoring_run(
+    return await _get_monitoring_run(
         monitoring_run_id=monitoring_run_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_outcome_review_detail.py
+++ b/src/app/routers/dpm_command_center_outcome_review_detail.py
@@ -12,6 +12,16 @@ router = APIRouter(
 )
 
 
+async def _get_outcome_review(
+    *,
+    outcome_review_id: str,
+) -> DpmOutcomeReviewGatewayResponse:
+    return await dpm_command_center_service().get_outcome_review(
+        outcome_review_id=outcome_review_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/outcome-reviews/{outcome_review_id}",
     response_model=DpmOutcomeReviewGatewayResponse,
@@ -30,7 +40,6 @@ async def get_outcome_review(
         examples=["or_20260415_001"],
     ),
 ) -> DpmOutcomeReviewGatewayResponse:
-    return await dpm_command_center_service().get_outcome_review(
+    return await _get_outcome_review(
         outcome_review_id=outcome_review_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_outcome_reviews.py
+++ b/src/app/routers/dpm_command_center_outcome_reviews.py
@@ -15,6 +15,16 @@ router = APIRouter(
 )
 
 
+async def _create_outcome_review(
+    *,
+    request: DpmOutcomeReviewForwardRequest,
+) -> DpmOutcomeReviewGatewayResponse:
+    return await dpm_command_center_service().create_outcome_review(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/outcome-reviews",
     response_model=DpmOutcomeReviewGatewayResponse,
@@ -29,7 +39,6 @@ router = APIRouter(
 async def create_outcome_review(
     request: DpmOutcomeReviewForwardRequest,
 ) -> DpmOutcomeReviewGatewayResponse:
-    return await dpm_command_center_service().create_outcome_review(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+    return await _create_outcome_review(
+        request=request,
     )

--- a/src/app/routers/foundation.py
+++ b/src/app/routers/foundation.py
@@ -7,6 +7,12 @@ from app.services.gateway_service_provider import foundation_service
 router = APIRouter(prefix="/api/v1/foundation", tags=["foundation"])
 
 
+async def _get_foundation_portfolios() -> FoundationPortfolioCatalogResponse:
+    service = foundation_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_portfolio_catalog(correlation_id=correlation_id)
+
+
 @router.get(
     "/portfolios",
     response_model=FoundationPortfolioCatalogResponse,
@@ -20,6 +26,4 @@ router = APIRouter(prefix="/api/v1/foundation", tags=["foundation"])
     ),
 )
 async def get_foundation_portfolios() -> FoundationPortfolioCatalogResponse:
-    service = foundation_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_portfolio_catalog(correlation_id=correlation_id)
+    return await _get_foundation_portfolios()

--- a/src/app/routers/foundation_workspace.py
+++ b/src/app/routers/foundation_workspace.py
@@ -7,6 +7,18 @@ from app.services.gateway_service_provider import foundation_service
 router = APIRouter(prefix="/api/v1/foundation", tags=["foundation"])
 
 
+async def _get_foundation_workspace(
+    *,
+    portfolio_id: str,
+) -> FoundationWorkspaceResponse:
+    service = foundation_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_portfolio_workspace(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/workspace",
     response_model=FoundationWorkspaceResponse,
@@ -28,9 +40,6 @@ async def get_foundation_workspace(
         examples=["PF_1001"],
     ),
 ) -> FoundationWorkspaceResponse:
-    service = foundation_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_portfolio_workspace(
+    return await _get_foundation_workspace(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/intake.py
+++ b/src/app/routers/intake.py
@@ -7,6 +7,20 @@ from app.services.gateway_service_provider import intake_service
 router = APIRouter(prefix="/api/v1/intake", tags=["intake"])
 
 
+async def _ingest_portfolio_bundle(
+    *,
+    request: IntakeBundleRequest,
+    idempotency_key: str | None,
+) -> EnvelopeResponse:
+    service = intake_service()
+    correlation_id = correlation_id_var.get()
+    return await service.ingest_portfolio_bundle(
+        body=request.body,
+        correlation_id=correlation_id,
+        idempotency_key=idempotency_key,
+    )
+
+
 @router.post(
     "/portfolio-bundle",
     response_model=EnvelopeResponse,
@@ -30,10 +44,7 @@ async def ingest_portfolio_bundle(
         examples=["bundle-idem-1001"],
     ),
 ) -> EnvelopeResponse:
-    service = intake_service()
-    correlation_id = correlation_id_var.get()
-    return await service.ingest_portfolio_bundle(
-        body=request.body,
-        correlation_id=correlation_id,
+    return await _ingest_portfolio_bundle(
+        request=request,
         idempotency_key=idempotency_key,
     )

--- a/src/app/routers/intake_upload_commits.py
+++ b/src/app/routers/intake_upload_commits.py
@@ -7,6 +7,23 @@ from app.services.gateway_service_provider import intake_service
 router = APIRouter(prefix="/api/v1/intake/uploads", tags=["intake"])
 
 
+async def _commit_upload(
+    *,
+    entity_type: str,
+    file: UploadFile,
+    allow_partial: bool,
+) -> EnvelopeResponse:
+    service = intake_service()
+    correlation_id = correlation_id_var.get()
+    return await service.commit_upload(
+        entity_type=entity_type,
+        filename=file.filename or "upload.csv",
+        content=await file.read(),
+        allow_partial=allow_partial,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/commit",
     response_model=EnvelopeResponse,
@@ -37,12 +54,8 @@ async def commit_upload(
         examples=[False],
     ),
 ) -> EnvelopeResponse:
-    service = intake_service()
-    correlation_id = correlation_id_var.get()
-    return await service.commit_upload(
+    return await _commit_upload(
         entity_type=entity_type,
-        filename=file.filename or "upload.csv",
-        content=await file.read(),
+        file=file,
         allow_partial=allow_partial,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/intake_uploads.py
+++ b/src/app/routers/intake_uploads.py
@@ -7,6 +7,23 @@ from app.services.gateway_service_provider import intake_service
 router = APIRouter(prefix="/api/v1/intake/uploads", tags=["intake"])
 
 
+async def _preview_upload(
+    *,
+    entity_type: str,
+    file: UploadFile,
+    sample_size: int,
+) -> EnvelopeResponse:
+    service = intake_service()
+    correlation_id = correlation_id_var.get()
+    return await service.preview_upload(
+        entity_type=entity_type,
+        filename=file.filename or "upload.csv",
+        content=await file.read(),
+        sample_size=sample_size,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/preview",
     response_model=EnvelopeResponse,
@@ -39,12 +56,8 @@ async def preview_upload(
         examples=[20],
     ),
 ) -> EnvelopeResponse:
-    service = intake_service()
-    correlation_id = correlation_id_var.get()
-    return await service.preview_upload(
+    return await _preview_upload(
         entity_type=entity_type,
-        filename=file.filename or "upload.csv",
-        content=await file.read(),
+        file=file,
         sample_size=sample_size,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/lookup_currency_catalog.py
+++ b/src/app/routers/lookup_currency_catalog.py
@@ -7,6 +7,24 @@ from app.services.gateway_service_provider import intake_service
 router = APIRouter(prefix="/api/v1/lookups", tags=["lookups"])
 
 
+async def _get_currency_lookups(
+    *,
+    instrument_page_limit: int | None,
+    source: str | None,
+    q: str | None,
+    limit: int | None,
+) -> LookupResponse:
+    service = intake_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_currency_lookups(
+        correlation_id=correlation_id,
+        instrument_page_limit=instrument_page_limit,
+        source=source,
+        q=q,
+        limit=limit,
+    )
+
+
 @router.get(
     "/currencies",
     response_model=LookupResponse,
@@ -47,10 +65,7 @@ async def get_currency_lookups(
         examples=[50],
     ),
 ) -> LookupResponse:
-    service = intake_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_currency_lookups(
-        correlation_id=correlation_id,
+    return await _get_currency_lookups(
         instrument_page_limit=instrument_page_limit,
         source=source,
         q=q,

--- a/src/app/routers/lookup_instrument_catalog.py
+++ b/src/app/routers/lookup_instrument_catalog.py
@@ -7,6 +7,22 @@ from app.services.gateway_service_provider import intake_service
 router = APIRouter(prefix="/api/v1/lookups", tags=["lookups"])
 
 
+async def _get_instrument_lookups(
+    *,
+    limit: int,
+    product_type: str | None,
+    q: str | None,
+) -> LookupResponse:
+    service = intake_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_instrument_lookups(
+        limit=limit,
+        correlation_id=correlation_id,
+        product_type=product_type,
+        q=q,
+    )
+
+
 @router.get(
     "/instruments",
     response_model=LookupResponse,
@@ -37,11 +53,8 @@ async def get_instrument_lookups(
         examples=["Apple"],
     ),
 ) -> LookupResponse:
-    service = intake_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_instrument_lookups(
+    return await _get_instrument_lookups(
         limit=limit,
-        correlation_id=correlation_id,
         product_type=product_type,
         q=q,
     )

--- a/src/app/routers/lookup_portfolio_catalog.py
+++ b/src/app/routers/lookup_portfolio_catalog.py
@@ -7,6 +7,24 @@ from app.services.gateway_service_provider import intake_service
 router = APIRouter(prefix="/api/v1/lookups", tags=["lookups"])
 
 
+async def _get_portfolio_lookups(
+    *,
+    cif_id: str | None,
+    booking_center: str | None,
+    q: str | None,
+    limit: int | None,
+) -> LookupResponse:
+    service = intake_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_portfolio_lookups(
+        correlation_id=correlation_id,
+        cif_id=cif_id,
+        booking_center=booking_center,
+        q=q,
+        limit=limit,
+    )
+
+
 @router.get(
     "/portfolios",
     response_model=LookupResponse,
@@ -48,10 +66,7 @@ async def get_portfolio_lookups(
         examples=[100],
     ),
 ) -> LookupResponse:
-    service = intake_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_portfolio_lookups(
-        correlation_id=correlation_id,
+    return await _get_portfolio_lookups(
         cif_id=cif_id,
         booking_center=booking_center,
         q=q,

--- a/src/app/routers/platform.py
+++ b/src/app/routers/platform.py
@@ -7,6 +7,21 @@ from app.services.platform_capabilities_service_provider import platform_capabil
 router = APIRouter(prefix="/api/v1/platform", tags=["platform"])
 
 
+async def _get_platform_capabilities(
+    *,
+    consumer_system: str,
+    tenant_id: str,
+    x_correlation_id: str | None,
+) -> PlatformCapabilitiesResponse:
+    service = platform_capabilities_service()
+    correlation_id = x_correlation_id or correlation_id_var.get() or ""
+    return await service.get_platform_capabilities(
+        consumer_system=consumer_system,
+        tenant_id=tenant_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/capabilities",
     response_model=PlatformCapabilitiesResponse,
@@ -52,10 +67,8 @@ async def get_platform_capabilities(
         ),
     ),
 ) -> PlatformCapabilitiesResponse:
-    service = platform_capabilities_service()
-    correlation_id = x_correlation_id or correlation_id_var.get() or ""
-    return await service.get_platform_capabilities(
+    return await _get_platform_capabilities(
         consumer_system=consumer_system,
         tenant_id=tenant_id,
-        correlation_id=correlation_id,
+        x_correlation_id=x_correlation_id,
     )

--- a/src/app/routers/proposal_artifact.py
+++ b/src/app/routers/proposal_artifact.py
@@ -7,6 +7,20 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _create_proposal_artifact(
+    *,
+    request: ProposalBodyRequest,
+    idempotency_key: str,
+) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_proposal_artifact(
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/artifact",
     response_model=ProposalEnvelopeResponse,
@@ -25,10 +39,7 @@ async def create_proposal_artifact(
         examples=["idem-artifact-1"],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.create_proposal_artifact(
-        body=request.body,
+    return await _create_proposal_artifact(
+        request=request,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_delivery_events.py
+++ b/src/app/routers/proposal_delivery_events.py
@@ -7,6 +7,18 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_delivery_events(
+    *,
+    proposal_id: str,
+) -> ProposalDeliveryEventsEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_delivery_events(
+        proposal_id=proposal_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/delivery-events",
     response_model=ProposalDeliveryEventsEnvelopeResponse,
@@ -23,9 +35,6 @@ async def get_delivery_events(
         examples=["pp_1"],
     ),
 ) -> ProposalDeliveryEventsEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_delivery_events(
+    return await _get_delivery_events(
         proposal_id=proposal_id,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_execution_updates.py
+++ b/src/app/routers/proposal_execution_updates.py
@@ -7,6 +7,22 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _record_execution_update(
+    *,
+    request: ProposalBodyRequest,
+    proposal_id: str,
+    idempotency_key: str | None,
+) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.record_execution_update(
+        proposal_id=proposal_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/execution-updates",
     response_model=ProposalEnvelopeResponse,
@@ -30,11 +46,8 @@ async def record_execution_update(
         examples=["idem-execution-update-1"],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.record_execution_update(
+    return await _record_execution_update(
+        request=request,
         proposal_id=proposal_id,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_idempotency_records.py
+++ b/src/app/routers/proposal_idempotency_records.py
@@ -7,6 +7,18 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal_idempotency_record(
+    *,
+    idempotency_key: str,
+) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_idempotency_record(
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/idempotency/{idempotency_key}",
     response_model=ProposalEnvelopeResponse,
@@ -23,9 +35,6 @@ async def get_proposal_idempotency_record(
         examples=["idem-create-1"],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal_idempotency_record(
+    return await _get_proposal_idempotency_record(
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_memo_detail.py
+++ b/src/app/routers/proposal_memo_detail.py
@@ -8,6 +8,20 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal_memo(
+    *,
+    proposal_id: str,
+    version_no: int,
+) -> ProposalMemoEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_memo(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/versions/{version_no}/memo",
     response_model=ProposalMemoEnvelopeResponse,
@@ -21,10 +35,7 @@ async def get_proposal_memo(
     proposal_id: str = PROPOSAL_ID_PATH,
     version_no: int = VERSION_NO_PATH,
 ) -> ProposalMemoEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal_memo(
+    return await _get_proposal_memo(
         proposal_id=proposal_id,
         version_no=version_no,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_memo_report_packages.py
+++ b/src/app/routers/proposal_memo_report_packages.py
@@ -11,6 +11,24 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _request_proposal_memo_report_package(
+    *,
+    request: ProposalMemoReportPackageRequest,
+    proposal_id: str,
+    version_no: int,
+    idempotency_key: str | None,
+) -> ProposalMemoReportPackageEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.request_proposal_memo_report_package(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.model_dump(exclude_none=True),
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/versions/{version_no}/memo/report-packages",
     response_model=ProposalMemoReportPackageEnvelopeResponse,
@@ -32,12 +50,9 @@ async def request_proposal_memo_report_package(
         examples=["idem-memo-report-package-1"],
     ),
 ) -> ProposalMemoReportPackageEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.request_proposal_memo_report_package(
+    return await _request_proposal_memo_report_package(
+        request=request,
         proposal_id=proposal_id,
         version_no=version_no,
-        body=request.model_dump(exclude_none=True),
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_memo_reporting.py
+++ b/src/app/routers/proposal_memo_reporting.py
@@ -11,6 +11,24 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _record_proposal_memo_report_package_event(
+    *,
+    request: ProposalBodyRequest,
+    proposal_id: str,
+    version_no: int,
+    idempotency_key: str | None,
+) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.record_proposal_memo_report_package_event(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/versions/{version_no}/memo/report-package-events",
     response_model=ProposalEnvelopeResponse,
@@ -31,12 +49,9 @@ async def record_proposal_memo_report_package_event(
         examples=["idem-memo-report-package-event-1"],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.record_proposal_memo_report_package_event(
+    return await _record_proposal_memo_report_package_event(
+        request=request,
         proposal_id=proposal_id,
         version_no=version_no,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_narrative_actions.py
+++ b/src/app/routers/proposal_narrative_actions.py
@@ -10,6 +10,22 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _regenerate_proposal_narrative(
+    *,
+    request: ProposalBodyRequest,
+    proposal_id: str,
+    version_no: int,
+) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.regenerate_proposal_narrative(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.body,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/versions/{version_no}/narrative/regenerate",
     response_model=ProposalEnvelopeResponse,
@@ -33,11 +49,8 @@ async def regenerate_proposal_narrative(
         examples=[2],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.regenerate_proposal_narrative(
+    return await _regenerate_proposal_narrative(
+        request=request,
         proposal_id=proposal_id,
         version_no=version_no,
-        body=request.body,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_narrative_reviews.py
+++ b/src/app/routers/proposal_narrative_reviews.py
@@ -10,6 +10,24 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _review_proposal_narrative(
+    *,
+    request: ProposalNarrativeReviewRequest,
+    proposal_id: str,
+    version_no: int,
+    idempotency_key: str | None,
+) -> ProposalNarrativeReviewEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.review_proposal_narrative(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        body=request.model_dump(exclude_none=True),
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/versions/{version_no}/narrative/review",
     response_model=ProposalNarrativeReviewEnvelopeResponse,
@@ -40,12 +58,9 @@ async def review_proposal_narrative(
         examples=["proposal-narrative-review-idem-001"],
     ),
 ) -> ProposalNarrativeReviewEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.review_proposal_narrative(
+    return await _review_proposal_narrative(
+        request=request,
         proposal_id=proposal_id,
         version_no=version_no,
-        body=request.model_dump(exclude_none=True),
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_narratives.py
+++ b/src/app/routers/proposal_narratives.py
@@ -7,6 +7,20 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal_narrative(
+    *,
+    proposal_id: str,
+    version_no: int,
+) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_narrative(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/versions/{version_no}/narrative",
     response_model=ProposalEnvelopeResponse,
@@ -29,10 +43,7 @@ async def get_proposal_narrative(
         examples=[2],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal_narrative(
+    return await _get_proposal_narrative(
         proposal_id=proposal_id,
         version_no=version_no,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_operation_correlation.py
+++ b/src/app/routers/proposal_operation_correlation.py
@@ -7,6 +7,18 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal_operation_by_correlation(
+    *,
+    operation_correlation_id: str,
+) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_operation_by_correlation(
+        operation_correlation_id=operation_correlation_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/operations/by-correlation/{operation_correlation_id}",
     response_model=ProposalEnvelopeResponse,
@@ -20,9 +32,6 @@ async def get_proposal_operation_by_correlation(
         examples=["corr-operation-001"],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal_operation_by_correlation(
+    return await _get_proposal_operation_by_correlation(
         operation_correlation_id=operation_correlation_id,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_risk_approval.py
+++ b/src/app/routers/proposal_risk_approval.py
@@ -10,6 +10,25 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _approve_risk(
+    *,
+    request: ProposalApprovalActionRequest,
+    proposal_id: str,
+    idempotency_key: str,
+) -> ProposalStateTransitionEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.approve_risk(
+        proposal_id=proposal_id,
+        actor_id=request.actor_id,
+        expected_state=request.expected_state,
+        details=request.details,
+        related_version_no=request.related_version_no,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/approve-risk",
     response_model=ProposalStateTransitionEnvelopeResponse,
@@ -29,14 +48,8 @@ async def approve_risk(
         examples=["idem-approve-risk-1"],
     ),
 ) -> ProposalStateTransitionEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.approve_risk(
+    return await _approve_risk(
+        request=request,
         proposal_id=proposal_id,
-        actor_id=request.actor_id,
-        expected_state=request.expected_state,
-        details=request.details,
-        related_version_no=request.related_version_no,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_version_async.py
+++ b/src/app/routers/proposal_version_async.py
@@ -7,6 +7,22 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _create_proposal_version_async(
+    *,
+    request: ProposalBodyRequest,
+    proposal_id: str,
+    idempotency_key: str,
+) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_proposal_version_async(
+        proposal_id=proposal_id,
+        body=request.body,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/versions/async",
     response_model=ProposalEnvelopeResponse,
@@ -29,11 +45,8 @@ async def create_proposal_version_async(
         examples=["idem-version-async-1"],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.create_proposal_version_async(
+    return await _create_proposal_version_async(
+        request=request,
         proposal_id=proposal_id,
-        body=request.body,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_version_replay_evidence.py
+++ b/src/app/routers/proposal_version_replay_evidence.py
@@ -7,6 +7,20 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _get_proposal_version_replay_evidence(
+    *,
+    proposal_id: str,
+    version_no: int,
+) -> ProposalEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_proposal_version_replay_evidence(
+        proposal_id=proposal_id,
+        version_no=version_no,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{proposal_id}/versions/{version_no}/replay-evidence",
     response_model=ProposalEnvelopeResponse,
@@ -27,10 +41,7 @@ async def get_proposal_version_replay_evidence(
         examples=[2],
     ),
 ) -> ProposalEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_proposal_version_replay_evidence(
+    return await _get_proposal_version_replay_evidence(
         proposal_id=proposal_id,
         version_no=version_no,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposal_workflow_decisions.py
+++ b/src/app/routers/proposal_workflow_decisions.py
@@ -10,6 +10,25 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _approve_compliance(
+    *,
+    request: ProposalApprovalActionRequest,
+    proposal_id: str,
+    idempotency_key: str,
+) -> ProposalStateTransitionEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    return await service.approve_compliance(
+        proposal_id=proposal_id,
+        actor_id=request.actor_id,
+        expected_state=request.expected_state,
+        details=request.details,
+        related_version_no=request.related_version_no,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/{proposal_id}/approve-compliance",
     response_model=ProposalStateTransitionEnvelopeResponse,
@@ -29,14 +48,8 @@ async def approve_compliance(
         examples=["idem-approve-compliance-1"],
     ),
 ) -> ProposalStateTransitionEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    return await service.approve_compliance(
+    return await _approve_compliance(
+        request=request,
         proposal_id=proposal_id,
-        actor_id=request.actor_id,
-        expected_state=request.expected_state,
-        details=request.details,
-        related_version_no=request.related_version_no,
         idempotency_key=idempotency_key,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/proposals.py
+++ b/src/app/routers/proposals.py
@@ -7,6 +7,30 @@ from app.services.advisory_service_provider import proposal_service
 router = APIRouter(prefix="/api/v1/proposals", tags=["proposals"])
 
 
+async def _list_proposals(
+    *,
+    portfolio_id: str | None,
+    state: str | None,
+    created_by: str | None,
+    created_from: str | None,
+    created_to: str | None,
+    limit: int,
+    cursor: str | None,
+) -> ProposalListEnvelopeResponse:
+    service = proposal_service()
+    correlation_id = correlation_id_var.get()
+    filters = {
+        "portfolio_id": portfolio_id,
+        "state": state,
+        "created_by": created_by,
+        "created_from": created_from,
+        "created_to": created_to,
+        "limit": limit,
+        "cursor": cursor,
+    }
+    return await service.list_proposals(filters=filters, correlation_id=correlation_id)
+
+
 @router.get(
     "",
     response_model=ProposalListEnvelopeResponse,
@@ -55,15 +79,12 @@ async def list_proposals(
         examples=["pp_00042"],
     ),
 ) -> ProposalListEnvelopeResponse:
-    service = proposal_service()
-    correlation_id = correlation_id_var.get()
-    filters = {
-        "portfolio_id": portfolio_id,
-        "state": state,
-        "created_by": created_by,
-        "created_from": created_from,
-        "created_to": created_to,
-        "limit": limit,
-        "cursor": cursor,
-    }
-    return await service.list_proposals(filters=filters, correlation_id=correlation_id)
+    return await _list_proposals(
+        portfolio_id=portfolio_id,
+        state=state,
+        created_by=created_by,
+        created_from=created_from,
+        created_to=created_to,
+        limit=limit,
+        cursor=cursor,
+    )

--- a/src/app/routers/source_products.py
+++ b/src/app/routers/source_products.py
@@ -10,6 +10,21 @@ from app.services.gateway_service_provider import source_product_service
 router = APIRouter(prefix="/api/v1/source-products", tags=["Source Products"])
 
 
+async def _get_external_order_execution_acknowledgement(
+    *,
+    request: ExternalOrderExecutionAcknowledgementRequest,
+    portfolio_id: str,
+    x_correlation_id: str | None,
+) -> ExternalOrderExecutionAcknowledgementResponse:
+    correlation_id = x_correlation_id or correlation_id_var.get() or ""
+    payload = request.model_dump(exclude_none=True)
+    return await source_product_service().get_external_order_execution_acknowledgement(
+        portfolio_id=portfolio_id,
+        payload=payload,
+        correlation_id=correlation_id,
+    )
+
+
 @router.post(
     "/portfolios/{portfolio_id}/external-order-execution-acknowledgement",
     response_model=ExternalOrderExecutionAcknowledgementResponse,
@@ -35,10 +50,8 @@ async def get_external_order_execution_acknowledgement(
         description="Optional caller-supplied correlation identifier propagated to lotus-core.",
     ),
 ) -> ExternalOrderExecutionAcknowledgementResponse:
-    correlation_id = x_correlation_id or correlation_id_var.get() or ""
-    payload = request.model_dump(exclude_none=True)
-    return await source_product_service().get_external_order_execution_acknowledgement(
+    return await _get_external_order_execution_acknowledgement(
+        request=request,
         portfolio_id=portfolio_id,
-        payload=payload,
-        correlation_id=correlation_id,
+        x_correlation_id=x_correlation_id,
     )

--- a/src/app/routers/workbench.py
+++ b/src/app/routers/workbench.py
@@ -7,6 +7,18 @@ from app.services.workbench_service_provider import workbench_service
 router = APIRouter(prefix="/api/v1/workbench", tags=["workbench"])
 
 
+async def _get_workbench_overview(
+    *,
+    portfolio_id: str,
+) -> WorkbenchOverviewResponse:
+    service = workbench_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_workbench_overview(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+    )
+
+
 @router.get(
     "/{portfolio_id}/overview",
     response_model=WorkbenchOverviewResponse,
@@ -25,9 +37,6 @@ async def get_workbench_overview(
         examples=["PF_1001"],
     ),
 ) -> WorkbenchOverviewResponse:
-    service = workbench_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_workbench_overview(
+    return await _get_workbench_overview(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id,
     )

--- a/src/app/routers/workbench_analytics.py
+++ b/src/app/routers/workbench_analytics.py
@@ -7,6 +7,26 @@ from app.services.workbench_service_provider import workbench_service
 router = APIRouter(prefix="/api/v1/workbench", tags=["workbench"])
 
 
+async def _get_workbench_analytics(
+    *,
+    portfolio_id: str,
+    period: str,
+    group_by: str,
+    benchmark_code: str,
+    session_id: str | None,
+) -> WorkbenchAnalyticsResponse:
+    service = workbench_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_workbench_analytics(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+        period=period,
+        group_by=group_by,
+        benchmark_code=benchmark_code,
+        session_id=session_id,
+    )
+
+
 @router.get(
     "/{portfolio_id}/analytics",
     response_model=WorkbenchAnalyticsResponse,
@@ -46,11 +66,8 @@ async def get_workbench_analytics(
         examples=["sess_1"],
     ),
 ) -> WorkbenchAnalyticsResponse:
-    service = workbench_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_workbench_analytics(
+    return await _get_workbench_analytics(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id,
         period=period,
         group_by=group_by,
         benchmark_code=benchmark_code,

--- a/src/app/routers/workbench_performance_evidence.py
+++ b/src/app/routers/workbench_performance_evidence.py
@@ -6,6 +6,21 @@ from app.services.workbench_service_provider import performance_workspace_servic
 router = APIRouter(prefix="/api/v1/workbench", tags=["workbench"])
 
 
+async def _get_performance_evidence_artifact(
+    *,
+    calculation_id: str,
+    artifact_name: str,
+) -> Response:
+    service = performance_workspace_service()
+    correlation_id = correlation_id_var.get()
+    content, content_type = await service.get_performance_evidence_artifact(
+        calculation_id=calculation_id,
+        artifact_name=artifact_name,
+        correlation_id=correlation_id,
+    )
+    return Response(content=content, media_type=content_type or "application/octet-stream")
+
+
 @router.get(
     "/{portfolio_id}/performance/evidence/artifacts/{calculation_id}/{artifact_name}",
     summary="Download Performance Evidence Artifact",
@@ -35,11 +50,7 @@ async def get_performance_evidence_artifact(
     ),
 ) -> Response:
     _ = portfolio_id
-    service = performance_workspace_service()
-    correlation_id = correlation_id_var.get()
-    content, content_type = await service.get_performance_evidence_artifact(
+    return await _get_performance_evidence_artifact(
         calculation_id=calculation_id,
         artifact_name=artifact_name,
-        correlation_id=correlation_id,
     )
-    return Response(content=content, media_type=content_type or "application/octet-stream")

--- a/src/app/routers/workbench_portfolio_360.py
+++ b/src/app/routers/workbench_portfolio_360.py
@@ -7,6 +7,20 @@ from app.services.workbench_service_provider import workbench_service
 router = APIRouter(prefix="/api/v1/workbench", tags=["workbench"])
 
 
+async def _get_portfolio_360(
+    *,
+    portfolio_id: str,
+    session_id: str | None,
+) -> WorkbenchPortfolio360Response:
+    service = workbench_service()
+    correlation_id = correlation_id_var.get()
+    return await service.get_portfolio_360(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+        session_id=session_id,
+    )
+
+
 @router.get(
     "/{portfolio_id}/portfolio-360",
     response_model=WorkbenchPortfolio360Response,
@@ -29,10 +43,7 @@ async def get_portfolio_360(
         examples=["sess_1"],
     ),
 ) -> WorkbenchPortfolio360Response:
-    service = workbench_service()
-    correlation_id = correlation_id_var.get()
-    return await service.get_portfolio_360(
+    return await _get_portfolio_360(
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id,
         session_id=session_id,
     )

--- a/src/app/routers/workbench_sandbox.py
+++ b/src/app/routers/workbench_sandbox.py
@@ -10,6 +10,21 @@ from app.services.workbench_service_provider import workbench_service
 router = APIRouter(prefix="/api/v1/workbench", tags=["workbench"])
 
 
+async def _create_sandbox_session(
+    *,
+    request: WorkbenchSandboxSessionCreateRequest,
+    portfolio_id: str,
+) -> WorkbenchSandboxStateResponse:
+    service = workbench_service()
+    correlation_id = correlation_id_var.get()
+    return await service.create_sandbox_session(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+        created_by=request.created_by,
+        ttl_hours=request.ttl_hours,
+    )
+
+
 @router.post(
     "/{portfolio_id}/sandbox/sessions",
     response_model=WorkbenchSandboxStateResponse,
@@ -28,11 +43,7 @@ async def create_sandbox_session(
         examples=["PF_1001"],
     ),
 ) -> WorkbenchSandboxStateResponse:
-    service = workbench_service()
-    correlation_id = correlation_id_var.get()
-    return await service.create_sandbox_session(
+    return await _create_sandbox_session(
+        request=request,
         portfolio_id=portfolio_id,
-        correlation_id=correlation_id,
-        created_by=request.created_by,
-        ttl_hours=request.ttl_hours,
     )

--- a/src/app/routers/workbench_sandbox_changes.py
+++ b/src/app/routers/workbench_sandbox_changes.py
@@ -10,6 +10,23 @@ from app.services.workbench_service_provider import workbench_service
 router = APIRouter(prefix="/api/v1/workbench", tags=["workbench"])
 
 
+async def _apply_sandbox_changes(
+    *,
+    request: WorkbenchSandboxApplyChangesRequest,
+    portfolio_id: str,
+    session_id: str,
+) -> WorkbenchSandboxStateResponse:
+    service = workbench_service()
+    correlation_id = correlation_id_var.get()
+    return await service.apply_sandbox_changes(
+        portfolio_id=portfolio_id,
+        session_id=session_id,
+        correlation_id=correlation_id,
+        changes=[item.model_dump(exclude_none=True) for item in request.changes],
+        evaluate_policy=request.evaluate_policy,
+    )
+
+
 @router.post(
     "/{portfolio_id}/sandbox/sessions/{session_id}/changes",
     response_model=WorkbenchSandboxStateResponse,
@@ -33,12 +50,8 @@ async def apply_sandbox_changes(
         examples=["sess_1"],
     ),
 ) -> WorkbenchSandboxStateResponse:
-    service = workbench_service()
-    correlation_id = correlation_id_var.get()
-    return await service.apply_sandbox_changes(
+    return await _apply_sandbox_changes(
+        request=request,
         portfolio_id=portfolio_id,
         session_id=session_id,
-        correlation_id=correlation_id,
-        changes=[item.model_dump(exclude_none=True) for item in request.changes],
-        evaluate_policy=request.evaluate_policy,
     )


### PR DESCRIPTION
## Summary
- Refactors 50 gateway route handlers into private route-owned forwarding helpers across proposal, foundation, intake, lookup, Workbench, domain-product, platform, source-product, and DPM command-center surfaces.
- Preserves public FastAPI paths, response models, request serialization, idempotency/correlation propagation, and upstream service authority.
- Keeps behavior code-only: no API contract, docs, wiki, context, or runtime behavior changes intended.

## Validation
- `python -m pytest tests/unit/test_proposal_service.py tests/unit/test_foundation_service.py tests/unit/test_intake_service.py tests/unit/test_workbench_service.py tests/unit/test_performance_workspace_service.py tests/unit/test_composite_performance_service.py tests/unit/test_domain_product_catalog_service.py tests/unit/test_source_product_execution_service.py tests/unit/test_dpm_command_center_service.py tests/contract/test_proposals_contract.py tests/contract/test_foundation_contract.py tests/contract/test_intake_contract.py tests/contract/test_lookup_contract.py tests/contract/test_workbench_contract.py tests/contract/test_domain_products_contract.py tests/contract/test_source_products_contract.py tests/contract/test_dpm_command_center_contract.py tests/contract/test_advise_gateway_route_coverage.py -q` -> 170 passed
- `make check` -> ruff check passed; ruff format check passed; monetary float guard passed (`Findings=189, allowlisted=189`); mypy passed over 396 source files; Workbench contract tests passed; unit/contract suite passed (`750 passed`)

## Sibling Refactor Pulse
- `lotus-core`: `perf/api-query-index-optimization` at `98ce8814 perf: parallelize analytics performance horizon reads`, clean working tree.
- `lotus-performance`: `feat/performance-modular-refactor` at `9f87ba0 Harden workspace summary nullable numerics`, clean working tree.
- `lotus-manage`: `feat/manage-hardening-wave-2` at `0b7ab70 move run support config out of router`, clean working tree.
- No gateway contract collision observed for this code-only forwarding refactor.

## Governance
- Commit count over `origin/main`: 50, preserving normal commit history for non-squash merge.
- No wiki change required: repo-local wiki truth is unchanged.
- No durable docs/context/RFC truth changed in this PR.