### PR TITLE
Refactor gateway route ownership batch 11

### DIFF
--- a/src/app/routers/analytics_diagnostics.py
+++ b/src/app/routers/analytics_diagnostics.py
@@ -85,6 +85,35 @@ def _raise_for_unsafe_support_reference(support_reference: str) -> None:
     )
 
 
+async def _lookup_analytics_diagnostics(
+    *,
+    support_reference: str,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> AnalyticsDiagnosticsResponse:
+    _validate_diagnostics_caller_context(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+    _raise_for_unauthorized_diagnostics_role(role)
+    _raise_for_unsafe_support_reference(support_reference)
+    response = resolve_support_reference(support_reference)
+    emit_gateway_protected_diagnostics_audit_log(
+        logger=logger,
+        status_code=status.HTTP_200_OK,
+        reason="lookup_succeeded",
+    )
+    return response
+
+
 @router.get(
     "/diagnostics/{support_reference}",
     response_model=AnalyticsDiagnosticsResponse,
@@ -121,7 +150,8 @@ async def lookup_analytics_diagnostics(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> AnalyticsDiagnosticsResponse:
-    _validate_diagnostics_caller_context(
+    return await _lookup_analytics_diagnostics(
+        support_reference=support_reference,
         actor_id=actor_id,
         caller_application=caller_application,
         tenant_id=tenant_id,
@@ -129,12 +159,3 @@ async def lookup_analytics_diagnostics(
         booking_center_code=booking_center_code,
         role=role,
     )
-    _raise_for_unauthorized_diagnostics_role(role)
-    _raise_for_unsafe_support_reference(support_reference)
-    response = resolve_support_reference(support_reference)
-    emit_gateway_protected_diagnostics_audit_log(
-        logger=logger,
-        status_code=status.HTTP_200_OK,
-        reason="lookup_succeeded",
-    )
-    return response

--- a/src/app/routers/dpm_command_center_pm_quality.py
+++ b/src/app/routers/dpm_command_center_pm_quality.py
@@ -17,6 +17,15 @@ router = APIRouter(
 )
 
 
+async def _create_pm_operating_quality_score_run(
+    request: DpmPmOperatingQualityForwardRequest,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().create_pm_operating_quality_score_run(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/pm-operating-quality/score-runs",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -32,7 +41,4 @@ router = APIRouter(
 async def create_pm_operating_quality_score_run(
     request: DpmPmOperatingQualityForwardRequest,
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().create_pm_operating_quality_score_run(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _create_pm_operating_quality_score_run(request)

--- a/src/app/routers/dpm_command_center_pm_quality_ai.py
+++ b/src/app/routers/dpm_command_center_pm_quality_ai.py
@@ -17,6 +17,18 @@ router = APIRouter(
 )
 
 
+async def _request_pm_operating_quality_summary(
+    *,
+    score_run_id: str,
+    request: DpmPmOperatingQualitySummaryRequest,
+) -> DpmPmOperatingQualitySummaryGatewayResponse:
+    return await dpm_command_center_service().request_pm_operating_quality_summary(
+        score_run_id=score_run_id,
+        request=request,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/pm-operating-quality/score-runs/{score_run_id}/ai-summary",
     response_model=DpmPmOperatingQualitySummaryGatewayResponse,
@@ -41,8 +53,7 @@ async def request_pm_operating_quality_summary(
         examples=["pmq_run_001"],
     ),
 ) -> DpmPmOperatingQualitySummaryGatewayResponse:
-    return await dpm_command_center_service().request_pm_operating_quality_summary(
+    return await _request_pm_operating_quality_summary(
         score_run_id=score_run_id,
         request=request,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_pm_quality_fairness.py
+++ b/src/app/routers/dpm_command_center_pm_quality_fairness.py
@@ -17,6 +17,15 @@ router = APIRouter(
 )
 
 
+async def _create_pm_operating_quality_fairness_analysis(
+    request: DpmPmOperatingQualityForwardRequest,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().create_pm_operating_quality_fairness_analysis(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/pm-operating-quality/fairness-analyses",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -35,7 +44,4 @@ router = APIRouter(
 async def create_pm_operating_quality_fairness_analysis(
     request: DpmPmOperatingQualityForwardRequest,
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().create_pm_operating_quality_fairness_analysis(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _create_pm_operating_quality_fairness_analysis(request)

--- a/src/app/routers/dpm_command_center_pm_quality_fairness_detail.py
+++ b/src/app/routers/dpm_command_center_pm_quality_fairness_detail.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _get_pm_operating_quality_fairness_analysis(
+    *,
+    fairness_analysis_id: str,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().get_pm_operating_quality_fairness_analysis(
+        fairness_analysis_id=fairness_analysis_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/pm-operating-quality/fairness-analyses/{fairness_analysis_id}",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -34,7 +44,6 @@ async def get_pm_operating_quality_fairness_analysis(
         examples=["pmq_fair_001"],
     ),
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().get_pm_operating_quality_fairness_analysis(
+    return await _get_pm_operating_quality_fairness_analysis(
         fairness_analysis_id=fairness_analysis_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_pm_quality_fairness_lookup.py
+++ b/src/app/routers/dpm_command_center_pm_quality_fairness_lookup.py
@@ -16,10 +16,22 @@ router = APIRouter(
 
 async def _list_pm_operating_quality_fairness_analyses(
     *,
-    filters: dict[str, str | int | None],
+    policy_id: str | None,
+    policy_version: str | None,
+    as_of_date: str | None,
+    state: str | None,
+    limit: int,
+    offset: int,
 ) -> DpmPmOperatingQualityGatewayResponse:
     return await dpm_command_center_service().list_pm_operating_quality_fairness_analyses(
-        filters=filters,
+        filters={
+            "policy_id": policy_id,
+            "policy_version": policy_version,
+            "as_of_date": as_of_date,
+            "state": state,
+            "limit": limit,
+            "offset": offset,
+        },
         correlation_id=correlation_id_var.get(),
     )
 
@@ -46,12 +58,10 @@ async def list_pm_operating_quality_fairness_analyses(
     offset: int = Query(default=0, ge=0, description="Rows to skip."),
 ) -> DpmPmOperatingQualityGatewayResponse:
     return await _list_pm_operating_quality_fairness_analyses(
-        filters={
-            "policy_id": policy_id,
-            "policy_version": policy_version,
-            "as_of_date": as_of_date,
-            "state": state,
-            "limit": limit,
-            "offset": offset,
-        },
+        policy_id=policy_id,
+        policy_version=policy_version,
+        as_of_date=as_of_date,
+        state=state,
+        limit=limit,
+        offset=offset,
     )

--- a/src/app/routers/dpm_command_center_pm_quality_fairness_lookup.py
+++ b/src/app/routers/dpm_command_center_pm_quality_fairness_lookup.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _list_pm_operating_quality_fairness_analyses(
+    *,
+    filters: dict[str, str | int | None],
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().list_pm_operating_quality_fairness_analyses(
+        filters=filters,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/pm-operating-quality/fairness-analyses",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -35,7 +45,7 @@ async def list_pm_operating_quality_fairness_analyses(
     limit: int = Query(default=50, ge=1, le=100, description="Maximum analyses to return."),
     offset: int = Query(default=0, ge=0, description="Rows to skip."),
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().list_pm_operating_quality_fairness_analyses(
+    return await _list_pm_operating_quality_fairness_analyses(
         filters={
             "policy_id": policy_id,
             "policy_version": policy_version,
@@ -44,5 +54,4 @@ async def list_pm_operating_quality_fairness_analyses(
             "limit": limit,
             "offset": offset,
         },
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_pm_quality_fairness_preview.py
+++ b/src/app/routers/dpm_command_center_pm_quality_fairness_preview.py
@@ -17,6 +17,15 @@ router = APIRouter(
 )
 
 
+async def _preview_pm_operating_quality_fairness_analysis(
+    request: DpmPmOperatingQualityForwardRequest,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().preview_pm_operating_quality_fairness_analysis(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/pm-operating-quality/fairness-analyses/preview",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -35,7 +44,4 @@ router = APIRouter(
 async def preview_pm_operating_quality_fairness_analysis(
     request: DpmPmOperatingQualityForwardRequest,
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().preview_pm_operating_quality_fairness_analysis(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _preview_pm_operating_quality_fairness_analysis(request)

--- a/src/app/routers/dpm_command_center_pm_quality_policies.py
+++ b/src/app/routers/dpm_command_center_pm_quality_policies.py
@@ -16,10 +16,20 @@ router = APIRouter(
 
 async def _list_pm_operating_quality_policies(
     *,
-    filters: dict[str, str | int | bool | None],
+    policy_id: str | None,
+    enabled: bool | None,
+    as_of_date: str | None,
+    limit: int,
+    offset: int,
 ) -> DpmPmOperatingQualityGatewayResponse:
     return await dpm_command_center_service().list_pm_operating_quality_policies(
-        filters=filters,
+        filters={
+            "policy_id": policy_id,
+            "enabled": enabled,
+            "as_of_date": as_of_date,
+            "limit": limit,
+            "offset": offset,
+        },
         correlation_id=correlation_id_var.get(),
     )
 
@@ -42,11 +52,9 @@ async def list_pm_operating_quality_policies(
     offset: int = Query(default=0, ge=0, description="Rows to skip."),
 ) -> DpmPmOperatingQualityGatewayResponse:
     return await _list_pm_operating_quality_policies(
-        filters={
-            "policy_id": policy_id,
-            "enabled": enabled,
-            "as_of_date": as_of_date,
-            "limit": limit,
-            "offset": offset,
-        },
+        policy_id=policy_id,
+        enabled=enabled,
+        as_of_date=as_of_date,
+        limit=limit,
+        offset=offset,
     )

--- a/src/app/routers/dpm_command_center_pm_quality_policies.py
+++ b/src/app/routers/dpm_command_center_pm_quality_policies.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _list_pm_operating_quality_policies(
+    *,
+    filters: dict[str, str | int | bool | None],
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().list_pm_operating_quality_policies(
+        filters=filters,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/pm-operating-quality/policies",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -31,7 +41,7 @@ async def list_pm_operating_quality_policies(
     limit: int = Query(default=50, ge=1, le=100, description="Maximum policies to return."),
     offset: int = Query(default=0, ge=0, description="Rows to skip."),
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().list_pm_operating_quality_policies(
+    return await _list_pm_operating_quality_policies(
         filters={
             "policy_id": policy_id,
             "enabled": enabled,
@@ -39,5 +49,4 @@ async def list_pm_operating_quality_policies(
             "limit": limit,
             "offset": offset,
         },
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_pm_quality_policy_actions.py
+++ b/src/app/routers/dpm_command_center_pm_quality_policy_actions.py
@@ -17,6 +17,20 @@ router = APIRouter(
 )
 
 
+async def _put_pm_operating_quality_policy(
+    *,
+    policy_id: str,
+    policy_version: str,
+    request: DpmPmOperatingQualityForwardRequest,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().put_pm_operating_quality_policy(
+        policy_id=policy_id,
+        policy_version=policy_version,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.put(
     "/pm-operating-quality/policies/{policy_id}/versions/{policy_version}",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -41,9 +55,8 @@ async def put_pm_operating_quality_policy(
         examples=["2026.05"],
     ),
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().put_pm_operating_quality_policy(
+    return await _put_pm_operating_quality_policy(
         policy_id=policy_id,
         policy_version=policy_version,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_command_center_pm_quality_policy_detail.py
+++ b/src/app/routers/dpm_command_center_pm_quality_policy_detail.py
@@ -14,6 +14,18 @@ router = APIRouter(
 )
 
 
+async def _get_pm_operating_quality_policy(
+    *,
+    policy_id: str,
+    policy_version: str,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().get_pm_operating_quality_policy(
+        policy_id=policy_id,
+        policy_version=policy_version,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/pm-operating-quality/policies/{policy_id}/versions/{policy_version}",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -36,8 +48,7 @@ async def get_pm_operating_quality_policy(
         examples=["2026.05"],
     ),
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().get_pm_operating_quality_policy(
+    return await _get_pm_operating_quality_policy(
         policy_id=policy_id,
         policy_version=policy_version,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_pm_quality_review_action_detail.py
+++ b/src/app/routers/dpm_command_center_pm_quality_review_action_detail.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _get_pm_operating_quality_review_action(
+    *,
+    review_action_id: str,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().get_pm_operating_quality_review_action(
+        review_action_id=review_action_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/pm-operating-quality/review-actions/{review_action_id}",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -35,7 +45,6 @@ async def get_pm_operating_quality_review_action(
         examples=["pmq_review_001"],
     ),
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().get_pm_operating_quality_review_action(
+    return await _get_pm_operating_quality_review_action(
         review_action_id=review_action_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_pm_quality_review_action_lookup.py
+++ b/src/app/routers/dpm_command_center_pm_quality_review_action_lookup.py
@@ -16,10 +16,24 @@ router = APIRouter(
 
 async def _list_pm_operating_quality_review_actions(
     *,
-    filters: dict[str, str | int | None],
+    target_type: str | None,
+    target_id: str | None,
+    policy_id: str | None,
+    as_of_date: str | None,
+    action_state: str | None,
+    limit: int,
+    offset: int,
 ) -> DpmPmOperatingQualityGatewayResponse:
     return await dpm_command_center_service().list_pm_operating_quality_review_actions(
-        filters=filters,
+        filters={
+            "target_type": target_type,
+            "target_id": target_id,
+            "policy_id": policy_id,
+            "as_of_date": as_of_date,
+            "action_state": action_state,
+            "limit": limit,
+            "offset": offset,
+        },
         correlation_id=correlation_id_var.get(),
     )
 
@@ -50,13 +64,11 @@ async def list_pm_operating_quality_review_actions(
     offset: int = Query(default=0, ge=0, description="Rows to skip."),
 ) -> DpmPmOperatingQualityGatewayResponse:
     return await _list_pm_operating_quality_review_actions(
-        filters={
-            "target_type": target_type,
-            "target_id": target_id,
-            "policy_id": policy_id,
-            "as_of_date": as_of_date,
-            "action_state": action_state,
-            "limit": limit,
-            "offset": offset,
-        },
+        target_type=target_type,
+        target_id=target_id,
+        policy_id=policy_id,
+        as_of_date=as_of_date,
+        action_state=action_state,
+        limit=limit,
+        offset=offset,
     )

--- a/src/app/routers/dpm_command_center_pm_quality_review_action_lookup.py
+++ b/src/app/routers/dpm_command_center_pm_quality_review_action_lookup.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _list_pm_operating_quality_review_actions(
+    *,
+    filters: dict[str, str | int | None],
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().list_pm_operating_quality_review_actions(
+        filters=filters,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/pm-operating-quality/review-actions",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -39,7 +49,7 @@ async def list_pm_operating_quality_review_actions(
     limit: int = Query(default=50, ge=1, le=100, description="Maximum review actions to return."),
     offset: int = Query(default=0, ge=0, description="Rows to skip."),
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().list_pm_operating_quality_review_actions(
+    return await _list_pm_operating_quality_review_actions(
         filters={
             "target_type": target_type,
             "target_id": target_id,
@@ -49,5 +59,4 @@ async def list_pm_operating_quality_review_actions(
             "limit": limit,
             "offset": offset,
         },
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_pm_quality_review_action_preview.py
+++ b/src/app/routers/dpm_command_center_pm_quality_review_action_preview.py
@@ -17,6 +17,15 @@ router = APIRouter(
 )
 
 
+async def _preview_pm_operating_quality_review_action(
+    request: DpmPmOperatingQualityForwardRequest,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().preview_pm_operating_quality_review_action(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/pm-operating-quality/review-actions/preview",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -35,7 +44,4 @@ router = APIRouter(
 async def preview_pm_operating_quality_review_action(
     request: DpmPmOperatingQualityForwardRequest,
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().preview_pm_operating_quality_review_action(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _preview_pm_operating_quality_review_action(request)

--- a/src/app/routers/dpm_command_center_pm_quality_review_actions.py
+++ b/src/app/routers/dpm_command_center_pm_quality_review_actions.py
@@ -17,6 +17,15 @@ router = APIRouter(
 )
 
 
+async def _create_pm_operating_quality_review_action(
+    request: DpmPmOperatingQualityForwardRequest,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().create_pm_operating_quality_review_action(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/pm-operating-quality/review-actions",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -33,7 +42,4 @@ router = APIRouter(
 async def create_pm_operating_quality_review_action(
     request: DpmPmOperatingQualityForwardRequest,
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().create_pm_operating_quality_review_action(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _create_pm_operating_quality_review_action(request)

--- a/src/app/routers/dpm_command_center_pm_quality_score_run_detail.py
+++ b/src/app/routers/dpm_command_center_pm_quality_score_run_detail.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _get_pm_operating_quality_score_run(
+    *,
+    score_run_id: str,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().get_pm_operating_quality_score_run(
+        score_run_id=score_run_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/pm-operating-quality/score-runs/{score_run_id}",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -32,7 +42,4 @@ async def get_pm_operating_quality_score_run(
         examples=["pmq_run_001"],
     ),
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().get_pm_operating_quality_score_run(
-        score_run_id=score_run_id,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_pm_operating_quality_score_run(score_run_id=score_run_id)

--- a/src/app/routers/dpm_command_center_pm_quality_score_run_lookup.py
+++ b/src/app/routers/dpm_command_center_pm_quality_score_run_lookup.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _list_pm_operating_quality_score_runs(
+    *,
+    filters: dict[str, str | int | None],
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().list_pm_operating_quality_score_runs(
+        filters=filters,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/pm-operating-quality/score-runs",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -34,7 +44,7 @@ async def list_pm_operating_quality_score_runs(
     limit: int = Query(default=50, ge=1, le=100, description="Maximum score runs to return."),
     offset: int = Query(default=0, ge=0, description="Rows to skip."),
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().list_pm_operating_quality_score_runs(
+    return await _list_pm_operating_quality_score_runs(
         filters={
             "pm_id": pm_id,
             "book_id": book_id,
@@ -44,5 +54,4 @@ async def list_pm_operating_quality_score_runs(
             "limit": limit,
             "offset": offset,
         },
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_pm_quality_score_run_lookup.py
+++ b/src/app/routers/dpm_command_center_pm_quality_score_run_lookup.py
@@ -16,10 +16,24 @@ router = APIRouter(
 
 async def _list_pm_operating_quality_score_runs(
     *,
-    filters: dict[str, str | int | None],
+    pm_id: str | None,
+    book_id: str | None,
+    policy_id: str | None,
+    as_of_date: str | None,
+    state: str | None,
+    limit: int,
+    offset: int,
 ) -> DpmPmOperatingQualityGatewayResponse:
     return await dpm_command_center_service().list_pm_operating_quality_score_runs(
-        filters=filters,
+        filters={
+            "pm_id": pm_id,
+            "book_id": book_id,
+            "policy_id": policy_id,
+            "as_of_date": as_of_date,
+            "state": state,
+            "limit": limit,
+            "offset": offset,
+        },
         correlation_id=correlation_id_var.get(),
     )
 
@@ -45,13 +59,11 @@ async def list_pm_operating_quality_score_runs(
     offset: int = Query(default=0, ge=0, description="Rows to skip."),
 ) -> DpmPmOperatingQualityGatewayResponse:
     return await _list_pm_operating_quality_score_runs(
-        filters={
-            "pm_id": pm_id,
-            "book_id": book_id,
-            "policy_id": policy_id,
-            "as_of_date": as_of_date,
-            "state": state,
-            "limit": limit,
-            "offset": offset,
-        },
+        pm_id=pm_id,
+        book_id=book_id,
+        policy_id=policy_id,
+        as_of_date=as_of_date,
+        state=state,
+        limit=limit,
+        offset=offset,
     )

--- a/src/app/routers/dpm_command_center_pm_quality_score_run_preview.py
+++ b/src/app/routers/dpm_command_center_pm_quality_score_run_preview.py
@@ -17,6 +17,15 @@ router = APIRouter(
 )
 
 
+async def _preview_pm_operating_quality_score_run(
+    request: DpmPmOperatingQualityForwardRequest,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().preview_pm_operating_quality_score_run(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/pm-operating-quality/score-runs/preview",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -33,7 +42,4 @@ router = APIRouter(
 async def preview_pm_operating_quality_score_run(
     request: DpmPmOperatingQualityForwardRequest,
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().preview_pm_operating_quality_score_run(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _preview_pm_operating_quality_score_run(request)

--- a/src/app/routers/dpm_command_center_pm_quality_summary_detail.py
+++ b/src/app/routers/dpm_command_center_pm_quality_summary_detail.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _get_pm_operating_quality_summary_invocation(
+    *,
+    summary_invocation_id: str,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().get_pm_operating_quality_summary_invocation(
+        summary_invocation_id=summary_invocation_id,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/pm-operating-quality/summary-invocations/{summary_invocation_id}",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -34,7 +44,6 @@ async def get_pm_operating_quality_summary_invocation(
         examples=["pmq_summary_001"],
     ),
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().get_pm_operating_quality_summary_invocation(
+    return await _get_pm_operating_quality_summary_invocation(
         summary_invocation_id=summary_invocation_id,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_command_center_pm_quality_summary_invocation_preview.py
+++ b/src/app/routers/dpm_command_center_pm_quality_summary_invocation_preview.py
@@ -17,6 +17,15 @@ router = APIRouter(
 )
 
 
+async def _preview_pm_operating_quality_summary_invocation(
+    request: DpmPmOperatingQualityForwardRequest,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().preview_pm_operating_quality_summary_invocation(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/pm-operating-quality/summary-invocations/preview",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -35,7 +44,4 @@ router = APIRouter(
 async def preview_pm_operating_quality_summary_invocation(
     request: DpmPmOperatingQualityForwardRequest,
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().preview_pm_operating_quality_summary_invocation(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _preview_pm_operating_quality_summary_invocation(request)

--- a/src/app/routers/dpm_command_center_pm_quality_summary_invocations.py
+++ b/src/app/routers/dpm_command_center_pm_quality_summary_invocations.py
@@ -17,6 +17,15 @@ router = APIRouter(
 )
 
 
+async def _create_pm_operating_quality_summary_invocation(
+    request: DpmPmOperatingQualityForwardRequest,
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().create_pm_operating_quality_summary_invocation(
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/pm-operating-quality/summary-invocations",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -34,7 +43,4 @@ router = APIRouter(
 async def create_pm_operating_quality_summary_invocation(
     request: DpmPmOperatingQualityForwardRequest,
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().create_pm_operating_quality_summary_invocation(
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _create_pm_operating_quality_summary_invocation(request)

--- a/src/app/routers/dpm_command_center_pm_quality_summary_lookup.py
+++ b/src/app/routers/dpm_command_center_pm_quality_summary_lookup.py
@@ -16,10 +16,24 @@ router = APIRouter(
 
 async def _list_pm_operating_quality_summary_invocations(
     *,
-    filters: dict[str, str | int | None],
+    score_run_id: str | None,
+    review_action_id: str | None,
+    policy_id: str | None,
+    as_of_date: str | None,
+    invocation_state: str | None,
+    limit: int,
+    offset: int,
 ) -> DpmPmOperatingQualityGatewayResponse:
     return await dpm_command_center_service().list_pm_operating_quality_summary_invocations(
-        filters=filters,
+        filters={
+            "score_run_id": score_run_id,
+            "review_action_id": review_action_id,
+            "policy_id": policy_id,
+            "as_of_date": as_of_date,
+            "invocation_state": invocation_state,
+            "limit": limit,
+            "offset": offset,
+        },
         correlation_id=correlation_id_var.get(),
     )
 
@@ -52,13 +66,11 @@ async def list_pm_operating_quality_summary_invocations(
     offset: int = Query(default=0, ge=0, description="Rows to skip."),
 ) -> DpmPmOperatingQualityGatewayResponse:
     return await _list_pm_operating_quality_summary_invocations(
-        filters={
-            "score_run_id": score_run_id,
-            "review_action_id": review_action_id,
-            "policy_id": policy_id,
-            "as_of_date": as_of_date,
-            "invocation_state": invocation_state,
-            "limit": limit,
-            "offset": offset,
-        },
+        score_run_id=score_run_id,
+        review_action_id=review_action_id,
+        policy_id=policy_id,
+        as_of_date=as_of_date,
+        invocation_state=invocation_state,
+        limit=limit,
+        offset=offset,
     )

--- a/src/app/routers/dpm_command_center_pm_quality_summary_lookup.py
+++ b/src/app/routers/dpm_command_center_pm_quality_summary_lookup.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _list_pm_operating_quality_summary_invocations(
+    *,
+    filters: dict[str, str | int | None],
+) -> DpmPmOperatingQualityGatewayResponse:
+    return await dpm_command_center_service().list_pm_operating_quality_summary_invocations(
+        filters=filters,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/pm-operating-quality/summary-invocations",
     response_model=DpmPmOperatingQualityGatewayResponse,
@@ -41,7 +51,7 @@ async def list_pm_operating_quality_summary_invocations(
     limit: int = Query(default=50, ge=1, le=100, description="Maximum invocations to return."),
     offset: int = Query(default=0, ge=0, description="Rows to skip."),
 ) -> DpmPmOperatingQualityGatewayResponse:
-    return await dpm_command_center_service().list_pm_operating_quality_summary_invocations(
+    return await _list_pm_operating_quality_summary_invocations(
         filters={
             "score_run_id": score_run_id,
             "review_action_id": review_action_id,
@@ -51,5 +61,4 @@ async def list_pm_operating_quality_summary_invocations(
             "limit": limit,
             "offset": offset,
         },
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_wave_campaign_definition_lookup.py
+++ b/src/app/routers/dpm_wave_campaign_definition_lookup.py
@@ -15,10 +15,20 @@ router = APIRouter(
 
 async def _list_campaign_definitions(
     *,
-    filters: dict[str, str | int | None],
+    campaign_id: str | None,
+    campaign_status: str | None,
+    as_of_date: str | None,
+    limit: int,
+    offset: int,
 ) -> DpmCampaignDefinitionGatewayResponse:
     return await dpm_wave_service().list_campaign_definitions(
-        filters=filters,
+        filters={
+            "campaign_id": campaign_id,
+            "campaign_status": campaign_status,
+            "as_of_date": as_of_date,
+            "limit": limit,
+            "offset": offset,
+        },
         correlation_id=correlation_id_var.get(),
     )
 
@@ -49,11 +59,9 @@ async def list_campaign_definitions(
     offset: int = Query(default=0, ge=0, description="Zero-based definition-list offset."),
 ) -> DpmCampaignDefinitionGatewayResponse:
     return await _list_campaign_definitions(
-        filters={
-            "campaign_id": campaign_id,
-            "campaign_status": campaign_status,
-            "as_of_date": as_of_date,
-            "limit": limit,
-            "offset": offset,
-        },
+        campaign_id=campaign_id,
+        campaign_status=campaign_status,
+        as_of_date=as_of_date,
+        limit=limit,
+        offset=offset,
     )

--- a/src/app/routers/dpm_wave_campaign_lifecycle.py
+++ b/src/app/routers/dpm_wave_campaign_lifecycle.py
@@ -16,6 +16,20 @@ router = APIRouter(
 )
 
 
+async def _retire_campaign_definition(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: DpmCampaignDefinitionLifecycleCommandRequest,
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await dpm_wave_service().retire_campaign_definition(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/retire",
     response_model=DpmCampaignDefinitionGatewayResponse,
@@ -36,9 +50,8 @@ async def retire_campaign_definition(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignDefinitionGatewayResponse:
-    return await dpm_wave_service().retire_campaign_definition(
+    return await _retire_campaign_definition(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_maker_checker_commands.py
+++ b/src/app/routers/dpm_wave_campaign_maker_checker_commands.py
@@ -16,6 +16,20 @@ router = APIRouter(
 )
 
 
+async def _create_campaign_maker_checker_control(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: DpmCampaignWorkflowForwardRequest,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().create_campaign_maker_checker_control(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/maker-checker-controls",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -33,9 +47,8 @@ async def create_campaign_maker_checker_control(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().create_campaign_maker_checker_control(
+    return await _create_campaign_maker_checker_control(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_operating_queue.py
+++ b/src/app/routers/dpm_wave_campaign_operating_queue.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _get_campaign_operating_queue(
+    *,
+    request: Request,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().get_campaign_operating_queue(
+        filters=campaign_workflow_query_params(request),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-operating-queue",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -30,7 +40,4 @@ router = APIRouter(
 async def get_campaign_operating_queue(
     request: Request,
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().get_campaign_operating_queue(
-        filters=campaign_workflow_query_params(request),
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_campaign_operating_queue(request=request)

--- a/src/app/routers/dpm_wave_campaign_preview_readiness.py
+++ b/src/app/routers/dpm_wave_campaign_preview_readiness.py
@@ -13,6 +13,24 @@ router = APIRouter(
 )
 
 
+async def _get_campaign_definition_preview_readiness(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    requested_as_of_date: str,
+    actor_id: str,
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await dpm_wave_service().get_campaign_definition_preview_readiness(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        filters={
+            "requested_as_of_date": requested_as_of_date,
+            "actor_id": actor_id,
+        },
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/preview-readiness",
     response_model=DpmCampaignDefinitionGatewayResponse,
@@ -41,12 +59,9 @@ async def get_campaign_definition_preview_readiness(
         examples=["pm_sg_1"],
     ),
 ) -> DpmCampaignDefinitionGatewayResponse:
-    return await dpm_wave_service().get_campaign_definition_preview_readiness(
+    return await _get_campaign_definition_preview_readiness(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        filters={
-            "requested_as_of_date": requested_as_of_date,
-            "actor_id": actor_id,
-        },
-        correlation_id=correlation_id_var.get(),
+        requested_as_of_date=requested_as_of_date,
+        actor_id=actor_id,
     )

--- a/src/app/routers/dpm_wave_campaign_readiness.py
+++ b/src/app/routers/dpm_wave_campaign_readiness.py
@@ -13,6 +13,18 @@ router = APIRouter(
 )
 
 
+async def _get_campaign_definition_lifecycle_events(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await dpm_wave_service().get_campaign_definition_lifecycle_events(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/lifecycle-events",
     response_model=DpmCampaignDefinitionGatewayResponse,
@@ -30,8 +42,7 @@ async def get_campaign_definition_lifecycle_events(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignDefinitionGatewayResponse:
-    return await dpm_wave_service().get_campaign_definition_lifecycle_events(
+    return await _get_campaign_definition_lifecycle_events(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        correlation_id=correlation_id_var.get(),
     )

--- a/src/app/routers/dpm_wave_campaign_supersede.py
+++ b/src/app/routers/dpm_wave_campaign_supersede.py
@@ -16,6 +16,20 @@ router = APIRouter(
 )
 
 
+async def _supersede_campaign_definition(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: DpmCampaignDefinitionLifecycleCommandRequest,
+) -> DpmCampaignDefinitionGatewayResponse:
+    return await dpm_wave_service().supersede_campaign_definition(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        body=request.body,
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.post(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/supersede",
     response_model=DpmCampaignDefinitionGatewayResponse,
@@ -36,9 +50,8 @@ async def supersede_campaign_definition(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignDefinitionGatewayResponse:
-    return await dpm_wave_service().supersede_campaign_definition(
+    return await _supersede_campaign_definition(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        body=request.body,
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_workflow.py
+++ b/src/app/routers/dpm_wave_campaign_workflow.py
@@ -14,6 +14,20 @@ router = APIRouter(
 )
 
 
+async def _list_campaign_maker_checker_controls(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: Request,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().list_campaign_maker_checker_controls(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        filters=campaign_maker_checker_query_params(request),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-definitions/{campaign_id}/versions/{campaign_version}/maker-checker-controls",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -31,9 +45,8 @@ async def list_campaign_maker_checker_controls(
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().list_campaign_maker_checker_controls(
+    return await _list_campaign_maker_checker_controls(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
-        filters=campaign_maker_checker_query_params(request),
-        correlation_id=correlation_id_var.get(),
+        request=request,
     )

--- a/src/app/routers/dpm_wave_campaign_workflow_automation.py
+++ b/src/app/routers/dpm_wave_campaign_workflow_automation.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _get_campaign_workflow_automation(
+    *,
+    request: Request,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().get_campaign_workflow_automation(
+        filters=campaign_workflow_query_params(request),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-workflow-automation",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -30,7 +40,4 @@ router = APIRouter(
 async def get_campaign_workflow_automation(
     request: Request,
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().get_campaign_workflow_automation(
-        filters=campaign_workflow_query_params(request),
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_campaign_workflow_automation(request=request)

--- a/src/app/routers/dpm_wave_campaign_workflow_boards.py
+++ b/src/app/routers/dpm_wave_campaign_workflow_boards.py
@@ -14,6 +14,16 @@ router = APIRouter(
 )
 
 
+async def _get_campaign_workflow_board(
+    *,
+    request: Request,
+) -> DpmCampaignWorkflowGatewayResponse:
+    return await dpm_wave_service().get_campaign_workflow_board(
+        filters=campaign_workflow_query_params(request),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
 @router.get(
     "/campaign-workflow-board",
     response_model=DpmCampaignWorkflowGatewayResponse,
@@ -30,7 +40,4 @@ router = APIRouter(
 async def get_campaign_workflow_board(
     request: Request,
 ) -> DpmCampaignWorkflowGatewayResponse:
-    return await dpm_wave_service().get_campaign_workflow_board(
-        filters=campaign_workflow_query_params(request),
-        correlation_id=correlation_id_var.get(),
-    )
+    return await _get_campaign_workflow_board(request=request)

--- a/src/app/routers/dpm_wave_lookup.py
+++ b/src/app/routers/dpm_wave_lookup.py
@@ -13,10 +13,22 @@ router = APIRouter(
 
 async def _list_waves(
     *,
-    filters: dict[str, str | int | None],
+    state: str | None,
+    trigger_type: str | None,
+    as_of_date: str | None,
+    supportability_state: str | None,
+    limit: int,
+    offset: int,
 ) -> DpmWaveGatewayResponse:
     return await dpm_wave_service().list_waves(
-        filters=filters,
+        filters={
+            "state": state,
+            "trigger_type": trigger_type,
+            "as_of_date": as_of_date,
+            "supportability_state": supportability_state,
+            "limit": limit,
+            "offset": offset,
+        },
         correlation_id=correlation_id_var.get(),
     )
 
@@ -54,12 +66,10 @@ async def list_waves(
     offset: int = Query(default=0, ge=0, description="Zero-based wave-list offset."),
 ) -> DpmWaveGatewayResponse:
     return await _list_waves(
-        filters={
-            "state": state,
-            "trigger_type": trigger_type,
-            "as_of_date": as_of_date,
-            "supportability_state": supportability_state,
-            "limit": limit,
-            "offset": offset,
-        },
+        state=state,
+        trigger_type=trigger_type,
+        as_of_date=as_of_date,
+        supportability_state=supportability_state,
+        limit=limit,
+        offset=offset,
     )

--- a/src/app/routers/portfolio_transactions.py
+++ b/src/app/routers/portfolio_transactions.py
@@ -58,6 +58,51 @@ async def _get_transaction_ledger(
     )
 
 
+async def _get_portfolio_transactions(
+    *,
+    portfolio_id: str,
+    as_of_date: str | None,
+    include_projected: bool,
+    transaction_type: str | None,
+    security_id: str | None,
+    instrument_id: str | None,
+    component_type: str | None,
+    linked_transaction_group_id: str | None,
+    fx_contract_id: str | None,
+    swap_event_id: str | None,
+    near_leg_group_id: str | None,
+    far_leg_group_id: str | None,
+    sort_by: str,
+    sort_order: str,
+    start_date: str | None,
+    end_date: str | None,
+    skip: int,
+    limit: int,
+) -> PortfolioTransactionLedgerResponse:
+    return await _get_transaction_ledger(
+        portfolio_id=portfolio_id,
+        filters=PortfolioTransactionLedgerFilters(
+            as_of_date=as_of_date,
+            include_projected=include_projected,
+            transaction_type=transaction_type,
+            security_id=security_id,
+            instrument_id=instrument_id,
+            component_type=component_type,
+            linked_transaction_group_id=linked_transaction_group_id,
+            fx_contract_id=fx_contract_id,
+            swap_event_id=swap_event_id,
+            near_leg_group_id=near_leg_group_id,
+            far_leg_group_id=far_leg_group_id,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            start_date=start_date,
+            end_date=end_date,
+            skip=skip,
+            limit=limit,
+        ),
+    )
+
+
 @router.get(
     "/portfolios/{portfolio_id}/transactions",
     response_model=PortfolioTransactionLedgerResponse,
@@ -161,7 +206,8 @@ async def get_portfolio_transactions(
         examples=["desc"],
     ),
 ) -> PortfolioTransactionLedgerResponse:
-    filters = PortfolioTransactionLedgerFilters(
+    return await _get_portfolio_transactions(
+        portfolio_id=portfolio_id,
         as_of_date=as_of_date,
         include_projected=include_projected,
         transaction_type=transaction_type,
@@ -179,8 +225,4 @@ async def get_portfolio_transactions(
         end_date=end_date,
         skip=skip,
         limit=limit,
-    )
-    return await _get_transaction_ledger(
-        portfolio_id=portfolio_id,
-        filters=filters,
     )

--- a/src/app/routers/workbench_performance.py
+++ b/src/app/routers/workbench_performance.py
@@ -42,6 +42,47 @@ async def _get_performance_summary(
     )
 
 
+async def _get_performance_workspace_summary(
+    *,
+    portfolio_id: str,
+    period: str,
+    chart_frequency: str,
+    contribution_dimension: str,
+    attribution_dimension: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    report_start_date: str | None,
+    report_end_date: str | None,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> PerformanceWorkspaceSummaryResponse:
+    require_workbench_caller_context(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+    return await _get_performance_summary(
+        portfolio_id=portfolio_id,
+        query=PerformanceSummaryQuery(
+            period=period,
+            chart_frequency=chart_frequency,
+            contribution_dimension=contribution_dimension,
+            attribution_dimension=attribution_dimension,
+            detail_basis=detail_basis,
+            benchmark_code=benchmark_code,
+            report_start_date=report_start_date,
+            report_end_date=report_end_date,
+        ),
+    )
+
+
 @router.get(
     "/{portfolio_id}/performance/summary",
     response_model=PerformanceWorkspaceSummaryResponse,
@@ -112,24 +153,20 @@ async def get_performance_workspace_summary(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> PerformanceWorkspaceSummaryResponse:
-    require_workbench_caller_context(
+    return await _get_performance_workspace_summary(
+        portfolio_id=portfolio_id,
+        period=period,
+        chart_frequency=chart_frequency,
+        contribution_dimension=contribution_dimension,
+        attribution_dimension=attribution_dimension,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
         actor_id=actor_id,
         caller_application=caller_application,
         tenant_id=tenant_id,
         region=region,
         booking_center_code=booking_center_code,
         role=role,
-    )
-    return await _get_performance_summary(
-        portfolio_id=portfolio_id,
-        query=PerformanceSummaryQuery(
-            period=period,
-            chart_frequency=chart_frequency,
-            contribution_dimension=contribution_dimension,
-            attribution_dimension=attribution_dimension,
-            detail_basis=detail_basis,
-            benchmark_code=benchmark_code,
-            report_start_date=report_start_date,
-            report_end_date=report_end_date,
-        ),
     )

--- a/src/app/routers/workbench_performance_advisor_brief.py
+++ b/src/app/routers/workbench_performance_advisor_brief.py
@@ -45,6 +45,53 @@ async def _get_advisor_brief(
     )
 
 
+async def _get_performance_advisor_brief(
+    *,
+    portfolio_id: str,
+    period: str,
+    chart_frequency: str,
+    contribution_dimension: str,
+    attribution_dimension: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    report_start_date: str | None,
+    report_end_date: str | None,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> AdvisorBriefResponse:
+    require_advisor_brief_caller_context(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+    try:
+        response = await _get_advisor_brief(
+            portfolio_id=portfolio_id,
+            query=AdvisorBriefQuery(
+                period=period,
+                chart_frequency=chart_frequency,
+                contribution_dimension=contribution_dimension,
+                attribution_dimension=attribution_dimension,
+                detail_basis=detail_basis,
+                benchmark_code=benchmark_code,
+                report_start_date=report_start_date,
+                report_end_date=report_end_date,
+            ),
+        )
+    except HTTPException as exc:
+        _emit_advisor_brief_read_audit(status_code=exc.status_code)
+        raise
+    _emit_advisor_brief_read_audit(status_code=200)
+    return response
+
+
 @router.get(
     "/{portfolio_id}/performance/advisor-brief",
     response_model=AdvisorBriefResponse,
@@ -115,7 +162,16 @@ async def get_performance_advisor_brief(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> AdvisorBriefResponse:
-    require_advisor_brief_caller_context(
+    return await _get_performance_advisor_brief(
+        portfolio_id=portfolio_id,
+        period=period,
+        chart_frequency=chart_frequency,
+        contribution_dimension=contribution_dimension,
+        attribution_dimension=attribution_dimension,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
         actor_id=actor_id,
         caller_application=caller_application,
         tenant_id=tenant_id,
@@ -123,22 +179,3 @@ async def get_performance_advisor_brief(
         booking_center_code=booking_center_code,
         role=role,
     )
-    try:
-        response = await _get_advisor_brief(
-            portfolio_id=portfolio_id,
-            query=AdvisorBriefQuery(
-                period=period,
-                chart_frequency=chart_frequency,
-                contribution_dimension=contribution_dimension,
-                attribution_dimension=attribution_dimension,
-                detail_basis=detail_basis,
-                benchmark_code=benchmark_code,
-                report_start_date=report_start_date,
-                report_end_date=report_end_date,
-            ),
-        )
-    except HTTPException as exc:
-        _emit_advisor_brief_read_audit(status_code=exc.status_code)
-        raise
-    _emit_advisor_brief_read_audit(status_code=200)
-    return response

--- a/src/app/routers/workbench_performance_advisor_brief_review_actions.py
+++ b/src/app/routers/workbench_performance_advisor_brief_review_actions.py
@@ -37,6 +37,49 @@ async def _apply_advisor_brief_review_action(
     )
 
 
+async def _post_performance_advisor_brief_review_action(
+    *,
+    portfolio_id: str,
+    request: AdvisorBriefWorkflowPackRunReviewActionRequest,
+    period: str,
+    chart_frequency: str,
+    contribution_dimension: str,
+    attribution_dimension: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    report_start_date: str | None,
+    report_end_date: str | None,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> AdvisorBriefResponse:
+    require_advisor_brief_caller_context(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+    return await _apply_advisor_brief_review_action(
+        portfolio_id=portfolio_id,
+        request=request,
+        query=AdvisorBriefQuery(
+            period=period,
+            chart_frequency=chart_frequency,
+            contribution_dimension=contribution_dimension,
+            attribution_dimension=attribution_dimension,
+            detail_basis=detail_basis,
+            benchmark_code=benchmark_code,
+            report_start_date=report_start_date,
+            report_end_date=report_end_date,
+        ),
+    )
+
+
 @router.post(
     "/{portfolio_id}/performance/advisor-brief/review-actions",
     response_model=AdvisorBriefResponse,
@@ -108,25 +151,21 @@ async def post_performance_advisor_brief_review_action(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> AdvisorBriefResponse:
-    require_advisor_brief_caller_context(
+    return await _post_performance_advisor_brief_review_action(
+        portfolio_id=portfolio_id,
+        request=request,
+        period=period,
+        chart_frequency=chart_frequency,
+        contribution_dimension=contribution_dimension,
+        attribution_dimension=attribution_dimension,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
         actor_id=actor_id,
         caller_application=caller_application,
         tenant_id=tenant_id,
         region=region,
         booking_center_code=booking_center_code,
         role=role,
-    )
-    return await _apply_advisor_brief_review_action(
-        portfolio_id=portfolio_id,
-        request=request,
-        query=AdvisorBriefQuery(
-            period=period,
-            chart_frequency=chart_frequency,
-            contribution_dimension=contribution_dimension,
-            attribution_dimension=attribution_dimension,
-            detail_basis=detail_basis,
-            benchmark_code=benchmark_code,
-            report_start_date=report_start_date,
-            report_end_date=report_end_date,
-        ),
     )

--- a/src/app/routers/workbench_performance_evidence.py
+++ b/src/app/routers/workbench_performance_evidence.py
@@ -8,9 +8,11 @@ router = APIRouter(prefix="/api/v1/workbench", tags=["workbench"])
 
 async def _get_performance_evidence_artifact(
     *,
+    portfolio_id: str,
     calculation_id: str,
     artifact_name: str,
 ) -> Response:
+    _ = portfolio_id
     service = performance_workspace_service()
     correlation_id = correlation_id_var.get()
     content, content_type = await service.get_performance_evidence_artifact(
@@ -49,8 +51,8 @@ async def get_performance_evidence_artifact(
         examples=["request.json"],
     ),
 ) -> Response:
-    _ = portfolio_id
     return await _get_performance_evidence_artifact(
+        portfolio_id=portfolio_id,
         calculation_id=calculation_id,
         artifact_name=artifact_name,
     )

--- a/src/app/routers/workbench_risk.py
+++ b/src/app/routers/workbench_risk.py
@@ -41,6 +41,45 @@ async def _get_risk_summary(
     )
 
 
+async def _get_workbench_risk_summary(
+    *,
+    portfolio_id: str,
+    period: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    as_of_date: str | None,
+    report_start_date: str | None,
+    report_end_date: str | None,
+    reporting_currency: str,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+) -> WorkbenchRiskSummaryResponse:
+    require_workbench_caller_context(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+    )
+    return await _get_risk_summary(
+        portfolio_id=portfolio_id,
+        query=RiskSummaryQuery(
+            period=period,
+            detail_basis=detail_basis,
+            benchmark_code=benchmark_code,
+            as_of_date=as_of_date,
+            report_start_date=report_start_date,
+            report_end_date=report_end_date,
+            reporting_currency=reporting_currency,
+        ),
+    )
+
+
 @router.get(
     "/{portfolio_id}/risk/summary",
     response_model=WorkbenchRiskSummaryResponse,
@@ -104,23 +143,19 @@ async def get_workbench_risk_summary(
     booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
 ) -> WorkbenchRiskSummaryResponse:
-    require_workbench_caller_context(
+    return await _get_workbench_risk_summary(
+        portfolio_id=portfolio_id,
+        period=period,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        as_of_date=as_of_date,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
+        reporting_currency=reporting_currency,
         actor_id=actor_id,
         caller_application=caller_application,
         tenant_id=tenant_id,
         region=region,
         booking_center_code=booking_center_code,
         role=role,
-    )
-    return await _get_risk_summary(
-        portfolio_id=portfolio_id,
-        query=RiskSummaryQuery(
-            period=period,
-            detail_basis=detail_basis,
-            benchmark_code=benchmark_code,
-            as_of_date=as_of_date,
-            report_start_date=report_start_date,
-            report_end_date=report_end_date,
-            reporting_currency=reporting_currency,
-        ),
     )

--- a/tests/unit/test_router_layer_boundaries.py
+++ b/tests/unit/test_router_layer_boundaries.py
@@ -71,6 +71,19 @@ def _direct_correlation_access(path: Path) -> list[str]:
     return handlers
 
 
+def _route_handler_dict_literals(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    handlers: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
+            continue
+        if not _is_router_handler(node):
+            continue
+        if any(isinstance(child, ast.Dict) for child in ast.walk(node)):
+            handlers.append(node.name)
+    return handlers
+
+
 def test_routers_do_not_import_service_factories_or_clients() -> None:
     offenders = {
         path.name: sorted(
@@ -89,6 +102,15 @@ def test_routers_do_not_import_service_factories_or_clients() -> None:
 def test_router_handlers_delegate_service_calls_to_private_helpers() -> None:
     offenders = {path.name: _direct_service_calls(path) for path in _ROUTER_ROOT.glob("*.py")}
     offenders = {name: calls for name, calls in offenders.items() if calls}
+
+    assert offenders == {}
+
+
+def test_dpm_router_handlers_delegate_filter_construction_to_private_helpers() -> None:
+    offenders = {
+        path.name: _route_handler_dict_literals(path) for path in _ROUTER_ROOT.glob("dpm_*.py")
+    }
+    offenders = {name: handlers for name, handlers in offenders.items() if handlers}
 
     assert offenders == {}
 

--- a/tests/unit/test_router_layer_boundaries.py
+++ b/tests/unit/test_router_layer_boundaries.py
@@ -86,6 +86,19 @@ def _route_handler_dict_literals(path: Path) -> list[str]:
     return handlers
 
 
+def _multi_statement_route_handlers(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    handlers: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
+            continue
+        if not _is_router_handler(node):
+            continue
+        if len(node.body) != 1:
+            handlers.append(node.name)
+    return handlers
+
+
 def test_routers_do_not_import_service_factories_or_clients() -> None:
     offenders = {
         path.name: sorted(
@@ -97,6 +110,15 @@ def test_routers_do_not_import_service_factories_or_clients() -> None:
         for path in _ROUTER_ROOT.glob("*.py")
     }
     offenders = {name: imports for name, imports in offenders.items() if imports}
+
+    assert offenders == {}
+
+
+def test_router_handlers_are_single_statement_delegators() -> None:
+    offenders = {
+        path.name: _multi_statement_route_handlers(path) for path in _ROUTER_ROOT.glob("*.py")
+    }
+    offenders = {name: handlers for name, handlers in offenders.items() if handlers}
 
     assert offenders == {}
 

--- a/tests/unit/test_router_layer_boundaries.py
+++ b/tests/unit/test_router_layer_boundaries.py
@@ -17,7 +17,11 @@ def _imported_modules(path: Path) -> set[str]:
 
 def _function_names(path: Path) -> set[str]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    return {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
+    return {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef)
+    }
 
 
 def _is_router_handler(node: ast.AsyncFunctionDef | ast.FunctionDef) -> bool:

--- a/tests/unit/test_router_layer_boundaries.py
+++ b/tests/unit/test_router_layer_boundaries.py
@@ -55,6 +55,22 @@ def _direct_service_calls(path: Path) -> list[str]:
     return calls
 
 
+def _direct_correlation_access(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    handlers: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
+            continue
+        if not _is_router_handler(node):
+            continue
+        if any(
+            isinstance(child, ast.Name) and child.id == "correlation_id_var"
+            for child in ast.walk(node)
+        ):
+            handlers.append(node.name)
+    return handlers
+
+
 def test_routers_do_not_import_service_factories_or_clients() -> None:
     offenders = {
         path.name: sorted(
@@ -73,6 +89,13 @@ def test_routers_do_not_import_service_factories_or_clients() -> None:
 def test_router_handlers_delegate_service_calls_to_private_helpers() -> None:
     offenders = {path.name: _direct_service_calls(path) for path in _ROUTER_ROOT.glob("*.py")}
     offenders = {name: calls for name, calls in offenders.items() if calls}
+
+    assert offenders == {}
+
+
+def test_router_handlers_delegate_correlation_to_private_helpers() -> None:
+    offenders = {path.name: _direct_correlation_access(path) for path in _ROUTER_ROOT.glob("*.py")}
+    offenders = {name: handlers for name, handlers in offenders.items() if handlers}
 
     assert offenders == {}
 

--- a/tests/unit/test_router_layer_boundaries.py
+++ b/tests/unit/test_router_layer_boundaries.py
@@ -79,7 +79,9 @@ def _route_handler_dict_literals(path: Path) -> list[str]:
             continue
         if not _is_router_handler(node):
             continue
-        if any(isinstance(child, ast.Dict) for child in ast.walk(node)):
+        if any(
+            isinstance(child, ast.Dict) for statement in node.body for child in ast.walk(statement)
+        ):
             handlers.append(node.name)
     return handlers
 
@@ -106,9 +108,9 @@ def test_router_handlers_delegate_service_calls_to_private_helpers() -> None:
     assert offenders == {}
 
 
-def test_dpm_router_handlers_delegate_filter_construction_to_private_helpers() -> None:
+def test_router_handlers_delegate_filter_construction_to_private_helpers() -> None:
     offenders = {
-        path.name: _route_handler_dict_literals(path) for path in _ROUTER_ROOT.glob("dpm_*.py")
+        path.name: _route_handler_dict_literals(path) for path in _ROUTER_ROOT.glob("*.py")
     }
     offenders = {name: handlers for name, handlers in offenders.items() if handlers}
 

--- a/tests/unit/test_router_layer_boundaries.py
+++ b/tests/unit/test_router_layer_boundaries.py
@@ -30,7 +30,7 @@ def _is_router_handler(node: ast.AsyncFunctionDef | ast.FunctionDef) -> bool:
     )
 
 
-def _direct_dpm_service_calls(path: Path) -> list[str]:
+def _direct_service_calls(path: Path) -> list[str]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     calls: list[str] = []
     for node in tree.body:
@@ -46,11 +46,7 @@ def _direct_dpm_service_calls(path: Path) -> list[str]:
             if not isinstance(child.func.value, ast.Call):
                 continue
             service_factory = child.func.value.func
-            if (
-                isinstance(service_factory, ast.Name)
-                and service_factory.id.startswith("dpm_")
-                and service_factory.id.endswith("_service")
-            ):
+            if isinstance(service_factory, ast.Name) and service_factory.id.endswith("_service"):
                 calls.append(f"{node.name}:{service_factory.id}.{child.func.attr}")
     return calls
 
@@ -70,10 +66,8 @@ def test_routers_do_not_import_service_factories_or_clients() -> None:
     assert offenders == {}
 
 
-def test_dpm_router_handlers_delegate_service_calls_to_private_helpers() -> None:
-    offenders = {
-        path.name: _direct_dpm_service_calls(path) for path in _ROUTER_ROOT.glob("dpm_*.py")
-    }
+def test_router_handlers_delegate_service_calls_to_private_helpers() -> None:
+    offenders = {path.name: _direct_service_calls(path) for path in _ROUTER_ROOT.glob("*.py")}
     offenders = {name: calls for name, calls in offenders.items() if calls}
 
     assert offenders == {}

--- a/tests/unit/test_router_layer_boundaries.py
+++ b/tests/unit/test_router_layer_boundaries.py
@@ -20,6 +20,41 @@ def _function_names(path: Path) -> set[str]:
     return {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
 
 
+def _is_router_handler(node: ast.AsyncFunctionDef | ast.FunctionDef) -> bool:
+    return any(
+        isinstance(decorator, ast.Call)
+        and isinstance(decorator.func, ast.Attribute)
+        and isinstance(decorator.func.value, ast.Name)
+        and decorator.func.value.id == "router"
+        for decorator in node.decorator_list
+    )
+
+
+def _direct_dpm_service_calls(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    calls: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
+            continue
+        if not _is_router_handler(node):
+            continue
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            if not isinstance(child.func, ast.Attribute):
+                continue
+            if not isinstance(child.func.value, ast.Call):
+                continue
+            service_factory = child.func.value.func
+            if (
+                isinstance(service_factory, ast.Name)
+                and service_factory.id.startswith("dpm_")
+                and service_factory.id.endswith("_service")
+            ):
+                calls.append(f"{node.name}:{service_factory.id}.{child.func.attr}")
+    return calls
+
+
 def test_routers_do_not_import_service_factories_or_clients() -> None:
     offenders = {
         path.name: sorted(
@@ -31,6 +66,15 @@ def test_routers_do_not_import_service_factories_or_clients() -> None:
         for path in _ROUTER_ROOT.glob("*.py")
     }
     offenders = {name: imports for name, imports in offenders.items() if imports}
+
+    assert offenders == {}
+
+
+def test_dpm_router_handlers_delegate_service_calls_to_private_helpers() -> None:
+    offenders = {
+        path.name: _direct_dpm_service_calls(path) for path in _ROUTER_ROOT.glob("dpm_*.py")
+    }
+    offenders = {name: calls for name, calls in offenders.items() if calls}
 
     assert offenders == {}
 


### PR DESCRIPTION
## Summary
- Completes the DPM route-handler ownership cleanup by moving remaining PM-quality, campaign lifecycle, maker-checker, workflow, and filter construction logic behind private helpers.
- Extends route-boundary regression coverage so router handlers stay as single-statement delegators, do not call service factories directly, do not touch correlation directly, and delegate filter construction below the FastAPI handler layer.
- Applies the same single-statement delegation pattern to selected analytics diagnostics, portfolio transactions, Workbench performance/advisor-brief/evidence, and Workbench risk routes without changing public paths, response models, query parameters, OpenAPI metadata, or upstream authority.

## Validation
- `python -m pytest tests/unit/test_dpm_command_center_service.py tests/unit/test_dpm_construction_service.py tests/contract/test_dpm_command_center_contract.py tests/contract/test_dpm_construction_contract.py tests/unit/test_router_layer_boundaries.py -q` -> 55 passed.
- `make check` -> ruff check passed; ruff format check passed; monetary float guard passed (`Findings=189, allowlisted=189`); mypy passed across 396 source files; Workbench contract passed; full unit/contract suite passed (`754 passed`).

## Sibling repo pulse
Read-only pulse before PR:
- `lotus-core`: `perf/api-query-index-optimization`, head `98ce8814 perf: parallelize analytics performance horizon reads`, clean.
- `lotus-performance`: `feat/performance-modular-refactor`, head `9f87ba0 Harden workspace summary nullable numerics`, clean.
- `lotus-manage`: `feat/manage-hardening-wave-2`, head `0b7ab70 move run support config out of router`, clean.

## Governance
- 50 small commits preserved for non-squash merge history.
- Code/test-only route ownership refactor; no durable platform/repository docs, wiki, RFC, context, contract, or operator-facing truth changed.
- No wiki source update required for this slice.