### PR TITLE
Reuse upstream headers in small clients

### DIFF
--- a/src/app/clients/lotus_ai_client.py
+++ b/src/app/clients/lotus_ai_client.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any
 
 from app.clients.observed_fanout import request_observed_fanout
-from app.middleware.correlation import propagation_headers
+from app.clients.upstream_headers import build_upstream_headers
 
 logger = logging.getLogger("analytics_ui.gateway")
 
@@ -53,7 +53,7 @@ class LotusAiClient:
             operation="ai.tasks.execute",
             method="POST",
             json_body=request_payload,
-            headers=propagation_headers(correlation_id),
+            headers=build_upstream_headers(correlation_id),
             retry_timeout_exceptions=False,
             path="/ai/tasks/execute",
         )
@@ -80,7 +80,7 @@ class LotusAiClient:
                 "workflow_surface": workflow_surface,
                 "task_request": task_request,
             },
-            headers=propagation_headers(correlation_id),
+            headers=build_upstream_headers(correlation_id),
             retry_timeout_exceptions=False,
             path="/platform/workflow-packs/execute",
         )
@@ -94,7 +94,7 @@ class LotusAiClient:
         return await self._request(
             operation="ai.workflow-packs.runs.consumer-view",
             method="GET",
-            headers=propagation_headers(correlation_id),
+            headers=build_upstream_headers(correlation_id),
             retry_timeout_exceptions=False,
             path=f"/platform/workflow-packs/runs/{run_id}/consumer-view",
         )
@@ -108,7 +108,7 @@ class LotusAiClient:
         return await self._request(
             operation="ai.workflow-packs.runs.operator-profile",
             method="GET",
-            headers=propagation_headers(correlation_id),
+            headers=build_upstream_headers(correlation_id),
             retry_timeout_exceptions=False,
             path=f"/platform/workflow-packs/runs/{run_id}/operator-profile",
         )
@@ -133,7 +133,7 @@ class LotusAiClient:
             operation="ai.workflow-packs.task-flows.list",
             method="GET",
             params=params,
-            headers=propagation_headers(correlation_id),
+            headers=build_upstream_headers(correlation_id),
             retry_timeout_exceptions=False,
             path="/platform/workflow-packs/task-flows",
         )
@@ -149,7 +149,7 @@ class LotusAiClient:
             operation="ai.workflow-packs.runs.review-actions",
             method="POST",
             json_body=request_payload,
-            headers=propagation_headers(correlation_id),
+            headers=build_upstream_headers(correlation_id),
             retry_timeout_exceptions=False,
             path=f"/platform/workflow-packs/runs/{run_id}/review-actions",
         )
@@ -162,7 +162,7 @@ class LotusAiClient:
         return await self._request(
             operation="ai.observability.runtime-status",
             method="GET",
-            headers=propagation_headers(correlation_id),
+            headers=build_upstream_headers(correlation_id),
             retry_timeout_exceptions=False,
             path="/platform/observability/runtime-status",
         )

--- a/src/app/clients/lotus_core_ingestion_client.py
+++ b/src/app/clients/lotus_core_ingestion_client.py
@@ -2,7 +2,10 @@ import logging
 from typing import Any
 
 from app.clients.observed_fanout import request_observed_fanout
-from app.middleware.correlation import propagation_headers
+from app.clients.upstream_headers import (
+    build_idempotent_upstream_headers,
+    build_upstream_headers,
+)
 
 LOGGER = logging.getLogger("analytics_ui.gateway")
 
@@ -27,9 +30,15 @@ class LotusCoreIngestionClient:
         idempotency_key: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/ingest/portfolio-bundle"
