### PR TITLE
Extract risk workspace request builders

### DIFF
--- a/src/app/services/risk_workspace_requests.py
+++ b/src/app/services/risk_workspace_requests.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from typing import Any
+
+SUMMARY_METRICS = [
+    "VOLATILITY",
+    "SHARPE",
+    "SORTINO",
+    "BETA",
+    "TRACKING_ERROR",
+    "INFORMATION_RATIO",
+    "VAR",
+]
+ROLLING_PORTFOLIO_METRICS = ["ROLLING_VOLATILITY", "ROLLING_MAX_DRAWDOWN"]
+ROLLING_BENCHMARK_METRICS = [
+    "ROLLING_BETA",
+    "ROLLING_TRACKING_ERROR",
+    "ROLLING_INFORMATION_RATIO",
+]
+ROLLING_SHARPE_METRIC = "ROLLING_SHARPE"
+ROLLING_DEFAULT_WINDOWS = [21, 63, 126, 252]
+DEFAULT_REPORTING_CURRENCY = "USD"
+
+
+def build_summary_request(
+    *,
+    portfolio_id: str,
+    period: str,
+    detail_basis: str,
+    as_of_date: str,
+    report_start_date: str | None,
+    report_end_date: str | None,
+    reporting_currency: str | None,
+) -> dict[str, Any]:
+    stateful_input: dict[str, Any] = {
+        "portfolio_id": portfolio_id,
+        "as_of_date": as_of_date,
+        "reporting_currency": resolve_reporting_currency(reporting_currency),
+        "net_or_gross": normalize_detail_basis(detail_basis),
+        "periods": build_risk_periods(
+            period=period,
+            report_start_date=report_start_date,
+            report_end_date=report_end_date,
+        ),
+        "metrics": SUMMARY_METRICS,
+        "options": {
+            "frequency": "DAILY",
+            "risk_free_mode": "ZERO",
+            "var": {
+                "method": "HISTORICAL",
+                "confidence": 0.95,
+                "horizon_days": 1,
+                "include_expected_shortfall": True,
+            },
+        },
+    }
+    return {"input_mode": "stateful", "stateful_input": stateful_input}
+
+
+def build_concentration_request(
+    *,
+    portfolio_id: str,
+    as_of_date: str,
+    reporting_currency: str | None,
+) -> dict[str, Any]:
+    stateful_input: dict[str, Any] = {
+        "portfolio_id": portfolio_id,
+        "as_of_date": as_of_date,
+        "reporting_currency": resolve_reporting_currency(reporting_currency),
+        "include_cash_positions": True,
+        "include_zero_quantity_positions": False,
+        "top_n": 10,
+    }
+    return {
+        "input_mode": "stateful",
+        "stateful_input": stateful_input,
+        "issuer_grouping_level": "ultimate_parent",
+        "enrichment_policy": "merge_caller_then_core",
+    }
+
+
+def build_drawdown_request(
+    *,
+    portfolio_id: str,
+    period: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    as_of_date: str,
+    report_start_date: str | None,
+    report_end_date: str | None,
+    reporting_currency: str | None,
+    include_underwater_series: bool,
+) -> dict[str, Any]:
+    stateful_input: dict[str, Any] = {
+        "portfolio_id": portfolio_id,
+        "as_of_date": as_of_date,
+        "reporting_currency": resolve_reporting_currency(reporting_currency),
+        "net_or_gross": normalize_detail_basis(detail_basis),
+        "periods": build_risk_periods(
+            period=period,
+            report_start_date=report_start_date,
+            report_end_date=report_end_date,
+        ),
+        "benchmark_policy": {
+            "include_benchmark": bool(benchmark_code),
+            "missing_benchmark_policy": "IGNORE",
+        },
+    }
+    return {
+        "input_mode": "stateful",
+        "stateful_input": stateful_input,
+        "analysis_options": {
+            "include_underwater_series": include_underwater_series,
+            "include_episode_list": True,
+            "top_n_episodes": 5,
+            "cdar_alpha": 0.95,
+            "minimum_episode_depth_bps": 0,
+            "duration_unit": "BUSINESS_DAYS",
+        },
+    }
+
+
+def build_rolling_request(
+    *,
+    portfolio_id: str,
+    period: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    as_of_date: str,
+    report_start_date: str | None,
+    report_end_date: str | None,
+    reporting_currency: str | None,
+    include_time_series: bool,
+    include_sharpe: bool,
+) -> dict[str, Any]:
+    metrics = list(ROLLING_PORTFOLIO_METRICS)
+    if include_sharpe:
+        metrics.append(ROLLING_SHARPE_METRIC)
+    if benchmark_code:
+        metrics.extend(ROLLING_BENCHMARK_METRICS)
+    stateful_input: dict[str, Any] = {
+        "portfolio_id": portfolio_id,
+        "as_of_date": as_of_date,
+        "reporting_currency": resolve_reporting_currency(reporting_currency),
+        "net_or_gross": normalize_detail_basis(detail_basis),
+        "periods": build_risk_periods(
+            period=period,
+            report_start_date=report_start_date,
+            report_end_date=report_end_date,
+        ),
+        "rolling_options": {
+            "window_lengths": ROLLING_DEFAULT_WINDOWS,
+            "metrics": metrics,
+            "annualization_basis": 252,
+            "min_observations_policy": "STRICT",
+            "alignment_policy": "INNER_JOIN",
+            "include_time_series": include_time_series,
+        },
+    }
+    return {"input_mode": "stateful", "stateful_input": stateful_input}
+
+
+def build_attribution_request(
+    *,
+    portfolio_id: str,
+    period: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    as_of_date: str,
+    report_start_date: str | None,
+    report_end_date: str | None,
+    reporting_currency: str | None,
+    attribution_type: str,
+    grouping_dimension: str,
+) -> dict[str, Any]:
+    stateful_input: dict[str, Any] = {
+        "portfolio_id": portfolio_id,
+        "as_of_date": as_of_date,
+        "reporting_currency": resolve_reporting_currency(reporting_currency),
+        "net_or_gross": normalize_detail_basis(detail_basis),
+        "periods": build_risk_periods(
+            period=period,
+            report_start_date=report_start_date,
+            report_end_date=report_end_date,
+        ),
+        "attribution_options": {
+            "attribution_types": [attribution_type],
+            "metrics": ["TRACKING_ERROR" if attribution_type == "ACTIVE_RISK" else "VOLATILITY"],
+            "grouping_dimensions": [grouping_dimension],
+            "annualization_basis": 252,
+        },
+    }
+    if benchmark_code and attribution_type == "ACTIVE_RISK":
+        stateful_input["benchmark_id"] = benchmark_code
+    return {"input_mode": "stateful", "stateful_input": stateful_input}
+
+
+def resolve_reporting_currency(value: str | None) -> str:
+    if value and value.strip():
+        return value.strip().upper()
+    return DEFAULT_REPORTING_CURRENCY
+
+
+def normalize_detail_basis(value: str) -> str:
+    return "GROSS" if value.upper() == "GROSS" else "NET"
+
+
+def normalize_period(value: str) -> str:
+    normalized = value.upper()
+    if normalized in {"MTD", "QTD", "YTD", "1Y", "3Y", "5Y", "SI", "YEAR", "EXPLICIT"}:
+        return normalized
+    if normalized == "ONE_YEAR":
+        return "1Y"
+    if normalized == "THREE_YEAR":
+        return "3Y"
+    if normalized == "FIVE_YEAR":
+        return "5Y"
+    if normalized == "ITD":
+        return "SI"
+    return "YTD"
+
+
+def build_risk_periods(
+    *,
+    period: str,
+    report_start_date: str | None,
+    report_end_date: str | None,
+) -> list[dict[str, Any]]:
+    normalized_period = normalize_period(period)
+    period_payload: dict[str, Any] = {"type": normalized_period, "name": normalized_period}
+    if normalized_period == "EXPLICIT" and report_start_date and report_end_date:
+        period_payload["from_date"] = report_start_date
+        period_payload["to_date"] = report_end_date
+    return [period_payload]

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -107,6 +107,8 @@ _RISK_ATTRIBUTION_ACTIVE_RISK_GATE_REASON = (
     "Issuer is supported for total risk only. Active risk by issuer remains "
     "unavailable until benchmark issuer exposure semantics are approved."
 )
