### PR TITLE
Refactor gateway route ownership batch 10

### DIFF
--- a/src/app/routers/dpm_command_center_outcome_review_ai_evidence_input.py
+++ b/src/app/routers/dpm_command_center_outcome_review_ai_evidence_input.py
@@ -12,6 +12,16 @@ router = APIRouter(
 )
 
 
+async def _get_outcome_review_ai_evidence_input(
+    *,
+    outcome_review_id: str,
+) -> DpmOutcomeReviewGatewayResponse:
+    return await dpm_command_center_service().get_outcome_review_ai_evidence_input(
+        outcome_review_id=outcome_review_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/outcome-reviews/{outcome_review_id}/ai-evidence-input",
     response_model=DpmOutcomeReviewGatewayResponse,
@@ -30,7 +40,6 @@ async def get_outcome_review_ai_evidence_input(
         examples=["or_20260415_001"],
     ),
 ) -> DpmOutcomeReviewGatewayResponse:
-    return await dpm_command_center_service().get_outcome_review_ai_evidence_input(
+    return await _get_outcome_review_ai_evidence_input(
         outcome_review_id=outcome_review_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_outcome_review_evidence.py
+++ b/src/app/routers/dpm_command_center_outcome_review_evidence.py
@@ -15,6 +15,18 @@ router = APIRouter(
 )
 
 
+async def _refresh_outcome_review_sources(
+    *,
+    request: DpmOutcomeReviewRefreshRequest,
+    outcome_review_id: str,
+) -> DpmOutcomeReviewGatewayResponse:
+    return await dpm_command_center_service().refresh_outcome_review_sources(
+        outcome_review_id=outcome_review_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/outcome-reviews/{outcome_review_id}/refresh-sources",
     response_model=DpmOutcomeReviewGatewayResponse,
@@ -34,8 +46,7 @@ async def refresh_outcome_review_sources(
         examples=["or_20260415_001"],
     ),
 ) -> DpmOutcomeReviewGatewayResponse:
-    return await dpm_command_center_service().refresh_outcome_review_sources(
+    return await _refresh_outcome_review_sources(
+        request=request,
         outcome_review_id=outcome_review_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_outcome_review_handoff.py
+++ b/src/app/routers/dpm_command_center_outcome_review_handoff.py
@@ -12,6 +12,16 @@ router = APIRouter(
 )
 
 
+async def _get_outcome_review_report_input(
+    *,
+    outcome_review_id: str,
+) -> DpmOutcomeReviewGatewayResponse:
+    return await dpm_command_center_service().get_outcome_review_report_input(
+        outcome_review_id=outcome_review_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/outcome-reviews/{outcome_review_id}/report-input",
     response_model=DpmOutcomeReviewGatewayResponse,
@@ -30,7 +40,6 @@ async def get_outcome_review_report_input(
         examples=["or_20260415_001"],
     ),
 ) -> DpmOutcomeReviewGatewayResponse:
-    return await dpm_command_center_service().get_outcome_review_report_input(
+    return await _get_outcome_review_report_input(
         outcome_review_id=outcome_review_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_outcome_review_lookups.py
+++ b/src/app/routers/dpm_command_center_outcome_review_lookups.py
@@ -12,6 +12,16 @@ router = APIRouter(
 )
 
 
+async def _get_run_outcome_review(
+    *,
+    rebalance_run_id: str,
+) -> DpmOutcomeReviewGatewayResponse:
+    return await dpm_command_center_service().get_run_outcome_review(
+        rebalance_run_id=rebalance_run_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/runs/{rebalance_run_id}/outcome-review",
     response_model=DpmOutcomeReviewGatewayResponse,
@@ -29,7 +39,6 @@ async def get_run_outcome_review(
         examples=["rr_20260415_001"],
     ),
 ) -> DpmOutcomeReviewGatewayResponse:
-    return await dpm_command_center_service().get_run_outcome_review(
+    return await _get_run_outcome_review(
         rebalance_run_id=rebalance_run_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_outcome_review_narratives.py
+++ b/src/app/routers/dpm_command_center_outcome_review_narratives.py
@@ -15,6 +15,18 @@ router = APIRouter(
 )
 
 
+async def _request_outcome_review_ai_narrative(
+    *,
+    request: DpmOutcomeReviewNarrativeRequest,
+    outcome_review_id: str,
+) -> DpmOutcomeReviewNarrativeGatewayResponse:
+    return await dpm_command_center_service().request_outcome_review_ai_narrative(
+        outcome_review_id=outcome_review_id,
+        request=request,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/outcome-reviews/{outcome_review_id}/ai-narrative",
     response_model=DpmOutcomeReviewNarrativeGatewayResponse,
@@ -36,8 +48,7 @@ async def request_outcome_review_ai_narrative(
         examples=["or_20260415_001"],
     ),
 ) -> DpmOutcomeReviewNarrativeGatewayResponse:
-    return await dpm_command_center_service().request_outcome_review_ai_narrative(
-        outcome_review_id=outcome_review_id,
+    return await _request_outcome_review_ai_narrative(
         request=request,
-        correlation_id=correlation_id_var.get(),
+        outcome_review_id=outcome_review_id,
     )

--- a/src/app/routers/dpm_command_center_outcome_review_preview.py
+++ b/src/app/routers/dpm_command_center_outcome_review_preview.py
@@ -15,6 +15,16 @@ router = APIRouter(
 )
 
 
+async def _preview_outcome_review(
+    *,
+    request: DpmOutcomeReviewForwardRequest,
+) -> DpmOutcomeReviewGatewayResponse:
+    return await dpm_command_center_service().preview_outcome_review(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/outcome-reviews/preview",
     response_model=DpmOutcomeReviewGatewayResponse,
@@ -30,7 +40,6 @@ router = APIRouter(
 async def preview_outcome_review(
     request: DpmOutcomeReviewForwardRequest,
 ) -> DpmOutcomeReviewGatewayResponse:
-    return await dpm_command_center_service().preview_outcome_review(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+    return await _preview_outcome_review(
+        request=request,
     )

--- a/src/app/routers/dpm_command_center_outcome_review_supportability.py
+++ b/src/app/routers/dpm_command_center_outcome_review_supportability.py
@@ -12,6 +12,16 @@ router = APIRouter(
 )
 
 
+async def _get_outcome_review_supportability(
+    *,
+    outcome_review_id: str,
+) -> DpmOutcomeReviewGatewayResponse:
+    return await dpm_command_center_service().get_outcome_review_supportability(
+        outcome_review_id=outcome_review_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/outcome-reviews/{outcome_review_id}/supportability",
     response_model=DpmOutcomeReviewGatewayResponse,
@@ -30,7 +40,6 @@ async def get_outcome_review_supportability(
         examples=["or_20260415_001"],
     ),
 ) -> DpmOutcomeReviewGatewayResponse:
-    return await dpm_command_center_service().get_outcome_review_supportability(
+    return await _get_outcome_review_supportability(
         outcome_review_id=outcome_review_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_portfolio_memory.py
+++ b/src/app/routers/dpm_command_center_portfolio_memory.py
@@ -23,6 +23,18 @@ router = APIRouter(
 )
 
 
+async def _get_portfolio_memory(
+    *,
+    portfolio_id: str,
+    limit: int,
+) -> DpmPortfolioMemoryGatewayResponse:
+    return await dpm_command_center_service().get_portfolio_memory(
+        portfolio_id=portfolio_id,
+        filters={"limit": limit},
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/memory",
     response_model=DpmPortfolioMemoryGatewayResponse,
@@ -52,8 +64,7 @@ async def get_portfolio_memory(
         examples=[100],
     ),
 ) -> DpmPortfolioMemoryGatewayResponse:
-    return await dpm_command_center_service().get_portfolio_memory(
+    return await _get_portfolio_memory(
         portfolio_id=portfolio_id,
-        filters={"limit": limit},
-        correlation_id=correlation_id_var.get(),
+        limit=limit,
     )

--- a/src/app/routers/dpm_command_center_wave_outcome_reviews.py
+++ b/src/app/routers/dpm_command_center_wave_outcome_reviews.py
@@ -12,6 +12,21 @@ router = APIRouter(
 )
 
 
+async def _list_wave_outcome_reviews(
+    *,
+    wave_id: str,
+    state: str | None,
+    limit: int,
+    cursor: str | None,
+) -> DpmOutcomeReviewGatewayResponse:
+    filters = {"state": state, "limit": limit, "cursor": cursor}
+    return await dpm_command_center_service().list_wave_outcome_reviews(
+        wave_id=wave_id,
+        filters=filters,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/waves/{wave_id}/outcome-reviews",
     response_model=DpmOutcomeReviewGatewayResponse,
@@ -46,9 +61,9 @@ async def list_wave_outcome_reviews(
         examples=["wave_or_cursor_0100"],
     ),
 ) -> DpmOutcomeReviewGatewayResponse:
-    filters = {"state": state, "limit": limit, "cursor": cursor}
-    return await dpm_command_center_service().list_wave_outcome_reviews(
+    return await _list_wave_outcome_reviews(
         wave_id=wave_id,
-        filters=filters,
-        correlation_id=correlation_id_var.get(),
+        state=state,
+        limit=limit,
+        cursor=cursor,
     )

--- a/src/app/routers/dpm_construction.py
+++ b/src/app/routers/dpm_construction.py
@@ -11,6 +11,16 @@ router = APIRouter(
 )
 
 
+async def _get_construction_alternative_set(
+    *,
+    alternative_set_id: str,
+) -> DpmConstructionGatewayResponse:
+    return await dpm_construction_service().get_alternative_set(
+        alternative_set_id=alternative_set_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/alternative-sets/{alternative_set_id}",
     response_model=DpmConstructionGatewayResponse,
@@ -31,7 +41,6 @@ async def get_construction_alternative_set(
         examples=["cas_001"],
     ),
 ) -> DpmConstructionGatewayResponse:
-    return await dpm_construction_service().get_alternative_set(
+    return await _get_construction_alternative_set(
         alternative_set_id=alternative_set_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_construction_actions.py
+++ b/src/app/routers/dpm_construction_actions.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _generate_construction_alternative_set(
+    request: DpmConstructionGenerateRequest,
+) -> DpmConstructionGatewayResponse:
+    return await dpm_construction_service().generate_alternative_set(
+        body=request.body,
+        idempotency_key=request.idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/alternative-sets/generate",
     response_model=DpmConstructionGatewayResponse,
@@ -30,8 +40,4 @@ router = APIRouter(
 async def generate_construction_alternative_set(
     request: DpmConstructionGenerateRequest,
 ) -> DpmConstructionGatewayResponse:
-    return await dpm_construction_service().generate_alternative_set(
-        body=request.body,
-        idempotency_key=request.idempotency_key,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _generate_construction_alternative_set(request)

--- a/src/app/routers/dpm_construction_selection.py
+++ b/src/app/routers/dpm_construction_selection.py
@@ -14,6 +14,18 @@ router = APIRouter(
 )
 
 
+async def _select_construction_alternative(
+    *,
+    alternative_set_id: str,
+    request: DpmConstructionSelectionRequest,
+) -> DpmConstructionGatewayResponse:
+    return await dpm_construction_service().select_alternative(
+        alternative_set_id=alternative_set_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/alternative-sets/{alternative_set_id}/selections",
     response_model=DpmConstructionGatewayResponse,
@@ -35,8 +47,7 @@ async def select_construction_alternative(
         examples=["cas_001"],
     ),
 ) -> DpmConstructionGatewayResponse:
-    return await dpm_construction_service().select_alternative(
+    return await _select_construction_alternative(
         alternative_set_id=alternative_set_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_proof_pack_ai.py
+++ b/src/app/routers/dpm_proof_pack_ai.py
@@ -14,6 +14,18 @@ router = APIRouter(
 )
 
 
+async def _request_proof_pack_pm_memo(
+    *,
+    proof_pack_id: str,
+    request: DpmProofPackMemoRequest,
+) -> DpmProofPackMemoGatewayResponse:
+    return await dpm_proof_pack_service().request_proof_pack_pm_memo(
+        proof_pack_id=proof_pack_id,
+        request=request,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{proof_pack_id}/ai-pm-memo",
     response_model=DpmProofPackMemoGatewayResponse,
@@ -36,8 +48,7 @@ async def request_proof_pack_pm_memo(
         examples=["dpp_rr_001"],
     ),
 ) -> DpmProofPackMemoGatewayResponse:
-    return await dpm_proof_pack_service().request_proof_pack_pm_memo(
+    return await _request_proof_pack_pm_memo(
         proof_pack_id=proof_pack_id,
         request=request,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_proof_pack_ai_evidence_input.py
+++ b/src/app/routers/dpm_proof_pack_ai_evidence_input.py
@@ -11,6 +11,16 @@ router = APIRouter(
 )
 
 
+async def _get_proof_pack_ai_evidence_input(
+    *,
+    proof_pack_id: str,
+) -> DpmProofPackGatewayResponse:
+    return await dpm_proof_pack_service().get_proof_pack_ai_evidence_input(
+        proof_pack_id=proof_pack_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{proof_pack_id}/ai-evidence-input",
     response_model=DpmProofPackGatewayResponse,
@@ -30,7 +40,4 @@ async def get_proof_pack_ai_evidence_input(
         examples=["dpp_rr_001"],
     ),
 ) -> DpmProofPackGatewayResponse:
-    return await dpm_proof_pack_service().get_proof_pack_ai_evidence_input(
-        proof_pack_id=proof_pack_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_proof_pack_ai_evidence_input(proof_pack_id=proof_pack_id)

--- a/src/app/routers/dpm_proof_pack_detail.py
+++ b/src/app/routers/dpm_proof_pack_detail.py
@@ -11,6 +11,16 @@ router = APIRouter(
 )
 
 
+async def _get_proof_pack(
+    *,
+    proof_pack_id: str,
+) -> DpmProofPackGatewayResponse:
+    return await dpm_proof_pack_service().get_proof_pack(
+        proof_pack_id=proof_pack_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{proof_pack_id}",
     response_model=DpmProofPackGatewayResponse,
@@ -32,7 +42,4 @@ async def get_proof_pack(
         examples=["dpp_rr_001"],
     ),
 ) -> DpmProofPackGatewayResponse:
-    return await dpm_proof_pack_service().get_proof_pack(
-        proof_pack_id=proof_pack_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_proof_pack(proof_pack_id=proof_pack_id)

--- a/src/app/routers/dpm_proof_pack_evidence.py
+++ b/src/app/routers/dpm_proof_pack_evidence.py
@@ -11,6 +11,16 @@ router = APIRouter(
 )
 
 
+async def _get_proof_pack_markdown(
+    *,
+    proof_pack_id: str,
+) -> DpmProofPackMarkdownResponse:
+    return await dpm_proof_pack_service().get_proof_pack_markdown(
+        proof_pack_id=proof_pack_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{proof_pack_id}/summary.md",
     response_model=DpmProofPackMarkdownResponse,
@@ -30,7 +40,4 @@ async def get_proof_pack_markdown(
         examples=["dpp_rr_001"],
     ),
 ) -> DpmProofPackMarkdownResponse:
-    return await dpm_proof_pack_service().get_proof_pack_markdown(
-        proof_pack_id=proof_pack_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_proof_pack_markdown(proof_pack_id=proof_pack_id)

--- a/src/app/routers/dpm_proof_pack_report_input.py
+++ b/src/app/routers/dpm_proof_pack_report_input.py
@@ -11,6 +11,16 @@ router = APIRouter(
 )
 
 
+async def _get_proof_pack_report_input(
+    *,
+    proof_pack_id: str,
+) -> DpmProofPackGatewayResponse:
+    return await dpm_proof_pack_service().get_proof_pack_report_input(
+        proof_pack_id=proof_pack_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{proof_pack_id}/report-input",
     response_model=DpmProofPackGatewayResponse,
@@ -30,7 +40,4 @@ async def get_proof_pack_report_input(
         examples=["dpp_rr_001"],
     ),
 ) -> DpmProofPackGatewayResponse:
-    return await dpm_proof_pack_service().get_proof_pack_report_input(
-        proof_pack_id=proof_pack_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_proof_pack_report_input(proof_pack_id=proof_pack_id)

--- a/src/app/routers/dpm_proof_packs.py
+++ b/src/app/routers/dpm_proof_packs.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _generate_proof_pack(
+    request: DpmProofPackGenerateRequest,
+) -> DpmProofPackGatewayResponse:
+    return await dpm_proof_pack_service().generate_proof_pack(
+        body=request.body,
+        idempotency_key=request.idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "",
     response_model=DpmProofPackGatewayResponse,
@@ -31,8 +41,4 @@ router = APIRouter(
 async def generate_proof_pack(
     request: DpmProofPackGenerateRequest,
 ) -> DpmProofPackGatewayResponse:
-    return await dpm_proof_pack_service().generate_proof_pack(
-        body=request.body,
-        idempotency_key=request.idempotency_key,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _generate_proof_pack(request)

--- a/src/app/routers/dpm_wave_actions.py
+++ b/src/app/routers/dpm_wave_actions.py
@@ -11,6 +11,18 @@ router = APIRouter(
 )
 
 
+async def _source_check_wave(
+    *,
+    wave_id: str,
+    request: DpmWaveForwardRequest,
+) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().source_check_wave(
+        wave_id=wave_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{wave_id}/source-check",
     response_model=DpmWaveGatewayResponse,
@@ -27,8 +39,7 @@ async def source_check_wave(
     request: DpmWaveForwardRequest,
     wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().source_check_wave(
+    return await _source_check_wave(
         wave_id=wave_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_ai.py
+++ b/src/app/routers/dpm_wave_ai.py
@@ -14,6 +14,18 @@ router = APIRouter(
 )
 
 
+async def _request_wave_pm_memo(
+    *,
+    wave_id: str,
+    request: DpmWaveMemoRequest,
+) -> DpmWaveMemoGatewayResponse:
+    return await dpm_wave_service().request_wave_pm_memo(
+        wave_id=wave_id,
+        request=request,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{wave_id}/ai-pm-memo",
     response_model=DpmWaveMemoGatewayResponse,
@@ -36,8 +48,7 @@ async def request_wave_pm_memo(
         examples=["dwv_001"],
     ),
 ) -> DpmWaveMemoGatewayResponse:
-    return await dpm_wave_service().request_wave_pm_memo(
+    return await _request_wave_pm_memo(
         wave_id=wave_id,
         request=request,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_wave_campaign_approval_commands.py
+++ b/src/app/routers/dpm_wave_campaign_approval_commands.py
@@ -16,6 +16,20 @@ router = APIRouter(
 )
 
 
+async def _create_campaign_approval_decision(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: DpmCampaignWorkflowForwardRequest,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().create_campaign_approval_decision(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/approval-decisions",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -33,9 +47,8 @@ async def create_campaign_approval_decision(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().create_campaign_approval_decision(
+    return await _create_campaign_approval_decision(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_approval_inbox.py
+++ b/src/app/routers/dpm_wave_campaign_approval_inbox.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _get_campaign_approval_inbox(
+    *,
+    request: Request,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().get_campaign_approval_inbox(
+        filters=campaign_workflow_query_params(request),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-approval-inbox",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -30,7 +40,4 @@ router = APIRouter(
 async def get_campaign_approval_inbox(
     request: Request,
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().get_campaign_approval_inbox(
-        filters=campaign_workflow_query_params(request),
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_campaign_approval_inbox(request=request)

--- a/src/app/routers/dpm_wave_campaign_approvals.py
+++ b/src/app/routers/dpm_wave_campaign_approvals.py
@@ -14,6 +14,20 @@ router = APIRouter(
 )
 
 
+async def _list_campaign_approval_decisions(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: Request,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().list_campaign_approval_decisions(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        filters=campaign_approval_query_params(request),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/approval-decisions",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -32,9 +46,8 @@ async def list_campaign_approval_decisions(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().list_campaign_approval_decisions(
+    return await _list_campaign_approval_decisions(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        filters=campaign_approval_query_params(request),
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_assignment_action_commands.py
+++ b/src/app/routers/dpm_wave_campaign_assignment_action_commands.py
@@ -16,6 +16,20 @@ router = APIRouter(
 )
 
 
+async def _create_campaign_assignment_action(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: DpmCampaignWorkflowForwardRequest,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().create_campaign_assignment_action(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-actions",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -33,9 +47,8 @@ async def create_campaign_assignment_action(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().create_campaign_assignment_action(
+    return await _create_campaign_assignment_action(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_assignment_task_actions.py
+++ b/src/app/routers/dpm_wave_campaign_assignment_task_actions.py
@@ -16,6 +16,20 @@ router = APIRouter(
 )
 
 
+async def _create_campaign_assignment_task(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: DpmCampaignWorkflowForwardRequest,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().create_campaign_assignment_task(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-tasks",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -33,9 +47,8 @@ async def create_campaign_assignment_task(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().create_campaign_assignment_task(
+    return await _create_campaign_assignment_task(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_assignment_task_transitions.py
+++ b/src/app/routers/dpm_wave_campaign_assignment_task_transitions.py
@@ -16,6 +16,22 @@ router = APIRouter(
 )
 
 
+async def _transition_campaign_assignment_task(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    task_ref: str,
+    request: DpmCampaignWorkflowForwardRequest,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().transition_campaign_assignment_task(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        task_ref=task_ref,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-tasks/{task_ref}/transitions",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -35,10 +51,9 @@ async def transition_campaign_assignment_task(
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
     task_ref: str = Path(..., description="Manage-owned campaign assignment task reference."),
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().transition_campaign_assignment_task(
+    return await _transition_campaign_assignment_task(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
         task_ref=task_ref,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_assignment_tasks.py
+++ b/src/app/routers/dpm_wave_campaign_assignment_tasks.py
@@ -14,6 +14,20 @@ router = APIRouter(
 )
 
 
+async def _list_campaign_assignment_tasks(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: Request,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().list_campaign_assignment_tasks(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        filters=campaign_assignment_query_params(request),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-tasks",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -32,9 +46,8 @@ async def list_campaign_assignment_tasks(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().list_campaign_assignment_tasks(
+    return await _list_campaign_assignment_tasks(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        filters=campaign_assignment_query_params(request),
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_assignment_views.py
+++ b/src/app/routers/dpm_wave_campaign_assignment_views.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _get_campaign_assignment_plan(
+    *,
+    request: Request,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().get_campaign_assignment_plan(
+        filters=campaign_workflow_query_params(request),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-assignment-plan",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -30,7 +40,4 @@ router = APIRouter(
 async def get_campaign_assignment_plan(
     request: Request,
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().get_campaign_assignment_plan(
-        filters=campaign_workflow_query_params(request),
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_campaign_assignment_plan(request=request)

--- a/src/app/routers/dpm_wave_campaign_assignments.py
+++ b/src/app/routers/dpm_wave_campaign_assignments.py
@@ -14,6 +14,20 @@ router = APIRouter(
 )
 
 
+async def _list_campaign_assignment_actions(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: Request,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().list_campaign_assignment_actions(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        filters=campaign_assignment_query_params(request),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-actions",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -31,9 +45,8 @@ async def list_campaign_assignment_actions(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().list_campaign_assignment_actions(
+    return await _list_campaign_assignment_actions(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        filters=campaign_assignment_query_params(request),
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_definition_detail.py
+++ b/src/app/routers/dpm_wave_campaign_definition_detail.py
@@ -13,6 +13,18 @@ router = APIRouter(
 )
 
 
+async def _get_campaign_definition(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await dpm_wave_service().get_campaign_definition(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}",
     response_model=DpmCampaignDefinitionGatewayResponse,
@@ -29,8 +41,7 @@ async def get_campaign_definition(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignDefinitionGatewayResponse:
-    return await dpm_wave_service().get_campaign_definition(
+    return await _get_campaign_definition(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_wave_campaign_definition_lookup.py
+++ b/src/app/routers/dpm_wave_campaign_definition_lookup.py
@@ -13,6 +13,16 @@ router = APIRouter(
 )
 
 
+async def _list_campaign_definitions(
+    *,
+    filters: dict[str, str | int | None],
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await dpm_wave_service().list_campaign_definitions(
+        filters=filters,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-definitions",
     response_model=DpmCampaignDefinitionGatewayResponse,
@@ -38,7 +48,7 @@ async def list_campaign_definitions(
     limit: int = Query(default=50, ge=1, le=200, description="Maximum definitions to return."),
     offset: int = Query(default=0, ge=0, description="Zero-based definition-list offset."),
 ) -> DpmCampaignDefinitionGatewayResponse:
-    return await dpm_wave_service().list_campaign_definitions(
+    return await _list_campaign_definitions(
         filters={
             "campaign_id": campaign_id,
             "campaign_status": campaign_status,
@@ -46,5 +56,4 @@ async def list_campaign_definitions(
             "limit": limit,
             "offset": offset,
         },
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_wave_campaign_definitions.py
+++ b/src/app/routers/dpm_wave_campaign_definitions.py
@@ -24,6 +24,20 @@ _UPSTREAM_ERROR_RESPONSES = manage_upstream_error_responses(
 )
 
 
+async def _put_campaign_definition(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: DpmCampaignDefinitionForwardRequest,
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await dpm_wave_service().put_campaign_definition(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.put(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}",
     response_model=DpmCampaignDefinitionGatewayResponse,
@@ -43,9 +57,8 @@ async def put_campaign_definition(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignDefinitionGatewayResponse:
-    return await dpm_wave_service().put_campaign_definition(
+    return await _put_campaign_definition(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_launch.py
+++ b/src/app/routers/dpm_wave_campaign_launch.py
@@ -13,6 +13,21 @@ router = APIRouter(
 )
 
 
+async def _get_campaign_definition_launch_history(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    limit: int,
+    offset: int,
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await dpm_wave_service().get_campaign_definition_launch_history(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        filters={"limit": limit, "offset": offset},
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch-history",
     response_model=DpmCampaignDefinitionGatewayResponse,
@@ -34,9 +49,9 @@ async def get_campaign_definition_launch_history(
     limit: int = Query(50, ge=1, le=500, description="Maximum launch-history records to return."),
     offset: int = Query(0, ge=0, description="Zero-based launch-history record offset."),
 ) -> DpmCampaignDefinitionGatewayResponse:
-    return await dpm_wave_service().get_campaign_definition_launch_history(
+    return await _get_campaign_definition_launch_history(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        filters={"limit": limit, "offset": offset},
-        correlation_id=correlation_id_var.get(),
+        limit=limit,
+        offset=offset,
     )

--- a/src/app/routers/dpm_wave_campaign_launch_actions.py
+++ b/src/app/routers/dpm_wave_campaign_launch_actions.py
@@ -14,6 +14,20 @@ router = APIRouter(
 )
 
 
+async def _launch_campaign_definition(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: DpmCampaignDefinitionLaunchRequest,
+) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().launch_campaign_definition(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch",
     response_model=DpmWaveGatewayResponse,
@@ -33,9 +47,8 @@ async def launch_campaign_definition(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().launch_campaign_definition(
+    return await _launch_campaign_definition(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_launch_package.py
+++ b/src/app/routers/dpm_wave_campaign_launch_package.py
@@ -11,6 +11,26 @@ router = APIRouter(
 )
 
 
+async def _get_campaign_definition_launch_package(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    requested_as_of_date: str,
+    actor_id: str,
+    correlation_id: str | None,
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await dpm_wave_service().get_campaign_definition_launch_package(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        filters={
+            "requested_as_of_date": requested_as_of_date,
+            "actor_id": actor_id,
+            "correlation_id": correlation_id,
+        },
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch-package",
     response_model=DpmCampaignDefinitionGatewayResponse,
@@ -43,13 +63,10 @@ async def get_campaign_definition_launch_package(
         description="Optional durable launch correlation id forwarded to Manage.",
     ),
 ) -> DpmCampaignDefinitionGatewayResponse:
-    return await dpm_wave_service().get_campaign_definition_launch_package(
+    return await _get_campaign_definition_launch_package(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        filters={
-            "requested_as_of_date": requested_as_of_date,
-            "actor_id": actor_id,
-            "correlation_id": correlation_id,
-        },
-        correlation_id=correlation_id_var.get(),
+        requested_as_of_date=requested_as_of_date,
+        actor_id=actor_id,
+        correlation_id=correlation_id,
     )

--- a/src/app/routers/dpm_wave_cancellation.py
+++ b/src/app/routers/dpm_wave_cancellation.py
@@ -11,6 +11,18 @@ router = APIRouter(
 )
 
 
+async def _cancel_wave(
+    *,
+    wave_id: str,
+    request: DpmWaveForwardRequest,
+) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().cancel_wave(
+        wave_id=wave_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{wave_id}/cancel",
     response_model=DpmWaveGatewayResponse,
@@ -27,8 +39,7 @@ async def cancel_wave(
     request: DpmWaveForwardRequest,
     wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().cancel_wave(
+    return await _cancel_wave(
         wave_id=wave_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_detail.py
+++ b/src/app/routers/dpm_wave_detail.py
@@ -11,6 +11,13 @@ router = APIRouter(
 )
 
 
+async def _get_wave(*, wave_id: str) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().get_wave(
+        wave_id=wave_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{wave_id}",
     response_model=DpmWaveGatewayResponse,
@@ -26,7 +33,4 @@ router = APIRouter(
 async def get_wave(
     wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().get_wave(
-        wave_id=wave_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_wave(wave_id=wave_id)

--- a/src/app/routers/dpm_wave_evidence.py
+++ b/src/app/routers/dpm_wave_evidence.py
@@ -11,6 +11,13 @@ router = APIRouter(
 )
 
 
+async def _get_wave_proof_pack_posture(*, wave_id: str) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().get_wave_proof_pack_posture(
+        wave_id=wave_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{wave_id}/proof-pack",
     response_model=DpmWaveGatewayResponse,
@@ -26,7 +33,4 @@ router = APIRouter(
 async def get_wave_proof_pack_posture(
     wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().get_wave_proof_pack_posture(
-        wave_id=wave_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_wave_proof_pack_posture(wave_id=wave_id)

--- a/src/app/routers/dpm_wave_handoff.py
+++ b/src/app/routers/dpm_wave_handoff.py
@@ -11,6 +11,18 @@ router = APIRouter(
 )
 
 
+async def _handoff_wave(
+    *,
+    wave_id: str,
+    request: DpmWaveForwardRequest,
+) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().handoff_wave(
+        wave_id=wave_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{wave_id}/handoff",
     response_model=DpmWaveGatewayResponse,
@@ -27,8 +39,7 @@ async def handoff_wave(
     request: DpmWaveForwardRequest,
     wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().handoff_wave(
+    return await _handoff_wave(
         wave_id=wave_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_item_selection.py
+++ b/src/app/routers/dpm_wave_item_selection.py
@@ -11,6 +11,20 @@ router = APIRouter(
 )
 
 
+async def _select_wave_item(
+    *,
+    wave_id: str,
+    wave_item_id: str,
+    request: DpmWaveForwardRequest,
+) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().select_wave_item(
+        wave_id=wave_id,
+        wave_item_id=wave_item_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{wave_id}/items/{wave_item_id}/select",
     response_model=DpmWaveGatewayResponse,
@@ -28,9 +42,8 @@ async def select_wave_item(
     wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
     wave_item_id: str = Path(..., description="Manage-owned rebalance-wave item identifier."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().select_wave_item(
+    return await _select_wave_item(
         wave_id=wave_id,
         wave_item_id=wave_item_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_items.py
+++ b/src/app/routers/dpm_wave_items.py
@@ -11,6 +11,13 @@ router = APIRouter(
 )
 
 
+async def _get_wave_items(*, wave_id: str) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().get_wave_items(
+        wave_id=wave_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{wave_id}/items",
     response_model=DpmWaveGatewayResponse,
@@ -26,7 +33,4 @@ router = APIRouter(
 async def get_wave_items(
     wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().get_wave_items(
-        wave_id=wave_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_wave_items(wave_id=wave_id)

--- a/src/app/routers/dpm_wave_lifecycle_actions.py
+++ b/src/app/routers/dpm_wave_lifecycle_actions.py
@@ -11,6 +11,18 @@ router = APIRouter(
 )
 
 
+async def _approve_wave(
+    *,
+    wave_id: str,
+    request: DpmWaveForwardRequest,
+) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().approve_wave(
+        wave_id=wave_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{wave_id}/approve",
     response_model=DpmWaveGatewayResponse,
@@ -27,8 +39,7 @@ async def approve_wave(
     request: DpmWaveForwardRequest,
     wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().approve_wave(
+    return await _approve_wave(
         wave_id=wave_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_lookup.py
+++ b/src/app/routers/dpm_wave_lookup.py
@@ -11,6 +11,16 @@ router = APIRouter(
 )
 
 
+async def _list_waves(
+    *,
+    filters: dict[str, str | int | None],
+) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().list_waves(
+        filters=filters,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "",
     response_model=DpmWaveGatewayResponse,
@@ -43,7 +53,7 @@ async def list_waves(
     limit: int = Query(default=50, ge=1, le=100, description="Maximum waves to return."),
     offset: int = Query(default=0, ge=0, description="Zero-based wave-list offset."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().list_waves(
+    return await _list_waves(
         filters={
             "state": state,
             "trigger_type": trigger_type,
@@ -52,5 +62,4 @@ async def list_waves(
             "limit": limit,
             "offset": offset,
         },
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_wave_operations_handoff_ai.py
+++ b/src/app/routers/dpm_wave_operations_handoff_ai.py
@@ -14,6 +14,18 @@ router = APIRouter(
 )
 
 
+async def _request_operations_handoff_summary(
+    *,
+    wave_id: str,
+    request: DpmOperationsHandoffSummaryRequest,
+) -> DpmOperationsHandoffSummaryGatewayResponse:
+    return await dpm_wave_service().request_operations_handoff_summary(
+        wave_id=wave_id,
+        request=request,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{wave_id}/operations-handoff-summary",
     response_model=DpmOperationsHandoffSummaryGatewayResponse,
@@ -37,8 +49,7 @@ async def request_operations_handoff_summary(
         examples=["dwv_001"],
     ),
 ) -> DpmOperationsHandoffSummaryGatewayResponse:
-    return await dpm_wave_service().request_operations_handoff_summary(
+    return await _request_operations_handoff_summary(
         wave_id=wave_id,
         request=request,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_wave_preview.py
+++ b/src/app/routers/dpm_wave_preview.py
@@ -14,6 +14,13 @@ router = APIRouter(
 )
 
 
+async def _preview_wave(request: DpmWaveForwardRequest) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().preview_wave(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/preview",
     response_model=DpmWaveGatewayResponse,
@@ -27,7 +34,4 @@ router = APIRouter(
     responses=UPSTREAM_WAVE_ERROR_RESPONSES,
 )
 async def preview_wave(request: DpmWaveForwardRequest) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().preview_wave(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _preview_wave(request)

--- a/src/app/routers/dpm_wave_report_input.py
+++ b/src/app/routers/dpm_wave_report_input.py
@@ -11,6 +11,13 @@ router = APIRouter(
 )
 
 
+async def _get_wave_report_input(*, wave_id: str) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().get_wave_report_input(
+        wave_id=wave_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{wave_id}/report-input",
     response_model=DpmWaveGatewayResponse,
@@ -27,7 +34,4 @@ router = APIRouter(
 async def get_wave_report_input(
     wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().get_wave_report_input(
-        wave_id=wave_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_wave_report_input(wave_id=wave_id)

--- a/src/app/routers/dpm_wave_simulation.py
+++ b/src/app/routers/dpm_wave_simulation.py
@@ -11,6 +11,18 @@ router = APIRouter(
 )
 
 
+async def _simulate_wave(
+    *,
+    wave_id: str,
+    request: DpmWaveForwardRequest,
+) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().simulate_wave(
+        wave_id=wave_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{wave_id}/simulate",
     response_model=DpmWaveGatewayResponse,
@@ -27,8 +39,7 @@ async def simulate_wave(
     request: DpmWaveForwardRequest,
     wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().simulate_wave(
+    return await _simulate_wave(
         wave_id=wave_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_supportability.py
+++ b/src/app/routers/dpm_wave_supportability.py
@@ -11,6 +11,13 @@ router = APIRouter(
 )
 
 
+async def _get_wave_supportability(*, wave_id: str) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().get_wave_supportability(
+        wave_id=wave_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/{wave_id}/supportability",
     response_model=DpmWaveGatewayResponse,
@@ -26,7 +33,4 @@ router = APIRouter(
 async def get_wave_supportability(
     wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().get_wave_supportability(
-        wave_id=wave_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_wave_supportability(wave_id=wave_id)

--- a/src/app/routers/dpm_wave_workflow_actions.py
+++ b/src/app/routers/dpm_wave_workflow_actions.py
@@ -11,6 +11,18 @@ router = APIRouter(
 )
 
 
+async def _stage_wave(
+    *,
+    wave_id: str,
+    request: DpmWaveForwardRequest,
+) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().stage_wave(
+        wave_id=wave_id,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/{wave_id}/stage",
     response_model=DpmWaveGatewayResponse,
@@ -26,8 +38,7 @@ async def stage_wave(
     request: DpmWaveForwardRequest,
     wave_id: str = Path(..., description="Manage-owned rebalance-wave identifier."),
 ) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().stage_wave(
+    return await _stage_wave(
         wave_id=wave_id,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_waves.py
+++ b/src/app/routers/dpm_waves.py
@@ -11,6 +11,14 @@ router = APIRouter(
 )
 
 
+async def _create_wave(request: DpmWaveCreateRequest) -> DpmWaveGatewayResponse:
+    return await dpm_wave_service().create_wave(
+        body=request.body,
+        idempotency_key=request.idempotency_key,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "",
     response_model=DpmWaveGatewayResponse,
@@ -24,8 +32,4 @@ router = APIRouter(
     responses=UPSTREAM_WAVE_ERROR_RESPONSES,
 )
 async def create_wave(request: DpmWaveCreateRequest) -> DpmWaveGatewayResponse:
-    return await dpm_wave_service().create_wave(
-        body=request.body,
-        idempotency_key=request.idempotency_key,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _create_wave(request)


### PR DESCRIPTION
## Summary
- Refactors DPM construction, proof-pack, wave, campaign assignment, campaign definition, and campaign launch route modules so FastAPI handlers delegate to private route-owner helpers.
- Preserves existing public API paths, request bodies, response models, OpenAPI metadata, query parameter handling, correlation propagation, and upstream lotus-manage authority.
- Keeps the gateway as the Experience API/BFF boundary: no local DPM calculations, readiness derivation, proof-pack evidence generation, campaign membership inference, OMS/execution claims, or domain-authoritative behavior added.

## Validation
- `python -m pytest tests/unit/test_dpm_command_center_service.py tests/unit/test_dpm_construction_service.py tests/contract/test_dpm_command_center_contract.py tests/contract/test_dpm_construction_contract.py -q` -> 49 passed.
- `make check` -> ruff check passed; ruff format check passed; monetary float guard passed (`Findings=189, allowlisted=189`); mypy passed across 396 source files; Workbench contract passed; full unit/contract suite passed (`750 passed`).

## Sibling repo pulse
Read-only pulse before PR:
- `lotus-core`: `perf/api-query-index-optimization`, head `98ce8814 perf: parallelize analytics performance horizon reads`, clean.
- `lotus-performance`: `feat/performance-modular-refactor`, head `9f87ba0 Harden workspace summary nullable numerics`, clean.
- `lotus-manage`: `feat/manage-hardening-wave-2`, head `0b7ab70 move run support config out of router`, clean.

## Governance
- 50 small commits preserved for non-squash merge history.
- Code-only route ownership refactor; no durable platform/repository docs, wiki, RFC, context, contract, or operator-facing truth changed.
- No wiki source update required for this slice.