-        headers = propagation_headers(correlation_id)
-        if idempotency_key:
-            headers["X-Idempotency-Key"] = idempotency_key
+        headers = (
+            build_idempotent_upstream_headers(
+                correlation_id,
+                idempotency_key,
+                idempotency_header="X-Idempotency-Key",
+            )
+            if idempotency_key
+            else build_upstream_headers(correlation_id)
+        )
         return await request_observed_fanout(
             logger=LOGGER,
             service="lotus-core",
@@ -87,7 +96,7 @@ class LotusCoreIngestionClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}{path}"
-        headers = propagation_headers(correlation_id)
+        headers = build_upstream_headers(correlation_id)
         form_data = {"entity_type": entity_type, **extra_data}
         files = {"file": (filename, content)}
         operation = (

--- a/src/app/clients/render_client.py
+++ b/src/app/clients/render_client.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any
 
 from app.clients.observed_fanout import request_observed_fanout
-from app.middleware.correlation import propagation_headers
+from app.clients.upstream_headers import build_upstream_headers
 
 logger = logging.getLogger("analytics_ui.gateway")
 
@@ -22,7 +22,7 @@ class RenderClient:
 
     async def get_metadata(self, *, correlation_id: str) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/metadata"
-        headers = propagation_headers(correlation_id)
+        headers = build_upstream_headers(correlation_id)
         return await request_observed_fanout(
             logger=logger,
             service="lotus-render",

--- a/src/app/clients/upstream_headers.py
+++ b/src/app/clients/upstream_headers.py
@@ -20,10 +20,11 @@ def build_idempotent_upstream_headers(
     idempotency_key: str,
     *,
     caller_headers: dict[str, str] | None = None,
+    idempotency_header: str = "Idempotency-Key",
 ) -> dict[str, str]:
     return build_upstream_headers(
         correlation_id,
-        extras={"Idempotency-Key": idempotency_key},
+        extras={idempotency_header: idempotency_key},
         caller_headers=caller_headers,
     )
 

--- a/tests/unit/test_upstream_headers.py
+++ b/tests/unit/test_upstream_headers.py
@@ -35,6 +35,18 @@ def test_build_idempotent_upstream_headers_preserves_reporting_merge_order() -> 
     assert headers["Idempotency-Key"] == "caller-overrides-existing-reporting-behavior"
 
 
+def test_build_idempotent_upstream_headers_supports_service_specific_header_name() -> None:
+    headers = build_idempotent_upstream_headers(
+        "corr-core-ingestion",
+        "idem-core-1",
+        idempotency_header="X-Idempotency-Key",
+    )
+
+    assert headers["X-Correlation-Id"] == "corr-core-ingestion"
+    assert headers["X-Idempotency-Key"] == "idem-core-1"
+    assert "Idempotency-Key" not in headers
+
+
 def test_build_archive_caller_headers_maps_gateway_archive_context() -> None:
     headers = build_archive_caller_headers(
         correlation_id="corr-archive",


### PR DESCRIPTION
## Summary
- reuses the shared upstream header helper in lotus-ai, lotus-render, and lotus-core ingestion clients
- extends idempotent upstream header construction for service-specific header names such as \X-Idempotency-Key\
- keeps correlation, request, trace, and idempotency propagation behavior covered by focused unit tests

## Validation
- Targeted: \python -m pytest tests/unit/test_upstream_headers.py tests/unit/test_upstream_clients.py -q\ passed, 180 tests
- Static: \make check\ passed ruff, format check, monetary-float guard, and mypy
- Unit/contract: \make check\ passed, 810 unit/contract tests
- Integration: \make ci\ passed, 207 integration tests
- Coverage: \make ci\ passed, 1017 tests with 90.92% coverage against 84% threshold
- Security: \make ci\ pip-audit passed with governed PYSEC-2026-161 exception
- Governance: no docs/wiki/OpenAPI/context changes; stranded-truth check returned no unmerged remote branches after \git fetch origin --prune\

## Tiering
- Feature Lane and PR Merge Gate local equivalents satisfied by \make check\ and \make ci\
- No platform end-to-end validation required: internal upstream client infrastructure refactor only