### PR TITLE
Harden Gateway HTTP resilience guardrails

### DIFF
--- a/docs/standards/enterprise-readiness.md
+++ b/docs/standards/enterprise-readiness.md
@@ -51,10 +51,17 @@ Evidence:
 ## Reliability and Operations Baseline
 
 - Standard resilient HTTP client behavior (timeouts, bounded retries, explicit failures).
+- Retry configuration is defensive: negative retry counts are clamped to a single attempt and
+  negative backoff values are clamped to zero-delay retry behavior, preventing configuration drift
+  from suppressing all upstream calls or producing invalid sleeps.
+- Shared upstream HTTP helpers fail closed on unsupported methods instead of silently downgrading to
+  a different verb; JSON fan-out currently supports `GET`, `POST`, and `PUT`, while binary fan-out
+  supports `GET` and `POST`.
 - Runbooks and migration/change controls are standardized in shared PPD standards.
 
 Evidence:
 - `src/app/clients/http_resilience.py`
+- `tests/unit/test_http_resilience.py`
 - `docs/standards/scalability-availability.md`
 - `docs/standards/migration-contract.md`
 

--- a/src/app/clients/http_resilience.py
+++ b/src/app/clients/http_resilience.py
@@ -3,6 +3,9 @@ from typing import Any
 
 import httpx
 
+_BINARY_REQUEST_METHODS = frozenset({"GET", "POST"})
+_JSON_REQUEST_METHODS = frozenset({"GET", "POST", "PUT"})
+
 
 def _retry_attempts(max_retries: int) -> int:
     return max(0, max_retries) + 1
@@ -23,6 +26,11 @@ def _response_payload(response: httpx.Response) -> dict[str, Any]:
     return {"detail": payload}
 
 
