### PR TITLE
Centralize upstream header construction

### DIFF
--- a/src/app/clients/advise_client.py
+++ b/src/app/clients/advise_client.py
@@ -4,7 +4,10 @@ import logging
 from typing import Any
 
 from app.clients.observed_fanout import request_observed_fanout
-from app.middleware.correlation import propagation_headers
+from app.clients.upstream_headers import (
+    build_idempotent_upstream_headers,
+    build_upstream_headers,
+)
 
 logger = logging.getLogger("analytics_ui.gateway")
 
@@ -39,7 +42,7 @@ class AdviseClient:
             max_retries=self._max_retries,
             backoff_seconds=self._retry_backoff_seconds,
             params={"consumer_system": consumer_system, "tenant_id": tenant_id},
-            headers=propagation_headers(correlation_id),
+            headers=build_upstream_headers(correlation_id),
         )
 
     async def get_capabilities(
@@ -265,13 +268,10 @@ class AdviseClient:
         idempotency_key: str | None,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        headers = self._headers(correlation_id)
-        if idempotency_key is not None:
-            headers["Idempotency-Key"] = idempotency_key
         return await self._post(
             f"/advisory/workspaces/{workspace_id}/handoff",
             body=body,
-            headers=headers,
+            headers=self._optional_idempotency_headers(correlation_id, idempotency_key),
             operation="advise.advisory.workspaces.handoff",
         )
 
@@ -822,13 +822,10 @@ class AdviseClient:
         idempotency_key: str | None,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        headers = self._headers(correlation_id)
-        if idempotency_key is not None:
-            headers["Idempotency-Key"] = idempotency_key
         return await self._post(
             f"/advisory/proposals/{proposal_id}/versions/{version_no}/narrative/review",
             body=body,
-            headers=headers,
+            headers=self._optional_idempotency_headers(correlation_id, idempotency_key),
             operation="advise.advisory.proposals.narrative.review",
         )
 
@@ -852,13 +849,10 @@ class AdviseClient:
         idempotency_key: str | None,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        headers = self._headers(correlation_id)
-        if idempotency_key is not None:
-            headers["Idempotency-Key"] = idempotency_key
         return await self._post(
             f"/advisory/proposals/{proposal_id}/execution-handoffs",
             body=body,
-            headers=headers,
+            headers=self._optional_idempotency_headers(correlation_id, idempotency_key),
             operation="advise.advisory.proposals.execution-handoffs.create",
         )
 
@@ -905,13 +899,10 @@ class AdviseClient:
         idempotency_key: str | None,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        headers = self._headers(correlation_id)
-        if idempotency_key is not None:
-            headers["Idempotency-Key"] = idempotency_key
         return await self._post(
             f"/advisory/proposals/{proposal_id}/execution-updates",
             body=body,
-            headers=headers,
+            headers=self._optional_idempotency_headers(correlation_id, idempotency_key),
             operation="advise.advisory.proposals.execution-updates.record",
         )
 
@@ -926,7 +917,7 @@ class AdviseClient:
         return await self._post(
             f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo",
             body=body,
-            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            headers=build_idempotent_upstream_headers(correlation_id, idempotency_key),
             operation="advise.advisory.proposals.memo.create",
         )
 
@@ -968,13 +959,10 @@ class AdviseClient:
         idempotency_key: str | None,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        headers = self._headers(correlation_id)
-        if idempotency_key is not None:
-            headers["Idempotency-Key"] = idempotency_key
         return await self._post(
             f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo/review",
             body=body,
-            headers=headers,
+            headers=self._optional_idempotency_headers(correlation_id, idempotency_key),
             operation="advise.advisory.proposals.memo.review",
         )
 
@@ -986,13 +974,10 @@ class AdviseClient:
         idempotency_key: str | None,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        headers = self._headers(correlation_id)
-        if idempotency_key is not None:
-            headers["Idempotency-Key"] = idempotency_key
         return await self._post(
             f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo/report-package-events",
             body=body,
-            headers=headers,
+            headers=self._optional_idempotency_headers(correlation_id, idempotency_key),
             operation="advise.advisory.proposals.memo.report-package-events",
         )
 
@@ -1004,13 +989,10 @@ class AdviseClient:
         idempotency_key: str | None,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        headers = self._headers(correlation_id)
-        if idempotency_key is not None:
-            headers["Idempotency-Key"] = idempotency_key
         return await self._post(
             f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo/report-packages",
             body=body,
-            headers=headers,
+            headers=self._optional_idempotency_headers(correlation_id, idempotency_key),
             operation="advise.advisory.proposals.memo.report-packages",
         )
 
@@ -1022,13 +1004,10 @@ class AdviseClient:
         idempotency_key: str | None,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
-        headers = self._headers(correlation_id)
-        if idempotency_key is not None:
-            headers["Idempotency-Key"] = idempotency_key
         return await self._post(
             f"/advisory/proposals/{proposal_id}/versions/{version_no}/memo/ai-commentary",
             body=body,
-            headers=headers,
+            headers=self._optional_idempotency_headers(correlation_id, idempotency_key),
             operation="advise.advisory.proposals.memo.ai-commentary",
         )
 
@@ -1062,10 +1041,7 @@ class AdviseClient:
         correlation_id: str,
         extras: dict[str, str] | None = None,
     ) -> dict[str, str]:
-        headers = propagation_headers(correlation_id)
-        if extras:
-            headers.update(extras)
-        return headers
+        return build_upstream_headers(correlation_id, extras=extras)
 
     def _optional_idempotency_headers(
         self,
@@ -1074,7 +1050,7 @@ class AdviseClient:
     ) -> dict[str, str]:
         if idempotency_key is None:
             return self._headers(correlation_id)
-        return self._headers(correlation_id, {"Idempotency-Key": idempotency_key})
+        return build_idempotent_upstream_headers(correlation_id, idempotency_key)
 
     async def _post(
         self,

--- a/src/app/clients/archive_client.py
+++ b/src/app/clients/archive_client.py
@@ -5,7 +5,7 @@ from app.clients.observed_fanout import (
     request_observed_binary_fanout,
     request_observed_fanout,
 )
-from app.middleware.correlation import propagation_headers
+from app.clients.upstream_headers import build_archive_caller_headers
 
 logger = logging.getLogger("analytics_ui.gateway")
 
@@ -74,16 +74,7 @@ class ArchiveClient:
         caller_headers: dict[str, str],
         correlation_id: str,
     ) -> dict[str, str]:
-        headers = propagation_headers(correlation_id)
-        headers.update(
-            {
-                "X-Caller-Service": "lotus-gateway",
-                "X-Actor-Type": caller_headers.get("X-Role", "user"),
-                "X-Actor-Id": caller_headers["X-Actor-Id"],
-                "X-Tenant-Id": caller_headers["X-Tenant-Id"],
-                "X-Region": caller_headers["X-Region"],
-            }
+        return build_archive_caller_headers(
+            correlation_id=correlation_id,
+            caller_headers=caller_headers,
         )
-        if booking_center_code := caller_headers.get("X-Booking-Center-Code"):
-            headers["X-Booking-Center-Code"] = booking_center_code
-        return headers

--- a/src/app/clients/dpm_client.py
+++ b/src/app/clients/dpm_client.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any
 
 from app.clients.observed_fanout import request_observed_binary_fanout, request_observed_fanout
-from app.middleware.correlation import propagation_headers
+from app.clients.upstream_headers import build_upstream_headers
 
 logger = logging.getLogger("analytics_ui.gateway")
 
@@ -1296,10 +1296,7 @@ class DpmClient:
         correlation_id: str,
         extras: dict[str, str] | None = None,
     ) -> dict[str, str]:
