### PR TITLE
Extract performance workspace service boundaries

### DIFF
--- a/src/app/services/performance_workspace_capabilities.py
+++ b/src/app/services/performance_workspace_capabilities.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from app.contracts.performance_workspace import (
+    AttributionSummaryView,
+    ContributionSummaryView,
+    PerformanceChartPoint,
+    PerformanceComparativeSummary,
+    PerformanceEvidenceView,
+    PerformanceModuleCapability,
+    PerformanceWorkspaceCapabilities,
+)
+from app.services.performance_workspace_controls import SUPPORTED_WORKSPACE_FREQUENCIES
+
+SUPPORTED_CONTRIBUTION_DIMENSIONS = ("asset_class", "sector", "country")
+SUPPORTED_ATTRIBUTION_DIMENSIONS = ("asset_class", "sector", "country", "currency")
+
+
+def build_module_capability(
+    state: str,
+    reason: str | None = None,
+    *,
+    coverage_level: str | None = None,
+    fallback_available: bool | None = None,
+    earliest_available_date: str | None = None,
+    latest_available_date: str | None = None,
+    supported_dimensions: Sequence[str] | None = None,
+    supported_frequencies: Sequence[str] | None = None,
+) -> PerformanceModuleCapability:
+    return PerformanceModuleCapability(
+        state=state,
+        reason=reason,
+        coverage_level=coverage_level,
+        fallback_available=fallback_available,
+        earliest_available_date=earliest_available_date,
+        latest_available_date=latest_available_date,
+        supported_dimensions=list(supported_dimensions) if supported_dimensions else None,
+        supported_frequencies=list(supported_frequencies) if supported_frequencies else None,
+    )
+
+
+def build_workspace_capabilities(
+    *,
+    benchmark_code: str | None,
+    net_performance: PerformanceComparativeSummary,
+    net_chart: list[PerformanceChartPoint],
+    contribution: ContributionSummaryView | None,
+    attribution: AttributionSummaryView | None,
+    evidence_view: PerformanceEvidenceView | None,
+    include_detail_blocks: bool = True,
+) -> PerformanceWorkspaceCapabilities:
+    has_return_history = len(net_chart) > 0
+    has_benchmark = bool(benchmark_code)
+    has_benchmark_returns = (
+        net_performance.benchmark_return_pct is not None
+        and net_performance.active_return_pct is not None
+    )
+    has_contribution_detail = bool(
+        contribution and (contribution.levels or contribution.position_rows)
+    )
+    has_position_ranking = bool(contribution and contribution.position_rows)
+    has_attribution_detail = bool(attribution and any(level.rows for level in attribution.levels))
+    has_attribution_summary = bool(
+        attribution
+        and (
+            attribution.levels
+            or attribution.active_return_pct is not None
+            or attribution.sum_of_effects_pct is not None
+            or attribution.residual_pct is not None
+        )
+    )
+    dated_history = [
+        point
+        for point in net_chart
+        if point.period_start is not None or point.period_end is not None
+    ]
+    earliest_history_date = (
+        min(point.period_start or point.period_end or "" for point in dated_history)
+        if dated_history
+        else None
+    )
+    latest_history_date = (
+        max(point.period_end or point.period_start or "" for point in dated_history)
+        if dated_history
+        else None
+    )
+
+    return PerformanceWorkspaceCapabilities(
+        summary_kpis=build_module_capability(
+            "supported",
+            "The performance workspace contract supports executive summary metrics.",
+        ),
+        return_path=(
+            build_module_capability(
+                "supported",
+                "Time-series return observations are available for the selected horizon.",
+                earliest_available_date=earliest_history_date,
+                latest_available_date=latest_history_date,
+                supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
+            )
+            if has_return_history
+            else build_module_capability(
+                "unavailable",
+                "Published return observations are not available for the selected horizon.",
+                supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
+            )
+        ),
+        benchmark_comparison=(
+            build_module_capability(
+                "supported",
+                "Benchmark-relative return metrics are available.",
+                earliest_available_date=earliest_history_date,
+                latest_available_date=latest_history_date,
+            )
+            if has_benchmark and has_benchmark_returns
+            else build_module_capability(
+                "partial",
+                "A benchmark is assigned, but benchmark-relative returns are incomplete.",
+                earliest_available_date=earliest_history_date,
+                latest_available_date=latest_history_date,
+            )
+            if has_benchmark
+            else build_module_capability(
+                "unavailable",
+                "No benchmark is assigned to this mandate.",
+            )
+        ),
+        multi_horizon_returns=(
+            build_module_capability(
+                "supported",
+                "The workspace supports benchmark-aware horizon comparisons.",
+                supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
+            )
+            if has_benchmark
+            else build_module_capability(
+                "partial",
+                (
+                    "Horizon comparisons remain available, "
+                    "but benchmark-relative output is unavailable."
+                ),
+                supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
+            )
+        ),
+        contribution_ranking=build_contribution_capability(
+            include_detail_blocks=include_detail_blocks,
+            has_position_ranking=has_position_ranking,
+            has_contribution_detail=has_contribution_detail,
+            supported_reason="Position-level contribution ranking is available.",
+            aggregate_reason="Contribution exists, but only aggregate rows are available.",
+            unavailable_reason=(
+                "Contribution analytics are not available for the current selection."
+            ),
+        ),
+        attribution_detail=build_attribution_capability(
+            include_detail_blocks=include_detail_blocks,
+            has_attribution_detail=has_attribution_detail,
+            has_attribution_summary=has_attribution_summary,
+        ),
+        contribution_detail=build_contribution_capability(
+            include_detail_blocks=include_detail_blocks,
+            has_position_ranking=has_position_ranking,
+            has_contribution_detail=has_contribution_detail,
+            supported_reason="Contribution detail is available for the current selection.",
+            aggregate_reason="Contribution exists, but only aggregate rows are available.",
+            unavailable_reason="Contribution detail is not available for the current selection.",
+        ),
+        evidence=build_evidence_capability(evidence_view=evidence_view),
+    )
+
+
+def build_evidence_capability(
+    *,
+    evidence_view: PerformanceEvidenceView | None,
+) -> PerformanceModuleCapability:
+    if evidence_view is None:
+        return build_module_capability(
+            "unavailable",
+            "No evidence posture is available for the current selection.",
+        )
+    if evidence_view.state == "supported":
+        return build_module_capability(
+            "supported",
+            evidence_view.reason,
+            coverage_level="calculation",
+            fallback_available=True,
+        )
+    if evidence_view.state == "partial":
+        return build_module_capability(
+            "partial",
+            evidence_view.reason,
+            coverage_level="calculation",
+            fallback_available=True,
+        )
+    return build_module_capability(
+        "unavailable",
+        evidence_view.reason,
+        coverage_level="calculation",
+    )
+
+
+def build_contribution_capability(
+    *,
+    include_detail_blocks: bool,
+    has_position_ranking: bool,
+    has_contribution_detail: bool,
+    supported_reason: str,
+    aggregate_reason: str,
+    unavailable_reason: str,
+) -> PerformanceModuleCapability:
+    if not include_detail_blocks or has_position_ranking:
+        return build_module_capability(
+            "supported",
+            supported_reason,
+            coverage_level="position",
+            supported_dimensions=SUPPORTED_CONTRIBUTION_DIMENSIONS,
+        )
+    if has_contribution_detail:
+        return build_module_capability(
+            "partial",
+            aggregate_reason,
+            coverage_level="aggregate",
+            fallback_available=True,
+            supported_dimensions=SUPPORTED_CONTRIBUTION_DIMENSIONS,
+        )
+    return build_module_capability(
+        "unavailable",
+        unavailable_reason,
+        supported_dimensions=SUPPORTED_CONTRIBUTION_DIMENSIONS,
+    )
+
+
+def build_attribution_capability(
+    *,
+    include_detail_blocks: bool,
+    has_attribution_detail: bool,
+    has_attribution_summary: bool,
+) -> PerformanceModuleCapability:
+    if not include_detail_blocks or has_attribution_detail:
+        return build_module_capability(
+            "supported",
+            "Benchmark-relative attribution detail is available.",
+            coverage_level="detail",
+            supported_dimensions=SUPPORTED_ATTRIBUTION_DIMENSIONS,
+            supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
+        )
+    if has_attribution_summary:
+        return build_module_capability(
+            "partial",
+            (
+                "Benchmark-relative attribution is available only at summary level "
+                "for the current selection."
+            ),
+            coverage_level="summary",
+            fallback_available=True,
+            supported_dimensions=SUPPORTED_ATTRIBUTION_DIMENSIONS,
+            supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
+        )
+    return build_module_capability(
+        "unavailable",
+        "Attribution detail is not available for the current selection.",
+        supported_dimensions=SUPPORTED_ATTRIBUTION_DIMENSIONS,
+        supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
+    )