+def _unsupported_method_payload(method: str) -> dict[str, str]:
+    request_method = method.upper() or "<blank>"
+    return {"detail": f"unsupported upstream HTTP method: {request_method}"}
+
+
 async def request_with_retry(
     *,
     method: str,
@@ -38,6 +46,10 @@ async def request_with_retry(
     files: dict[str, Any] | None = None,
     retry_timeout_exceptions: bool = True,
 ) -> tuple[int, dict[str, Any]]:
+    request_method = method.upper()
+    if request_method not in _JSON_REQUEST_METHODS:
+        return 503, _unsupported_method_payload(method)
+
     attempts = _retry_attempts(max_retries)
     for attempt in range(attempts):
         try:
@@ -45,7 +57,6 @@ async def request_with_retry(
                 timeout=timeout_seconds,
                 follow_redirects=True,
             ) as client:
-                request_method = method.upper()
                 if request_method == "GET":
                     response = await client.get(url, params=params, headers=headers)
                 elif request_method == "PUT":
@@ -91,6 +102,10 @@ async def request_binary_with_retry(
     headers: dict[str, str] | None = None,
     retry_timeout_exceptions: bool = True,
 ) -> tuple[int, bytes, dict[str, str], dict[str, Any]]:
+    request_method = method.upper()
+    if request_method not in _BINARY_REQUEST_METHODS:
+        return 503, b"", {}, _unsupported_method_payload(method)
+
     attempts = _retry_attempts(max_retries)
     for attempt in range(attempts):
         try:
@@ -98,7 +113,7 @@ async def request_binary_with_retry(
                 timeout=timeout_seconds,
                 follow_redirects=True,
             ) as client:
-                if method.upper() == "GET":
+                if request_method == "GET":
                     response = await client.get(url, params=params, headers=headers)
                 else:
                     response = await client.post(url, headers=headers)

--- a/src/app/clients/http_resilience.py
+++ b/src/app/clients/http_resilience.py
@@ -4,6 +4,15 @@ from typing import Any
 import httpx
 
 
+def _retry_attempts(max_retries: int) -> int:
+    return max(0, max_retries) + 1
+
+
+def _retry_delay(backoff_seconds: float, attempt: int) -> float:
+    bounded_backoff = backoff_seconds if backoff_seconds > 0.0 else 0.0
+    return bounded_backoff * (2.0**attempt)
+
+
 def _response_payload(response: httpx.Response) -> dict[str, Any]:
     try:
         payload = response.json()
@@ -29,7 +38,7 @@ async def request_with_retry(
     files: dict[str, Any] | None = None,
     retry_timeout_exceptions: bool = True,
 ) -> tuple[int, dict[str, Any]]:
-    attempts = max_retries + 1
+    attempts = _retry_attempts(max_retries)
     for attempt in range(attempts):
         try:
             async with httpx.AsyncClient(
@@ -53,7 +62,7 @@ async def request_with_retry(
 
             should_retry_status = retry_status_codes and response.status_code in retry_status_codes
             if should_retry_status and attempt < max_retries:
-                await asyncio.sleep(backoff_seconds * (2**attempt))
+                await asyncio.sleep(_retry_delay(backoff_seconds, attempt))
                 continue
             return response.status_code, _response_payload(response)
         except httpx.TimeoutException as exc:
@@ -61,11 +70,11 @@ async def request_with_retry(
                 return 503, {"detail": f"upstream communication failure: {exc.__class__.__name__}"}
             if attempt >= max_retries:
                 return 503, {"detail": f"upstream communication failure: {exc.__class__.__name__}"}
-            await asyncio.sleep(backoff_seconds * (2**attempt))
+            await asyncio.sleep(_retry_delay(backoff_seconds, attempt))
         except httpx.RequestError as exc:
             if attempt >= max_retries:
                 return 503, {"detail": f"upstream communication failure: {exc.__class__.__name__}"}
-            await asyncio.sleep(backoff_seconds * (2**attempt))
+            await asyncio.sleep(_retry_delay(backoff_seconds, attempt))
 
     return 503, {"detail": "upstream communication failure: exhausted retries"}
 
@@ -82,7 +91,7 @@ async def request_binary_with_retry(
     headers: dict[str, str] | None = None,
     retry_timeout_exceptions: bool = True,
 ) -> tuple[int, bytes, dict[str, str], dict[str, Any]]:
-    attempts = max_retries + 1
+    attempts = _retry_attempts(max_retries)
     for attempt in range(attempts):
         try:
             async with httpx.AsyncClient(
@@ -96,7 +105,7 @@ async def request_binary_with_retry(
 
             should_retry_status = retry_status_codes and response.status_code in retry_status_codes
             if should_retry_status and attempt < max_retries:
-                await asyncio.sleep(backoff_seconds * (2**attempt))
+                await asyncio.sleep(_retry_delay(backoff_seconds, attempt))
                 continue
             error_payload: dict[str, Any] = {}
             if response.status_code >= 400:
@@ -117,7 +126,7 @@ async def request_binary_with_retry(
                     {},
                     {"detail": f"upstream communication failure: {exc.__class__.__name__}"},
                 )
-            await asyncio.sleep(backoff_seconds * (2**attempt))
+            await asyncio.sleep(_retry_delay(backoff_seconds, attempt))
         except httpx.RequestError as exc:
             if attempt >= max_retries:
                 return (
@@ -126,6 +135,6 @@ async def request_binary_with_retry(
                     {},
                     {"detail": f"upstream communication failure: {exc.__class__.__name__}"},
                 )
-            await asyncio.sleep(backoff_seconds * (2**attempt))
+            await asyncio.sleep(_retry_delay(backoff_seconds, attempt))
 
     return 503, b"", {}, {"detail": "upstream communication failure: exhausted retries"}

--- a/tests/unit/test_http_resilience.py
+++ b/tests/unit/test_http_resilience.py
@@ -192,6 +192,31 @@ class _BinaryTextErrorAsyncClient:
         return httpx.Response(502, text="archive unavailable", request=httpx.Request("GET", url))
 
 
+class _BinarySuccessAsyncClient:
+    calls = 0
+    follow_redirects = None
+
+    def __init__(self, timeout: float, follow_redirects: bool = False):
+        _ = timeout
+        _BinarySuccessAsyncClient.follow_redirects = follow_redirects
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, params=None, headers=None):
+        _ = params, headers
+        _BinarySuccessAsyncClient.calls += 1
+        return httpx.Response(
+            200,
+            content=b"binary-content",
+            headers={"Content-Type": "application/pdf"},
+            request=httpx.Request("GET", url),
+        )
+
+
 @pytest.mark.asyncio
 async def test_request_with_retry_retries_on_timeout(monkeypatch):
     _FlakyAsyncClient.calls = 0
@@ -327,17 +352,21 @@ async def test_request_with_retry_forwards_post_query_params(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_request_with_retry_handles_negative_retry_configuration():
+async def test_request_with_retry_clamps_negative_retry_configuration(monkeypatch):
+    _RedirectAwareAsyncClient.requested_urls = []
+    monkeypatch.setattr("httpx.AsyncClient", _RedirectAwareAsyncClient)
+
     status, payload = await request_with_retry(
         method="GET",
         url="http://service/health",
         timeout_seconds=1.0,
         max_retries=-1,
-        backoff_seconds=0.0,
+        backoff_seconds=-1.0,
     )
 
-    assert status == 503
-    assert payload == {"detail": "upstream communication failure: exhausted retries"}
+    assert status == 200
+    assert payload == {"redirected": True}
+    assert _RedirectAwareAsyncClient.requested_urls == ["http://service/health"]
 
 
 class _RedirectAwareAsyncClient:
@@ -417,3 +446,23 @@ async def test_request_binary_with_retry_returns_text_error_payload(monkeypatch)
     assert content == b"archive unavailable"
     assert headers["content-length"] == "19"
     assert error_payload == {"detail": "archive unavailable"}
+
+
+@pytest.mark.asyncio
+async def test_request_binary_with_retry_clamps_negative_retry_configuration(monkeypatch):
+    _BinarySuccessAsyncClient.calls = 0
+    monkeypatch.setattr("httpx.AsyncClient", _BinarySuccessAsyncClient)
+
+    status, content, headers, error_payload = await request_binary_with_retry(
+        method="GET",
+        url="http://archive/documents/doc_1/download",
+        timeout_seconds=1.0,
+        max_retries=-1,
+        backoff_seconds=-1.0,
+    )
+
+    assert status == 200
+    assert content == b"binary-content"
+    assert headers["content-type"] == "application/pdf"
+    assert error_payload == {}
+    assert _BinarySuccessAsyncClient.calls == 1

--- a/tests/unit/test_http_resilience.py
+++ b/tests/unit/test_http_resilience.py
@@ -217,6 +217,12 @@ class _BinarySuccessAsyncClient:
         )
 
 
+class _UnexpectedAsyncClient:
+    def __init__(self, timeout: float, follow_redirects: bool = False):
+        _ = timeout, follow_redirects
+        raise AssertionError("AsyncClient should not be opened for unsupported methods")
+
+
 @pytest.mark.asyncio
 async def test_request_with_retry_retries_on_timeout(monkeypatch):
     _FlakyAsyncClient.calls = 0
@@ -369,6 +375,20 @@ async def test_request_with_retry_clamps_negative_retry_configuration(monkeypatc
     assert _RedirectAwareAsyncClient.requested_urls == ["http://service/health"]
 
 
+@pytest.mark.asyncio
+async def test_request_with_retry_rejects_unsupported_method(monkeypatch):
+    monkeypatch.setattr("httpx.AsyncClient", _UnexpectedAsyncClient)
+
+    status, payload = await request_with_retry(
+        method="PATCH",
+        url="http://service/health",
+        timeout_seconds=1.0,
+    )
+
+    assert status == 503
+    assert payload == {"detail": "unsupported upstream HTTP method: PATCH"}
+
+
 class _RedirectAwareAsyncClient:
     requested_urls: list[str] = []
     follow_redirects = None
@@ -466,3 +486,19 @@ async def test_request_binary_with_retry_clamps_negative_retry_configuration(mon
     assert headers["content-type"] == "application/pdf"
     assert error_payload == {}
     assert _BinarySuccessAsyncClient.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_request_binary_with_retry_rejects_unsupported_method(monkeypatch):
+    monkeypatch.setattr("httpx.AsyncClient", _UnexpectedAsyncClient)
+
+    status, content, headers, error_payload = await request_binary_with_retry(
+        method="PUT",
+        url="http://archive/documents/doc_1/download",
+        timeout_seconds=1.0,
+    )
+
+    assert status == 503
+    assert content == b""
+    assert headers == {}
+    assert error_payload == {"detail": "unsupported upstream HTTP method: PUT"}

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -31,5 +31,8 @@
 - preserve correlation, evidence, supportability, and degraded-state signals
 - redact sensitive audit metadata across normalized key variants before logging
 - evaluate write capability rules with path-segment-aware matching before allowing privileged actions
+- keep upstream HTTP retries bounded and defensive: negative retry counts still make one attempt,
+  negative backoff is clamped, and unsupported shared-client methods fail closed instead of being
+  sent as another verb
 - keep gateway contracts product-oriented instead of accreting thin pass-through clutter
 - document endpoint-specific parameter conventions explicitly when they differ by route family


### PR DESCRIPTION
## Summary
- Clamps shared upstream HTTP retry configuration so negative retry counts still make one bounded attempt and negative backoff values cannot produce invalid sleep behavior.
- Fails closed for unsupported shared-client HTTP methods instead of silently sending an unintended verb.
- Documents the HTTP resilience guardrails in the enterprise readiness standard and repo-authored security/governance wiki source.

## Validation
- `python -m pytest tests/unit/test_http_resilience.py -q` - 14 passed.
- `python -m ruff check docs/standards/enterprise-readiness.md wiki/Security-and-Governance.md src/app/clients/http_resilience.py tests/unit/test_http_resilience.py` - passed.
- `make check` - passed: ruff, format, monetary-float guard, mypy, Workbench contract, and `804 passed` unit/contract tests.
- `make ci` - passed:
  - ruff check and format check passed.
  - monetary float guard passed (`Findings=189, allowlisted=189`).
  - mypy passed (`403 source files`).
  - Workbench contract passed (`3 passed`).
  - migration contract check passed (`no-schema mode`).
  - integration suite passed (`207 passed`).
  - combined unit/contract/integration coverage suite passed (`1011 passed`, total coverage `90.67%`, floor `84%`).
  - pip audit passed with no known vulnerabilities after the governed `PYSEC-2026-161` FastAPI/Starlette temporary exception.

## Governance
- Repository profile: Experience API.
- Tiering: Feature Lane and PR Merge Gate local proof completed through `make ci`; GitHub PR checks remain the merge authority.
- Stranded truth: `git branch -r --no-merged origin/main` showed only `origin/feat/gateway-backend-hardening-15`, the active PR branch.
- Wiki: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reports expected drift in `Security-and-Governance.md` because this branch updates repo-authored wiki source; publish after merge to `main`.
- Merge strategy: preserve normal commit history with merge commit; do not squash.