### PR TITLE
Centralize HTTP communication failure payloads

### DIFF
--- a/src/app/clients/http_resilience.py
+++ b/src/app/clients/http_resilience.py
@@ -31,6 +31,20 @@ def _unsupported_method_payload(method: str) -> dict[str, str]:
     return {"detail": f"unsupported upstream HTTP method: {request_method}"}
 
 
+def _communication_failure_payload(reason: str) -> dict[str, str]:
+    return {"detail": f"upstream communication failure: {reason}"}
+
+
+def _communication_failure_result(reason: str) -> tuple[int, dict[str, str]]:
+    return 503, _communication_failure_payload(reason)
+
+
+def _binary_communication_failure_result(
+    reason: str,
+) -> tuple[int, bytes, dict[str, str], dict[str, str]]:
+    return 503, b"", {}, _communication_failure_payload(reason)
+
+
 async def request_with_retry(
     *,
     method: str,
@@ -78,16 +92,16 @@ async def request_with_retry(
             return response.status_code, _response_payload(response)
         except httpx.TimeoutException as exc:
             if not retry_timeout_exceptions:
-                return 503, {"detail": f"upstream communication failure: {exc.__class__.__name__}"}
+                return _communication_failure_result(exc.__class__.__name__)
             if attempt >= max_retries:
-                return 503, {"detail": f"upstream communication failure: {exc.__class__.__name__}"}
+                return _communication_failure_result(exc.__class__.__name__)
             await asyncio.sleep(_retry_delay(backoff_seconds, attempt))
         except httpx.RequestError as exc:
             if attempt >= max_retries:
-                return 503, {"detail": f"upstream communication failure: {exc.__class__.__name__}"}
+                return _communication_failure_result(exc.__class__.__name__)
             await asyncio.sleep(_retry_delay(backoff_seconds, attempt))
 
-    return 503, {"detail": "upstream communication failure: exhausted retries"}
+    return _communication_failure_result("exhausted retries")
 
 
 async def request_binary_with_retry(
@@ -128,28 +142,13 @@ async def request_binary_with_retry(
             return response.status_code, response.content, dict(response.headers), error_payload
         except httpx.TimeoutException as exc:
             if not retry_timeout_exceptions:
-                return (
-                    503,
-                    b"",
-                    {},
-                    {"detail": f"upstream communication failure: {exc.__class__.__name__}"},
-                )
+                return _binary_communication_failure_result(exc.__class__.__name__)
             if attempt >= max_retries:
-                return (
-                    503,
-                    b"",
-                    {},
-                    {"detail": f"upstream communication failure: {exc.__class__.__name__}"},
-                )
+                return _binary_communication_failure_result(exc.__class__.__name__)
             await asyncio.sleep(_retry_delay(backoff_seconds, attempt))
         except httpx.RequestError as exc:
             if attempt >= max_retries:
-                return (
-                    503,
-                    b"",
-                    {},
-                    {"detail": f"upstream communication failure: {exc.__class__.__name__}"},
-                )
+                return _binary_communication_failure_result(exc.__class__.__name__)
             await asyncio.sleep(_retry_delay(backoff_seconds, attempt))
 
-    return 503, b"", {}, {"detail": "upstream communication failure: exhausted retries"}
+    return _binary_communication_failure_result("exhausted retries")

--- a/tests/unit/test_http_resilience.py
+++ b/tests/unit/test_http_resilience.py
@@ -217,6 +217,24 @@ class _BinarySuccessAsyncClient:
         )
 
 
+class _BinaryNetworkErrorAsyncClient:
+    follow_redirects = None
+
+    def __init__(self, timeout: float, follow_redirects: bool = False):
+        _ = timeout
+        _BinaryNetworkErrorAsyncClient.follow_redirects = follow_redirects
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, params=None, headers=None):
+        _ = url, params, headers
+        raise httpx.NetworkError("binary disconnected")
+
+
 class _UnexpectedAsyncClient:
     def __init__(self, timeout: float, follow_redirects: bool = False):
         _ = timeout, follow_redirects
@@ -502,3 +520,21 @@ async def test_request_binary_with_retry_rejects_unsupported_method(monkeypatch)
     assert content == b""
     assert headers == {}
     assert error_payload == {"detail": "unsupported upstream HTTP method: PUT"}
+
+
+@pytest.mark.asyncio
+async def test_request_binary_with_retry_returns_structured_communication_failure(monkeypatch):
+    monkeypatch.setattr("httpx.AsyncClient", _BinaryNetworkErrorAsyncClient)
+
+    status, content, headers, error_payload = await request_binary_with_retry(
+        method="GET",
+        url="http://archive/documents/doc_1/download",
+        timeout_seconds=1.0,
+        max_retries=0,
+        backoff_seconds=0.0,
+    )
+
+    assert status == 503
+    assert content == b""
+    assert headers == {}
+    assert error_payload == {"detail": "upstream communication failure: NetworkError"}


### PR DESCRIPTION
## Summary
- centralizes shared upstream communication failure payload construction for JSON and binary HTTP resilience paths
- keeps binary upstream failure responses structured and covered by unit regression coverage

## Validation
- Static: ruff check, ruff format --check, monetary-float guard, mypy via \make check\ and \make ci\
- Unit/contract: \make check\ passed, including 805 unit/contract tests
- Integration: \make ci\ passed, including 207 integration tests
- Coverage: \make ci\ passed, 1012 tests with 90.70% total coverage against 84% threshold
- Security: \make ci\ pip-audit passed with governed PYSEC-2026-161 exception
- Governance: no docs/wiki/OpenAPI/context changes; stranded-truth check returned no unmerged remote branches after \git fetch origin --prune\

## Tiering
- Feature Lane and PR Merge Gate local equivalents satisfied by \make check\ and \make ci\
- No platform end-to-end validation required: internal shared HTTP resilience helper refactor only