--- a/src/app/services/performance_workspace_controls.py
+++ b/src/app/services/performance_workspace_controls.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date, timedelta
+
+SUPPORTED_WORKSPACE_FREQUENCIES = ("monthly", "quarterly")
+SUPPORTED_WORKSPACE_SUMMARY_PERIODS = ("YTD", "1Y", "2Y", "5Y", "10Y", "SI", "EXPLICIT")
+SUPPORTED_ATTRIBUTION_TREND_FREQUENCIES = ("monthly", "quarterly", "yearly")
+
+
+def normalize_workspace_dimension(
+    *,
+    requested_dimension: str,
+    supported_dimensions: Sequence[str],
+    warnings: list[str],
+    warning_code: str,
+) -> tuple[str, bool]:
+    normalized_dimension = requested_dimension.strip().lower()
+    if normalized_dimension in supported_dimensions:
+        return normalized_dimension, True
+    warnings.append(warning_code)
+    return supported_dimensions[0], False
+
+
+def normalize_workspace_chart_frequency(
+    *,
+    chart_frequency: str,
+    warnings: list[str],
+    warning_code: str = "PERFORMANCE_CHART_FREQUENCY_NORMALIZED",
+) -> tuple[str, bool]:
+    normalized_frequency = chart_frequency.strip().lower()
+    if normalized_frequency in SUPPORTED_WORKSPACE_FREQUENCIES:
+        return normalized_frequency, True
+    warnings.append(warning_code)
+    return "monthly", False
+
+
+def resolve_workspace_summary_request(
+    *,
+    period: str,
+    report_start_date: date,
+) -> tuple[str, str | None]:
+    normalized_period = period.upper()
+    if normalized_period in SUPPORTED_WORKSPACE_SUMMARY_PERIODS:
+        return (
+            normalized_period,
+            report_start_date.isoformat() if normalized_period == "EXPLICIT" else None,
+        )
+    return "EXPLICIT", report_start_date.isoformat()
+
+
+def resolve_report_start_date(*, as_of_date: date, period: str) -> date:
+    normalized_period = period.upper()
+    if normalized_period == "MTD":
+        return as_of_date.replace(day=1)
+    if normalized_period == "QTD":
+        quarter_month = ((as_of_date.month - 1) // 3) * 3 + 1
+        return as_of_date.replace(month=quarter_month, day=1)
+    if normalized_period == "YTD":
+        return as_of_date.replace(month=1, day=1)
+    if normalized_period == "1Y":
+        return shift_years(anchor=as_of_date, years=1)
+    if normalized_period == "3Y":
+        return shift_years(anchor=as_of_date, years=3)
+    if normalized_period == "5Y":
+        return shift_years(anchor=as_of_date, years=5)
+    return as_of_date.replace(month=1, day=1)
+
+
+def resolve_requested_window(
+    *,
+    default_report_end_date: str,
+    period: str,
+    explicit_start_date: str | None,
+    explicit_end_date: str | None,
+) -> tuple[str, date, str]:
+    report_end = date.fromisoformat(explicit_end_date or default_report_end_date)
+    effective_period = period.upper()
+    if explicit_start_date:
+        report_start = date.fromisoformat(explicit_start_date)
+        if report_start > report_end:
+            report_start, report_end = report_end, report_start
+        return report_end.isoformat(), report_start, "EXPLICIT"
+    return (
+        report_end.isoformat(),
+        resolve_report_start_date(as_of_date=report_end, period=effective_period),
+        effective_period,
+    )
+
+
+def normalize_attribution_trend_frequency(
+    *,
+    chart_frequency: str,
+    warnings: list[str],
+) -> str:
+    normalized_frequency = chart_frequency.lower()
+    if normalized_frequency in SUPPORTED_ATTRIBUTION_TREND_FREQUENCIES:
+        return normalized_frequency
+    warnings.append("ATTRIBUTION_TREND_FREQUENCY_NORMALIZED_TO_MONTHLY")
+    return "monthly"
+
+
+def build_attribution_trend_windows(
+    *,
+    start_date: date,
+    end_date: date,
+    chart_frequency: str,
+) -> list[tuple[date, date]]:
+    if start_date > end_date:
+        return []
+    windows: list[tuple[date, date]] = []
+    cursor = start_date
+    while cursor <= end_date:
+        window_end = resolve_attribution_trend_window_end(
+            window_start=cursor,
+            end_date=end_date,
+            chart_frequency=chart_frequency,
+        )
+        windows.append((cursor, window_end))
+        cursor = window_end + timedelta(days=1)
+    return windows
+
+
+def resolve_attribution_trend_window_end(
+    *,
+    window_start: date,
+    end_date: date,
+    chart_frequency: str,
+) -> date:
+    if chart_frequency == "quarterly":
+        quarter_end_month = ((window_start.month - 1) // 3 + 1) * 3
+        return min(
+            date(
+                window_start.year,
+                quarter_end_month,
+                last_day_of_month(year=window_start.year, month=quarter_end_month),
+            ),
+            end_date,
+        )
+    if chart_frequency == "yearly":
+        return min(date(window_start.year, 12, 31), end_date)
+    return min(
+        date(
+            window_start.year,
+            window_start.month,
+            last_day_of_month(year=window_start.year, month=window_start.month),
+        ),
+        end_date,
+    )
+
+
+def last_day_of_month(*, year: int, month: int) -> int:
+    if month == 12:
+        return 31
+    return (date(year, month + 1, 1) - timedelta(days=1)).day
+
+
+def shift_years(*, anchor: date, years: int) -> date:
+    try:
+        return anchor.replace(year=anchor.year - years) + timedelta(days=1)
+    except ValueError:
+        return anchor.replace(month=2, day=28, year=anchor.year - years) + timedelta(days=1)

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -51,8 +51,16 @@ from app.contracts.workbench import WorkbenchOverviewResponse, WorkbenchPartialF
 from app.middleware.server_timing import server_timing_span
 from app.precision_policy import quantize_performance
 from app.services.async_ttl_cache import AsyncTtlCache
+from app.services.performance_workspace_capabilities import (
+    SUPPORTED_ATTRIBUTION_DIMENSIONS,
+    SUPPORTED_CONTRIBUTION_DIMENSIONS,
+    build_attribution_capability,
+    build_contribution_capability,
+    build_evidence_capability,
+    build_module_capability,
+    build_workspace_capabilities,
+)
 from app.services.performance_workspace_controls import (
-    SUPPORTED_WORKSPACE_FREQUENCIES,
     build_attribution_trend_windows,
     last_day_of_month,
     normalize_attribution_trend_frequency,
@@ -84,8 +92,6 @@ STANDARD_PERIOD_ANALYSES = (
 )
 
 STANDARD_HORIZON_COMPARISON_PERIODS = ("MTD", "QTD", "YTD")
-SUPPORTED_CONTRIBUTION_DIMENSIONS = ("asset_class", "sector", "country")
-SUPPORTED_ATTRIBUTION_DIMENSIONS = ("asset_class", "sector", "country", "currency")
 LINEAGE_COMPLETION_POLL_ATTEMPTS = 3
 LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS = 0.25
 
@@ -903,15 +909,15 @@ class PerformanceWorkspaceService:
         supported_dimensions: Sequence[str] | None = None,
         supported_frequencies: Sequence[str] | None = None,
     ) -> PerformanceModuleCapability:
-        return PerformanceModuleCapability(
+        return build_module_capability(
             state=state,
             reason=reason,
             coverage_level=coverage_level,
             fallback_available=fallback_available,
             earliest_available_date=earliest_available_date,
             latest_available_date=latest_available_date,
-            supported_dimensions=list(supported_dimensions) if supported_dimensions else None,
-            supported_frequencies=list(supported_frequencies) if supported_frequencies else None,
+            supported_dimensions=supported_dimensions,
+            supported_frequencies=supported_frequencies,
         )
 
     def _extract_calculation_id_from_result(
@@ -1444,126 +1450,14 @@ class PerformanceWorkspaceService:
         evidence_view: PerformanceEvidenceView | None,
         include_detail_blocks: bool = True,
     ) -> PerformanceWorkspaceCapabilities:
-        has_return_history = len(net_chart) > 0
-        has_benchmark = bool(benchmark_code)
-        has_benchmark_returns = (
-            net_performance.benchmark_return_pct is not None
-            and net_performance.active_return_pct is not None
-        )
-        has_contribution_detail = bool(
-            contribution and (contribution.levels or contribution.position_rows)
-        )
-        has_position_ranking = bool(contribution and contribution.position_rows)
-        has_attribution_detail = bool(
-            attribution and any(level.rows for level in attribution.levels)
-        )
-        has_attribution_summary = bool(
-            attribution
-            and (
-                attribution.levels
-                or attribution.active_return_pct is not None
-                or attribution.sum_of_effects_pct is not None
-                or attribution.residual_pct is not None
-            )
-        )
-        dated_history = [
-            point
-            for point in net_chart
-            if point.period_start is not None or point.period_end is not None
-        ]
-        earliest_history_date = (
-            min(point.period_start or point.period_end or "" for point in dated_history)
-            if dated_history
-            else None
-        )
-        latest_history_date = (
-            max(point.period_end or point.period_start or "" for point in dated_history)
-            if dated_history
-            else None
-        )
-
-        return PerformanceWorkspaceCapabilities(
-            summary_kpis=self._capability(
-                "supported",
-                "The performance workspace contract supports executive summary metrics.",
-            ),
-            return_path=(
-                self._capability(
-                    "supported",
-                    "Time-series return observations are available for the selected horizon.",
-                    earliest_available_date=earliest_history_date,
-                    latest_available_date=latest_history_date,
-                    supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
-                )
-                if has_return_history
-                else self._capability(
-                    "unavailable",
-                    "Published return observations are not available for the selected horizon.",
-                    supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
-                )
-            ),
-            benchmark_comparison=(
-                self._capability(
-                    "supported",
-                    "Benchmark-relative return metrics are available.",
-                    earliest_available_date=earliest_history_date,
-                    latest_available_date=latest_history_date,
-                )
-                if has_benchmark and has_benchmark_returns
-                else self._capability(
-                    "partial",
-                    "A benchmark is assigned, but benchmark-relative returns are incomplete.",
-                    earliest_available_date=earliest_history_date,
-                    latest_available_date=latest_history_date,
-                )
-                if has_benchmark
-                else self._capability(
-                    "unavailable",
-                    "No benchmark is assigned to this mandate.",
-                )
-            ),
-            multi_horizon_returns=(
-                self._capability(
-                    "supported",
-                    "The workspace supports benchmark-aware horizon comparisons.",
-                    supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
-                )
-                if has_benchmark
-                else self._capability(
-                    "partial",
-                    (
-                        "Horizon comparisons remain available, "
-                        "but benchmark-relative output is unavailable."
-                    ),
-                    supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
-                )
-            ),
-            contribution_ranking=self._build_contribution_capability(
-                include_detail_blocks=include_detail_blocks,
-                has_position_ranking=has_position_ranking,
-                has_contribution_detail=has_contribution_detail,
-                supported_reason="Position-level contribution ranking is available.",
-                aggregate_reason="Contribution exists, but only aggregate rows are available.",
-                unavailable_reason=(
-                    "Contribution analytics are not available for the current selection."
-                ),
-            ),
-            attribution_detail=self._build_attribution_capability(
-                include_detail_blocks=include_detail_blocks,
-                has_attribution_detail=has_attribution_detail,
-                has_attribution_summary=has_attribution_summary,
-            ),
-            contribution_detail=self._build_contribution_capability(
-                include_detail_blocks=include_detail_blocks,
-                has_position_ranking=has_position_ranking,
-                has_contribution_detail=has_contribution_detail,
-                supported_reason="Contribution detail is available for the current selection.",
-                aggregate_reason="Contribution exists, but only aggregate rows are available.",
-                unavailable_reason=(
-                    "Contribution detail is not available for the current selection."
-                ),
-            ),
-            evidence=self._build_evidence_capability(evidence_view=evidence_view),
+        return build_workspace_capabilities(
+            benchmark_code=benchmark_code,
+            net_performance=net_performance,
+            net_chart=net_chart,
+            contribution=contribution,
+            attribution=attribution,
+            evidence_view=evidence_view,
+            include_detail_blocks=include_detail_blocks,
         )
 
     def _build_evidence_capability(
@@ -1571,30 +1465,7 @@ class PerformanceWorkspaceService:
         *,
         evidence_view: PerformanceEvidenceView | None,
     ) -> PerformanceModuleCapability:
-        if evidence_view is None:
-            return self._capability(
-                "unavailable",
-                "No evidence posture is available for the current selection.",
-            )
-        if evidence_view.state == "supported":
-            return self._capability(
-                "supported",
-                evidence_view.reason,
-                coverage_level="calculation",
-                fallback_available=True,
-            )
-        if evidence_view.state == "partial":
-            return self._capability(
-                "partial",
-                evidence_view.reason,
-                coverage_level="calculation",
-                fallback_available=True,
-            )
-        return self._capability(
-            "unavailable",
-            evidence_view.reason,
-            coverage_level="calculation",
-        )
+        return build_evidence_capability(evidence_view=evidence_view)
 
     def _build_contribution_capability(
         self,
@@ -1606,25 +1477,13 @@ class PerformanceWorkspaceService:
         aggregate_reason: str,
         unavailable_reason: str,
     ) -> PerformanceModuleCapability:
-        if not include_detail_blocks or has_position_ranking:
-            return self._capability(
-                "supported",
-                supported_reason,
-                coverage_level="position",
-                supported_dimensions=SUPPORTED_CONTRIBUTION_DIMENSIONS,
-            )
-        if has_contribution_detail:
-            return self._capability(
-                "partial",
-                aggregate_reason,
-                coverage_level="aggregate",
-                fallback_available=True,
-                supported_dimensions=SUPPORTED_CONTRIBUTION_DIMENSIONS,
-            )
-        return self._capability(
-            "unavailable",
-            unavailable_reason,
-            supported_dimensions=SUPPORTED_CONTRIBUTION_DIMENSIONS,
+        return build_contribution_capability(
+            include_detail_blocks=include_detail_blocks,
+            has_position_ranking=has_position_ranking,
+            has_contribution_detail=has_contribution_detail,
+            supported_reason=supported_reason,
+            aggregate_reason=aggregate_reason,
+            unavailable_reason=unavailable_reason,
         )
 
     def _build_attribution_capability(
@@ -1634,31 +1493,10 @@ class PerformanceWorkspaceService:
         has_attribution_detail: bool,
         has_attribution_summary: bool,
     ) -> PerformanceModuleCapability:
-        if not include_detail_blocks or has_attribution_detail:
-            return self._capability(
-                "supported",
-                "Benchmark-relative attribution detail is available.",
-                coverage_level="detail",
-                supported_dimensions=SUPPORTED_ATTRIBUTION_DIMENSIONS,
-                supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
-            )
-        if has_attribution_summary:
-            return self._capability(
-                "partial",
-                (
-                    "Benchmark-relative attribution is available only at summary level "
-                    "for the current selection."
-                ),
-                coverage_level="summary",
-                fallback_available=True,
-                supported_dimensions=SUPPORTED_ATTRIBUTION_DIMENSIONS,
-                supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
-            )
-        return self._capability(
-            "unavailable",
-            "Attribution detail is not available for the current selection.",
-            supported_dimensions=SUPPORTED_ATTRIBUTION_DIMENSIONS,
-            supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
+        return build_attribution_capability(
+            include_detail_blocks=include_detail_blocks,
+            has_attribution_detail=has_attribution_detail,
+            has_attribution_summary=has_attribution_summary,
         )
 
     async def _determine_report_end_date(

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Mapping, Sequence
-from datetime import date, timedelta
+from datetime import date
 from typing import Any, TypeAlias, cast
 
 from fastapi import HTTPException
@@ -51,6 +51,19 @@ from app.contracts.workbench import WorkbenchOverviewResponse, WorkbenchPartialF
 from app.middleware.server_timing import server_timing_span
 from app.precision_policy import quantize_performance
 from app.services.async_ttl_cache import AsyncTtlCache
+from app.services.performance_workspace_controls import (
+    SUPPORTED_WORKSPACE_FREQUENCIES,
+    build_attribution_trend_windows,
+    last_day_of_month,
+    normalize_attribution_trend_frequency,
+    normalize_workspace_chart_frequency,
+    normalize_workspace_dimension,
+    resolve_attribution_trend_window_end,
+    resolve_report_start_date,
+    resolve_requested_window,
+    resolve_workspace_summary_request,
+    shift_years,
+)
 from app.services.source_supportability import (
     extract_calculation_supportability,
     source_supportability_reason,
@@ -73,8 +86,6 @@ STANDARD_PERIOD_ANALYSES = (
 STANDARD_HORIZON_COMPARISON_PERIODS = ("MTD", "QTD", "YTD")
 SUPPORTED_CONTRIBUTION_DIMENSIONS = ("asset_class", "sector", "country")
 SUPPORTED_ATTRIBUTION_DIMENSIONS = ("asset_class", "sector", "country", "currency")
-SUPPORTED_WORKSPACE_FREQUENCIES = ("monthly", "quarterly")
-SUPPORTED_WORKSPACE_SUMMARY_PERIODS = ("YTD", "1Y", "2Y", "5Y", "10Y", "SI", "EXPLICIT")
 LINEAGE_COMPLETION_POLL_ATTEMPTS = 3
 LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS = 0.25
 
@@ -1944,11 +1955,12 @@ class PerformanceWorkspaceService:
         warnings: list[str],
         warning_code: str,
     ) -> tuple[str, bool]:
-        normalized_dimension = requested_dimension.strip().lower()
-        if normalized_dimension in supported_dimensions:
-            return normalized_dimension, True
-        warnings.append(warning_code)
-        return supported_dimensions[0], False
+        return normalize_workspace_dimension(
+            requested_dimension=requested_dimension,
+            supported_dimensions=supported_dimensions,
+            warnings=warnings,
+            warning_code=warning_code,
+        )
 
     def _normalize_workspace_chart_frequency(
         self,
@@ -1957,11 +1969,11 @@ class PerformanceWorkspaceService:
         warnings: list[str],
         warning_code: str = "PERFORMANCE_CHART_FREQUENCY_NORMALIZED",
     ) -> tuple[str, bool]:
-        normalized_frequency = chart_frequency.strip().lower()
-        if normalized_frequency in SUPPORTED_WORKSPACE_FREQUENCIES:
-            return normalized_frequency, True
-        warnings.append(warning_code)
-        return "monthly", False
+        return normalize_workspace_chart_frequency(
+            chart_frequency=chart_frequency,
+            warnings=warnings,
+            warning_code=warning_code,
+        )
 
     def _resolve_workspace_summary_request(
         self,
@@ -1969,13 +1981,10 @@ class PerformanceWorkspaceService:
         period: str,
         report_start_date: date,
     ) -> tuple[str, str | None]:
-        normalized_period = period.upper()
-        if normalized_period in SUPPORTED_WORKSPACE_SUMMARY_PERIODS:
-            return (
-                normalized_period,
-                report_start_date.isoformat() if normalized_period == "EXPLICIT" else None,
-            )
-        return "EXPLICIT", report_start_date.isoformat()
+        return resolve_workspace_summary_request(
+            period=period,
+            report_start_date=report_start_date,
+        )
 
     async def _fetch_workspace_summary_result(
         self,
@@ -3006,21 +3015,7 @@ class PerformanceWorkspaceService:
         )
 
     def _resolve_report_start_date(self, *, as_of_date: date, period: str) -> date:
-        normalized_period = period.upper()
-        if normalized_period == "MTD":
-            return as_of_date.replace(day=1)
-        if normalized_period == "QTD":
-            quarter_month = ((as_of_date.month - 1) // 3) * 3 + 1
-            return as_of_date.replace(month=quarter_month, day=1)
-        if normalized_period == "YTD":
-            return as_of_date.replace(month=1, day=1)
-        if normalized_period == "1Y":
-            return self._shift_years(as_of_date, 1)
-        if normalized_period == "3Y":
-            return self._shift_years(as_of_date, 3)
-        if normalized_period == "5Y":
-            return self._shift_years(as_of_date, 5)
-        return as_of_date.replace(month=1, day=1)
+        return resolve_report_start_date(as_of_date=as_of_date, period=period)
 
     def _resolve_requested_window(
         self,
@@ -3030,17 +3025,11 @@ class PerformanceWorkspaceService:
         explicit_start_date: str | None,
         explicit_end_date: str | None,
     ) -> tuple[str, date, str]:
-        report_end = date.fromisoformat(explicit_end_date or default_report_end_date)
-        effective_period = period.upper()
-        if explicit_start_date:
-            report_start = date.fromisoformat(explicit_start_date)
-            if report_start > report_end:
-                report_start, report_end = report_end, report_start
-            return report_end.isoformat(), report_start, "EXPLICIT"
-        return (
-            report_end.isoformat(),
-            self._resolve_report_start_date(as_of_date=report_end, period=effective_period),
-            effective_period,
+        return resolve_requested_window(
+            default_report_end_date=default_report_end_date,
+            period=period,
+            explicit_start_date=explicit_start_date,
+            explicit_end_date=explicit_end_date,
         )
 
     def _normalize_attribution_trend_frequency(
@@ -3049,11 +3038,10 @@ class PerformanceWorkspaceService:
         chart_frequency: str,
         warnings: list[str],
     ) -> str:
-        normalized_frequency = chart_frequency.lower()
-        if normalized_frequency in {"monthly", "quarterly", "yearly"}:
-            return normalized_frequency
-        warnings.append("ATTRIBUTION_TREND_FREQUENCY_NORMALIZED_TO_MONTHLY")
-        return "monthly"
+        return normalize_attribution_trend_frequency(
+            chart_frequency=chart_frequency,
+            warnings=warnings,
+        )
 
     def _build_attribution_trend_windows(
         self,
@@ -3062,19 +3050,11 @@ class PerformanceWorkspaceService:
         end_date: date,
         chart_frequency: str,
     ) -> list[tuple[date, date]]:
-        if start_date > end_date:
-            return []
-        windows: list[tuple[date, date]] = []
-        cursor = start_date
-        while cursor <= end_date:
-            window_end = self._resolve_attribution_trend_window_end(
-                window_start=cursor,
-                end_date=end_date,
-                chart_frequency=chart_frequency,
-            )
-            windows.append((cursor, window_end))
-            cursor = window_end + timedelta(days=1)
-        return windows
+        return build_attribution_trend_windows(
+            start_date=start_date,
+            end_date=end_date,
+            chart_frequency=chart_frequency,
+        )
 
     def _resolve_attribution_trend_window_end(
         self,
@@ -3083,37 +3063,17 @@ class PerformanceWorkspaceService:
         end_date: date,
         chart_frequency: str,
     ) -> date:
-        if chart_frequency == "quarterly":
-            quarter_end_month = ((window_start.month - 1) // 3 + 1) * 3
-            return min(
-                date(
-                    window_start.year,
-                    quarter_end_month,
-                    self._last_day_of_month(window_start.year, quarter_end_month),
-                ),
-                end_date,
-            )
-        if chart_frequency == "yearly":
-            return min(date(window_start.year, 12, 31), end_date)
-        return min(
-            date(
-                window_start.year,
-                window_start.month,
-                self._last_day_of_month(window_start.year, window_start.month),
-            ),
-            end_date,
+        return resolve_attribution_trend_window_end(
+            window_start=window_start,
+            end_date=end_date,
+            chart_frequency=chart_frequency,
         )
 
     def _last_day_of_month(self, year: int, month: int) -> int:
-        if month == 12:
-            return 31
-        return (date(year, month + 1, 1) - timedelta(days=1)).day
+        return last_day_of_month(year=year, month=month)
 
     def _shift_years(self, anchor: date, years: int) -> date:
-        try:
-            return anchor.replace(year=anchor.year - years) + timedelta(days=1)
-        except ValueError:
-            return anchor.replace(month=2, day=28, year=anchor.year - years) + timedelta(days=1)
+        return shift_years(anchor=anchor, years=years)
 
     def _parse_twr_result(
         self,

--- a/tests/unit/test_performance_workspace_capabilities.py
+++ b/tests/unit/test_performance_workspace_capabilities.py
@@ -1,0 +1,60 @@
+from app.contracts.performance_workspace import (
+    PerformanceChartPoint,
+    PerformanceComparativeSummary,
+    PerformanceEvidenceView,
+)
+from app.services.performance_workspace_capabilities import build_workspace_capabilities
+
+
+def test_build_workspace_capabilities_reports_supported_benchmark_history() -> None:
+    capabilities = build_workspace_capabilities(
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+        net_performance=PerformanceComparativeSummary(
+            metric_basis="NET",
+            benchmark_return_pct=0.03,
+            active_return_pct=0.01,
+        ),
+        net_chart=[
+            PerformanceChartPoint(
+                label="2026-01",
+                frequency="monthly",
+                period_start="2026-01-01",
+                period_end="2026-01-31",
+            ),
+            PerformanceChartPoint(
+                label="2026-02",
+                frequency="monthly",
+                period_start="2026-02-01",
+                period_end="2026-02-28",
+            ),
+        ],
+        contribution=None,
+        attribution=None,
+        evidence_view=PerformanceEvidenceView(state="supported", reason="Evidence complete."),
+    )
+
+    assert capabilities.return_path.state == "supported"
+    assert capabilities.return_path.earliest_available_date == "2026-01-01"
+    assert capabilities.return_path.latest_available_date == "2026-02-28"
+    assert capabilities.benchmark_comparison.state == "supported"
+    assert capabilities.multi_horizon_returns.state == "supported"
+    assert capabilities.evidence.state == "supported"
+    assert capabilities.evidence.coverage_level == "calculation"
+
+
+def test_build_workspace_capabilities_reports_partial_without_benchmark() -> None:
+    capabilities = build_workspace_capabilities(
+        benchmark_code=None,
+        net_performance=PerformanceComparativeSummary(metric_basis="NET"),
+        net_chart=[],
+        contribution=None,
+        attribution=None,
+        evidence_view=None,
+    )
+
+    assert capabilities.return_path.state == "unavailable"
+    assert capabilities.benchmark_comparison.state == "unavailable"
+    assert capabilities.multi_horizon_returns.state == "partial"
+    assert capabilities.contribution_ranking.state == "unavailable"
+    assert capabilities.attribution_detail.state == "unavailable"
+    assert capabilities.evidence.state == "unavailable"

--- a/tests/unit/test_performance_workspace_controls.py
+++ b/tests/unit/test_performance_workspace_controls.py
@@ -12,24 +12,14 @@ from app.services.performance_workspace_controls import (
 
 
 def test_resolve_report_start_date_uses_canonical_period_boundaries() -> None:
-    assert resolve_report_start_date(as_of_date=date(2026, 3, 31), period="MTD") == date(
-        2026, 3, 1
-    )
-    assert resolve_report_start_date(as_of_date=date(2026, 5, 24), period="QTD") == date(
-        2026, 4, 1
-    )
-    assert resolve_report_start_date(as_of_date=date(2026, 3, 31), period="YTD") == date(
-        2026, 1, 1
-    )
-    assert resolve_report_start_date(as_of_date=date(2026, 3, 31), period="1Y") == date(
-        2025, 4, 1
-    )
+    assert resolve_report_start_date(as_of_date=date(2026, 3, 31), period="MTD") == date(2026, 3, 1)
+    assert resolve_report_start_date(as_of_date=date(2026, 5, 24), period="QTD") == date(2026, 4, 1)
+    assert resolve_report_start_date(as_of_date=date(2026, 3, 31), period="YTD") == date(2026, 1, 1)
+    assert resolve_report_start_date(as_of_date=date(2026, 3, 31), period="1Y") == date(2025, 4, 1)
 
 
 def test_resolve_report_start_date_handles_leap_day_anniversaries() -> None:
-    assert resolve_report_start_date(as_of_date=date(2024, 2, 29), period="1Y") == date(
-        2023, 3, 1
-    )
+    assert resolve_report_start_date(as_of_date=date(2024, 2, 29), period="1Y") == date(2023, 3, 1)
 
 
 def test_resolve_requested_window_swaps_reversed_explicit_dates() -> None:
@@ -62,10 +52,13 @@ def test_workspace_control_normalizers_append_warnings_for_unsupported_values() 
         warnings=warnings,
         warning_code="DIMENSION_NORMALIZED",
     ) == ("asset_class", False)
-    assert normalize_attribution_trend_frequency(
-        chart_frequency="weekly",
-        warnings=warnings,
-    ) == "monthly"
+    assert (
+        normalize_attribution_trend_frequency(
+            chart_frequency="weekly",
+            warnings=warnings,
+        )
+        == "monthly"
+    )
 
     assert warnings == [
         "FREQUENCY_NORMALIZED",

--- a/tests/unit/test_performance_workspace_controls.py
+++ b/tests/unit/test_performance_workspace_controls.py
@@ -1,0 +1,106 @@
+from datetime import date
+
+from app.services.performance_workspace_controls import (
+    build_attribution_trend_windows,
+    normalize_attribution_trend_frequency,
+    normalize_workspace_chart_frequency,
+    normalize_workspace_dimension,
+    resolve_requested_window,
+    resolve_report_start_date,
+    resolve_workspace_summary_request,
+)
+
+
+def test_resolve_report_start_date_uses_canonical_period_boundaries() -> None:
+    assert resolve_report_start_date(as_of_date=date(2026, 3, 31), period="MTD") == date(
+        2026, 3, 1
+    )
+    assert resolve_report_start_date(as_of_date=date(2026, 5, 24), period="QTD") == date(
+        2026, 4, 1
+    )
+    assert resolve_report_start_date(as_of_date=date(2026, 3, 31), period="YTD") == date(
+        2026, 1, 1
+    )
+    assert resolve_report_start_date(as_of_date=date(2026, 3, 31), period="1Y") == date(
+        2025, 4, 1
+    )
+
+
+def test_resolve_report_start_date_handles_leap_day_anniversaries() -> None:
+    assert resolve_report_start_date(as_of_date=date(2024, 2, 29), period="1Y") == date(
+        2023, 3, 1
+    )
+
+
+def test_resolve_requested_window_swaps_reversed_explicit_dates() -> None:
+    assert resolve_requested_window(
+        default_report_end_date="2026-03-31",
+        period="YTD",
+        explicit_start_date="2026-04-30",
+        explicit_end_date="2026-01-31",
+    ) == ("2026-04-30", date(2026, 1, 31), "EXPLICIT")
+
+
+def test_resolve_workspace_summary_request_normalizes_unsupported_period() -> None:
+    assert resolve_workspace_summary_request(
+        period="QTD",
+        report_start_date=date(2026, 4, 1),
+    ) == ("EXPLICIT", "2026-04-01")
+
+
+def test_workspace_control_normalizers_append_warnings_for_unsupported_values() -> None:
+    warnings: list[str] = []
+
+    assert normalize_workspace_chart_frequency(
+        chart_frequency="weekly",
+        warnings=warnings,
+        warning_code="FREQUENCY_NORMALIZED",
+    ) == ("monthly", False)
+    assert normalize_workspace_dimension(
+        requested_dimension="issuer",
+        supported_dimensions=("asset_class", "sector"),
+        warnings=warnings,
+        warning_code="DIMENSION_NORMALIZED",
+    ) == ("asset_class", False)
+    assert normalize_attribution_trend_frequency(
+        chart_frequency="weekly",
+        warnings=warnings,
+    ) == "monthly"
+
+    assert warnings == [
+        "FREQUENCY_NORMALIZED",
+        "DIMENSION_NORMALIZED",
+        "ATTRIBUTION_TREND_FREQUENCY_NORMALIZED_TO_MONTHLY",
+    ]
+
+
+def test_build_attribution_trend_windows_respects_frequency_boundaries() -> None:
+    monthly_windows = build_attribution_trend_windows(
+        start_date=date(2026, 1, 15),
+        end_date=date(2026, 3, 10),
+        chart_frequency="monthly",
+    )
+    quarterly_windows = build_attribution_trend_windows(
+        start_date=date(2026, 1, 15),
+        end_date=date(2026, 5, 10),
+        chart_frequency="quarterly",
+    )
+    yearly_windows = build_attribution_trend_windows(
+        start_date=date(2026, 10, 15),
+        end_date=date(2027, 2, 10),
+        chart_frequency="yearly",
+    )
+
+    assert monthly_windows == [
+        (date(2026, 1, 15), date(2026, 1, 31)),
+        (date(2026, 2, 1), date(2026, 2, 28)),
+        (date(2026, 3, 1), date(2026, 3, 10)),
+    ]
+    assert quarterly_windows == [
+        (date(2026, 1, 15), date(2026, 3, 31)),
+        (date(2026, 4, 1), date(2026, 5, 10)),
+    ]
+    assert yearly_windows == [
+        (date(2026, 10, 15), date(2026, 12, 31)),
+        (date(2027, 1, 1), date(2027, 2, 10)),
+    ]

--- a/tests/unit/test_performance_workspace_controls.py
+++ b/tests/unit/test_performance_workspace_controls.py
@@ -5,8 +5,8 @@ from app.services.performance_workspace_controls import (
     normalize_attribution_trend_frequency,
     normalize_workspace_chart_frequency,
     normalize_workspace_dimension,
-    resolve_requested_window,
     resolve_report_start_date,
+    resolve_requested_window,
     resolve_workspace_summary_request,
 )
 


### PR DESCRIPTION
## Summary
- Extract performance workspace control normalization and date/window resolution into a reusable helper module.
- Extract performance workspace capability composition into a reusable helper module.
- Keep existing service private wrappers stable while reducing monolith implementation size.
- Add focused unit coverage for controls and capability posture.

## Validation
- python -m pytest tests/unit/test_performance_workspace_controls.py -q
- python -m pytest tests/unit/test_performance_workspace_capabilities.py -q
- python -m pytest tests/unit/test_performance_workspace_capabilities.py tests/unit/test_performance_workspace_controls.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Governance
- Experience API internal refactor only; no OpenAPI or route contract behavior changed.
- No docs/wiki publication required for this slice because product/operator truth did not change.
- Stranded truth baseline before work: no unmerged remote branches.