+
+
 class RiskWorkspaceService:
     def __init__(
         self,

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -51,20 +51,24 @@ from app.contracts.risk_workspace import (
 from app.contracts.workbench import WorkbenchPartialFailure
 from app.services.async_ttl_cache import AsyncTtlCache
 from app.services.domain_client_protocols import RiskWorkspaceClient
+from app.services.risk_workspace_requests import (
+    SUMMARY_METRICS as _SUMMARY_METRICS,
+)
+from app.services.risk_workspace_requests import (
+    build_attribution_request,
+    build_concentration_request,
+    build_drawdown_request,
+    build_risk_periods,
+    build_rolling_request,
+    build_summary_request,
+    normalize_period,
+    resolve_reporting_currency,
+)
 from app.services.source_supportability import (
     extract_calculation_supportability,
     source_supportability_reason,
 )
 
-_SUMMARY_METRICS = [
-    "VOLATILITY",
-    "SHARPE",
-    "SORTINO",
-    "BETA",
-    "TRACKING_ERROR",
-    "INFORMATION_RATIO",
-    "VAR",
-]
 _BENCHMARK_DEPENDENT_METRICS = {"BETA", "TRACKING_ERROR", "INFORMATION_RATIO"}
 _RISK_FREE_DEPENDENT_METRICS = {"SHARPE"}
 _DRAWDOWN_SUPPORTABILITY_KEY_BENCHMARK = "benchmark_relative_drawdown"
@@ -76,14 +80,6 @@ _ROLLING_METRIC_LABELS = {
     "ROLLING_INFORMATION_RATIO": "Rolling Information Ratio",
     "ROLLING_MAX_DRAWDOWN": "Rolling Max Drawdown",
 }
-_ROLLING_PORTFOLIO_METRICS = ["ROLLING_VOLATILITY", "ROLLING_MAX_DRAWDOWN"]
-_ROLLING_BENCHMARK_METRICS = [
-    "ROLLING_BETA",
-    "ROLLING_TRACKING_ERROR",
-    "ROLLING_INFORMATION_RATIO",
-]
-_ROLLING_SHARPE_METRIC = "ROLLING_SHARPE"
-_ROLLING_DEFAULT_WINDOWS = [21, 63, 126, 252]
 _METRIC_LABELS = {
     "VOLATILITY": "Volatility",
     "DRAWDOWN": "Drawdown",
@@ -111,9 +107,6 @@ _RISK_ATTRIBUTION_ACTIVE_RISK_GATE_REASON = (
     "Issuer is supported for total risk only. Active risk by issuer remains "
     "unavailable until benchmark issuer exposure semantics are approved."
 )
-_DEFAULT_REPORTING_CURRENCY = "USD"
-
-
 class RiskWorkspaceService:
     def __init__(
         self,
@@ -572,29 +565,15 @@ def _build_summary_request(
     report_end_date: str | None,
     reporting_currency: str | None,
 ) -> dict[str, Any]:
-    stateful_input: dict[str, Any] = {
-        "portfolio_id": portfolio_id,
-        "as_of_date": as_of_date,
-        "reporting_currency": _resolve_reporting_currency(reporting_currency),
-        "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
-        "periods": _build_risk_periods(
-            period=period,
-            report_start_date=report_start_date,
-            report_end_date=report_end_date,
-        ),
-        "metrics": _SUMMARY_METRICS,
-        "options": {
-            "frequency": "DAILY",
-            "risk_free_mode": "ZERO",
-            "var": {
-                "method": "HISTORICAL",
-                "confidence": 0.95,
-                "horizon_days": 1,
-                "include_expected_shortfall": True,
-            },
-        },
-    }
-    return {"input_mode": "stateful", "stateful_input": stateful_input}
+    return build_summary_request(
+        portfolio_id=portfolio_id,
+        period=period,
+        detail_basis=detail_basis,
+        as_of_date=as_of_date,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
+        reporting_currency=reporting_currency,
+    )
 
 
 def _build_concentration_request(
@@ -603,20 +582,11 @@ def _build_concentration_request(
     as_of_date: str,
     reporting_currency: str | None,
 ) -> dict[str, Any]:
-    stateful_input: dict[str, Any] = {
-        "portfolio_id": portfolio_id,
-        "as_of_date": as_of_date,
-        "reporting_currency": _resolve_reporting_currency(reporting_currency),
-        "include_cash_positions": True,
-        "include_zero_quantity_positions": False,
-        "top_n": 10,
-    }
-    return {
-        "input_mode": "stateful",
-        "stateful_input": stateful_input,
-        "issuer_grouping_level": "ultimate_parent",
-        "enrichment_policy": "merge_caller_then_core",
-    }
+    return build_concentration_request(
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        reporting_currency=reporting_currency,
+    )
 
 
 def _build_drawdown_request(
@@ -631,33 +601,17 @@ def _build_drawdown_request(
     reporting_currency: str | None,
     include_underwater_series: bool,
 ) -> dict[str, Any]:
-    stateful_input: dict[str, Any] = {
-        "portfolio_id": portfolio_id,
-        "as_of_date": as_of_date,
-        "reporting_currency": _resolve_reporting_currency(reporting_currency),
-        "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
-        "periods": _build_risk_periods(
-            period=period,
-            report_start_date=report_start_date,
-            report_end_date=report_end_date,
-        ),
-        "benchmark_policy": {
-            "include_benchmark": bool(benchmark_code),
-            "missing_benchmark_policy": "IGNORE",
-        },
-    }
-    return {
-        "input_mode": "stateful",
-        "stateful_input": stateful_input,
-        "analysis_options": {
-            "include_underwater_series": include_underwater_series,
-            "include_episode_list": True,
-            "top_n_episodes": 5,
-            "cdar_alpha": 0.95,
-            "minimum_episode_depth_bps": 0,
-            "duration_unit": "BUSINESS_DAYS",
-        },
-    }
+    return build_drawdown_request(
+        portfolio_id=portfolio_id,
+        period=period,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        as_of_date=as_of_date,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
+        reporting_currency=reporting_currency,
+        include_underwater_series=include_underwater_series,
+    )
 
 
 def _build_rolling_request(
@@ -673,31 +627,18 @@ def _build_rolling_request(
     include_time_series: bool,
     include_sharpe: bool,
 ) -> dict[str, Any]:
-    metrics = list(_ROLLING_PORTFOLIO_METRICS)
-    if include_sharpe:
-        metrics.append(_ROLLING_SHARPE_METRIC)
-    if benchmark_code:
-        metrics.extend(_ROLLING_BENCHMARK_METRICS)
-    stateful_input: dict[str, Any] = {
-        "portfolio_id": portfolio_id,
-        "as_of_date": as_of_date,
-        "reporting_currency": _resolve_reporting_currency(reporting_currency),
-        "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
-        "periods": _build_risk_periods(
-            period=period,
-            report_start_date=report_start_date,
-            report_end_date=report_end_date,
-        ),
-        "rolling_options": {
-            "window_lengths": _ROLLING_DEFAULT_WINDOWS,
-            "metrics": metrics,
-            "annualization_basis": 252,
-            "min_observations_policy": "STRICT",
-            "alignment_policy": "INNER_JOIN",
-            "include_time_series": include_time_series,
-        },
-    }
-    return {"input_mode": "stateful", "stateful_input": stateful_input}
+    return build_rolling_request(
+        portfolio_id=portfolio_id,
+        period=period,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        as_of_date=as_of_date,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
+        reporting_currency=reporting_currency,
+        include_time_series=include_time_series,
+        include_sharpe=include_sharpe,
+    )
 
 
 def _build_attribution_request(
@@ -713,32 +654,22 @@ def _build_attribution_request(
     attribution_type: str,
     grouping_dimension: str,
 ) -> dict[str, Any]:
-    stateful_input: dict[str, Any] = {
-        "portfolio_id": portfolio_id,
-        "as_of_date": as_of_date,
-        "reporting_currency": _resolve_reporting_currency(reporting_currency),
-        "net_or_gross": "GROSS" if detail_basis.upper() == "GROSS" else "NET",
-        "periods": _build_risk_periods(
-            period=period,
-            report_start_date=report_start_date,
-            report_end_date=report_end_date,
-        ),
-        "attribution_options": {
-            "attribution_types": [attribution_type],
-            "metrics": ["TRACKING_ERROR" if attribution_type == "ACTIVE_RISK" else "VOLATILITY"],
-            "grouping_dimensions": [grouping_dimension],
-            "annualization_basis": 252,
-        },
-    }
-    if benchmark_code and attribution_type == "ACTIVE_RISK":
-        stateful_input["benchmark_id"] = benchmark_code
-    return {"input_mode": "stateful", "stateful_input": stateful_input}
+    return build_attribution_request(
+        portfolio_id=portfolio_id,
+        period=period,
+        detail_basis=detail_basis,
+        benchmark_code=benchmark_code,
+        as_of_date=as_of_date,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
+        reporting_currency=reporting_currency,
+        attribution_type=attribution_type,
+        grouping_dimension=grouping_dimension,
+    )
 
 
 def _resolve_reporting_currency(value: str | None) -> str:
-    if value and value.strip():
-        return value.strip().upper()
-    return _DEFAULT_REPORTING_CURRENCY
+    return resolve_reporting_currency(value)
 
 
 def _normalize_risk_attribution_type(value: str) -> str:
@@ -2072,18 +2003,7 @@ def _resolve_as_of_date(value: str | None) -> str:
 
 
 def _normalize_period(value: str) -> str:
-    normalized = value.upper()
-    if normalized in {"MTD", "QTD", "YTD", "1Y", "3Y", "5Y", "SI", "YEAR", "EXPLICIT"}:
-        return normalized
-    if normalized == "ONE_YEAR":
-        return "1Y"
-    if normalized == "THREE_YEAR":
-        return "3Y"
-    if normalized == "FIVE_YEAR":
-        return "5Y"
-    if normalized == "ITD":
-        return "SI"
-    return "YTD"
+    return normalize_period(value)
 
 
 def _build_risk_periods(
@@ -2092,12 +2012,11 @@ def _build_risk_periods(
     report_start_date: str | None,
     report_end_date: str | None,
 ) -> list[dict[str, Any]]:
-    normalized_period = _normalize_period(period)
-    period_payload: dict[str, Any] = {"type": normalized_period, "name": normalized_period}
-    if normalized_period == "EXPLICIT" and report_start_date and report_end_date:
-        period_payload["from_date"] = report_start_date
-        period_payload["to_date"] = report_end_date
-    return [period_payload]
+    return build_risk_periods(
+        period=period,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
+    )
 
 
 def _map_drawdown_summary(summary_payload: dict[str, Any]) -> WorkbenchRiskDrawdownSummary:

--- a/tests/unit/test_risk_workspace_requests.py
+++ b/tests/unit/test_risk_workspace_requests.py
@@ -128,9 +128,7 @@ def test_build_attribution_request_includes_benchmark_only_for_active_risk() -> 
 
     assert "benchmark_id" not in total_risk_request["stateful_input"]
     assert active_risk_request["stateful_input"]["benchmark_id"] == "BMK_1"
-    assert total_risk_request["stateful_input"]["attribution_options"]["metrics"] == [
-        "VOLATILITY"
-    ]
+    assert total_risk_request["stateful_input"]["attribution_options"]["metrics"] == ["VOLATILITY"]
     assert active_risk_request["stateful_input"]["attribution_options"]["metrics"] == [
         "TRACKING_ERROR"
     ]

--- a/tests/unit/test_risk_workspace_requests.py
+++ b/tests/unit/test_risk_workspace_requests.py
@@ -1,0 +1,136 @@
+from app.services.risk_workspace_requests import (
+    build_attribution_request,
+    build_risk_periods,
+    build_rolling_request,
+    build_summary_request,
+    normalize_detail_basis,
+    normalize_period,
+    resolve_reporting_currency,
+)
+
+
+def test_normalize_period_accepts_canonical_values_and_legacy_aliases() -> None:
+    assert normalize_period("YTD") == "YTD"
+    assert normalize_period("one_year") == "1Y"
+    assert normalize_period("THREE_YEAR") == "3Y"
+    assert normalize_period("five_year") == "5Y"
+    assert normalize_period("ITD") == "SI"
+    assert normalize_period("unsupported") == "YTD"
+
+
+def test_build_risk_periods_preserves_explicit_window_when_complete() -> None:
+    assert build_risk_periods(
+        period="EXPLICIT",
+        report_start_date="2026-01-01",
+        report_end_date="2026-04-10",
+    ) == [
+        {
+            "type": "EXPLICIT",
+            "name": "EXPLICIT",
+            "from_date": "2026-01-01",
+            "to_date": "2026-04-10",
+        }
+    ]
+
+
+def test_resolve_reporting_currency_defaults_and_normalizes() -> None:
+    assert resolve_reporting_currency(None) == "USD"
+    assert resolve_reporting_currency("   ") == "USD"
+    assert resolve_reporting_currency("sgd") == "SGD"
+
+
+def test_normalize_detail_basis_fails_closed_to_net() -> None:
+    assert normalize_detail_basis("GROSS") == "GROSS"
+    assert normalize_detail_basis("net") == "NET"
+    assert normalize_detail_basis("unsupported") == "NET"
+
+
+def test_build_summary_request_uses_stateful_lotus_risk_contract() -> None:
+    request = build_summary_request(
+        portfolio_id="PF_1",
+        period="ONE_YEAR",
+        detail_basis="GROSS",
+        as_of_date="2026-04-10",
+        report_start_date=None,
+        report_end_date=None,
+        reporting_currency="eur",
+    )
+
+    stateful_input = request["stateful_input"]
+    assert request["input_mode"] == "stateful"
+    assert stateful_input["portfolio_id"] == "PF_1"
+    assert stateful_input["reporting_currency"] == "EUR"
+    assert stateful_input["net_or_gross"] == "GROSS"
+    assert stateful_input["periods"] == [{"type": "1Y", "name": "1Y"}]
+    assert stateful_input["metrics"] == [
+        "VOLATILITY",
+        "SHARPE",
+        "SORTINO",
+        "BETA",
+        "TRACKING_ERROR",
+        "INFORMATION_RATIO",
+        "VAR",
+    ]
+
+
+def test_build_rolling_request_selects_metrics_by_dependency_context() -> None:
+    request = build_rolling_request(
+        portfolio_id="PF_1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-10",
+        report_start_date=None,
+        report_end_date=None,
+        reporting_currency="USD",
+        include_time_series=True,
+        include_sharpe=True,
+    )
+
+    rolling_options = request["stateful_input"]["rolling_options"]
+    assert rolling_options["window_lengths"] == [21, 63, 126, 252]
+    assert rolling_options["metrics"] == [
+        "ROLLING_VOLATILITY",
+        "ROLLING_MAX_DRAWDOWN",
+        "ROLLING_SHARPE",
+        "ROLLING_BETA",
+        "ROLLING_TRACKING_ERROR",
+        "ROLLING_INFORMATION_RATIO",
+    ]
+    assert rolling_options["include_time_series"] is True
+
+
+def test_build_attribution_request_includes_benchmark_only_for_active_risk() -> None:
+    total_risk_request = build_attribution_request(
+        portfolio_id="PF_1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-10",
+        report_start_date=None,
+        report_end_date=None,
+        reporting_currency="USD",
+        attribution_type="TOTAL_RISK",
+        grouping_dimension="SECTOR",
+    )
+    active_risk_request = build_attribution_request(
+        portfolio_id="PF_1",
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_1",
+        as_of_date="2026-04-10",
+        report_start_date=None,
+        report_end_date=None,
+        reporting_currency="USD",
+        attribution_type="ACTIVE_RISK",
+        grouping_dimension="SECTOR",
+    )
+
+    assert "benchmark_id" not in total_risk_request["stateful_input"]
+    assert active_risk_request["stateful_input"]["benchmark_id"] == "BMK_1"
+    assert total_risk_request["stateful_input"]["attribution_options"]["metrics"] == [
+        "VOLATILITY"
+    ]
+    assert active_risk_request["stateful_input"]["attribution_options"]["metrics"] == [
+        "TRACKING_ERROR"
+    ]


### PR DESCRIPTION
## Summary
- Extract risk workspace stateful request construction into a reusable request-builder module.
- Centralize risk period alias normalization, reporting currency defaulting, detail-basis normalization, rolling window defaults, and attribution request shape.
- Keep service-level wrapper functions stable while reducing request assembly inside RiskWorkspaceService.
- Add focused unit coverage for risk request construction and canonical alias behavior.

## Validation
- python -m pytest tests/unit/test_risk_workspace_requests.py -q
- python -m pytest tests/unit/test_risk_workspace_requests.py tests/unit/test_risk_workspace_service.py -q
- make check
- make ci

## Governance
- Experience API internal refactor only; no OpenAPI or route contract behavior changed.
- No docs/wiki publication required because product/operator truth did not change.
- Stranded truth baseline before work: no unmerged remote branches and no open PRs.