### PR TITLE
Refactor gateway service dependency boundaries batch 12

### DIFF
--- a/src/app/services/advise_client_factory.py
+++ b/src/app/services/advise_client_factory.py
@@ -2,6 +2,15 @@ from app.clients.advise_client import AdviseClient
 from app.config import settings
 
 
+def advise_client_signature() -> tuple[object, ...]:
+    return (
+        settings.decisioning_service_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
 def build_advise_client() -> AdviseClient:
     return AdviseClient(
         base_url=settings.decisioning_service_base_url,

--- a/src/app/services/advisor_cockpit_service.py
+++ b/src/app/services/advisor_cockpit_service.py
@@ -1,12 +1,12 @@
 from typing import Any
 
-from app.clients.advise_client import AdviseClient
 from app.contracts.advisor_cockpit import AdvisorCockpitEnvelopeResponse
+from app.services.upstream_client_protocols import AdvisorCockpitClient
 from app.services.upstream_envelope import build_gateway_envelope, raise_for_upstream_error
 
 
 class AdvisorCockpitService:
-    def __init__(self, advise_client: AdviseClient):
+    def __init__(self, advise_client: AdvisorCockpitClient):
         self._advise_client = advise_client
 
     async def list_actions(

--- a/src/app/services/advisory_policy_service.py
+++ b/src/app/services/advisory_policy_service.py
@@ -1,12 +1,12 @@
 from typing import Any
 
-from app.clients.advise_client import AdviseClient
 from app.contracts.advisory_policy import AdvisoryPolicyEnvelopeResponse
+from app.services.upstream_client_protocols import AdvisoryPolicyClient
 from app.services.upstream_envelope import build_gateway_envelope, raise_for_upstream_error
 
 
 class AdvisoryPolicyService:
-    def __init__(self, advise_client: AdviseClient):
+    def __init__(self, advise_client: AdvisoryPolicyClient):
         self._advise_client = advise_client
 
     async def list_policy_packs(self, correlation_id: str) -> AdvisoryPolicyEnvelopeResponse:

--- a/src/app/services/advisory_service_factory.py
+++ b/src/app/services/advisory_service_factory.py
@@ -1,5 +1,4 @@
-from app.config import settings
-from app.services.advise_client_factory import build_advise_client
+from app.services.advise_client_factory import advise_client_signature, build_advise_client
 from app.services.advisor_cockpit_service import AdvisorCockpitService
 from app.services.advisory_policy_service import AdvisoryPolicyService
 from app.services.advisory_workspace_service import AdvisoryWorkspaceService
@@ -8,12 +7,7 @@ from app.services.proposal_service import ProposalService
 
 
 def advisory_service_signature() -> tuple[object, ...]:
-    return (
-        settings.decisioning_service_base_url,
-        settings.upstream_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
-    )
+    return advise_client_signature()
 
 
 def build_advisory_policy_service() -> AdvisoryPolicyService:

--- a/src/app/services/advisory_service_factory.py
+++ b/src/app/services/advisory_service_factory.py
@@ -1,9 +1,19 @@
+from app.config import settings
 from app.services.advise_client_factory import build_advise_client
 from app.services.advisor_cockpit_service import AdvisorCockpitService
 from app.services.advisory_policy_service import AdvisoryPolicyService
 from app.services.advisory_workspace_service import AdvisoryWorkspaceService
 from app.services.bank_demo_proof_service import BankDemoProofService
 from app.services.proposal_service import ProposalService
+
+
+def advisory_service_signature() -> tuple[object, ...]:
+    return (
+        settings.decisioning_service_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
 
 
 def build_advisory_policy_service() -> AdvisoryPolicyService:

--- a/src/app/services/advisory_service_provider.py
+++ b/src/app/services/advisory_service_provider.py
@@ -1,6 +1,7 @@
 from app.services.advisor_cockpit_service import AdvisorCockpitService
 from app.services.advisory_policy_service import AdvisoryPolicyService
 from app.services.advisory_service_factory import (
+    advisory_service_signature,
     build_advisor_cockpit_service,
     build_advisory_policy_service,
     build_advisory_workspace_service,
@@ -11,22 +12,58 @@ from app.services.advisory_workspace_service import AdvisoryWorkspaceService
 from app.services.bank_demo_proof_service import BankDemoProofService
 from app.services.proposal_service import ProposalService
 
+_ADVISORY_POLICY_SERVICE: AdvisoryPolicyService | None = None
+_ADVISORY_POLICY_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_ADVISORY_WORKSPACE_SERVICE: AdvisoryWorkspaceService | None = None
+_ADVISORY_WORKSPACE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_ADVISOR_COCKPIT_SERVICE: AdvisorCockpitService | None = None
+_ADVISOR_COCKPIT_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_BANK_DEMO_PROOF_SERVICE: BankDemoProofService | None = None
+_BANK_DEMO_PROOF_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_PROPOSAL_SERVICE: ProposalService | None = None
+_PROPOSAL_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+
 
 def advisory_policy_service() -> AdvisoryPolicyService:
-    return build_advisory_policy_service()
+    global _ADVISORY_POLICY_SERVICE, _ADVISORY_POLICY_SERVICE_SIGNATURE
+    signature = advisory_service_signature()
+    if _ADVISORY_POLICY_SERVICE is None or _ADVISORY_POLICY_SERVICE_SIGNATURE != signature:
+        _ADVISORY_POLICY_SERVICE = build_advisory_policy_service()
+        _ADVISORY_POLICY_SERVICE_SIGNATURE = signature
+    return _ADVISORY_POLICY_SERVICE
 
 
 def advisory_workspace_service() -> AdvisoryWorkspaceService:
-    return build_advisory_workspace_service()
+    global _ADVISORY_WORKSPACE_SERVICE, _ADVISORY_WORKSPACE_SERVICE_SIGNATURE
+    signature = advisory_service_signature()
+    if _ADVISORY_WORKSPACE_SERVICE is None or _ADVISORY_WORKSPACE_SERVICE_SIGNATURE != signature:
+        _ADVISORY_WORKSPACE_SERVICE = build_advisory_workspace_service()
+        _ADVISORY_WORKSPACE_SERVICE_SIGNATURE = signature
+    return _ADVISORY_WORKSPACE_SERVICE
 
 
 def advisor_cockpit_service() -> AdvisorCockpitService:
-    return build_advisor_cockpit_service()
+    global _ADVISOR_COCKPIT_SERVICE, _ADVISOR_COCKPIT_SERVICE_SIGNATURE
+    signature = advisory_service_signature()
+    if _ADVISOR_COCKPIT_SERVICE is None or _ADVISOR_COCKPIT_SERVICE_SIGNATURE != signature:
+        _ADVISOR_COCKPIT_SERVICE = build_advisor_cockpit_service()
+        _ADVISOR_COCKPIT_SERVICE_SIGNATURE = signature
+    return _ADVISOR_COCKPIT_SERVICE
 
 
 def bank_demo_proof_service() -> BankDemoProofService:
-    return build_bank_demo_proof_service()
+    global _BANK_DEMO_PROOF_SERVICE, _BANK_DEMO_PROOF_SERVICE_SIGNATURE
+    signature = advisory_service_signature()
+    if _BANK_DEMO_PROOF_SERVICE is None or _BANK_DEMO_PROOF_SERVICE_SIGNATURE != signature:
+        _BANK_DEMO_PROOF_SERVICE = build_bank_demo_proof_service()
+        _BANK_DEMO_PROOF_SERVICE_SIGNATURE = signature
+    return _BANK_DEMO_PROOF_SERVICE
 
 
 def proposal_service() -> ProposalService:
-    return build_proposal_service()
+    global _PROPOSAL_SERVICE, _PROPOSAL_SERVICE_SIGNATURE
+    signature = advisory_service_signature()
+    if _PROPOSAL_SERVICE is None or _PROPOSAL_SERVICE_SIGNATURE != signature:
+        _PROPOSAL_SERVICE = build_proposal_service()
+        _PROPOSAL_SERVICE_SIGNATURE = signature
+    return _PROPOSAL_SERVICE

--- a/src/app/services/advisory_service_provider.py
+++ b/src/app/services/advisory_service_provider.py
@@ -11,6 +11,7 @@ from app.services.advisory_service_factory import (
 from app.services.advisory_workspace_service import AdvisoryWorkspaceService
 from app.services.bank_demo_proof_service import BankDemoProofService
 from app.services.proposal_service import ProposalService
+from app.services.service_provider_cache import resolve_cached_service
 
 _ADVISORY_POLICY_SERVICE: AdvisoryPolicyService | None = None
 _ADVISORY_POLICY_SERVICE_SIGNATURE: tuple[object, ...] | None = None
@@ -26,44 +27,64 @@ _PROPOSAL_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 
 def advisory_policy_service() -> AdvisoryPolicyService:
     global _ADVISORY_POLICY_SERVICE, _ADVISORY_POLICY_SERVICE_SIGNATURE
-    signature = advisory_service_signature()
-    if _ADVISORY_POLICY_SERVICE is None or _ADVISORY_POLICY_SERVICE_SIGNATURE != signature:
-        _ADVISORY_POLICY_SERVICE = build_advisory_policy_service()
-        _ADVISORY_POLICY_SERVICE_SIGNATURE = signature
-    return _ADVISORY_POLICY_SERVICE
+    service, signature = resolve_cached_service(
+        _ADVISORY_POLICY_SERVICE,
+        _ADVISORY_POLICY_SERVICE_SIGNATURE,
+        advisory_service_signature(),
+        build_advisory_policy_service,
+    )
+    _ADVISORY_POLICY_SERVICE = service
+    _ADVISORY_POLICY_SERVICE_SIGNATURE = signature
+    return service
 
 
 def advisory_workspace_service() -> AdvisoryWorkspaceService:
     global _ADVISORY_WORKSPACE_SERVICE, _ADVISORY_WORKSPACE_SERVICE_SIGNATURE
-    signature = advisory_service_signature()
-    if _ADVISORY_WORKSPACE_SERVICE is None or _ADVISORY_WORKSPACE_SERVICE_SIGNATURE != signature:
-        _ADVISORY_WORKSPACE_SERVICE = build_advisory_workspace_service()
-        _ADVISORY_WORKSPACE_SERVICE_SIGNATURE = signature
-    return _ADVISORY_WORKSPACE_SERVICE
+    service, signature = resolve_cached_service(
+        _ADVISORY_WORKSPACE_SERVICE,
+        _ADVISORY_WORKSPACE_SERVICE_SIGNATURE,
+        advisory_service_signature(),
+        build_advisory_workspace_service,
+    )
+    _ADVISORY_WORKSPACE_SERVICE = service
+    _ADVISORY_WORKSPACE_SERVICE_SIGNATURE = signature
+    return service
 
 
 def advisor_cockpit_service() -> AdvisorCockpitService:
     global _ADVISOR_COCKPIT_SERVICE, _ADVISOR_COCKPIT_SERVICE_SIGNATURE
-    signature = advisory_service_signature()
-    if _ADVISOR_COCKPIT_SERVICE is None or _ADVISOR_COCKPIT_SERVICE_SIGNATURE != signature:
-        _ADVISOR_COCKPIT_SERVICE = build_advisor_cockpit_service()
-        _ADVISOR_COCKPIT_SERVICE_SIGNATURE = signature
-    return _ADVISOR_COCKPIT_SERVICE
+    service, signature = resolve_cached_service(
+        _ADVISOR_COCKPIT_SERVICE,
+        _ADVISOR_COCKPIT_SERVICE_SIGNATURE,
+        advisory_service_signature(),
+        build_advisor_cockpit_service,
+    )
+    _ADVISOR_COCKPIT_SERVICE = service
+    _ADVISOR_COCKPIT_SERVICE_SIGNATURE = signature
+    return service
 
 
 def bank_demo_proof_service() -> BankDemoProofService:
     global _BANK_DEMO_PROOF_SERVICE, _BANK_DEMO_PROOF_SERVICE_SIGNATURE
-    signature = advisory_service_signature()
-    if _BANK_DEMO_PROOF_SERVICE is None or _BANK_DEMO_PROOF_SERVICE_SIGNATURE != signature:
-        _BANK_DEMO_PROOF_SERVICE = build_bank_demo_proof_service()
-        _BANK_DEMO_PROOF_SERVICE_SIGNATURE = signature
-    return _BANK_DEMO_PROOF_SERVICE
+    service, signature = resolve_cached_service(
+        _BANK_DEMO_PROOF_SERVICE,
+        _BANK_DEMO_PROOF_SERVICE_SIGNATURE,
+        advisory_service_signature(),
+        build_bank_demo_proof_service,
+    )
+    _BANK_DEMO_PROOF_SERVICE = service
+    _BANK_DEMO_PROOF_SERVICE_SIGNATURE = signature
+    return service
 
 
 def proposal_service() -> ProposalService:
     global _PROPOSAL_SERVICE, _PROPOSAL_SERVICE_SIGNATURE
-    signature = advisory_service_signature()
-    if _PROPOSAL_SERVICE is None or _PROPOSAL_SERVICE_SIGNATURE != signature:
-        _PROPOSAL_SERVICE = build_proposal_service()
-        _PROPOSAL_SERVICE_SIGNATURE = signature
-    return _PROPOSAL_SERVICE
+    service, signature = resolve_cached_service(
+        _PROPOSAL_SERVICE,
+        _PROPOSAL_SERVICE_SIGNATURE,
+        advisory_service_signature(),
+        build_proposal_service,
+    )
+    _PROPOSAL_SERVICE = service
+    _PROPOSAL_SERVICE_SIGNATURE = signature
+    return service

--- a/src/app/services/analytics_client_factory.py
+++ b/src/app/services/analytics_client_factory.py
@@ -2,6 +2,24 @@ from app.clients.lotus_analytics_client import LotusAnalyticsClient
 from app.config import settings
 
 
+def performance_analytics_client_signature() -> tuple[object, ...]:
+    return (
+        settings.performance_analytics_base_url,
+        settings.performance_analytics_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
+def risk_analytics_client_signature() -> tuple[object, ...]:
+    return (
+        settings.risk_analytics_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
 def build_performance_analytics_client() -> LotusAnalyticsClient:
     return LotusAnalyticsClient(
         base_url=settings.performance_analytics_base_url,

--- a/src/app/services/archive_client_factory.py
+++ b/src/app/services/archive_client_factory.py
@@ -2,6 +2,15 @@ from app.clients.archive_client import ArchiveClient
 from app.config import settings
 
 
+def archive_client_signature() -> tuple[object, ...]:
+    return (
+        settings.archive_service_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
 def build_archive_client() -> ArchiveClient:
     return ArchiveClient(
         base_url=settings.archive_service_base_url,

--- a/src/app/services/archive_document_service_factory.py
+++ b/src/app/services/archive_document_service_factory.py
@@ -3,6 +3,16 @@ from app.services.archive_client_factory import build_archive_client
 from app.services.archive_document_service import ArchiveDocumentService
 
 
+def archive_document_service_signature() -> tuple[object, ...]:
+    return (
+        settings.archive_service_base_url,
+        settings.contract_version,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
 def build_archive_document_service() -> ArchiveDocumentService:
     return ArchiveDocumentService(
         archive_client=build_archive_client(),

--- a/src/app/services/archive_document_service_factory.py
+++ b/src/app/services/archive_document_service_factory.py
@@ -1,15 +1,12 @@
 from app.config import settings
-from app.services.archive_client_factory import build_archive_client
+from app.services.archive_client_factory import archive_client_signature, build_archive_client
 from app.services.archive_document_service import ArchiveDocumentService
 
 
 def archive_document_service_signature() -> tuple[object, ...]:
     return (
-        settings.archive_service_base_url,
+        *archive_client_signature(),
         settings.contract_version,
-        settings.upstream_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
     )
 
 

--- a/src/app/services/bank_demo_proof_service.py
+++ b/src/app/services/bank_demo_proof_service.py
@@ -1,12 +1,12 @@
 from typing import Any
 
-from app.clients.advise_client import AdviseClient
 from app.contracts.bank_demo_proof import BankDemoProofEnvelopeResponse
+from app.services.upstream_client_protocols import BankDemoProofClient
 from app.services.upstream_envelope import build_gateway_envelope, raise_for_upstream_error
 
 
 class BankDemoProofService:
-    def __init__(self, advise_client: AdviseClient):
+    def __init__(self, advise_client: BankDemoProofClient):
         self._advise_client = advise_client
 
     async def get_scenario_contract(self, *, correlation_id: str) -> BankDemoProofEnvelopeResponse:

--- a/src/app/services/composite_performance_service_factory.py
+++ b/src/app/services/composite_performance_service_factory.py
@@ -1,5 +1,15 @@
+from app.config import settings
 from app.services.analytics_client_factory import build_performance_analytics_client
 from app.services.composite_performance_service import CompositePerformanceService
+
+
+def composite_performance_service_signature() -> tuple[object, ...]:
+    return (
+        settings.performance_analytics_base_url,
+        settings.performance_analytics_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
 
 
 def build_composite_performance_service() -> CompositePerformanceService:

--- a/src/app/services/composite_performance_service_factory.py
+++ b/src/app/services/composite_performance_service_factory.py
@@ -1,15 +1,12 @@
-from app.config import settings
-from app.services.analytics_client_factory import build_performance_analytics_client
+from app.services.analytics_client_factory import (
+    build_performance_analytics_client,
+    performance_analytics_client_signature,
+)
 from app.services.composite_performance_service import CompositePerformanceService
 
 
 def composite_performance_service_signature() -> tuple[object, ...]:
-    return (
-        settings.performance_analytics_base_url,
-        settings.performance_analytics_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
-    )
+    return performance_analytics_client_signature()
 
 
 def build_composite_performance_service() -> CompositePerformanceService:

--- a/src/app/services/domain_product_catalog_service_factory.py
+++ b/src/app/services/domain_product_catalog_service_factory.py
@@ -2,6 +2,14 @@ from app.config import settings
 from app.services.domain_product_catalog_service import DomainProductCatalogService
 
 
+def domain_product_catalog_service_signature() -> tuple[object, ...]:
+    return (
+        settings.domain_product_catalog_path,
+        settings.domain_product_dependency_graph_path,
+        settings.domain_product_live_trust_certification_path,
+    )
+
+
 def build_domain_product_catalog_service() -> DomainProductCatalogService:
     return DomainProductCatalogService(
         catalog_path=settings.domain_product_catalog_path,

--- a/src/app/services/dpm_command_center_ai_context.py
+++ b/src/app/services/dpm_command_center_ai_context.py
@@ -222,29 +222,6 @@ def pm_quality_summary_task_payload(
     return task_payload
 
 
-def workflow_pack_task_request(
-    *,
-    correlation_id: str,
-    summary: str,
-    payload: dict[str, object],
-    source_refs: list[str],
-) -> dict[str, object]:
-    return {
-        "task_id": "explain.v1",
-        "input_mode": "STRUCTURED_CONTEXT",
-        "caller": {
-            "caller_app": "lotus-gateway",
-            "correlation_id": correlation_id,
-        },
-        "context": {
-            "summary": summary,
-            "payload": payload,
-            "source_refs": source_refs,
-        },
-        "expected_output_label": "EXPLANATION_ONLY",
-    }
-
-
 def _source_ref_label(value: object) -> str | None:
     if isinstance(value, str):
         return value

--- a/src/app/services/dpm_command_center_service.py
+++ b/src/app/services/dpm_command_center_service.py
@@ -3,7 +3,6 @@ from typing import Any
 from fastapi import HTTPException, status
 
 from app.clients.dpm_client import DpmClient
-from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_command_center import (
     DpmCommandCenterGatewayResponse,
@@ -21,6 +20,7 @@ from app.contracts.dpm_command_center import (
 )
 from app.services import dpm_command_center_ai_context, dpm_command_center_supportability
 from app.services.lotus_ai_workflow import require_lotus_ai_client
+from app.services.upstream_client_protocols import LotusAiWorkflowClient
 from app.services.upstream_envelope import (
     build_upstream_status_gateway_envelope,
     raise_product_safe_service_error,
@@ -29,7 +29,11 @@ from app.services.upstream_envelope import (
 
 
 class DpmCommandCenterService:
-    def __init__(self, dpm_client: DpmClient, lotus_ai_client: LotusAiClient | None = None):
+    def __init__(
+        self,
+        dpm_client: DpmClient,
+        lotus_ai_client: LotusAiWorkflowClient | None = None,
+    ):
         self._dpm_client = dpm_client
         self._lotus_ai_client = lotus_ai_client
 

--- a/src/app/services/dpm_command_center_service.py
+++ b/src/app/services/dpm_command_center_service.py
@@ -19,7 +19,10 @@ from app.contracts.dpm_command_center import (
     DpmPortfolioMemoryGatewayResponse,
 )
 from app.services import dpm_command_center_ai_context, dpm_command_center_supportability
-from app.services.lotus_ai_workflow import require_lotus_ai_client
+from app.services.lotus_ai_workflow import (
+    build_workflow_pack_task_request,
+    require_lotus_ai_client,
+)
 from app.services.upstream_client_protocols import LotusAiWorkflowClient
 from app.services.upstream_envelope import (
     build_upstream_status_gateway_envelope,
@@ -192,7 +195,7 @@ class DpmCommandCenterService:
             environment="DEVELOPMENT",
             caller_identity_class="INTERNAL_SERVICE",
             workflow_surface="dpm-exception-summary-ai-evidence",
-            task_request=dpm_command_center_ai_context.workflow_pack_task_request(
+            task_request=build_workflow_pack_task_request(
                 correlation_id=correlation_id,
                 summary=(
                     "Generate review-gated DPM exception summary from manage-owned "
@@ -454,7 +457,7 @@ class DpmCommandCenterService:
             environment="DEVELOPMENT",
             caller_identity_class="INTERNAL_SERVICE",
             workflow_surface="dpm-outcome-review-ai-evidence",
-            task_request=dpm_command_center_ai_context.workflow_pack_task_request(
+            task_request=build_workflow_pack_task_request(
                 correlation_id=correlation_id,
                 summary=(
                     "Generate review-gated outcome-review narrative from bounded "
@@ -850,7 +853,7 @@ class DpmCommandCenterService:
             environment="DEVELOPMENT",
             caller_identity_class="INTERNAL_SERVICE",
             workflow_surface="dpm-pm-quality-ai-evidence",
-            task_request=dpm_command_center_ai_context.workflow_pack_task_request(
+            task_request=build_workflow_pack_task_request(
                 correlation_id=correlation_id,
                 summary=(
                     "Generate review-gated PM operating quality summary from "

--- a/src/app/services/dpm_construction_service.py
+++ b/src/app/services/dpm_construction_service.py
@@ -1,11 +1,11 @@
 from typing import Any
 
-from app.clients.dpm_client import DpmClient
 from app.contracts.dpm_construction import (
     DpmConstructionErrorDetail,
     DpmConstructionGatewayResponse,
     DpmConstructionSupportability,
 )
+from app.services.upstream_client_protocols import DpmConstructionClient
 from app.services.upstream_envelope import (
     build_upstream_status_gateway_envelope,
     raise_product_safe_upstream_error,
@@ -13,7 +13,7 @@ from app.services.upstream_envelope import (
 
 
 class DpmConstructionService:
-    def __init__(self, dpm_client: DpmClient):
+    def __init__(self, dpm_client: DpmConstructionClient):
         self._dpm_client = dpm_client
 
     async def generate_alternative_set(

--- a/src/app/services/dpm_proof_pack_service.py
+++ b/src/app/services/dpm_proof_pack_service.py
@@ -2,8 +2,6 @@ from typing import Any
 
 from fastapi import status
 
-from app.clients.dpm_client import DpmClient
-from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_proof_packs import (
     DpmProofPackErrorDetail,
@@ -14,6 +12,7 @@ from app.contracts.dpm_proof_packs import (
     DpmProofPackSupportability,
 )
 from app.services.lotus_ai_workflow import require_lotus_ai_client
+from app.services.upstream_client_protocols import DpmProofPackClient, LotusAiWorkflowClient
 from app.services.upstream_envelope import (
     build_upstream_status_gateway_envelope,
     raise_product_safe_service_error,
@@ -22,7 +21,11 @@ from app.services.upstream_envelope import (
 
 
 class DpmProofPackService:
-    def __init__(self, dpm_client: DpmClient, lotus_ai_client: LotusAiClient | None = None):
+    def __init__(
+        self,
+        dpm_client: DpmProofPackClient,
+        lotus_ai_client: LotusAiWorkflowClient | None = None,
+    ):
         self._dpm_client = dpm_client
         self._lotus_ai_client = lotus_ai_client
 

--- a/src/app/services/dpm_proof_pack_service.py
+++ b/src/app/services/dpm_proof_pack_service.py
@@ -22,6 +22,20 @@ from app.services.upstream_envelope import (
     raise_product_safe_upstream_error,
 )
 
+_PROOF_PACK_PM_MEMO_BLOCKED_ACTIONS = [
+    "place_orders",
+    "approve_rebalance",
+    "override_controls",
+    "invent_missing_evidence",
+    "contact_client",
+]
+_PROOF_PACK_PM_MEMO_UNSUPPORTED_CLAIMS = [
+    "client_contact",
+    "trade_approval",
+    "portfolio_manager_scoring",
+    "execution_instruction",
+]
+
 
 class DpmProofPackService:
     def __init__(
@@ -124,24 +138,7 @@ class DpmProofPackService:
         task_payload: dict[str, object] = {
             "ai_evidence_input": manage_payload,
             "memo_request": memo_request,
-            "supportability": {
-                "source_state": supportability.state,
-                "reason_codes": supportability.reason_codes,
-                "blocked_actions": [
-                    "place_orders",
-                    "approve_rebalance",
-                    "override_controls",
-                    "invent_missing_evidence",
-                    "contact_client",
-                ],
-                "requires_human_review": True,
-                "unsupported_claims": [
-                    "client_contact",
-                    "trade_approval",
-                    "portfolio_manager_scoring",
-                    "execution_instruction",
-                ],
-            },
+            "supportability": _proof_pack_pm_memo_supportability_payload(supportability),
         }
         ai_status, ai_payload = await lotus_ai_client.execute_workflow_pack(
             pack_id="dpm_pm_memo.pack",
@@ -298,6 +295,18 @@ def _proof_pack_ai_source_refs(payload: dict[str, Any], proof_pack_id: str) -> l
     source_refs.append(f"lotus-manage:proof-pack-ai-evidence:{proof_pack_id}")
 
     return sorted(set(source_refs))
+
+
+def _proof_pack_pm_memo_supportability_payload(
+    supportability: DpmProofPackSupportability,
+) -> dict[str, object]:
+    return {
+        "source_state": supportability.state,
+        "reason_codes": supportability.reason_codes,
+        "blocked_actions": _PROOF_PACK_PM_MEMO_BLOCKED_ACTIONS,
+        "requires_human_review": True,
+        "unsupported_claims": _PROOF_PACK_PM_MEMO_UNSUPPORTED_CLAIMS,
+    }
 
 
 def _raise_manage_upstream_error(upstream_status: int, payload: dict[str, Any]) -> None:

--- a/src/app/services/dpm_proof_pack_service.py
+++ b/src/app/services/dpm_proof_pack_service.py
@@ -11,7 +11,10 @@ from app.contracts.dpm_proof_packs import (
     DpmProofPackMemoRequest,
     DpmProofPackSupportability,
 )
-from app.services.lotus_ai_workflow import require_lotus_ai_client
+from app.services.lotus_ai_workflow import (
+    build_workflow_pack_task_request,
+    require_lotus_ai_client,
+)
 from app.services.upstream_client_protocols import DpmProofPackClient, LotusAiWorkflowClient
 from app.services.upstream_envelope import (
     build_upstream_status_gateway_envelope,
@@ -118,7 +121,7 @@ class DpmProofPackService:
             "requested_outputs": request.requested_outputs,
             "audience": request.audience,
         }
-        task_payload = {
+        task_payload: dict[str, object] = {
             "ai_evidence_input": manage_payload,
             "memo_request": memo_request,
             "supportability": {
@@ -146,23 +149,15 @@ class DpmProofPackService:
             environment="DEVELOPMENT",
             caller_identity_class="INTERNAL_SERVICE",
             workflow_surface="dpm-proof-pack-ai-evidence",
-            task_request={
-                "task_id": "explain.v1",
-                "input_mode": "STRUCTURED_CONTEXT",
-                "caller": {
-                    "caller_app": "lotus-gateway",
-                    "correlation_id": correlation_id,
-                },
-                "context": {
-                    "summary": (
-                        "Generate review-gated proof-pack PM memo from bounded AI evidence "
-                        f"for {proof_pack_id}."
-                    ),
-                    "payload": task_payload,
-                    "source_refs": _proof_pack_ai_source_refs(manage_payload, proof_pack_id),
-                },
-                "expected_output_label": "EXPLANATION_ONLY",
-            },
+            task_request=build_workflow_pack_task_request(
+                correlation_id=correlation_id,
+                summary=(
+                    "Generate review-gated proof-pack PM memo from bounded AI evidence "
+                    f"for {proof_pack_id}."
+                ),
+                payload=task_payload,
+                source_refs=_proof_pack_ai_source_refs(manage_payload, proof_pack_id),
+            ),
             correlation_id=correlation_id,
         )
         if ai_status >= status.HTTP_400_BAD_REQUEST:

--- a/src/app/services/dpm_service_factory.py
+++ b/src/app/services/dpm_service_factory.py
@@ -9,14 +9,28 @@ from app.services.dpm_proof_pack_service import DpmProofPackService
 from app.services.dpm_wave_service import DpmWaveService
 
 
-def dpm_service_signature() -> tuple[object, ...]:
+def manage_client_signature() -> tuple[object, ...]:
     return (
         settings.management_service_base_url,
-        settings.ai_service_base_url,
         settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
+def lotus_ai_client_signature() -> tuple[object, ...]:
+    return (
+        settings.ai_service_base_url,
         settings.ai_service_timeout_seconds,
         settings.upstream_max_retries,
         settings.upstream_retry_backoff_seconds,
+    )
+
+
+def dpm_service_signature() -> tuple[object, ...]:
+    return (
+        *manage_client_signature(),
+        *lotus_ai_client_signature(),
     )
 
 

--- a/src/app/services/dpm_service_factory.py
+++ b/src/app/services/dpm_service_factory.py
@@ -9,6 +9,17 @@ from app.services.dpm_proof_pack_service import DpmProofPackService
 from app.services.dpm_wave_service import DpmWaveService
 
 
+def dpm_service_signature() -> tuple[object, ...]:
+    return (
+        settings.management_service_base_url,
+        settings.ai_service_base_url,
+        settings.upstream_timeout_seconds,
+        settings.ai_service_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
 def build_manage_client() -> DpmClient:
     return DpmClient(
         base_url=settings.management_service_base_url,

--- a/src/app/services/dpm_service_provider.py
+++ b/src/app/services/dpm_service_provider.py
@@ -6,21 +6,51 @@ from app.services.dpm_service_factory import (
     build_dpm_construction_service,
     build_dpm_proof_pack_service,
     build_dpm_wave_service,
+    dpm_service_signature,
 )
 from app.services.dpm_wave_service import DpmWaveService
 
+_DPM_COMMAND_CENTER_SERVICE: DpmCommandCenterService | None = None
+_DPM_COMMAND_CENTER_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_DPM_CONSTRUCTION_SERVICE: DpmConstructionService | None = None
+_DPM_CONSTRUCTION_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_DPM_PROOF_PACK_SERVICE: DpmProofPackService | None = None
+_DPM_PROOF_PACK_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_DPM_WAVE_SERVICE: DpmWaveService | None = None
+_DPM_WAVE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+
 
 def dpm_command_center_service() -> DpmCommandCenterService:
-    return build_dpm_command_center_service()
+    global _DPM_COMMAND_CENTER_SERVICE, _DPM_COMMAND_CENTER_SERVICE_SIGNATURE
+    signature = dpm_service_signature()
+    if _DPM_COMMAND_CENTER_SERVICE is None or _DPM_COMMAND_CENTER_SERVICE_SIGNATURE != signature:
+        _DPM_COMMAND_CENTER_SERVICE = build_dpm_command_center_service()
+        _DPM_COMMAND_CENTER_SERVICE_SIGNATURE = signature
+    return _DPM_COMMAND_CENTER_SERVICE
 
 
 def dpm_construction_service() -> DpmConstructionService:
-    return build_dpm_construction_service()
+    global _DPM_CONSTRUCTION_SERVICE, _DPM_CONSTRUCTION_SERVICE_SIGNATURE
+    signature = dpm_service_signature()
+    if _DPM_CONSTRUCTION_SERVICE is None or _DPM_CONSTRUCTION_SERVICE_SIGNATURE != signature:
+        _DPM_CONSTRUCTION_SERVICE = build_dpm_construction_service()
+        _DPM_CONSTRUCTION_SERVICE_SIGNATURE = signature
+    return _DPM_CONSTRUCTION_SERVICE
 
 
 def dpm_proof_pack_service() -> DpmProofPackService:
-    return build_dpm_proof_pack_service()
+    global _DPM_PROOF_PACK_SERVICE, _DPM_PROOF_PACK_SERVICE_SIGNATURE
+    signature = dpm_service_signature()
+    if _DPM_PROOF_PACK_SERVICE is None or _DPM_PROOF_PACK_SERVICE_SIGNATURE != signature:
+        _DPM_PROOF_PACK_SERVICE = build_dpm_proof_pack_service()
+        _DPM_PROOF_PACK_SERVICE_SIGNATURE = signature
+    return _DPM_PROOF_PACK_SERVICE
 
 
 def dpm_wave_service() -> DpmWaveService:
-    return build_dpm_wave_service()
+    global _DPM_WAVE_SERVICE, _DPM_WAVE_SERVICE_SIGNATURE
+    signature = dpm_service_signature()
+    if _DPM_WAVE_SERVICE is None or _DPM_WAVE_SERVICE_SIGNATURE != signature:
+        _DPM_WAVE_SERVICE = build_dpm_wave_service()
+        _DPM_WAVE_SERVICE_SIGNATURE = signature
+    return _DPM_WAVE_SERVICE

--- a/src/app/services/dpm_service_provider.py
+++ b/src/app/services/dpm_service_provider.py
@@ -9,6 +9,7 @@ from app.services.dpm_service_factory import (
     dpm_service_signature,
 )
 from app.services.dpm_wave_service import DpmWaveService
+from app.services.service_provider_cache import resolve_cached_service
 
 _DPM_COMMAND_CENTER_SERVICE: DpmCommandCenterService | None = None
 _DPM_COMMAND_CENTER_SERVICE_SIGNATURE: tuple[object, ...] | None = None
@@ -22,35 +23,51 @@ _DPM_WAVE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 
 def dpm_command_center_service() -> DpmCommandCenterService:
     global _DPM_COMMAND_CENTER_SERVICE, _DPM_COMMAND_CENTER_SERVICE_SIGNATURE
-    signature = dpm_service_signature()
-    if _DPM_COMMAND_CENTER_SERVICE is None or _DPM_COMMAND_CENTER_SERVICE_SIGNATURE != signature:
-        _DPM_COMMAND_CENTER_SERVICE = build_dpm_command_center_service()
-        _DPM_COMMAND_CENTER_SERVICE_SIGNATURE = signature
-    return _DPM_COMMAND_CENTER_SERVICE
+    service, signature = resolve_cached_service(
+        _DPM_COMMAND_CENTER_SERVICE,
+        _DPM_COMMAND_CENTER_SERVICE_SIGNATURE,
+        dpm_service_signature(),
+        build_dpm_command_center_service,
+    )
+    _DPM_COMMAND_CENTER_SERVICE = service
+    _DPM_COMMAND_CENTER_SERVICE_SIGNATURE = signature
+    return service
 
 
 def dpm_construction_service() -> DpmConstructionService:
     global _DPM_CONSTRUCTION_SERVICE, _DPM_CONSTRUCTION_SERVICE_SIGNATURE
-    signature = dpm_service_signature()
-    if _DPM_CONSTRUCTION_SERVICE is None or _DPM_CONSTRUCTION_SERVICE_SIGNATURE != signature:
-        _DPM_CONSTRUCTION_SERVICE = build_dpm_construction_service()
-        _DPM_CONSTRUCTION_SERVICE_SIGNATURE = signature
-    return _DPM_CONSTRUCTION_SERVICE
+    service, signature = resolve_cached_service(
+        _DPM_CONSTRUCTION_SERVICE,
+        _DPM_CONSTRUCTION_SERVICE_SIGNATURE,
+        dpm_service_signature(),
+        build_dpm_construction_service,
+    )
+    _DPM_CONSTRUCTION_SERVICE = service
+    _DPM_CONSTRUCTION_SERVICE_SIGNATURE = signature
+    return service
 
 
 def dpm_proof_pack_service() -> DpmProofPackService:
     global _DPM_PROOF_PACK_SERVICE, _DPM_PROOF_PACK_SERVICE_SIGNATURE
-    signature = dpm_service_signature()
-    if _DPM_PROOF_PACK_SERVICE is None or _DPM_PROOF_PACK_SERVICE_SIGNATURE != signature:
-        _DPM_PROOF_PACK_SERVICE = build_dpm_proof_pack_service()
-        _DPM_PROOF_PACK_SERVICE_SIGNATURE = signature
-    return _DPM_PROOF_PACK_SERVICE
+    service, signature = resolve_cached_service(
+        _DPM_PROOF_PACK_SERVICE,
+        _DPM_PROOF_PACK_SERVICE_SIGNATURE,
+        dpm_service_signature(),
+        build_dpm_proof_pack_service,
+    )
+    _DPM_PROOF_PACK_SERVICE = service
+    _DPM_PROOF_PACK_SERVICE_SIGNATURE = signature
+    return service
 
 
 def dpm_wave_service() -> DpmWaveService:
     global _DPM_WAVE_SERVICE, _DPM_WAVE_SERVICE_SIGNATURE
-    signature = dpm_service_signature()
-    if _DPM_WAVE_SERVICE is None or _DPM_WAVE_SERVICE_SIGNATURE != signature:
-        _DPM_WAVE_SERVICE = build_dpm_wave_service()
-        _DPM_WAVE_SERVICE_SIGNATURE = signature
-    return _DPM_WAVE_SERVICE
+    service, signature = resolve_cached_service(
+        _DPM_WAVE_SERVICE,
+        _DPM_WAVE_SERVICE_SIGNATURE,
+        dpm_service_signature(),
+        build_dpm_wave_service,
+    )
+    _DPM_WAVE_SERVICE = service
+    _DPM_WAVE_SERVICE_SIGNATURE = signature
+    return service

--- a/src/app/services/dpm_wave_service.py
+++ b/src/app/services/dpm_wave_service.py
@@ -15,7 +15,10 @@ from app.contracts.dpm_waves import (
     DpmWaveMemoRequest,
     DpmWaveSupportability,
 )
-from app.services.lotus_ai_workflow import require_lotus_ai_client
+from app.services.lotus_ai_workflow import (
+    build_workflow_pack_task_request,
+    require_lotus_ai_client,
+)
 from app.services.upstream_client_protocols import LotusAiWorkflowClient
 from app.services.upstream_envelope import (
     build_upstream_status_gateway_envelope,
@@ -698,7 +701,7 @@ class DpmWaveService:
             "requested_outputs": request.requested_outputs,
             "audience": request.audience,
         }
-        task_payload = {
+        task_payload: dict[str, object] = {
             "wave_report_input": manage_payload,
             "memo_request": memo_request,
             "supportability": {
@@ -716,23 +719,15 @@ class DpmWaveService:
             environment="DEVELOPMENT",
             caller_identity_class="INTERNAL_SERVICE",
             workflow_surface="dpm-wave-ai-evidence",
-            task_request={
-                "task_id": "explain.v1",
-                "input_mode": "STRUCTURED_CONTEXT",
-                "caller": {
-                    "caller_app": "lotus-gateway",
-                    "correlation_id": correlation_id,
-                },
-                "context": {
-                    "summary": (
-                        "Generate review-gated DPM wave PM memo from manage-owned report input "
-                        f"for {wave_id}."
-                    ),
-                    "payload": task_payload,
-                    "source_refs": _wave_report_source_refs(manage_payload, wave_id),
-                },
-                "expected_output_label": "EXPLANATION_ONLY",
-            },
+            task_request=build_workflow_pack_task_request(
+                correlation_id=correlation_id,
+                summary=(
+                    "Generate review-gated DPM wave PM memo from manage-owned report input "
+                    f"for {wave_id}."
+                ),
+                payload=task_payload,
+                source_refs=_wave_report_source_refs(manage_payload, wave_id),
+            ),
             correlation_id=correlation_id,
         )
         if ai_status >= status.HTTP_400_BAD_REQUEST:
@@ -775,7 +770,7 @@ class DpmWaveService:
             "requested_outputs": request.requested_outputs,
             "audience": request.audience,
         }
-        task_payload = {
+        task_payload: dict[str, object] = {
             "wave_report_input": manage_payload,
             "handoff_summary_request": handoff_summary_request,
             "supportability": {
@@ -793,23 +788,15 @@ class DpmWaveService:
             environment="DEVELOPMENT",
             caller_identity_class="INTERNAL_SERVICE",
             workflow_surface="dpm-operations-handoff-ai-evidence",
-            task_request={
-                "task_id": "explain.v1",
-                "input_mode": "STRUCTURED_CONTEXT",
-                "caller": {
-                    "caller_app": "lotus-gateway",
-                    "correlation_id": correlation_id,
-                },
-                "context": {
-                    "summary": (
-                        "Generate review-gated DPM operations handoff summary from "
-                        f"manage-owned handoff evidence for {wave_id}."
-                    ),
-                    "payload": task_payload,
-                    "source_refs": _wave_report_source_refs(manage_payload, wave_id),
-                },
-                "expected_output_label": "EXPLANATION_ONLY",
-            },
+            task_request=build_workflow_pack_task_request(
+                correlation_id=correlation_id,
+                summary=(
+                    "Generate review-gated DPM operations handoff summary from "
+                    f"manage-owned handoff evidence for {wave_id}."
+                ),
+                payload=task_payload,
+                source_refs=_wave_report_source_refs(manage_payload, wave_id),
+            ),
             correlation_id=correlation_id,
         )
         if ai_status >= status.HTTP_400_BAD_REQUEST:

--- a/src/app/services/dpm_wave_service.py
+++ b/src/app/services/dpm_wave_service.py
@@ -704,14 +704,7 @@ class DpmWaveService:
         task_payload: dict[str, object] = {
             "wave_report_input": manage_payload,
             "memo_request": memo_request,
-            "supportability": {
-                "source_state": supportability.state,
-                "reason_codes": supportability.reason_codes,
-                "blocked_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
-                "forbidden_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
-                "requires_human_review": True,
-                "unsupported_claims": _WAVE_PM_MEMO_UNSUPPORTED_CLAIMS,
-            },
+            "supportability": _wave_pm_memo_supportability_payload(supportability),
         }
         ai_status, ai_payload = await lotus_ai_client.execute_workflow_pack(
             pack_id="dpm_wave_pm_memo.pack",
@@ -773,14 +766,7 @@ class DpmWaveService:
         task_payload: dict[str, object] = {
             "wave_report_input": manage_payload,
             "handoff_summary_request": handoff_summary_request,
-            "supportability": {
-                "source_state": supportability.state,
-                "reason_codes": supportability.reason_codes,
-                "blocked_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
-                "forbidden_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
-                "requires_human_review": True,
-                "unsupported_claims": _OPERATIONS_HANDOFF_UNSUPPORTED_CLAIMS,
-            },
+            "supportability": _operations_handoff_supportability_payload(supportability),
         }
         ai_status, ai_payload = await lotus_ai_client.execute_workflow_pack(
             pack_id="dpm_operations_handoff_summary.pack",
@@ -951,6 +937,32 @@ def _wave_report_source_refs(payload: dict[str, Any], wave_id: str) -> list[str]
 def _source_ref_token(value: object) -> str:
     token = str(value)
     return token.removeprefix("report-input:")
+
+
+def _wave_pm_memo_supportability_payload(
+    supportability: DpmWaveSupportability,
+) -> dict[str, object]:
+    return {
+        "source_state": supportability.state,
+        "reason_codes": supportability.reason_codes,
+        "blocked_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
+        "forbidden_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
+        "requires_human_review": True,
+        "unsupported_claims": _WAVE_PM_MEMO_UNSUPPORTED_CLAIMS,
+    }
+
+
+def _operations_handoff_supportability_payload(
+    supportability: DpmWaveSupportability,
+) -> dict[str, object]:
+    return {
+        "source_state": supportability.state,
+        "reason_codes": supportability.reason_codes,
+        "blocked_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
+        "forbidden_actions": _WAVE_PM_MEMO_BLOCKED_ACTIONS,
+        "requires_human_review": True,
+        "unsupported_claims": _OPERATIONS_HANDOFF_UNSUPPORTED_CLAIMS,
+    }
 
 
 def _raise_manage_wave_upstream_error(upstream_status: int, payload: dict[str, Any]) -> None:

--- a/src/app/services/dpm_wave_service.py
+++ b/src/app/services/dpm_wave_service.py
@@ -3,7 +3,6 @@ from typing import Any
 from fastapi import status
 
 from app.clients.dpm_client import DpmClient
-from app.clients.lotus_ai_client import LotusAiClient
 from app.config import settings
 from app.contracts.dpm_waves import (
     DpmCampaignDefinitionGatewayResponse,
@@ -17,6 +16,7 @@ from app.contracts.dpm_waves import (
     DpmWaveSupportability,
 )
 from app.services.lotus_ai_workflow import require_lotus_ai_client
+from app.services.upstream_client_protocols import LotusAiWorkflowClient
 from app.services.upstream_envelope import (
     build_upstream_status_gateway_envelope,
     build_upstream_status_payload_gateway_envelope,
@@ -47,7 +47,11 @@ _OPERATIONS_HANDOFF_UNSUPPORTED_CLAIMS = [
 
 
 class DpmWaveService:
-    def __init__(self, dpm_client: DpmClient, lotus_ai_client: LotusAiClient | None = None):
+    def __init__(
+        self,
+        dpm_client: DpmClient,
+        lotus_ai_client: LotusAiWorkflowClient | None = None,
+    ):
         self._dpm_client = dpm_client
         self._lotus_ai_client = lotus_ai_client
 

--- a/src/app/services/foundation_service_factory.py
+++ b/src/app/services/foundation_service_factory.py
@@ -1,8 +1,23 @@
+from app.config import settings
 from app.services.analytics_client_factory import build_performance_analytics_client
 from app.services.dpm_service_factory import build_manage_client
 from app.services.foundation_service import FoundationService
 from app.services.lotus_core_client_factory import build_lotus_core_query_client
 from app.services.reporting_client_factory import build_reporting_client
+
+
+def foundation_service_signature() -> tuple[object, ...]:
+    return (
+        settings.portfolio_data_query_base_url,
+        settings.portfolio_data_control_plane_base_url,
+        settings.performance_analytics_base_url,
+        settings.management_service_base_url,
+        settings.reporting_aggregation_base_url,
+        settings.upstream_timeout_seconds,
+        settings.performance_analytics_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
 
 
 def build_foundation_service() -> FoundationService:

--- a/src/app/services/foundation_service_factory.py
+++ b/src/app/services/foundation_service_factory.py
@@ -1,22 +1,22 @@
-from app.config import settings
-from app.services.analytics_client_factory import build_performance_analytics_client
-from app.services.dpm_service_factory import build_manage_client
+from app.services.analytics_client_factory import (
+    build_performance_analytics_client,
+    performance_analytics_client_signature,
+)
+from app.services.dpm_service_factory import build_manage_client, manage_client_signature
 from app.services.foundation_service import FoundationService
-from app.services.lotus_core_client_factory import build_lotus_core_query_client
-from app.services.reporting_client_factory import build_reporting_client
+from app.services.lotus_core_client_factory import (
+    build_lotus_core_query_client,
+    lotus_core_query_client_signature,
+)
+from app.services.reporting_client_factory import build_reporting_client, reporting_client_signature
 
 
 def foundation_service_signature() -> tuple[object, ...]:
     return (
-        settings.portfolio_data_query_base_url,
-        settings.portfolio_data_control_plane_base_url,
-        settings.performance_analytics_base_url,
-        settings.management_service_base_url,
-        settings.reporting_aggregation_base_url,
-        settings.upstream_timeout_seconds,
-        settings.performance_analytics_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
+        *lotus_core_query_client_signature(),
+        *performance_analytics_client_signature(),
+        *manage_client_signature(),
+        *reporting_client_signature(),
     )
 
 

--- a/src/app/services/gateway_service_provider.py
+++ b/src/app/services/gateway_service_provider.py
@@ -1,42 +1,119 @@
 from app.services.archive_document_service import ArchiveDocumentService
-from app.services.archive_document_service_factory import build_archive_document_service
+from app.services.archive_document_service_factory import (
+    archive_document_service_signature,
+    build_archive_document_service,
+)
 from app.services.composite_performance_service import CompositePerformanceService
 from app.services.composite_performance_service_factory import (
     build_composite_performance_service,
+    composite_performance_service_signature,
 )
 from app.services.domain_product_catalog_service import DomainProductCatalogService
 from app.services.domain_product_catalog_service_factory import (
     build_domain_product_catalog_service,
+    domain_product_catalog_service_signature,
 )
 from app.services.foundation_service import FoundationService
-from app.services.foundation_service_factory import build_foundation_service
+from app.services.foundation_service_factory import (
+    build_foundation_service,
+    foundation_service_signature,
+)
 from app.services.intake_service import IntakeService
-from app.services.intake_service_factory import build_intake_service
+from app.services.intake_service_factory import build_intake_service, intake_service_signature
+from app.services.service_provider_cache import resolve_cached_service
 from app.services.source_product_execution_service import SourceProductExecutionService
 from app.services.source_product_execution_service_factory import (
     build_source_product_execution_service,
+    source_product_execution_service_signature,
 )
+
+_ARCHIVE_DOCUMENT_SERVICE: ArchiveDocumentService | None = None
+_ARCHIVE_DOCUMENT_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_DOMAIN_PRODUCT_CATALOG_SERVICE: DomainProductCatalogService | None = None
+_DOMAIN_PRODUCT_CATALOG_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_COMPOSITE_PERFORMANCE_SERVICE: CompositePerformanceService | None = None
+_COMPOSITE_PERFORMANCE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_SOURCE_PRODUCT_SERVICE: SourceProductExecutionService | None = None
+_SOURCE_PRODUCT_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_FOUNDATION_SERVICE: FoundationService | None = None
+_FOUNDATION_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_INTAKE_SERVICE: IntakeService | None = None
+_INTAKE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 
 
 def archive_document_service() -> ArchiveDocumentService:
-    return build_archive_document_service()
+    global _ARCHIVE_DOCUMENT_SERVICE, _ARCHIVE_DOCUMENT_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _ARCHIVE_DOCUMENT_SERVICE,
+        _ARCHIVE_DOCUMENT_SERVICE_SIGNATURE,
+        archive_document_service_signature(),
+        build_archive_document_service,
+    )
+    _ARCHIVE_DOCUMENT_SERVICE = service
+    _ARCHIVE_DOCUMENT_SERVICE_SIGNATURE = signature
+    return service
 
 
 def domain_product_catalog_service() -> DomainProductCatalogService:
-    return build_domain_product_catalog_service()
+    global _DOMAIN_PRODUCT_CATALOG_SERVICE, _DOMAIN_PRODUCT_CATALOG_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _DOMAIN_PRODUCT_CATALOG_SERVICE,
+        _DOMAIN_PRODUCT_CATALOG_SERVICE_SIGNATURE,
+        domain_product_catalog_service_signature(),
+        build_domain_product_catalog_service,
+    )
+    _DOMAIN_PRODUCT_CATALOG_SERVICE = service
+    _DOMAIN_PRODUCT_CATALOG_SERVICE_SIGNATURE = signature
+    return service
 
 
 def composite_performance_service() -> CompositePerformanceService:
-    return build_composite_performance_service()
+    global _COMPOSITE_PERFORMANCE_SERVICE, _COMPOSITE_PERFORMANCE_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _COMPOSITE_PERFORMANCE_SERVICE,
+        _COMPOSITE_PERFORMANCE_SERVICE_SIGNATURE,
+        composite_performance_service_signature(),
+        build_composite_performance_service,
+    )
+    _COMPOSITE_PERFORMANCE_SERVICE = service
+    _COMPOSITE_PERFORMANCE_SERVICE_SIGNATURE = signature
+    return service
 
 
 def source_product_service() -> SourceProductExecutionService:
-    return build_source_product_execution_service()
+    global _SOURCE_PRODUCT_SERVICE, _SOURCE_PRODUCT_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _SOURCE_PRODUCT_SERVICE,
+        _SOURCE_PRODUCT_SERVICE_SIGNATURE,
+        source_product_execution_service_signature(),
+        build_source_product_execution_service,
+    )
+    _SOURCE_PRODUCT_SERVICE = service
+    _SOURCE_PRODUCT_SERVICE_SIGNATURE = signature
+    return service
 
 
 def foundation_service() -> FoundationService:
-    return build_foundation_service()
+    global _FOUNDATION_SERVICE, _FOUNDATION_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _FOUNDATION_SERVICE,
+        _FOUNDATION_SERVICE_SIGNATURE,
+        foundation_service_signature(),
+        build_foundation_service,
+    )
+    _FOUNDATION_SERVICE = service
+    _FOUNDATION_SERVICE_SIGNATURE = signature
+    return service
 
 
 def intake_service() -> IntakeService:
-    return build_intake_service()
+    global _INTAKE_SERVICE, _INTAKE_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _INTAKE_SERVICE,
+        _INTAKE_SERVICE_SIGNATURE,
+        intake_service_signature(),
+        build_intake_service,
+    )
+    _INTAKE_SERVICE = service
+    _INTAKE_SERVICE_SIGNATURE = signature
+    return service

--- a/src/app/services/intake_service_factory.py
+++ b/src/app/services/intake_service_factory.py
@@ -1,8 +1,20 @@
+from app.config import settings
 from app.services.intake_service import IntakeService
 from app.services.lotus_core_client_factory import (
     build_lotus_core_ingestion_client,
     build_lotus_core_query_client,
 )
+
+
+def intake_service_signature() -> tuple[object, ...]:
+    return (
+        settings.portfolio_data_ingestion_base_url,
+        settings.portfolio_data_query_base_url,
+        settings.portfolio_data_control_plane_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
 
 
 def build_intake_service() -> IntakeService:

--- a/src/app/services/intake_service_factory.py
+++ b/src/app/services/intake_service_factory.py
@@ -1,19 +1,16 @@
-from app.config import settings
 from app.services.intake_service import IntakeService
 from app.services.lotus_core_client_factory import (
     build_lotus_core_ingestion_client,
     build_lotus_core_query_client,
+    lotus_core_ingestion_client_signature,
+    lotus_core_query_client_signature,
 )
 
 
 def intake_service_signature() -> tuple[object, ...]:
     return (
-        settings.portfolio_data_ingestion_base_url,
-        settings.portfolio_data_query_base_url,
-        settings.portfolio_data_control_plane_base_url,
-        settings.upstream_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
+        *lotus_core_ingestion_client_signature(),
+        *lotus_core_query_client_signature(),
     )
 
 

--- a/src/app/services/lotus_ai_workflow.py
+++ b/src/app/services/lotus_ai_workflow.py
@@ -16,3 +16,26 @@ def require_lotus_ai_client(client: LotusAiWorkflowClient | None) -> LotusAiWork
             detail=LOTUS_AI_NOT_CONFIGURED_DETAIL,
         )
     return client
+
+
+def build_workflow_pack_task_request(
+    *,
+    correlation_id: str,
+    summary: str,
+    payload: dict[str, object],
+    source_refs: list[str],
+) -> dict[str, object]:
+    return {
+        "task_id": "explain.v1",
+        "input_mode": "STRUCTURED_CONTEXT",
+        "caller": {
+            "caller_app": "lotus-gateway",
+            "correlation_id": correlation_id,
+        },
+        "context": {
+            "summary": summary,
+            "payload": payload,
+            "source_refs": source_refs,
+        },
+        "expected_output_label": "EXPLANATION_ONLY",
+    }

--- a/src/app/services/lotus_ai_workflow.py
+++ b/src/app/services/lotus_ai_workflow.py
@@ -2,12 +2,12 @@
 
 from fastapi import HTTPException, status
 
-from app.clients.lotus_ai_client import LotusAiClient
+from app.services.upstream_client_protocols import LotusAiWorkflowClient
 
 LOTUS_AI_NOT_CONFIGURED_DETAIL = "lotus-ai workflow-pack execution is not configured for Gateway."
 
 
-def require_lotus_ai_client(client: LotusAiClient | None) -> LotusAiClient:
+def require_lotus_ai_client(client: LotusAiWorkflowClient | None) -> LotusAiWorkflowClient:
     """Return a configured lotus-ai client or raise the standard Gateway service error."""
 
     if client is None:

--- a/src/app/services/lotus_core_client_factory.py
+++ b/src/app/services/lotus_core_client_factory.py
@@ -3,6 +3,25 @@ from app.clients.lotus_core_query_client import LotusCoreQueryClient
 from app.config import settings
 
 
+def lotus_core_ingestion_client_signature() -> tuple[object, ...]:
+    return (
+        settings.portfolio_data_ingestion_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
+def lotus_core_query_client_signature() -> tuple[object, ...]:
+    return (
+        settings.portfolio_data_query_base_url,
+        settings.portfolio_data_control_plane_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
 def build_lotus_core_ingestion_client() -> LotusCoreIngestionClient:
     return LotusCoreIngestionClient(
         base_url=settings.portfolio_data_ingestion_base_url,

--- a/src/app/services/platform_capabilities_service_factory.py
+++ b/src/app/services/platform_capabilities_service_factory.py
@@ -10,6 +10,24 @@ from app.services.platform_capabilities_service import PlatformCapabilitiesServi
 from app.services.reporting_client_factory import build_reporting_client
 
 
+def platform_capabilities_service_signature() -> tuple[object, ...]:
+    return (
+        settings.decisioning_service_base_url,
+        settings.management_service_base_url,
+        settings.portfolio_data_query_base_url,
+        settings.portfolio_data_control_plane_base_url,
+        settings.performance_analytics_base_url,
+        settings.risk_analytics_base_url,
+        settings.reporting_aggregation_base_url,
+        settings.contract_version,
+        settings.upstream_timeout_seconds,
+        settings.performance_analytics_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+        settings.platform_capabilities_source_timeout_seconds,
+    )
+
+
 def build_platform_capabilities_service() -> PlatformCapabilitiesService:
     return PlatformCapabilitiesService(
         advise_client=build_advise_client(),

--- a/src/app/services/platform_capabilities_service_factory.py
+++ b/src/app/services/platform_capabilities_service_factory.py
@@ -1,29 +1,29 @@
 from app.config import settings
-from app.services.advise_client_factory import build_advise_client
+from app.services.advise_client_factory import advise_client_signature, build_advise_client
 from app.services.analytics_client_factory import (
     build_performance_analytics_client,
     build_risk_analytics_client,
+    performance_analytics_client_signature,
+    risk_analytics_client_signature,
 )
-from app.services.dpm_service_factory import build_manage_client
-from app.services.lotus_core_client_factory import build_lotus_core_query_client
+from app.services.dpm_service_factory import build_manage_client, manage_client_signature
+from app.services.lotus_core_client_factory import (
+    build_lotus_core_query_client,
+    lotus_core_query_client_signature,
+)
 from app.services.platform_capabilities_service import PlatformCapabilitiesService
-from app.services.reporting_client_factory import build_reporting_client
+from app.services.reporting_client_factory import build_reporting_client, reporting_client_signature
 
 
 def platform_capabilities_service_signature() -> tuple[object, ...]:
     return (
-        settings.decisioning_service_base_url,
-        settings.management_service_base_url,
-        settings.portfolio_data_query_base_url,
-        settings.portfolio_data_control_plane_base_url,
-        settings.performance_analytics_base_url,
-        settings.risk_analytics_base_url,
-        settings.reporting_aggregation_base_url,
+        *advise_client_signature(),
+        *manage_client_signature(),
+        *lotus_core_query_client_signature(),
+        *performance_analytics_client_signature(),
+        *risk_analytics_client_signature(),
+        *reporting_client_signature(),
         settings.contract_version,
-        settings.upstream_timeout_seconds,
-        settings.performance_analytics_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
         settings.platform_capabilities_source_timeout_seconds,
     )
 

--- a/src/app/services/platform_capabilities_service_provider.py
+++ b/src/app/services/platform_capabilities_service_provider.py
@@ -3,6 +3,7 @@ from app.services.platform_capabilities_service_factory import (
     build_platform_capabilities_service,
     platform_capabilities_service_signature,
 )
+from app.services.service_provider_cache import resolve_cached_service
 
 _PLATFORM_CAPABILITIES_SERVICE: PlatformCapabilitiesService | None = None
 _PLATFORM_CAPABILITIES_SERVICE_SIGNATURE: tuple[object, ...] | None = None
@@ -10,11 +11,12 @@ _PLATFORM_CAPABILITIES_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 
 def platform_capabilities_service() -> PlatformCapabilitiesService:
     global _PLATFORM_CAPABILITIES_SERVICE, _PLATFORM_CAPABILITIES_SERVICE_SIGNATURE
-    signature = platform_capabilities_service_signature()
-    if (
-        _PLATFORM_CAPABILITIES_SERVICE is None
-        or _PLATFORM_CAPABILITIES_SERVICE_SIGNATURE != signature
-    ):
-        _PLATFORM_CAPABILITIES_SERVICE = build_platform_capabilities_service()
-        _PLATFORM_CAPABILITIES_SERVICE_SIGNATURE = signature
-    return _PLATFORM_CAPABILITIES_SERVICE
+    service, signature = resolve_cached_service(
+        _PLATFORM_CAPABILITIES_SERVICE,
+        _PLATFORM_CAPABILITIES_SERVICE_SIGNATURE,
+        platform_capabilities_service_signature(),
+        build_platform_capabilities_service,
+    )
+    _PLATFORM_CAPABILITIES_SERVICE = service
+    _PLATFORM_CAPABILITIES_SERVICE_SIGNATURE = signature
+    return service

--- a/src/app/services/platform_capabilities_service_provider.py
+++ b/src/app/services/platform_capabilities_service_provider.py
@@ -1,8 +1,20 @@
 from app.services.platform_capabilities_service import PlatformCapabilitiesService
 from app.services.platform_capabilities_service_factory import (
     build_platform_capabilities_service,
+    platform_capabilities_service_signature,
 )
+
+_PLATFORM_CAPABILITIES_SERVICE: PlatformCapabilitiesService | None = None
+_PLATFORM_CAPABILITIES_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 
 
 def platform_capabilities_service() -> PlatformCapabilitiesService:
-    return build_platform_capabilities_service()
+    global _PLATFORM_CAPABILITIES_SERVICE, _PLATFORM_CAPABILITIES_SERVICE_SIGNATURE
+    signature = platform_capabilities_service_signature()
+    if (
+        _PLATFORM_CAPABILITIES_SERVICE is None
+        or _PLATFORM_CAPABILITIES_SERVICE_SIGNATURE != signature
+    ):
+        _PLATFORM_CAPABILITIES_SERVICE = build_platform_capabilities_service()
+        _PLATFORM_CAPABILITIES_SERVICE_SIGNATURE = signature
+    return _PLATFORM_CAPABILITIES_SERVICE

--- a/src/app/services/portfolio_service_factory.py
+++ b/src/app/services/portfolio_service_factory.py
@@ -1,8 +1,14 @@
 from app.config import settings
-from app.services.advise_client_factory import build_advise_client
-from app.services.analytics_client_factory import build_performance_analytics_client
-from app.services.dpm_service_factory import build_manage_client
-from app.services.lotus_core_client_factory import build_lotus_core_query_client
+from app.services.advise_client_factory import advise_client_signature, build_advise_client
+from app.services.analytics_client_factory import (
+    build_performance_analytics_client,
+    performance_analytics_client_signature,
+)
+from app.services.dpm_service_factory import build_manage_client, manage_client_signature
+from app.services.lotus_core_client_factory import (
+    build_lotus_core_query_client,
+    lotus_core_query_client_signature,
+)
 from app.services.performance_workspace_service import PerformanceWorkspaceService
 from app.services.portfolio_service import PortfolioService
 from app.services.workbench_service import WorkbenchService
@@ -10,15 +16,10 @@ from app.services.workbench_service import WorkbenchService
 
 def portfolio_service_signature() -> tuple[object, ...]:
     return (
-        settings.portfolio_data_query_base_url,
-        settings.portfolio_data_control_plane_base_url,
-        settings.performance_analytics_base_url,
-        settings.management_service_base_url,
-        settings.decisioning_service_base_url,
-        settings.upstream_timeout_seconds,
-        settings.performance_analytics_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
+        *lotus_core_query_client_signature(),
+        *performance_analytics_client_signature(),
+        *manage_client_signature(),
+        *advise_client_signature(),
         settings.portfolio_upstream_cache_ttl_seconds,
     )
 

--- a/src/app/services/portfolio_service_provider.py
+++ b/src/app/services/portfolio_service_provider.py
@@ -5,6 +5,7 @@ from app.services.portfolio_service_factory import (
     build_portfolio_service,
     portfolio_service_signature,
 )
+from app.services.service_provider_cache import resolve_cached_service
 
 _PORTFOLIO_SERVICE: PortfolioService | None = None
 _PORTFOLIO_SERVICE_SIGNATURE: tuple[object, ...] | None = None
@@ -14,20 +15,25 @@ _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 
 def portfolio_service() -> PortfolioService:
     global _PORTFOLIO_SERVICE, _PORTFOLIO_SERVICE_SIGNATURE
-    signature = portfolio_service_signature()
-    if _PORTFOLIO_SERVICE is None or _PORTFOLIO_SERVICE_SIGNATURE != signature:
-        _PORTFOLIO_SERVICE = build_portfolio_service()
-        _PORTFOLIO_SERVICE_SIGNATURE = signature
-    return _PORTFOLIO_SERVICE
+    service, signature = resolve_cached_service(
+        _PORTFOLIO_SERVICE,
+        _PORTFOLIO_SERVICE_SIGNATURE,
+        portfolio_service_signature(),
+        build_portfolio_service,
+    )
+    _PORTFOLIO_SERVICE = service
+    _PORTFOLIO_SERVICE_SIGNATURE = signature
+    return service
 
 
 def portfolio_performance_workspace_service() -> PerformanceWorkspaceService:
     global _PERFORMANCE_WORKSPACE_SERVICE, _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE
-    signature = portfolio_service_signature()
-    if (
-        _PERFORMANCE_WORKSPACE_SERVICE is None
-        or _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE != signature
-    ):
-        _PERFORMANCE_WORKSPACE_SERVICE = build_portfolio_performance_workspace_service()
-        _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE = signature
-    return _PERFORMANCE_WORKSPACE_SERVICE
+    service, signature = resolve_cached_service(
+        _PERFORMANCE_WORKSPACE_SERVICE,
+        _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE,
+        portfolio_service_signature(),
+        build_portfolio_performance_workspace_service,
+    )
+    _PERFORMANCE_WORKSPACE_SERVICE = service
+    _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE = signature
+    return service

--- a/src/app/services/reporting_batch_control_service_factory.py
+++ b/src/app/services/reporting_batch_control_service_factory.py
@@ -1,5 +1,16 @@
+from app.config import settings
 from app.services.reporting_batch_control_service import ReportingBatchControlService
 from app.services.reporting_client_factory import build_render_client, build_reporting_client
+
+
+def reporting_batch_control_service_signature() -> tuple[object, ...]:
+    return (
+        settings.reporting_aggregation_base_url,
+        settings.render_service_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
 
 
 def build_reporting_batch_control_service() -> ReportingBatchControlService:

--- a/src/app/services/reporting_batch_control_service_factory.py
+++ b/src/app/services/reporting_batch_control_service_factory.py
@@ -1,15 +1,16 @@
-from app.config import settings
 from app.services.reporting_batch_control_service import ReportingBatchControlService
-from app.services.reporting_client_factory import build_render_client, build_reporting_client
+from app.services.reporting_client_factory import (
+    build_render_client,
+    build_reporting_client,
+    render_client_signature,
+    reporting_client_signature,
+)
 
 
 def reporting_batch_control_service_signature() -> tuple[object, ...]:
     return (
-        settings.reporting_aggregation_base_url,
-        settings.render_service_base_url,
-        settings.upstream_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
+        *reporting_client_signature(),
+        *render_client_signature(),
     )
 
 

--- a/src/app/services/reporting_batch_lifecycle_service_factory.py
+++ b/src/app/services/reporting_batch_lifecycle_service_factory.py
@@ -1,5 +1,16 @@
+from app.config import settings
 from app.services.reporting_batch_lifecycle_service import ReportingBatchLifecycleService
 from app.services.reporting_client_factory import build_render_client, build_reporting_client
+
+
+def reporting_batch_lifecycle_service_signature() -> tuple[object, ...]:
+    return (
+        settings.reporting_aggregation_base_url,
+        settings.render_service_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
 
 
 def build_reporting_batch_lifecycle_service() -> ReportingBatchLifecycleService:

--- a/src/app/services/reporting_batch_lifecycle_service_factory.py
+++ b/src/app/services/reporting_batch_lifecycle_service_factory.py
@@ -1,15 +1,16 @@
-from app.config import settings
 from app.services.reporting_batch_lifecycle_service import ReportingBatchLifecycleService
-from app.services.reporting_client_factory import build_render_client, build_reporting_client
+from app.services.reporting_client_factory import (
+    build_render_client,
+    build_reporting_client,
+    render_client_signature,
+    reporting_client_signature,
+)
 
 
 def reporting_batch_lifecycle_service_signature() -> tuple[object, ...]:
     return (
-        settings.reporting_aggregation_base_url,
-        settings.render_service_base_url,
-        settings.upstream_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
+        *reporting_client_signature(),
+        *render_client_signature(),
     )
 
 

--- a/src/app/services/reporting_batch_scheduler_service_factory.py
+++ b/src/app/services/reporting_batch_scheduler_service_factory.py
@@ -1,5 +1,15 @@
+from app.config import settings
 from app.services.reporting_batch_scheduler_service import ReportingBatchSchedulerService
 from app.services.reporting_client_factory import build_reporting_client
+
+
+def reporting_batch_scheduler_service_signature() -> tuple[object, ...]:
+    return (
+        settings.reporting_aggregation_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
 
 
 def build_reporting_batch_scheduler_service() -> ReportingBatchSchedulerService:

--- a/src/app/services/reporting_batch_scheduler_service_factory.py
+++ b/src/app/services/reporting_batch_scheduler_service_factory.py
@@ -1,15 +1,9 @@
-from app.config import settings
 from app.services.reporting_batch_scheduler_service import ReportingBatchSchedulerService
-from app.services.reporting_client_factory import build_reporting_client
+from app.services.reporting_client_factory import build_reporting_client, reporting_client_signature
 
 
 def reporting_batch_scheduler_service_signature() -> tuple[object, ...]:
-    return (
-        settings.reporting_aggregation_base_url,
-        settings.upstream_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
-    )
+    return reporting_client_signature()
 
 
 def build_reporting_batch_scheduler_service() -> ReportingBatchSchedulerService:

--- a/src/app/services/reporting_client_factory.py
+++ b/src/app/services/reporting_client_factory.py
@@ -3,6 +3,24 @@ from app.clients.reporting_client import ReportingClient
 from app.config import settings
 
 
+def reporting_client_signature() -> tuple[object, ...]:
+    return (
+        settings.reporting_aggregation_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
+def render_client_signature() -> tuple[object, ...]:
+    return (
+        settings.render_service_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
 def build_reporting_client() -> ReportingClient:
     return ReportingClient(
         base_url=settings.reporting_aggregation_base_url,

--- a/src/app/services/reporting_job_query_service_factory.py
+++ b/src/app/services/reporting_job_query_service_factory.py
@@ -1,5 +1,15 @@
+from app.config import settings
 from app.services.reporting_client_factory import build_reporting_client
 from app.services.reporting_job_query_service import ReportingJobQueryService
+
+
+def reporting_job_query_service_signature() -> tuple[object, ...]:
+    return (
+        settings.reporting_aggregation_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
 
 
 def build_reporting_job_query_service() -> ReportingJobQueryService:

--- a/src/app/services/reporting_job_query_service_factory.py
+++ b/src/app/services/reporting_job_query_service_factory.py
@@ -1,15 +1,9 @@
-from app.config import settings
-from app.services.reporting_client_factory import build_reporting_client
+from app.services.reporting_client_factory import build_reporting_client, reporting_client_signature
 from app.services.reporting_job_query_service import ReportingJobQueryService
 
 
 def reporting_job_query_service_signature() -> tuple[object, ...]:
-    return (
-        settings.reporting_aggregation_base_url,
-        settings.upstream_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
-    )
+    return reporting_client_signature()
 
 
 def build_reporting_job_query_service() -> ReportingJobQueryService:

--- a/src/app/services/reporting_job_submission_service_factory.py
+++ b/src/app/services/reporting_job_submission_service_factory.py
@@ -1,15 +1,9 @@
-from app.config import settings
-from app.services.reporting_client_factory import build_reporting_client
+from app.services.reporting_client_factory import build_reporting_client, reporting_client_signature
 from app.services.reporting_job_submission_service import ReportingJobSubmissionService
 
 
 def reporting_job_submission_service_signature() -> tuple[object, ...]:
-    return (
-        settings.reporting_aggregation_base_url,
-        settings.upstream_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
-    )
+    return reporting_client_signature()
 
 
 def build_reporting_job_submission_service() -> ReportingJobSubmissionService:

--- a/src/app/services/reporting_job_submission_service_factory.py
+++ b/src/app/services/reporting_job_submission_service_factory.py
@@ -1,5 +1,15 @@
+from app.config import settings
 from app.services.reporting_client_factory import build_reporting_client
 from app.services.reporting_job_submission_service import ReportingJobSubmissionService
+
+
+def reporting_job_submission_service_signature() -> tuple[object, ...]:
+    return (
+        settings.reporting_aggregation_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
 
 
 def build_reporting_job_submission_service() -> ReportingJobSubmissionService:

--- a/src/app/services/reporting_portfolio_service_factory.py
+++ b/src/app/services/reporting_portfolio_service_factory.py
@@ -1,15 +1,12 @@
 from app.config import settings
-from app.services.reporting_client_factory import build_reporting_client
+from app.services.reporting_client_factory import build_reporting_client, reporting_client_signature
 from app.services.reporting_portfolio_service import ReportingPortfolioService
 
 
 def reporting_portfolio_service_signature() -> tuple[object, ...]:
     return (
-        settings.reporting_aggregation_base_url,
+        *reporting_client_signature(),
         settings.contract_version,
-        settings.upstream_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
     )
 
 

--- a/src/app/services/reporting_portfolio_service_factory.py
+++ b/src/app/services/reporting_portfolio_service_factory.py
@@ -3,6 +3,16 @@ from app.services.reporting_client_factory import build_reporting_client
 from app.services.reporting_portfolio_service import ReportingPortfolioService
 
 
+def reporting_portfolio_service_signature() -> tuple[object, ...]:
+    return (
+        settings.reporting_aggregation_base_url,
+        settings.contract_version,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
 def build_reporting_portfolio_service() -> ReportingPortfolioService:
     return ReportingPortfolioService(
         reporting_client=build_reporting_client(),

--- a/src/app/services/reporting_service_provider.py
+++ b/src/app/services/reporting_service_provider.py
@@ -1,44 +1,122 @@
 from app.services.reporting_batch_control_service import ReportingBatchControlService
 from app.services.reporting_batch_control_service_factory import (
     build_reporting_batch_control_service,
+    reporting_batch_control_service_signature,
 )
 from app.services.reporting_batch_lifecycle_service import ReportingBatchLifecycleService
 from app.services.reporting_batch_lifecycle_service_factory import (
     build_reporting_batch_lifecycle_service,
+    reporting_batch_lifecycle_service_signature,
 )
 from app.services.reporting_batch_scheduler_service import ReportingBatchSchedulerService
 from app.services.reporting_batch_scheduler_service_factory import (
     build_reporting_batch_scheduler_service,
+    reporting_batch_scheduler_service_signature,
 )
 from app.services.reporting_job_query_service import ReportingJobQueryService
-from app.services.reporting_job_query_service_factory import build_reporting_job_query_service
+from app.services.reporting_job_query_service_factory import (
+    build_reporting_job_query_service,
+    reporting_job_query_service_signature,
+)
 from app.services.reporting_job_submission_service import ReportingJobSubmissionService
 from app.services.reporting_job_submission_service_factory import (
     build_reporting_job_submission_service,
+    reporting_job_submission_service_signature,
 )
 from app.services.reporting_portfolio_service import ReportingPortfolioService
-from app.services.reporting_portfolio_service_factory import build_reporting_portfolio_service
+from app.services.reporting_portfolio_service_factory import (
+    build_reporting_portfolio_service,
+    reporting_portfolio_service_signature,
+)
+from app.services.service_provider_cache import resolve_cached_service
+
+_REPORTING_PORTFOLIO_SERVICE: ReportingPortfolioService | None = None
+_REPORTING_PORTFOLIO_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_REPORTING_JOB_SUBMISSION_SERVICE: ReportingJobSubmissionService | None = None
+_REPORTING_JOB_SUBMISSION_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_REPORTING_JOB_QUERY_SERVICE: ReportingJobQueryService | None = None
+_REPORTING_JOB_QUERY_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_REPORTING_BATCH_CONTROL_SERVICE: ReportingBatchControlService | None = None
+_REPORTING_BATCH_CONTROL_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_REPORTING_BATCH_LIFECYCLE_SERVICE: ReportingBatchLifecycleService | None = None
+_REPORTING_BATCH_LIFECYCLE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_REPORTING_BATCH_SCHEDULER_SERVICE: ReportingBatchSchedulerService | None = None
+_REPORTING_BATCH_SCHEDULER_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 
 
 def reporting_portfolio_service() -> ReportingPortfolioService:
-    return build_reporting_portfolio_service()
+    global _REPORTING_PORTFOLIO_SERVICE, _REPORTING_PORTFOLIO_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _REPORTING_PORTFOLIO_SERVICE,
+        _REPORTING_PORTFOLIO_SERVICE_SIGNATURE,
+        reporting_portfolio_service_signature(),
+        build_reporting_portfolio_service,
+    )
+    _REPORTING_PORTFOLIO_SERVICE = service
+    _REPORTING_PORTFOLIO_SERVICE_SIGNATURE = signature
+    return service
 
 
 def reporting_job_submission_service() -> ReportingJobSubmissionService:
-    return build_reporting_job_submission_service()
+    global _REPORTING_JOB_SUBMISSION_SERVICE, _REPORTING_JOB_SUBMISSION_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _REPORTING_JOB_SUBMISSION_SERVICE,
+        _REPORTING_JOB_SUBMISSION_SERVICE_SIGNATURE,
+        reporting_job_submission_service_signature(),
+        build_reporting_job_submission_service,
+    )
+    _REPORTING_JOB_SUBMISSION_SERVICE = service
+    _REPORTING_JOB_SUBMISSION_SERVICE_SIGNATURE = signature
+    return service
 
 
 def reporting_job_query_service() -> ReportingJobQueryService:
-    return build_reporting_job_query_service()
+    global _REPORTING_JOB_QUERY_SERVICE, _REPORTING_JOB_QUERY_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _REPORTING_JOB_QUERY_SERVICE,
+        _REPORTING_JOB_QUERY_SERVICE_SIGNATURE,
+        reporting_job_query_service_signature(),
+        build_reporting_job_query_service,
+    )
+    _REPORTING_JOB_QUERY_SERVICE = service
+    _REPORTING_JOB_QUERY_SERVICE_SIGNATURE = signature
+    return service
 
 
 def reporting_batch_control_service() -> ReportingBatchControlService:
-    return build_reporting_batch_control_service()
+    global _REPORTING_BATCH_CONTROL_SERVICE, _REPORTING_BATCH_CONTROL_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _REPORTING_BATCH_CONTROL_SERVICE,
+        _REPORTING_BATCH_CONTROL_SERVICE_SIGNATURE,
+        reporting_batch_control_service_signature(),
+        build_reporting_batch_control_service,
+    )
+    _REPORTING_BATCH_CONTROL_SERVICE = service
+    _REPORTING_BATCH_CONTROL_SERVICE_SIGNATURE = signature
+    return service
 
 
 def reporting_batch_lifecycle_service() -> ReportingBatchLifecycleService:
-    return build_reporting_batch_lifecycle_service()
+    global _REPORTING_BATCH_LIFECYCLE_SERVICE, _REPORTING_BATCH_LIFECYCLE_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _REPORTING_BATCH_LIFECYCLE_SERVICE,
+        _REPORTING_BATCH_LIFECYCLE_SERVICE_SIGNATURE,
+        reporting_batch_lifecycle_service_signature(),
+        build_reporting_batch_lifecycle_service,
+    )
+    _REPORTING_BATCH_LIFECYCLE_SERVICE = service
+    _REPORTING_BATCH_LIFECYCLE_SERVICE_SIGNATURE = signature
+    return service
 
 
 def reporting_batch_scheduler_service() -> ReportingBatchSchedulerService:
-    return build_reporting_batch_scheduler_service()
+    global _REPORTING_BATCH_SCHEDULER_SERVICE, _REPORTING_BATCH_SCHEDULER_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _REPORTING_BATCH_SCHEDULER_SERVICE,
+        _REPORTING_BATCH_SCHEDULER_SERVICE_SIGNATURE,
+        reporting_batch_scheduler_service_signature(),
+        build_reporting_batch_scheduler_service,
+    )
+    _REPORTING_BATCH_SCHEDULER_SERVICE = service
+    _REPORTING_BATCH_SCHEDULER_SERVICE_SIGNATURE = signature
+    return service

--- a/src/app/services/service_provider_cache.py
+++ b/src/app/services/service_provider_cache.py
@@ -1,0 +1,15 @@
+from collections.abc import Callable
+from typing import TypeVar
+
+ServiceT = TypeVar("ServiceT")
+
+
+def resolve_cached_service(
+    service: ServiceT | None,
+    cached_signature: tuple[object, ...] | None,
+    current_signature: tuple[object, ...],
+    build_service: Callable[[], ServiceT],
+) -> tuple[ServiceT, tuple[object, ...]]:
+    if service is None or cached_signature != current_signature:
+        return build_service(), current_signature
+    return service, cached_signature

--- a/src/app/services/source_product_execution_service_factory.py
+++ b/src/app/services/source_product_execution_service_factory.py
@@ -1,16 +1,12 @@
-from app.config import settings
-from app.services.lotus_core_client_factory import build_lotus_core_query_client
+from app.services.lotus_core_client_factory import (
+    build_lotus_core_query_client,
+    lotus_core_query_client_signature,
+)
 from app.services.source_product_execution_service import SourceProductExecutionService
 
 
 def source_product_execution_service_signature() -> tuple[object, ...]:
-    return (
-        settings.portfolio_data_query_base_url,
-        settings.portfolio_data_control_plane_base_url,
-        settings.upstream_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
-    )
+    return lotus_core_query_client_signature()
 
 
 def build_source_product_execution_service() -> SourceProductExecutionService:

--- a/src/app/services/source_product_execution_service_factory.py
+++ b/src/app/services/source_product_execution_service_factory.py
@@ -1,5 +1,16 @@
+from app.config import settings
 from app.services.lotus_core_client_factory import build_lotus_core_query_client
 from app.services.source_product_execution_service import SourceProductExecutionService
+
+
+def source_product_execution_service_signature() -> tuple[object, ...]:
+    return (
+        settings.portfolio_data_query_base_url,
+        settings.portfolio_data_control_plane_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
 
 
 def build_source_product_execution_service() -> SourceProductExecutionService:

--- a/src/app/services/upstream_client_protocols.py
+++ b/src/app/services/upstream_client_protocols.py
@@ -1,0 +1,68 @@
+from typing import Any, Protocol
+
+
+class DpmConstructionClient(Protocol):
+    async def generate_construction_alternative_set(
+        self,
+        *,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_construction_alternative_set(
+        self,
+        *,
+        alternative_set_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def select_construction_alternative(
+        self,
+        *,
+        alternative_set_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+
+class DpmProofPackClient(Protocol):
+    async def generate_proof_pack(
+        self,
+        *,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_proof_pack(
+        self,
+        *,
+        proof_pack_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_proof_pack_markdown(
+        self,
+        *,
+        proof_pack_id: str,
+        correlation_id: str,
+    ) -> tuple[int, str, dict[str, Any]]: ...
+
+    async def get_proof_pack_report_input(
+        self,
+        *,
+        proof_pack_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_proof_pack_ai_evidence_input(
+        self,
+        *,
+        proof_pack_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+
+class LotusAiWorkflowClient(Protocol):
+    async def execute_workflow_pack(self, **kwargs: Any) -> tuple[int, dict[str, Any]]: ...

--- a/src/app/services/upstream_client_protocols.py
+++ b/src/app/services/upstream_client_protocols.py
@@ -76,3 +76,24 @@ class LotusAiWorkflowClient(Protocol):
         task_request: dict[str, Any],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
+
+
+class BankDemoProofClient(Protocol):
+    async def get_bank_demo_proof_scenario_contract(
+        self,
+        *,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_bank_demo_supported_claim_register(
+        self,
+        *,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def build_bank_demo_proof_pack(
+        self,
+        *,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...

--- a/src/app/services/upstream_client_protocols.py
+++ b/src/app/services/upstream_client_protocols.py
@@ -65,4 +65,14 @@ class DpmProofPackClient(Protocol):
 
 
 class LotusAiWorkflowClient(Protocol):
-    async def execute_workflow_pack(self, **kwargs: Any) -> tuple[int, dict[str, Any]]: ...
+    async def execute_workflow_pack(
+        self,
+        *,
+        pack_id: str,
+        version: str,
+        environment: str,
+        caller_identity_class: str,
+        workflow_surface: str | None,
+        task_request: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...

--- a/src/app/services/upstream_client_protocols.py
+++ b/src/app/services/upstream_client_protocols.py
@@ -140,6 +140,132 @@ class AdvisorCockpitClient(Protocol):
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
 
+
+class AdvisoryPolicyClient(Protocol):
+    async def list_policy_packs(
+        self,
+        *,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_policy_pack_version(
+        self,
+        *,
+        policy_pack_id: str,
+        policy_version: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def validate_policy_pack_version(
+        self,
+        *,
+        policy_pack_id: str,
+        policy_version: str,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def activate_policy_pack_version(
+        self,
+        *,
+        policy_pack_id: str,
+        policy_version: str,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def create_policy_evaluation(
+        self,
+        *,
+        proposal_id: str,
+        proposal_version_id: str,
+        body: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_policy_review_queue(
+        self,
+        *,
+        evaluation_status: str | None,
+        portfolio_id: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_policy_evaluation(
+        self,
+        *,
+        evaluation_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def replay_policy_evaluation(
+        self,
+        *,
+        evaluation_id: str,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def record_policy_evaluation_event(
+        self,
+        *,
+        evaluation_id: str,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_policy_evaluation_lineage(
+        self,
+        *,
+        evaluation_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_policy_sign_off_package(
+        self,
+        *,
+        evaluation_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_policy_evaluation_workflow(
+        self,
+        *,
+        evaluation_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def record_policy_sign_off_decision(
+        self,
+        *,
+        evaluation_id: str,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def request_policy_report_package(
+        self,
+        *,
+        evaluation_id: str,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def request_policy_ai_evidence(
+        self,
+        *,
+        evaluation_id: str,
+        body: dict[str, Any],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
     async def get_bank_demo_supported_claim_register(
         self,
         *,

--- a/src/app/services/upstream_client_protocols.py
+++ b/src/app/services/upstream_client_protocols.py
@@ -85,6 +85,19 @@ class BankDemoProofClient(Protocol):
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
 
+    async def get_bank_demo_supported_claim_register(
+        self,
+        *,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def build_bank_demo_proof_pack(
+        self,
+        *,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
 
 class AdvisorCockpitClient(Protocol):
     async def list_advisor_cockpit_actions(
@@ -263,18 +276,5 @@ class AdvisoryPolicyClient(Protocol):
         evaluation_id: str,
         body: dict[str, Any],
         idempotency_key: str | None,
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]: ...
-
-    async def get_bank_demo_supported_claim_register(
-        self,
-        *,
-        correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]: ...
-
-    async def build_bank_demo_proof_pack(
-        self,
-        *,
-        body: dict[str, Any],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...

--- a/src/app/services/upstream_client_protocols.py
+++ b/src/app/services/upstream_client_protocols.py
@@ -85,6 +85,61 @@ class BankDemoProofClient(Protocol):
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
 
+
+class AdvisorCockpitClient(Protocol):
+    async def list_advisor_cockpit_actions(
+        self,
+        *,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def list_advisor_cockpit_preparation_packets(
+        self,
+        *,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_advisor_cockpit_action(
+        self,
+        *,
+        action_item_id: str,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_advisor_cockpit_snapshot(
+        self,
+        *,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_advisor_cockpit_supportability(
+        self,
+        *,
+        params: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def acknowledge_advisor_cockpit_action(
+        self,
+        *,
+        action_item_id: str,
+        body: dict[str, Any],
+        params: dict[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def evaluate_advisor_cockpit_house_view_cohort(
+        self,
+        *,
+        body: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
     async def get_bank_demo_supported_claim_register(
         self,
         *,

--- a/src/app/services/workbench_service_factory.py
+++ b/src/app/services/workbench_service_factory.py
@@ -1,12 +1,22 @@
 from app.config import settings
-from app.services.advise_client_factory import build_advise_client
+from app.services.advise_client_factory import advise_client_signature, build_advise_client
 from app.services.advisor_brief_service import AdvisorBriefService
 from app.services.analytics_client_factory import (
     build_performance_analytics_client,
     build_risk_analytics_client,
+    performance_analytics_client_signature,
+    risk_analytics_client_signature,
 )
-from app.services.dpm_service_factory import build_lotus_ai_client, build_manage_client
-from app.services.lotus_core_client_factory import build_lotus_core_query_client
+from app.services.dpm_service_factory import (
+    build_lotus_ai_client,
+    build_manage_client,
+    lotus_ai_client_signature,
+    manage_client_signature,
+)
+from app.services.lotus_core_client_factory import (
+    build_lotus_core_query_client,
+    lotus_core_query_client_signature,
+)
 from app.services.performance_workspace_service import PerformanceWorkspaceService
 from app.services.risk_workspace_service import RiskWorkspaceService
 from app.services.workbench_service import WorkbenchService
@@ -14,18 +24,12 @@ from app.services.workbench_service import WorkbenchService
 
 def workbench_service_signature() -> tuple[object, ...]:
     return (
-        settings.portfolio_data_query_base_url,
-        settings.portfolio_data_control_plane_base_url,
-        settings.performance_analytics_base_url,
-        settings.risk_analytics_base_url,
-        settings.ai_service_base_url,
-        settings.management_service_base_url,
-        settings.decisioning_service_base_url,
-        settings.upstream_timeout_seconds,
-        settings.performance_analytics_timeout_seconds,
-        settings.ai_service_timeout_seconds,
-        settings.upstream_max_retries,
-        settings.upstream_retry_backoff_seconds,
+        *lotus_core_query_client_signature(),
+        *performance_analytics_client_signature(),
+        *risk_analytics_client_signature(),
+        *lotus_ai_client_signature(),
+        *manage_client_signature(),
+        *advise_client_signature(),
         settings.portfolio_upstream_cache_ttl_seconds,
         settings.advisor_brief_cache_ttl_seconds,
         settings.risk_bff_cache_ttl_seconds,

--- a/src/app/services/workbench_service_provider.py
+++ b/src/app/services/workbench_service_provider.py
@@ -1,6 +1,7 @@
 from app.services.advisor_brief_service import AdvisorBriefService
 from app.services.performance_workspace_service import PerformanceWorkspaceService
 from app.services.risk_workspace_service import RiskWorkspaceService
+from app.services.service_provider_cache import resolve_cached_service
 from app.services.workbench_service import WorkbenchService
 from app.services.workbench_service_factory import (
     build_advisor_brief_service,
@@ -22,38 +23,51 @@ _RISK_WORKSPACE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 
 def workbench_service() -> WorkbenchService:
     global _WORKBENCH_SERVICE, _WORKBENCH_SERVICE_SIGNATURE
-    signature = workbench_service_signature()
-    if _WORKBENCH_SERVICE is None or _WORKBENCH_SERVICE_SIGNATURE != signature:
-        _WORKBENCH_SERVICE = build_workbench_service()
-        _WORKBENCH_SERVICE_SIGNATURE = signature
-    return _WORKBENCH_SERVICE
+    service, signature = resolve_cached_service(
+        _WORKBENCH_SERVICE,
+        _WORKBENCH_SERVICE_SIGNATURE,
+        workbench_service_signature(),
+        build_workbench_service,
+    )
+    _WORKBENCH_SERVICE = service
+    _WORKBENCH_SERVICE_SIGNATURE = signature
+    return service
 
 
 def performance_workspace_service() -> PerformanceWorkspaceService:
     global _PERFORMANCE_WORKSPACE_SERVICE, _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE
-    signature = workbench_service_signature()
-    if (
-        _PERFORMANCE_WORKSPACE_SERVICE is None
-        or _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE != signature
-    ):
-        _PERFORMANCE_WORKSPACE_SERVICE = build_performance_workspace_service(workbench_service())
-        _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE = signature
-    return _PERFORMANCE_WORKSPACE_SERVICE
+    service, signature = resolve_cached_service(
+        _PERFORMANCE_WORKSPACE_SERVICE,
+        _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE,
+        workbench_service_signature(),
+        lambda: build_performance_workspace_service(workbench_service()),
+    )
+    _PERFORMANCE_WORKSPACE_SERVICE = service
+    _PERFORMANCE_WORKSPACE_SERVICE_SIGNATURE = signature
+    return service
 
 
 def advisor_brief_service() -> AdvisorBriefService:
     global _ADVISOR_BRIEF_SERVICE, _ADVISOR_BRIEF_SERVICE_SIGNATURE
-    signature = workbench_service_signature()
-    if _ADVISOR_BRIEF_SERVICE is None or _ADVISOR_BRIEF_SERVICE_SIGNATURE != signature:
-        _ADVISOR_BRIEF_SERVICE = build_advisor_brief_service(performance_workspace_service())
-        _ADVISOR_BRIEF_SERVICE_SIGNATURE = signature
-    return _ADVISOR_BRIEF_SERVICE
+    service, signature = resolve_cached_service(
+        _ADVISOR_BRIEF_SERVICE,
+        _ADVISOR_BRIEF_SERVICE_SIGNATURE,
+        workbench_service_signature(),
+        lambda: build_advisor_brief_service(performance_workspace_service()),
+    )
+    _ADVISOR_BRIEF_SERVICE = service
+    _ADVISOR_BRIEF_SERVICE_SIGNATURE = signature
+    return service
 
 
 def risk_workspace_service() -> RiskWorkspaceService:
     global _RISK_WORKSPACE_SERVICE, _RISK_WORKSPACE_SERVICE_SIGNATURE
-    signature = workbench_service_signature()
-    if _RISK_WORKSPACE_SERVICE is None or _RISK_WORKSPACE_SERVICE_SIGNATURE != signature:
-        _RISK_WORKSPACE_SERVICE = build_risk_workspace_service()
-        _RISK_WORKSPACE_SERVICE_SIGNATURE = signature
-    return _RISK_WORKSPACE_SERVICE
+    service, signature = resolve_cached_service(
+        _RISK_WORKSPACE_SERVICE,
+        _RISK_WORKSPACE_SERVICE_SIGNATURE,
+        workbench_service_signature(),
+        build_risk_workspace_service,
+    )
+    _RISK_WORKSPACE_SERVICE = service
+    _RISK_WORKSPACE_SERVICE_SIGNATURE = signature
+    return service

--- a/tests/unit/test_advise_client_factory.py
+++ b/tests/unit/test_advise_client_factory.py
@@ -1,4 +1,4 @@
-from app.services.advise_client_factory import build_advise_client
+from app.services.advise_client_factory import advise_client_signature, build_advise_client
 
 
 def test_advise_client_factory_builds_configured_lotus_advise_client(monkeypatch) -> None:
@@ -25,3 +25,4 @@ def test_advise_client_factory_builds_configured_lotus_advise_client(monkeypatch
     assert client._timeout == 6.5
     assert client._max_retries == 4
     assert client._retry_backoff_seconds == 0.75
+    assert advise_client_signature() == ("http://advise:8000/", 6.5, 4, 0.75)

--- a/tests/unit/test_advisor_cockpit_service.py
+++ b/tests/unit/test_advisor_cockpit_service.py
@@ -53,6 +53,53 @@ class _FakeAdviseClient:
         )
         return self.status, self.payload
 
+    async def get_advisor_cockpit_action(
+        self,
+        *,
+        action_item_id: str,
+        params: dict[str, object],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        self.calls.append(
+            (
+                "get_advisor_cockpit_action",
+                {
+                    "action_item_id": action_item_id,
+                    "params": params,
+                    "correlation_id": correlation_id,
+                },
+            )
+        )
+        return self.status, self.payload
+
+    async def get_advisor_cockpit_snapshot(
+        self,
+        *,
+        params: dict[str, object],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        self.calls.append(
+            (
+                "get_advisor_cockpit_snapshot",
+                {"params": params, "correlation_id": correlation_id},
+            )
+        )
+        return self.status, self.payload
+
+    async def get_advisor_cockpit_supportability(
+        self,
+        *,
+        params: dict[str, object],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        self.calls.append(
+            (
+                "get_advisor_cockpit_supportability",
+                {"params": params, "correlation_id": correlation_id},
+            )
+        )
+        return self.status, self.payload
+
     async def acknowledge_advisor_cockpit_action(
         self,
         *,
@@ -94,7 +141,7 @@ class _FakeAdviseClient:
 @pytest.mark.asyncio
 async def test_advisor_cockpit_service_preserves_advise_owned_action_posture() -> None:
     advise_client = _FakeAdviseClient()
-    service = AdvisorCockpitService(advise_client=advise_client)  # type: ignore[arg-type]
+    service = AdvisorCockpitService(advise_client=advise_client)
 
     response = await service.list_actions(
         params={
@@ -142,7 +189,7 @@ async def test_advisor_cockpit_service_preserves_advise_owned_preparation_packet
             "client_ready_publication": "BLOCKED",
         },
     }
-    service = AdvisorCockpitService(advise_client=advise_client)  # type: ignore[arg-type]
+    service = AdvisorCockpitService(advise_client=advise_client)
 
     response = await service.list_preparation_packets(
         params={
@@ -181,7 +228,7 @@ async def test_advisor_cockpit_service_preserves_house_view_cohort_product() -> 
         "affected_portfolios": [{"portfolio_id": "PB_SG_GLOBAL_BAL_001"}],
         "supportability": {"state": "READY"},
     }
-    service = AdvisorCockpitService(advise_client=advise_client)  # type: ignore[arg-type]
+    service = AdvisorCockpitService(advise_client=advise_client)
     body = {
         "tactical_view": {"tactical_view_id": "thv_2026_05_asia_duration"},
         "candidate_portfolios": [{"portfolio_id": "PB_SG_GLOBAL_BAL_001"}],
@@ -206,7 +253,7 @@ async def test_advisor_cockpit_service_propagates_acknowledgement_conflict() -> 
     advise_client = _FakeAdviseClient()
     advise_client.status = 409
     advise_client.payload = {"detail": "ADVISOR_COCKPIT_ACKNOWLEDGEMENT_IDEMPOTENCY_CONFLICT"}
-    service = AdvisorCockpitService(advise_client=advise_client)  # type: ignore[arg-type]
+    service = AdvisorCockpitService(advise_client=advise_client)
 
     with pytest.raises(HTTPException) as exc:
         await service.acknowledge_action(

--- a/tests/unit/test_advisory_policy_service.py
+++ b/tests/unit/test_advisory_policy_service.py
@@ -13,6 +13,179 @@ class _FakeAdviseClient:
             "client_ready": {"status": "BLOCKED", "blockers": ["requires_compliance_signoff"]},
         }
 
+    def _response(self, method: str, payload: dict[str, object]) -> tuple[int, dict[str, object]]:
+        self.calls.append((method, payload))
+        return self.status, self.payload
+
+    async def list_policy_packs(self, *, correlation_id: str) -> tuple[int, dict[str, object]]:
+        return self._response("list_policy_packs", {"correlation_id": correlation_id})
+
+    async def get_policy_pack_version(
+        self,
+        *,
+        policy_pack_id: str,
+        policy_version: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        return self._response(
+            "get_policy_pack_version",
+            {
+                "policy_pack_id": policy_pack_id,
+                "policy_version": policy_version,
+                "correlation_id": correlation_id,
+            },
+        )
+
+    async def validate_policy_pack_version(
+        self,
+        *,
+        policy_pack_id: str,
+        policy_version: str,
+        body: dict[str, object],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        return self._response(
+            "validate_policy_pack_version",
+            {
+                "policy_pack_id": policy_pack_id,
+                "policy_version": policy_version,
+                "body": body,
+                "idempotency_key": idempotency_key,
+                "correlation_id": correlation_id,
+            },
+        )
+
+    async def activate_policy_pack_version(
+        self,
+        *,
+        policy_pack_id: str,
+        policy_version: str,
+        body: dict[str, object],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        return self._response(
+            "activate_policy_pack_version",
+            {
+                "policy_pack_id": policy_pack_id,
+                "policy_version": policy_version,
+                "body": body,
+                "idempotency_key": idempotency_key,
+                "correlation_id": correlation_id,
+            },
+        )
+
+    async def create_policy_evaluation(
+        self,
+        *,
+        proposal_id: str,
+        proposal_version_id: str,
+        body: dict[str, object],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        return self._response(
+            "create_policy_evaluation",
+            {
+                "proposal_id": proposal_id,
+                "proposal_version_id": proposal_version_id,
+                "body": body,
+                "idempotency_key": idempotency_key,
+                "correlation_id": correlation_id,
+            },
+        )
+
+    async def get_policy_review_queue(
+        self,
+        *,
+        evaluation_status: str | None,
+        portfolio_id: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        return self._response(
+            "get_policy_review_queue",
+            {
+                "evaluation_status": evaluation_status,
+                "portfolio_id": portfolio_id,
+                "correlation_id": correlation_id,
+            },
+        )
+
+    async def get_policy_evaluation(
+        self,
+        *,
+        evaluation_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        return self._response(
+            "get_policy_evaluation",
+            {"evaluation_id": evaluation_id, "correlation_id": correlation_id},
+        )
+
+    async def replay_policy_evaluation(
+        self,
+        *,
+        evaluation_id: str,
+        body: dict[str, object],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        return self._response(
+            "replay_policy_evaluation",
+            {"evaluation_id": evaluation_id, "body": body, "correlation_id": correlation_id},
+        )
+
+    async def record_policy_evaluation_event(
+        self,
+        *,
+        evaluation_id: str,
+        body: dict[str, object],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        return self._response(
+            "record_policy_evaluation_event",
+            {
+                "evaluation_id": evaluation_id,
+                "body": body,
+                "idempotency_key": idempotency_key,
+                "correlation_id": correlation_id,
+            },
+        )
+
+    async def get_policy_evaluation_lineage(
+        self,
+        *,
+        evaluation_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        return self._response(
+            "get_policy_evaluation_lineage",
+            {"evaluation_id": evaluation_id, "correlation_id": correlation_id},
+        )
+
+    async def get_policy_sign_off_package(
+        self,
+        *,
+        evaluation_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        return self._response(
+            "get_policy_sign_off_package",
+            {"evaluation_id": evaluation_id, "correlation_id": correlation_id},
+        )
+
+    async def get_policy_evaluation_workflow(
+        self,
+        *,
+        evaluation_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        return self._response(
+            "get_policy_evaluation_workflow",
+            {"evaluation_id": evaluation_id, "correlation_id": correlation_id},
+        )
+
     async def request_policy_ai_evidence(
         self,
         *,
@@ -21,18 +194,15 @@ class _FakeAdviseClient:
         idempotency_key: str | None,
         correlation_id: str,
     ) -> tuple[int, dict[str, object]]:
-        self.calls.append(
-            (
-                "request_policy_ai_evidence",
-                {
-                    "evaluation_id": evaluation_id,
-                    "body": body,
-                    "idempotency_key": idempotency_key,
-                    "correlation_id": correlation_id,
-                },
-            )
+        return self._response(
+            "request_policy_ai_evidence",
+            {
+                "evaluation_id": evaluation_id,
+                "body": body,
+                "idempotency_key": idempotency_key,
+                "correlation_id": correlation_id,
+            },
         )
-        return self.status, self.payload
 
     async def record_policy_sign_off_decision(
         self,
@@ -42,24 +212,39 @@ class _FakeAdviseClient:
         idempotency_key: str | None,
         correlation_id: str,
     ) -> tuple[int, dict[str, object]]:
-        self.calls.append(
-            (
-                "record_policy_sign_off_decision",
-                {
-                    "evaluation_id": evaluation_id,
-                    "body": body,
-                    "idempotency_key": idempotency_key,
-                    "correlation_id": correlation_id,
-                },
-            )
+        return self._response(
+            "record_policy_sign_off_decision",
+            {
+                "evaluation_id": evaluation_id,
+                "body": body,
+                "idempotency_key": idempotency_key,
+                "correlation_id": correlation_id,
+            },
         )
-        return self.status, self.payload
+
+    async def request_policy_report_package(
+        self,
+        *,
+        evaluation_id: str,
+        body: dict[str, object],
+        idempotency_key: str | None,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, object]]:
+        return self._response(
+            "request_policy_report_package",
+            {
+                "evaluation_id": evaluation_id,
+                "body": body,
+                "idempotency_key": idempotency_key,
+                "correlation_id": correlation_id,
+            },
+        )
 
 
 @pytest.mark.asyncio
 async def test_policy_service_preserves_source_owned_policy_posture() -> None:
     advise_client = _FakeAdviseClient()
-    service = AdvisoryPolicyService(advise_client=advise_client)  # type: ignore[arg-type]
+    service = AdvisoryPolicyService(advise_client=advise_client)
 
     response = await service.request_policy_ai_evidence(
         evaluation_id="pev_001",
@@ -97,7 +282,7 @@ async def test_policy_service_propagates_advise_rejections_without_rewriting() -
             "blockers": ["requires_supervisory_review"],
         }
     }
-    service = AdvisoryPolicyService(advise_client=advise_client)  # type: ignore[arg-type]
+    service = AdvisoryPolicyService(advise_client=advise_client)
 
     with pytest.raises(HTTPException) as exc:
         await service.record_policy_sign_off_decision(

--- a/tests/unit/test_advisory_service_provider.py
+++ b/tests/unit/test_advisory_service_provider.py
@@ -23,3 +23,32 @@ def test_advisory_service_provider_wires_advise_backed_services(monkeypatch) -> 
 
     for service in services:
         assert service._advise_client._base_url == "http://advise-provider:8000"
+
+
+def test_advisory_service_provider_reuses_services_for_unchanged_signature(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.advise_client_factory.settings.decisioning_service_base_url",
+        "http://advise-provider-cache:8000",
+    )
+
+    first = advisory_policy_service()
+    second = advisory_policy_service()
+
+    assert first is second
+
+
+def test_advisory_service_provider_rebuilds_when_advise_routing_changes(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.advise_client_factory.settings.decisioning_service_base_url",
+        "http://advise-provider-a:8000",
+    )
+    first = proposal_service()
+
+    monkeypatch.setattr(
+        "app.services.advise_client_factory.settings.decisioning_service_base_url",
+        "http://advise-provider-b:8000",
+    )
+    second = proposal_service()
+
+    assert first is not second
+    assert second._advise_client._base_url == "http://advise-provider-b:8000"

--- a/tests/unit/test_analytics_client_factory.py
+++ b/tests/unit/test_analytics_client_factory.py
@@ -1,6 +1,8 @@
 from app.services.analytics_client_factory import (
     build_performance_analytics_client,
     build_risk_analytics_client,
+    performance_analytics_client_signature,
+    risk_analytics_client_signature,
 )
 
 
@@ -28,6 +30,7 @@ def test_performance_analytics_client_factory_uses_performance_settings(monkeypa
     assert client._timeout == 7.5
     assert client._max_retries == 4
     assert client._retry_backoff_seconds == 0.75
+    assert performance_analytics_client_signature() == ("http://performance:8000/", 7.5, 4, 0.75)
 
 
 def test_risk_analytics_client_factory_uses_risk_settings(monkeypatch) -> None:
@@ -54,3 +57,4 @@ def test_risk_analytics_client_factory_uses_risk_settings(monkeypatch) -> None:
     assert client._timeout == 6.5
     assert client._max_retries == 3
     assert client._retry_backoff_seconds == 0.5
+    assert risk_analytics_client_signature() == ("http://risk:8000/", 6.5, 3, 0.5)

--- a/tests/unit/test_archive_client_factory.py
+++ b/tests/unit/test_archive_client_factory.py
@@ -1,4 +1,4 @@
-from app.services.archive_client_factory import build_archive_client
+from app.services.archive_client_factory import archive_client_signature, build_archive_client
 
 
 def test_archive_client_factory_builds_configured_archive_client(monkeypatch) -> None:
@@ -25,3 +25,4 @@ def test_archive_client_factory_builds_configured_archive_client(monkeypatch) ->
     assert client._timeout == 6.5
     assert client._max_retries == 4
     assert client._retry_backoff_seconds == 0.75
+    assert archive_client_signature() == ("http://archive:8000/", 6.5, 4, 0.75)

--- a/tests/unit/test_bank_demo_proof_service.py
+++ b/tests/unit/test_bank_demo_proof_service.py
@@ -55,7 +55,7 @@ async def test_bank_demo_proof_service_preserves_advise_owned_claim_posture() ->
             },
         ]
     }
-    service = BankDemoProofService(advise_client=advise_client)  # type: ignore[arg-type]
+    service = BankDemoProofService(advise_client=advise_client)
 
     response = await service.get_supported_claim_register(correlation_id="corr-rfc0028-claims")
 
@@ -76,7 +76,7 @@ async def test_bank_demo_proof_service_forwards_sanitized_capture_request() -> N
         },
         "sanitized_runtime_summary": {"primary_portfolio_id": "PB_SG_GLOBAL_BAL_001"},
     }
-    service = BankDemoProofService(advise_client=advise_client)  # type: ignore[arg-type]
+    service = BankDemoProofService(advise_client=advise_client)
 
     response = await service.build_proof_pack(
         body={"live_runtime_payload": {"parity": {}}, "runtime_posture": {"endpoints": []}},
@@ -108,7 +108,7 @@ async def test_bank_demo_proof_service_propagates_advise_material_drift_conflict
     advise_client.payload = {
         "detail": "RFC0028_BACKEND_PROOF_MATERIAL_REVIEW_BLOCKED: policy_evaluation='APPROVED'"
     }
-    service = BankDemoProofService(advise_client=advise_client)  # type: ignore[arg-type]
+    service = BankDemoProofService(advise_client=advise_client)
 
     with pytest.raises(HTTPException) as exc_info:
         await service.build_proof_pack(body={}, correlation_id="corr-rfc0028-proof")

--- a/tests/unit/test_dpm_command_center_ai_context.py
+++ b/tests/unit/test_dpm_command_center_ai_context.py
@@ -13,7 +13,6 @@ from app.services.dpm_command_center_ai_context import (
     pm_quality_score_run_from,
     pm_quality_summary_source_refs,
     pm_quality_summary_task_payload,
-    workflow_pack_task_request,
 )
 
 
@@ -222,27 +221,3 @@ def test_ai_handoff_task_payloads_preserve_review_boundaries() -> None:
     assert pm_quality_payload["supportability"]["requires_human_review"] is True
     assert "contact_client" in pm_quality_payload["supportability"]["forbidden_actions"]
     assert "trade_approval" in pm_quality_payload["supportability"]["unsupported_claims"]
-
-
-def test_workflow_pack_task_request_uses_gateway_caller_and_source_refs() -> None:
-    task_request = workflow_pack_task_request(
-        correlation_id="corr-1",
-        summary="Generate bounded narrative.",
-        payload={"evidence": "bounded"},
-        source_refs=["lotus-manage:source:1"],
-    )
-
-    assert task_request == {
-        "task_id": "explain.v1",
-        "input_mode": "STRUCTURED_CONTEXT",
-        "caller": {
-            "caller_app": "lotus-gateway",
-            "correlation_id": "corr-1",
-        },
-        "context": {
-            "summary": "Generate bounded narrative.",
-            "payload": {"evidence": "bounded"},
-            "source_refs": ["lotus-manage:source:1"],
-        },
-        "expected_output_label": "EXPLANATION_ONLY",
-    }

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -1568,7 +1568,7 @@ async def test_dpm_pm_operating_quality_summary_uses_manage_score_run_and_lotus_
     )
     service = DpmCommandCenterService(
         dpm_client=dpm_client,  # type: ignore[arg-type]
-        lotus_ai_client=ai_client,  # type: ignore[arg-type]
+        lotus_ai_client=ai_client,
     )
 
     response = await service.request_pm_operating_quality_summary(
@@ -1624,7 +1624,7 @@ async def test_dpm_pm_operating_quality_summary_preserves_lotus_ai_errors() -> N
     ai_client = _FakeLotusAiClient((422, {"detail": "pm ranking output blocked"}))
     service = DpmCommandCenterService(
         dpm_client=dpm_client,  # type: ignore[arg-type]
-        lotus_ai_client=ai_client,  # type: ignore[arg-type]
+        lotus_ai_client=ai_client,
     )
 
     with pytest.raises(HTTPException) as exc_info:

--- a/tests/unit/test_dpm_construction_service.py
+++ b/tests/unit/test_dpm_construction_service.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import pytest
 from fastapi import HTTPException
 
@@ -56,7 +58,7 @@ class _FakeDpmClient:
 async def test_dpm_construction_preserves_manage_alternative_set_payload() -> None:
     manage_payload = _construction_alternative_set()
     client = _FakeDpmClient((200, manage_payload))
-    service = DpmConstructionService(dpm_client=client)  # type: ignore[arg-type]
+    service = DpmConstructionService(dpm_client=client)
 
     response = await service.generate_alternative_set(
         body={"input_mode": "stateless", "methods": ["REGIME_STRESS_AWARE"]},
@@ -77,9 +79,10 @@ async def test_dpm_construction_preserves_manage_alternative_set_payload() -> No
         "REGIME_SCENARIO_PACK_READY",
         "TARGET_METHOD_COMPARISON_AVAILABLE",
     ]
-    currency_context = response.data["alternatives"][0]["diagnostics"]["authority_context"][
-        "currency_overlay_context"
-    ]
+    alternatives = cast(list[dict[str, Any]], response.data["alternatives"])
+    diagnostics = cast(dict[str, Any], alternatives[0]["diagnostics"])
+    authority_context = cast(dict[str, Any], diagnostics["authority_context"])
+    currency_context = cast(dict[str, Any], authority_context["currency_overlay_context"])
     assert currency_context["external_hedge_policy_source_product_name"] == ("ExternalHedgePolicy")
     assert currency_context["external_hedge_policy_source_product_version"] == "v1"
     assert currency_context["external_hedge_policy_source_id"] == ("sha256:external-hedge-policy")
@@ -106,9 +109,10 @@ async def test_dpm_construction_preserves_manage_alternative_set_payload() -> No
     ]
     assert "hedge_policy_approval" in currency_context["blocked_capabilities"]
     assert "eligible_instrument_selection" in currency_context["blocked_capabilities"]
-    acknowledgement_context = response.data["alternatives"][0]["diagnostics"]["authority_context"][
-        "execution_acknowledgement_context"
-    ]
+    acknowledgement_context = cast(
+        dict[str, Any],
+        authority_context["execution_acknowledgement_context"],
+    )
     assert acknowledgement_context["source_product_name"] == (
         "ExternalOrderExecutionAcknowledgement"
     )
@@ -143,7 +147,7 @@ async def test_dpm_construction_preserves_manage_alternative_set_payload() -> No
 async def test_dpm_construction_retrieves_manage_alternative_set_without_mutation() -> None:
     manage_payload = _construction_alternative_set()
     client = _FakeDpmClient((200, manage_payload))
-    service = DpmConstructionService(dpm_client=client)  # type: ignore[arg-type]
+    service = DpmConstructionService(dpm_client=client)
 
     response = await service.get_alternative_set(
         alternative_set_id="cas_1",
@@ -175,7 +179,7 @@ async def test_dpm_construction_selection_preserves_manage_decision() -> None:
             },
         )
     )
-    service = DpmConstructionService(dpm_client=client)  # type: ignore[arg-type]
+    service = DpmConstructionService(dpm_client=client)
 
     response = await service.select_alternative(
         alternative_set_id="cas_1",
@@ -207,7 +211,7 @@ async def test_dpm_construction_selection_preserves_manage_decision() -> None:
 @pytest.mark.asyncio
 async def test_dpm_construction_forwards_manage_errors_as_product_safe_detail() -> None:
     client = _FakeDpmClient((409, {"detail": "CONSTRUCTION_IDEMPOTENCY_KEY_CONFLICT"}))
-    service = DpmConstructionService(dpm_client=client)  # type: ignore[arg-type]
+    service = DpmConstructionService(dpm_client=client)
 
     with pytest.raises(HTTPException) as exc_info:
         await service.generate_alternative_set(
@@ -225,7 +229,7 @@ async def test_dpm_construction_forwards_manage_errors_as_product_safe_detail() 
     }
 
 
-def _construction_alternative_set() -> dict[str, object]:
+def _construction_alternative_set() -> dict[str, Any]:
     return {
         "alternative_set_id": "cas_1",
         "portfolio_id": "PB_SG_GLOBAL_BAL_001",

--- a/tests/unit/test_dpm_proof_pack_service.py
+++ b/tests/unit/test_dpm_proof_pack_service.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import pytest
 from fastapi import HTTPException
 
@@ -76,7 +78,7 @@ class _FakeLotusAiClient:
 async def test_dpm_proof_pack_generation_preserves_manage_payload() -> None:
     manage_payload = _proof_pack_generate_payload()
     client = _FakeDpmClient((200, manage_payload))
-    service = DpmProofPackService(dpm_client=client)  # type: ignore[arg-type]
+    service = DpmProofPackService(dpm_client=client)
 
     response = await service.generate_proof_pack(
         body={"source_type": "REBALANCE_RUN", "rebalance_run_id": "rr_001"},
@@ -117,7 +119,7 @@ async def test_dpm_proof_pack_generation_preserves_manage_payload() -> None:
 async def test_dpm_proof_pack_lookup_does_not_reconstruct_sections_or_hashes() -> None:
     manage_payload = _proof_pack_lookup_payload()
     client = _FakeDpmClient((200, manage_payload))
-    service = DpmProofPackService(dpm_client=client)  # type: ignore[arg-type]
+    service = DpmProofPackService(dpm_client=client)
 
     response = await service.get_proof_pack(
         proof_pack_id="dpp_rr_001",
@@ -127,7 +129,8 @@ async def test_dpm_proof_pack_lookup_does_not_reconstruct_sections_or_hashes() -
     assert response.data == manage_payload
     assert response.supportability.state == "DEGRADED"
     assert response.supportability.section_state_counts == {"READY": 1, "DEGRADED": 1}
-    assert response.data["proof_pack"]["source_hashes"] == {
+    proof_pack = cast(dict[str, Any], response.data["proof_pack"])
+    assert proof_pack["source_hashes"] == {
         "mandate": "sha256:mandate",
         "rebalance_run": "sha256:run",
     }
@@ -143,7 +146,7 @@ async def test_dpm_proof_pack_lookup_does_not_reconstruct_sections_or_hashes() -
 @pytest.mark.asyncio
 async def test_dpm_proof_pack_markdown_preserves_manage_text() -> None:
     client = _FakeDpmClient((200, "# DPM proof pack\n\n- Status: READY\n", {}))
-    service = DpmProofPackService(dpm_client=client)  # type: ignore[arg-type]
+    service = DpmProofPackService(dpm_client=client)
 
     response = await service.get_proof_pack_markdown(
         proof_pack_id="dpp_rr_001",
@@ -175,13 +178,13 @@ async def test_dpm_proof_pack_handoff_inputs_preserve_manage_payloads() -> None:
         "reason_codes": ["AI_EVIDENCE_INPUT_READY"],
     }
 
-    report_response = await DpmProofPackService(  # type: ignore[arg-type]
+    report_response = await DpmProofPackService(
         dpm_client=_FakeDpmClient((200, report_payload))
     ).get_proof_pack_report_input(
         proof_pack_id="dpp_rr_001",
         correlation_id="corr-report-input-1",
     )
-    ai_response = await DpmProofPackService(  # type: ignore[arg-type]
+    ai_response = await DpmProofPackService(
         dpm_client=_FakeDpmClient((200, ai_payload))
     ).get_proof_pack_ai_evidence_input(
         proof_pack_id="dpp_rr_001",
@@ -233,7 +236,7 @@ async def test_dpm_proof_pack_pm_memo_executes_lotus_ai_with_manage_evidence() -
     }
     dpm_client = _FakeDpmClient((200, manage_payload))
     ai_client = _FakeLotusAiClient((200, ai_payload))
-    service = DpmProofPackService(  # type: ignore[arg-type]
+    service = DpmProofPackService(
         dpm_client=dpm_client,
         lotus_ai_client=ai_client,
     )
@@ -257,24 +260,28 @@ async def test_dpm_proof_pack_pm_memo_executes_lotus_ai_with_manage_evidence() -
         "requested_outputs": ["pm_memo", "evidence_gaps"],
         "audience": ["portfolio_manager"],
     }
-    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    workflow_pack_run = cast(dict[str, Any], response.data["workflow_pack_run"])
+    assert workflow_pack_run["workflow_authority_owner"] == "lotus-manage"
     [ai_call] = ai_client.calls
     assert ai_call["pack_id"] == "dpm_pm_memo.pack"
     assert ai_call["version"] == "v1"
     assert ai_call["workflow_surface"] == "dpm-proof-pack-ai-evidence"
     assert ai_call["correlation_id"] == "corr-proof-pack-memo-1"
-    task_request = ai_call["task_request"]
+    task_request = cast(dict[str, Any], ai_call["task_request"])
+    task_context = cast(dict[str, Any], task_request["context"])
+    task_payload = cast(dict[str, Any], task_context["payload"])
     assert task_request["task_id"] == "explain.v1"
-    assert task_request["context"]["payload"]["ai_evidence_input"] == manage_payload
-    assert task_request["context"]["payload"]["memo_request"] == response.memo_request
-    assert task_request["context"]["payload"]["supportability"]["blocked_actions"] == [
+    assert task_payload["ai_evidence_input"] == manage_payload
+    assert task_payload["memo_request"] == response.memo_request
+    supportability = cast(dict[str, Any], task_payload["supportability"])
+    assert supportability["blocked_actions"] == [
         "place_orders",
         "approve_rebalance",
         "override_controls",
         "invent_missing_evidence",
         "contact_client",
     ]
-    assert task_request["context"]["source_refs"] == [
+    assert task_context["source_refs"] == [
         "lotus-manage:proof-pack-ai-evidence:ai-evidence:dpp_rr_001",
         "lotus-manage:proof-pack-ai-evidence:dpp_rr_001",
         "lotus-manage:proof-pack:dpp_rr_001",
@@ -283,7 +290,7 @@ async def test_dpm_proof_pack_pm_memo_executes_lotus_ai_with_manage_evidence() -
 
 @pytest.mark.asyncio
 async def test_dpm_proof_pack_pm_memo_requires_lotus_ai_client() -> None:
-    service = DpmProofPackService(dpm_client=_FakeDpmClient((200, {})))  # type: ignore[arg-type]
+    service = DpmProofPackService(dpm_client=_FakeDpmClient((200, {})))
 
     with pytest.raises(HTTPException) as exc_info:
         await service.request_proof_pack_pm_memo(
@@ -300,7 +307,7 @@ async def test_dpm_proof_pack_pm_memo_requires_lotus_ai_client() -> None:
 
 @pytest.mark.asyncio
 async def test_dpm_proof_pack_pm_memo_preserves_lotus_ai_error() -> None:
-    service = DpmProofPackService(  # type: ignore[arg-type]
+    service = DpmProofPackService(
         dpm_client=_FakeDpmClient((200, {"proof_pack_id": "dpp_rr_001"})),
         lotus_ai_client=_FakeLotusAiClient(
             (422, {"detail": "PROOF_PACK_PM_MEMO_GUARDRAIL_BLOCKED: missing content_hash"})
@@ -326,7 +333,7 @@ async def test_dpm_proof_pack_pm_memo_preserves_lotus_ai_error() -> None:
 @pytest.mark.asyncio
 async def test_dpm_proof_pack_forwards_manage_errors_as_product_safe_detail() -> None:
     client = _FakeDpmClient((503, {"detail": "upstream communication failure: TimeoutException"}))
-    service = DpmProofPackService(dpm_client=client)  # type: ignore[arg-type]
+    service = DpmProofPackService(dpm_client=client)
 
     with pytest.raises(HTTPException) as exc_info:
         await service.get_proof_pack(
@@ -343,7 +350,7 @@ async def test_dpm_proof_pack_forwards_manage_errors_as_product_safe_detail() ->
     }
 
 
-def _proof_pack_generate_payload() -> dict[str, object]:
+def _proof_pack_generate_payload() -> dict[str, Any]:
     return {
         "proof_pack": {
             "proof_pack_id": "dpp_rr_001",
@@ -369,7 +376,7 @@ def _proof_pack_generate_payload() -> dict[str, object]:
     }
 
 
-def _proof_pack_lookup_payload() -> dict[str, object]:
+def _proof_pack_lookup_payload() -> dict[str, Any]:
     return {
         "proof_pack": {
             "proof_pack_id": "dpp_rr_001",

--- a/tests/unit/test_dpm_service_factory.py
+++ b/tests/unit/test_dpm_service_factory.py
@@ -5,6 +5,8 @@ from app.services.dpm_service_factory import (
     build_dpm_wave_service,
     build_lotus_ai_client,
     build_manage_client,
+    lotus_ai_client_signature,
+    manage_client_signature,
 )
 
 
@@ -45,6 +47,8 @@ def test_dpm_service_factory_builds_governed_manage_and_ai_clients(monkeypatch) 
     assert ai_client._timeout == 55.0
     assert ai_client._max_retries == 4
     assert ai_client._retry_backoff_seconds == 0.75
+    assert manage_client_signature() == ("http://manage:8000", 6.5, 4, 0.75)
+    assert lotus_ai_client_signature() == ("http://ai:8000", 55.0, 4, 0.75)
 
 
 def test_dpm_service_factory_wires_all_dpm_route_services(monkeypatch) -> None:

--- a/tests/unit/test_dpm_service_provider.py
+++ b/tests/unit/test_dpm_service_provider.py
@@ -1,3 +1,7 @@
+from typing import cast
+
+from app.clients.dpm_client import DpmClient
+from app.clients.lotus_ai_client import LotusAiClient
 from app.services.dpm_service_provider import (
     dpm_command_center_service,
     dpm_construction_service,
@@ -22,9 +26,40 @@ def test_dpm_service_provider_wires_manage_and_ai_backed_services(monkeypatch) -
     wave = dpm_wave_service()
 
     assert command_center._dpm_client._base_url == "http://manage-provider:8000"
-    assert command_center._lotus_ai_client._base_url == "http://ai-provider:8000"
-    assert construction._dpm_client._base_url == "http://manage-provider:8000"
-    assert proof_pack._dpm_client._base_url == "http://manage-provider:8000"
-    assert proof_pack._lotus_ai_client._base_url == "http://ai-provider:8000"
+    assert cast(LotusAiClient, command_center._lotus_ai_client)._base_url == (
+        "http://ai-provider:8000"
+    )
+    assert cast(DpmClient, construction._dpm_client)._base_url == "http://manage-provider:8000"
+    assert cast(DpmClient, proof_pack._dpm_client)._base_url == "http://manage-provider:8000"
+    assert cast(LotusAiClient, proof_pack._lotus_ai_client)._base_url == ("http://ai-provider:8000")
     assert wave._dpm_client._base_url == "http://manage-provider:8000"
-    assert wave._lotus_ai_client._base_url == "http://ai-provider:8000"
+    assert cast(LotusAiClient, wave._lotus_ai_client)._base_url == "http://ai-provider:8000"
+
+
+def test_dpm_service_provider_reuses_services_for_unchanged_signature(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.dpm_service_factory.settings.management_service_base_url",
+        "http://manage-provider-cache:8000",
+    )
+
+    first = dpm_command_center_service()
+    second = dpm_command_center_service()
+
+    assert first is second
+
+
+def test_dpm_service_provider_rebuilds_when_manage_routing_changes(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.dpm_service_factory.settings.management_service_base_url",
+        "http://manage-provider-a:8000",
+    )
+    first = dpm_wave_service()
+
+    monkeypatch.setattr(
+        "app.services.dpm_service_factory.settings.management_service_base_url",
+        "http://manage-provider-b:8000",
+    )
+    second = dpm_wave_service()
+
+    assert first is not second
+    assert second._dpm_client._base_url == "http://manage-provider-b:8000"

--- a/tests/unit/test_dpm_wave_service.py
+++ b/tests/unit/test_dpm_wave_service.py
@@ -953,7 +953,7 @@ async def test_dpm_wave_pm_memo_uses_manage_report_input_and_lotus_ai_pack() -> 
     ai_client = _FakeLotusAiClient((200, ai_payload))
     service = DpmWaveService(
         dpm_client=dpm_client,  # type: ignore[arg-type]
-        lotus_ai_client=ai_client,  # type: ignore[arg-type]
+        lotus_ai_client=ai_client,
     )
 
     response = await service.request_wave_pm_memo(
@@ -1041,7 +1041,7 @@ async def test_dpm_operations_handoff_summary_uses_manage_handoff_evidence_and_l
     ai_client = _FakeLotusAiClient((200, ai_payload))
     service = DpmWaveService(
         dpm_client=dpm_client,  # type: ignore[arg-type]
-        lotus_ai_client=ai_client,  # type: ignore[arg-type]
+        lotus_ai_client=ai_client,
     )
 
     response = await service.request_operations_handoff_summary(

--- a/tests/unit/test_gateway_service_provider.py
+++ b/tests/unit/test_gateway_service_provider.py
@@ -44,3 +44,32 @@ def test_gateway_service_provider_wires_smaller_route_services(monkeypatch) -> N
         intake_service()._lotus_core_ingestion_client._base_url
         == "http://core-ingestion-provider:8000"
     )
+
+
+def test_gateway_service_provider_reuses_services_for_unchanged_signature(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.archive_client_factory.settings.archive_service_base_url",
+        "http://archive-provider-cache:8000",
+    )
+
+    first = archive_document_service()
+    second = archive_document_service()
+
+    assert first is second
+
+
+def test_gateway_service_provider_rebuilds_when_core_query_routing_changes(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.lotus_core_client_factory.settings.portfolio_data_query_base_url",
+        "http://core-query-provider-a:8001",
+    )
+    first = source_product_service()
+
+    monkeypatch.setattr(
+        "app.services.lotus_core_client_factory.settings.portfolio_data_query_base_url",
+        "http://core-query-provider-b:8001",
+    )
+    second = source_product_service()
+
+    assert first is not second
+    assert second._lotus_core_query_client._query_base_url == "http://core-query-provider-b:8001"

--- a/tests/unit/test_lotus_ai_workflow.py
+++ b/tests/unit/test_lotus_ai_workflow.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException, status
 from app.clients.lotus_ai_client import LotusAiClient
 from app.services.lotus_ai_workflow import (
     LOTUS_AI_NOT_CONFIGURED_DETAIL,
+    build_workflow_pack_task_request,
     require_lotus_ai_client,
 )
 
@@ -22,3 +23,27 @@ def test_require_lotus_ai_client_raises_product_safe_unavailable_error() -> None
 
     assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert exc_info.value.detail == LOTUS_AI_NOT_CONFIGURED_DETAIL
+
+
+def test_build_workflow_pack_task_request_uses_gateway_structured_context() -> None:
+    request = build_workflow_pack_task_request(
+        correlation_id="corr-ai-task",
+        summary="Generate review-gated narrative.",
+        payload={"evidence": {"content_hash": "sha256:evidence"}},
+        source_refs=["lotus-manage:evidence:1"],
+    )
+
+    assert request == {
+        "task_id": "explain.v1",
+        "input_mode": "STRUCTURED_CONTEXT",
+        "caller": {
+            "caller_app": "lotus-gateway",
+            "correlation_id": "corr-ai-task",
+        },
+        "context": {
+            "summary": "Generate review-gated narrative.",
+            "payload": {"evidence": {"content_hash": "sha256:evidence"}},
+            "source_refs": ["lotus-manage:evidence:1"],
+        },
+        "expected_output_label": "EXPLANATION_ONLY",
+    }

--- a/tests/unit/test_lotus_core_client_factory.py
+++ b/tests/unit/test_lotus_core_client_factory.py
@@ -1,6 +1,8 @@
 from app.services.lotus_core_client_factory import (
     build_lotus_core_ingestion_client,
     build_lotus_core_query_client,
+    lotus_core_ingestion_client_signature,
+    lotus_core_query_client_signature,
 )
 
 
@@ -30,6 +32,12 @@ def test_lotus_core_ingestion_client_factory_builds_configured_ingestion_client(
     assert client._timeout == 6.5
     assert client._max_retries == 4
     assert client._retry_backoff_seconds == 0.75
+    assert lotus_core_ingestion_client_signature() == (
+        "http://core-ingestion:8000/",
+        6.5,
+        4,
+        0.75,
+    )
 
 
 def test_lotus_core_query_client_factory_builds_configured_query_client(monkeypatch) -> None:
@@ -61,3 +69,10 @@ def test_lotus_core_query_client_factory_builds_configured_query_client(monkeypa
     assert client._timeout == 6.5
     assert client._max_retries == 4
     assert client._retry_backoff_seconds == 0.75
+    assert lotus_core_query_client_signature() == (
+        "http://core-query:8001/",
+        "http://core-control:8002/",
+        6.5,
+        4,
+        0.75,
+    )

--- a/tests/unit/test_platform_capabilities_service_provider.py
+++ b/tests/unit/test_platform_capabilities_service_provider.py
@@ -8,3 +8,34 @@ def test_platform_capabilities_service_provider_uses_configured_timeout(monkeypa
     )
 
     assert platform_capabilities_service()._source_timeout_seconds == 9.25
+
+
+def test_platform_capabilities_service_provider_reuses_unchanged_signature(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.platform_capabilities_service_factory.settings.platform_capabilities_source_timeout_seconds",
+        7.5,
+    )
+
+    first = platform_capabilities_service()
+    second = platform_capabilities_service()
+
+    assert first is second
+
+
+def test_platform_capabilities_service_provider_rebuilds_when_source_timeout_changes(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.platform_capabilities_service_factory.settings.platform_capabilities_source_timeout_seconds",
+        8.0,
+    )
+    first = platform_capabilities_service()
+
+    monkeypatch.setattr(
+        "app.services.platform_capabilities_service_factory.settings.platform_capabilities_source_timeout_seconds",
+        8.5,
+    )
+    second = platform_capabilities_service()
+
+    assert first is not second
+    assert second._source_timeout_seconds == 8.5

--- a/tests/unit/test_reporting_client_factory.py
+++ b/tests/unit/test_reporting_client_factory.py
@@ -1,4 +1,9 @@
-from app.services.reporting_client_factory import build_render_client, build_reporting_client
+from app.services.reporting_client_factory import (
+    build_render_client,
+    build_reporting_client,
+    render_client_signature,
+    reporting_client_signature,
+)
 
 
 def test_reporting_client_factory_builds_governed_reporting_client(monkeypatch) -> None:
@@ -25,6 +30,7 @@ def test_reporting_client_factory_builds_governed_reporting_client(monkeypatch) 
     assert client._timeout == 7.5
     assert client._max_retries == 5
     assert client._retry_backoff_seconds == 0.65
+    assert reporting_client_signature() == ("http://report:8000/", 7.5, 5, 0.65)
 
 
 def test_reporting_client_factory_builds_governed_render_client(monkeypatch) -> None:
@@ -51,3 +57,4 @@ def test_reporting_client_factory_builds_governed_render_client(monkeypatch) -> 
     assert client._timeout == 8.5
     assert client._max_retries == 6
     assert client._retry_backoff_seconds == 0.8
+    assert render_client_signature() == ("http://render:8000/", 8.5, 6, 0.8)

--- a/tests/unit/test_reporting_service_provider.py
+++ b/tests/unit/test_reporting_service_provider.py
@@ -70,3 +70,20 @@ def test_reporting_service_provider_rebuilds_when_reporting_routing_changes(monk
 
     assert first is not second
     assert second._reporting_client._base_url == "http://reporting-provider-b:8000"
+
+
+def test_reporting_batch_provider_rebuilds_when_render_routing_changes(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.reporting_client_factory.settings.render_service_base_url",
+        "http://render-provider-a:8000",
+    )
+    first = reporting_batch_control_service()
+
+    monkeypatch.setattr(
+        "app.services.reporting_client_factory.settings.render_service_base_url",
+        "http://render-provider-b:8000",
+    )
+    second = reporting_batch_control_service()
+
+    assert first is not second
+    assert second._render_client._base_url == "http://render-provider-b:8000"

--- a/tests/unit/test_reporting_service_provider.py
+++ b/tests/unit/test_reporting_service_provider.py
@@ -1,0 +1,72 @@
+from app.services.reporting_service_provider import (
+    reporting_batch_control_service,
+    reporting_batch_lifecycle_service,
+    reporting_batch_scheduler_service,
+    reporting_job_query_service,
+    reporting_job_submission_service,
+    reporting_portfolio_service,
+)
+
+
+def test_reporting_service_provider_wires_reporting_backed_services(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.reporting_client_factory.settings.reporting_aggregation_base_url",
+        "http://reporting-provider:8000",
+    )
+    monkeypatch.setattr(
+        "app.services.reporting_client_factory.settings.render_service_base_url",
+        "http://render-provider:8000",
+    )
+
+    assert (
+        reporting_portfolio_service()._reporting_client._base_url
+        == "http://reporting-provider:8000"
+    )
+    assert (
+        reporting_job_submission_service()._reporting_client._base_url
+        == "http://reporting-provider:8000"
+    )
+    assert (
+        reporting_job_query_service()._reporting_client._base_url
+        == "http://reporting-provider:8000"
+    )
+    assert (
+        reporting_batch_control_service()._render_client._base_url == "http://render-provider:8000"
+    )
+    assert (
+        reporting_batch_lifecycle_service()._render_client._base_url
+        == "http://render-provider:8000"
+    )
+    assert (
+        reporting_batch_scheduler_service()._reporting_client._base_url
+        == "http://reporting-provider:8000"
+    )
+
+
+def test_reporting_service_provider_reuses_services_for_unchanged_signature(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.reporting_client_factory.settings.reporting_aggregation_base_url",
+        "http://reporting-provider-cache:8000",
+    )
+
+    first = reporting_job_query_service()
+    second = reporting_job_query_service()
+
+    assert first is second
+
+
+def test_reporting_service_provider_rebuilds_when_reporting_routing_changes(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.reporting_client_factory.settings.reporting_aggregation_base_url",
+        "http://reporting-provider-a:8000",
+    )
+    first = reporting_job_submission_service()
+
+    monkeypatch.setattr(
+        "app.services.reporting_client_factory.settings.reporting_aggregation_base_url",
+        "http://reporting-provider-b:8000",
+    )
+    second = reporting_job_submission_service()
+
+    assert first is not second
+    assert second._reporting_client._base_url == "http://reporting-provider-b:8000"

--- a/tests/unit/test_service_layer_boundaries.py
+++ b/tests/unit/test_service_layer_boundaries.py
@@ -2,6 +2,7 @@ import ast
 from pathlib import Path
 
 _SERVICE_ROOT = Path(__file__).parents[2] / "src" / "app" / "services"
+_TEST_ROOT = Path(__file__).parents[2] / "tests" / "unit"
 
 
 def _imported_modules(path: Path) -> set[str]:
@@ -80,5 +81,21 @@ def test_services_delegate_workflow_task_request_shape_to_shared_helper() -> Non
                 inline_task_request_lines.append(node.lineno)
         if inline_task_request_lines:
             offenders[path.relative_to(_SERVICE_ROOT).as_posix()] = inline_task_request_lines
+
+    assert offenders == {}
+
+
+def test_non_dpm_service_tests_do_not_need_arg_type_suppressions() -> None:
+    allowed = {
+        "test_dpm_command_center_service.py",
+        "test_dpm_wave_service.py",
+    }
+    offenders: dict[str, int] = {}
+    for path in _TEST_ROOT.glob("test_*_service.py"):
+        if path.name in allowed:
+            continue
+        suppression_count = path.read_text(encoding="utf-8").count("# type: ignore[arg-type]")
+        if suppression_count:
+            offenders[path.name] = suppression_count
 
     assert offenders == {}

--- a/tests/unit/test_service_layer_boundaries.py
+++ b/tests/unit/test_service_layer_boundaries.py
@@ -3,6 +3,20 @@ from pathlib import Path
 
 _SERVICE_ROOT = Path(__file__).parents[2] / "src" / "app" / "services"
 _TEST_ROOT = Path(__file__).parents[2] / "tests" / "unit"
+_CLIENT_FACTORY_FILES = {
+    "advise_client_factory.py",
+    "analytics_client_factory.py",
+    "archive_client_factory.py",
+    "dpm_service_factory.py",
+    "lotus_core_client_factory.py",
+    "reporting_client_factory.py",
+}
+_UPSTREAM_ROUTING_SETTING_SUFFIXES = (
+    "_base_url",
+    "_timeout_seconds",
+    "_max_retries",
+    "_retry_backoff_seconds",
+)
 
 
 def _imported_modules(path: Path) -> set[str]:
@@ -97,5 +111,28 @@ def test_non_dpm_service_tests_do_not_need_arg_type_suppressions() -> None:
         suppression_count = path.read_text(encoding="utf-8").count("# type: ignore[arg-type]")
         if suppression_count:
             offenders[path.name] = suppression_count
+
+    assert offenders == {}
+
+
+def test_non_client_service_factories_do_not_repeat_upstream_routing_settings() -> None:
+    offenders: dict[str, list[str]] = {}
+    for path in _SERVICE_ROOT.glob("*_service_factory.py"):
+        if path.name in _CLIENT_FACTORY_FILES:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        repeated_settings = sorted(
+            {
+                node.attr
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "settings"
+                and node.attr != "platform_capabilities_source_timeout_seconds"
+                and node.attr.endswith(_UPSTREAM_ROUTING_SETTING_SUFFIXES)
+            }
+        )
+        if repeated_settings:
+            offenders[path.relative_to(_SERVICE_ROOT).as_posix()] = repeated_settings
 
     assert offenders == {}

--- a/tests/unit/test_service_layer_boundaries.py
+++ b/tests/unit/test_service_layer_boundaries.py
@@ -49,6 +49,23 @@ def test_service_providers_do_not_return_direct_builder_calls() -> None:
     assert offenders == {}
 
 
+def test_service_providers_use_shared_cache_helper() -> None:
+    offenders: list[str] = []
+    for path in _SERVICE_ROOT.glob("*_service_provider.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        helper_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "resolve_cached_service"
+        ]
+        if not helper_calls:
+            offenders.append(path.relative_to(_SERVICE_ROOT).as_posix())
+
+    assert offenders == []
+
+
 def test_services_delegate_workflow_task_request_shape_to_shared_helper() -> None:
     offenders: dict[str, list[int]] = {}
     for path in _SERVICE_ROOT.rglob("*.py"):

--- a/tests/unit/test_service_layer_boundaries.py
+++ b/tests/unit/test_service_layer_boundaries.py
@@ -27,3 +27,23 @@ def test_service_layer_does_not_depend_on_router_modules() -> None:
     offenders = {name: imports for name, imports in offenders.items() if imports}
 
     assert offenders == {}
+
+
+def test_service_providers_do_not_return_direct_builder_calls() -> None:
+    offenders: dict[str, list[str]] = {}
+    for path in _SERVICE_ROOT.glob("*_service_provider.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        direct_builder_returns: list[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Return):
+                continue
+            if not isinstance(node.value, ast.Call):
+                continue
+            if not isinstance(node.value.func, ast.Name):
+                continue
+            if node.value.func.id.startswith("build_"):
+                direct_builder_returns.append(node.value.func.id)
+        if direct_builder_returns:
+            offenders[path.relative_to(_SERVICE_ROOT).as_posix()] = sorted(direct_builder_returns)
+
+    assert offenders == {}

--- a/tests/unit/test_service_layer_boundaries.py
+++ b/tests/unit/test_service_layer_boundaries.py
@@ -47,3 +47,21 @@ def test_service_providers_do_not_return_direct_builder_calls() -> None:
             offenders[path.relative_to(_SERVICE_ROOT).as_posix()] = sorted(direct_builder_returns)
 
     assert offenders == {}
+
+
+def test_services_delegate_workflow_task_request_shape_to_shared_helper() -> None:
+    offenders: dict[str, list[int]] = {}
+    for path in _SERVICE_ROOT.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        inline_task_request_lines: list[int] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.keyword):
+                continue
+            if node.arg != "task_request":
+                continue
+            if isinstance(node.value, ast.Dict):
+                inline_task_request_lines.append(node.lineno)
+        if inline_task_request_lines:
+            offenders[path.relative_to(_SERVICE_ROOT).as_posix()] = inline_task_request_lines
+
+    assert offenders == {}

--- a/tests/unit/test_service_provider_cache.py
+++ b/tests/unit/test_service_provider_cache.py
@@ -1,0 +1,58 @@
+from app.services.service_provider_cache import resolve_cached_service
+
+
+def test_resolve_cached_service_builds_when_cache_empty() -> None:
+    created: list[str] = []
+
+    def build_service() -> str:
+        created.append("built")
+        return "service-a"
+
+    service, signature = resolve_cached_service(
+        service=None,
+        cached_signature=None,
+        current_signature=("route-a",),
+        build_service=build_service,
+    )
+
+    assert service == "service-a"
+    assert signature == ("route-a",)
+    assert created == ["built"]
+
+
+def test_resolve_cached_service_reuses_matching_signature() -> None:
+    created: list[str] = []
+
+    def build_service() -> str:
+        created.append("built")
+        return "service-b"
+
+    service, signature = resolve_cached_service(
+        service="cached-service",
+        cached_signature=("route-a",),
+        current_signature=("route-a",),
+        build_service=build_service,
+    )
+
+    assert service == "cached-service"
+    assert signature == ("route-a",)
+    assert created == []
+
+
+def test_resolve_cached_service_rebuilds_when_signature_changes() -> None:
+    created: list[str] = []
+
+    def build_service() -> str:
+        created.append("built")
+        return "service-b"
+
+    service, signature = resolve_cached_service(
+        service="cached-service",
+        cached_signature=("route-a",),
+        current_signature=("route-b",),
+        build_service=build_service,
+    )
+
+    assert service == "service-b"
+    assert signature == ("route-b",)
+    assert created == ["built"]

--- a/tests/unit/test_service_provider_cache.py
+++ b/tests/unit/test_service_provider_cache.py
@@ -39,6 +39,25 @@ def test_resolve_cached_service_reuses_matching_signature() -> None:
     assert created == []
 
 
+def test_resolve_cached_service_reuses_falsey_cached_service() -> None:
+    created: list[str] = []
+
+    def build_service() -> str:
+        created.append("built")
+        return "rebuilt-service"
+
+    service, signature = resolve_cached_service(
+        service="",
+        cached_signature=("route-a",),
+        current_signature=("route-a",),
+        build_service=build_service,
+    )
+
+    assert service == ""
+    assert signature == ("route-a",)
+    assert created == []
+
+
 def test_resolve_cached_service_rebuilds_when_signature_changes() -> None:
     created: list[str] = []
 

--- a/tests/unit/test_workbench_service_provider.py
+++ b/tests/unit/test_workbench_service_provider.py
@@ -1,0 +1,71 @@
+from app.services.workbench_service_provider import (
+    advisor_brief_service,
+    performance_workspace_service,
+    risk_workspace_service,
+    workbench_service,
+)
+
+
+def test_workbench_service_provider_reuses_services_for_unchanged_signature(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.lotus_core_client_factory.settings.portfolio_data_query_base_url",
+        "http://core-query-workbench-cache:8001",
+    )
+
+    first = workbench_service()
+    second = workbench_service()
+
+    assert first is second
+
+
+def test_workbench_service_provider_rebuilds_when_core_routing_changes(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.lotus_core_client_factory.settings.portfolio_data_query_base_url",
+        "http://core-query-workbench-a:8001",
+    )
+    first = workbench_service()
+
+    monkeypatch.setattr(
+        "app.services.lotus_core_client_factory.settings.portfolio_data_query_base_url",
+        "http://core-query-workbench-b:8001",
+    )
+    second = workbench_service()
+
+    assert first is not second
+    assert second._lotus_core_query_client._query_base_url == "http://core-query-workbench-b:8001"
+
+
+def test_workbench_child_providers_rebuild_when_shared_signature_changes(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.analytics_client_factory.settings.performance_analytics_base_url",
+        "http://performance-workbench-a:8000",
+    )
+    first_performance = performance_workspace_service()
+    first_advisor_brief = advisor_brief_service()
+
+    monkeypatch.setattr(
+        "app.services.analytics_client_factory.settings.performance_analytics_base_url",
+        "http://performance-workbench-b:8000",
+    )
+    second_performance = performance_workspace_service()
+    second_advisor_brief = advisor_brief_service()
+
+    assert first_performance is not second_performance
+    assert first_advisor_brief is not second_advisor_brief
+
+
+def test_workbench_risk_provider_rebuilds_when_risk_routing_changes(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.analytics_client_factory.settings.risk_analytics_base_url",
+        "http://risk-workbench-a:8000",
+    )
+    first = risk_workspace_service()
+
+    monkeypatch.setattr(
+        "app.services.analytics_client_factory.settings.risk_analytics_base_url",
+        "http://risk-workbench-b:8000",
+    )
+    second = risk_workspace_service()
+
+    assert first is not second
+    assert second._risk_client._base_url == "http://risk-workbench-b:8000"


### PR DESCRIPTION
## Summary
- Cache Gateway service providers by routing signatures through a shared provider cache helper.
- Centralize upstream client signatures and compose service/provider rebuild keys from those signatures.
- Move lotus-ai workflow task request construction to a shared helper and narrow selected service dependencies to protocols.
- Add boundary and focused unit tests for provider caching, signature composition, workflow task request construction, and non-DPM type-suppression isolation.

## Validation
- make check
  - ruff check: passed
  - ruff format --check: passed
  - monetary float guard: passed (Findings=189, allowlisted=189)
  - mypy src: passed (398 source files)
  - Workbench contract: passed
  - unit + contract tests: 779 passed

## Sibling refactor pulse
- lotus-core: perf/api-query-index-optimization @ 98ce8814, clean
- lotus-performance: feat/performance-modular-refactor @ 9f87ba0, clean
- lotus-manage: feat/manage-hardening-wave-2 @ 0b7ab70, clean

## Wiki
- No wiki/source documentation change required; this is code/test-only service-boundary and provider-lifecycle hardening.