-        headers = propagation_headers(correlation_id)
-        if extras:
-            headers.update(extras)
-        return headers
+        return build_upstream_headers(correlation_id, extras=extras)
 
     async def _get(
         self,

--- a/src/app/clients/reporting_client.py
+++ b/src/app/clients/reporting_client.py
@@ -2,7 +2,10 @@ import logging
 from typing import Any
 
 from app.clients.observed_fanout import request_observed_fanout
-from app.middleware.correlation import propagation_headers
+from app.clients.upstream_headers import (
+    build_idempotent_upstream_headers,
+    build_upstream_headers,
+)
 
 logger = logging.getLogger("analytics_ui.gateway")
 
@@ -28,7 +31,7 @@ class ReportingClient:
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/aggregations/portfolios/{portfolio_id}"
         params = {"as_of_date": as_of_date, "live": "true"}
-        headers = propagation_headers(correlation_id)
+        headers = build_upstream_headers(correlation_id)
         return await self._request(
             operation="report.aggregations.portfolio-snapshot",
             method="GET",
@@ -45,7 +48,7 @@ class ReportingClient:
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/integration/capabilities"
         params = {"consumerSystem": consumer_system, "tenantId": tenant_id}
-        headers = propagation_headers(correlation_id)
+        headers = build_upstream_headers(correlation_id)
         return await self._request(
             operation="report.integration.capabilities",
             method="GET",
@@ -61,7 +64,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/portfolios/{portfolio_id}/summary"
-        headers = propagation_headers(correlation_id)
+        headers = build_upstream_headers(correlation_id)
         return await self._request(
             operation="report.portfolio.summary",
             method="POST",
@@ -77,7 +80,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/portfolios/{portfolio_id}/review"
-        headers = propagation_headers(correlation_id)
+        headers = build_upstream_headers(correlation_id)
         return await self._request(
             operation="report.portfolio.review",
             method="POST",
@@ -95,9 +98,11 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/portfolio-reviews"
-        headers = propagation_headers(correlation_id)
-        headers["Idempotency-Key"] = idempotency_key
-        headers.update(caller_headers)
+        headers = build_idempotent_upstream_headers(
+            correlation_id,
+            idempotency_key,
+            caller_headers=caller_headers,
+        )
         return await self._request(
             operation="report.portfolio-review-jobs.submit",
             method="POST",
@@ -115,9 +120,11 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/outcome-reviews"
-        headers = propagation_headers(correlation_id)
-        headers["Idempotency-Key"] = idempotency_key
-        headers.update(caller_headers)
+        headers = build_idempotent_upstream_headers(
+            correlation_id,
+            idempotency_key,
+            caller_headers=caller_headers,
+        )
         return await self._request(
             operation="report.outcome-review-jobs.submit",
             method="POST",
@@ -134,8 +141,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/jobs/{job_id}"
-        headers = propagation_headers(correlation_id)
-        headers.update(caller_headers)
+        headers = build_upstream_headers(correlation_id, caller_headers=caller_headers)
         return await self._request(
             operation="report.jobs.get",
             method="GET",
@@ -151,8 +157,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/jobs"
-        headers = propagation_headers(correlation_id)
-        headers.update(caller_headers)
+        headers = build_upstream_headers(correlation_id, caller_headers=caller_headers)
         return await self._request(
             operation="report.jobs.list",
             method="GET",
@@ -169,8 +174,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/jobs/{job_id}/events"
-        headers = propagation_headers(correlation_id)
-        headers.update(caller_headers)
+        headers = build_upstream_headers(correlation_id, caller_headers=caller_headers)
         return await self._request(
             operation="report.jobs.events",
             method="GET",
@@ -186,8 +190,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/jobs/{job_id}/lineage"
-        headers = propagation_headers(correlation_id)
-        headers.update(caller_headers)
+        headers = build_upstream_headers(correlation_id, caller_headers=caller_headers)
         return await self._request(
             operation="report.jobs.lineage",
             method="GET",
@@ -203,8 +206,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/snapshots/{snapshot_id}"
-        headers = propagation_headers(correlation_id)
-        headers.update(caller_headers)
+        headers = build_upstream_headers(correlation_id, caller_headers=caller_headers)
         return await self._request(
             operation="report.snapshots.get",
             method="GET",
@@ -220,8 +222,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/snapshots/{snapshot_id}/lineage"
-        headers = propagation_headers(correlation_id)
-        headers.update(caller_headers)
+        headers = build_upstream_headers(correlation_id, caller_headers=caller_headers)
         return await self._request(
             operation="report.snapshots.lineage",
             method="GET",
@@ -237,8 +238,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/jobs/{job_id}/cancel"
-        headers = propagation_headers(correlation_id)
-        headers.update(caller_headers)
+        headers = build_upstream_headers(correlation_id, caller_headers=caller_headers)
         return await self._request(
             operation="report.jobs.cancel",
             method="POST",
@@ -255,9 +255,11 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/batches"
-        headers = propagation_headers(correlation_id)
-        headers["Idempotency-Key"] = idempotency_key
-        headers.update(caller_headers)
+        headers = build_idempotent_upstream_headers(
+            correlation_id,
+            idempotency_key,
+            caller_headers=caller_headers,
+        )
         return await self._request(
             operation="report.batches.create",
             method="POST",
@@ -274,8 +276,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/batches/{batch_id}"
-        headers = propagation_headers(correlation_id)
-        headers.update(caller_headers)
+        headers = build_upstream_headers(correlation_id, caller_headers=caller_headers)
         return await self._request(
             operation="report.batches.get",
             method="GET",
@@ -293,8 +294,7 @@ class ReportingClient:
         payload: dict[str, Any] | None = None,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/batches/{batch_id}:{action}"
-        headers = propagation_headers(correlation_id)
-        headers.update(caller_headers)
+        headers = build_upstream_headers(correlation_id, caller_headers=caller_headers)
         return await self._request(
             operation=f"report.batches.{action}",
             method="POST",
@@ -310,8 +310,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/batch-schedules"
-        headers = propagation_headers(correlation_id)
-        headers.update(caller_headers)
+        headers = build_upstream_headers(correlation_id, caller_headers=caller_headers)
         return await self._request(
             operation="report.batch-schedules.list",
             method="GET",
@@ -327,8 +326,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/reports/batch-schedules:run-due"
-        headers = propagation_headers(correlation_id)
-        headers.update(caller_headers)
+        headers = build_upstream_headers(correlation_id, caller_headers=caller_headers)
         return await self._request(
             operation="report.batch-schedules.run-due",
             method="POST",

--- a/src/app/clients/upstream_headers.py
+++ b/src/app/clients/upstream_headers.py
@@ -1,0 +1,48 @@
+from app.middleware.correlation import propagation_headers
+
+
+def build_upstream_headers(
+    correlation_id: str,
+    *,
+    extras: dict[str, str] | None = None,
+    caller_headers: dict[str, str] | None = None,
+) -> dict[str, str]:
+    headers = propagation_headers(correlation_id)
+    if extras:
+        headers.update(extras)
+    if caller_headers:
+        headers.update(caller_headers)
+    return headers
+
+
+def build_idempotent_upstream_headers(
+    correlation_id: str,
+    idempotency_key: str,
+    *,
+    caller_headers: dict[str, str] | None = None,
+) -> dict[str, str]:
+    return build_upstream_headers(
+        correlation_id,
+        extras={"Idempotency-Key": idempotency_key},
+        caller_headers=caller_headers,
+    )
+
+
+def build_archive_caller_headers(
+    *,
+    correlation_id: str,
+    caller_headers: dict[str, str],
+) -> dict[str, str]:
+    headers = build_upstream_headers(
+        correlation_id,
+        extras={
+            "X-Caller-Service": "lotus-gateway",
+            "X-Actor-Type": caller_headers.get("X-Role", "user"),
+            "X-Actor-Id": caller_headers["X-Actor-Id"],
+            "X-Tenant-Id": caller_headers["X-Tenant-Id"],
+            "X-Region": caller_headers["X-Region"],
+        },
+    )
+    if booking_center_code := caller_headers.get("X-Booking-Center-Code"):
+        headers["X-Booking-Center-Code"] = booking_center_code
+    return headers

--- a/tests/unit/test_upstream_headers.py
+++ b/tests/unit/test_upstream_headers.py
@@ -1,0 +1,73 @@
+from app.clients.upstream_headers import (
+    build_archive_caller_headers,
+    build_idempotent_upstream_headers,
+    build_upstream_headers,
+)
+
+
+def test_build_upstream_headers_adds_correlation_and_extras_without_mutating_inputs() -> None:
+    extras = {"X-Test": "value"}
+
+    headers = build_upstream_headers("corr-headers", extras=extras)
+
+    assert headers["X-Correlation-Id"] == "corr-headers"
+    assert headers["X-Request-Id"].startswith("req_")
+    assert headers["X-Trace-Id"]
+    assert headers["traceparent"].startswith("00-")
+    assert headers["X-Test"] == "value"
+    assert extras == {"X-Test": "value"}
+
+
+def test_build_idempotent_upstream_headers_preserves_reporting_merge_order() -> None:
+    caller_headers = {
+        "X-Actor-Id": "advisor-123",
+        "Idempotency-Key": "caller-overrides-existing-reporting-behavior",
+    }
+
+    headers = build_idempotent_upstream_headers(
+        "corr-report",
+        "generated-idempotency-key",
+        caller_headers=caller_headers,
+    )
+
+    assert headers["X-Correlation-Id"] == "corr-report"
+    assert headers["X-Actor-Id"] == "advisor-123"
+    assert headers["Idempotency-Key"] == "caller-overrides-existing-reporting-behavior"
+
+
+def test_build_archive_caller_headers_maps_gateway_archive_context() -> None:
+    headers = build_archive_caller_headers(
+        correlation_id="corr-archive",
+        caller_headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-private-bank",
+            "X-Region": "SG",
+            "X-Role": "relationship-manager",
+            "X-Booking-Center-Code": "SG",
+        },
+    )
+
+    assert headers["X-Correlation-Id"] == "corr-archive"
+    assert headers["X-Request-Id"].startswith("req_")
+    assert headers["X-Trace-Id"]
+    assert headers["traceparent"].startswith("00-")
+    assert headers["X-Caller-Service"] == "lotus-gateway"
+    assert headers["X-Actor-Type"] == "relationship-manager"
+    assert headers["X-Actor-Id"] == "advisor-123"
+    assert headers["X-Tenant-Id"] == "tenant-private-bank"
+    assert headers["X-Region"] == "SG"
+    assert headers["X-Booking-Center-Code"] == "SG"
+
+
+def test_build_archive_caller_headers_defaults_actor_type() -> None:
+    headers = build_archive_caller_headers(
+        correlation_id="corr-archive",
+        caller_headers={
+            "X-Actor-Id": "advisor-123",
+            "X-Tenant-Id": "tenant-private-bank",
+            "X-Region": "SG",
+        },
+    )
+
+    assert headers["X-Actor-Type"] == "user"
+    assert "X-Booking-Center-Code" not in headers


### PR DESCRIPTION
## Summary
- adds a shared upstream header helper for correlation, trace, idempotency, caller, and archive caller-context headers
- removes repeated header assembly from advise, manage, report, and archive clients
- adds unit coverage for merge order, archive caller-context mapping, generated propagation metadata, and default actor posture

## Validation
- Targeted: \python -m pytest tests/unit/test_upstream_headers.py tests/unit/test_upstream_clients.py -q\ passed, 179 tests
- Static: \make check\ passed ruff, format check, monetary-float guard, and mypy
- Unit/contract: \make check\ passed, 809 unit/contract tests
- Integration: \make ci\ passed, 207 integration tests
- Coverage: \make ci\ passed, 1016 tests with 90.92% coverage against 84% threshold
- Security: \make ci\ pip-audit passed with governed PYSEC-2026-161 exception
- Governance: no docs/wiki/OpenAPI/context changes; stranded-truth check returned no unmerged remote branches after \git fetch origin --prune\

## Tiering
- Feature Lane and PR Merge Gate local equivalents satisfied by \make check\ and \make ci\
- No platform end-to-end validation required: internal upstream client infrastructure refactor only