### PR TITLE
Extract performance evidence helpers

### DIFF
--- a/src/app/services/performance_workspace_evidence.py
+++ b/src/app/services/performance_workspace_evidence.py
@@ -52,11 +52,7 @@ def build_performance_evidence_view(
 ) -> PerformanceEvidenceView:
     source_services = sorted(
         {service for service in ["lotus-performance"] if calculations}
-        | {
-            item.source_service
-            for item in source_supportability
-            if item.source_service is not None
-        }
+        | {item.source_service for item in source_supportability if item.source_service is not None}
     )
     upstream_dates = {
         snapshot.as_of_date

--- a/src/app/services/performance_workspace_evidence.py
+++ b/src/app/services/performance_workspace_evidence.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeAlias
+
+from app.contracts.performance_workspace import (
+    PerformanceCalculationEvidenceView,
+    PerformanceEvidenceArtifactView,
+    PerformanceEvidenceStageView,
+    PerformanceEvidenceUpstreamSnapshotView,
+    PerformanceEvidenceView,
+    PerformanceSourceSupportabilityView,
+)
+from app.services.performance_workspace_capabilities import (
+    SUPPORTED_ATTRIBUTION_DIMENSIONS,
+    SUPPORTED_CONTRIBUTION_DIMENSIONS,
+)
+from app.services.source_supportability import (
+    extract_calculation_supportability,
+    source_supportability_reason,
+)
+
+UpstreamPayload: TypeAlias = dict[str, Any]
+UpstreamResult: TypeAlias = tuple[int, UpstreamPayload]
+GatheredResult: TypeAlias = UpstreamResult | BaseException
+
+
+def extract_calculation_id_from_result(result: GatheredResult | None) -> str | None:
+    if result is None or isinstance(result, BaseException):
+        return None
+    _, payload = result
+    if not isinstance(payload, dict):
+        return None
+    calculation_id = payload.get("calculation_id")
+    if calculation_id is None:
+        return None
+    return str(calculation_id)
+
+
+def build_performance_evidence_view(
+    *,
+    state: str,
+    reason: str,
+    as_of_date: str,
+    period: str,
+    basis: str,
+    benchmark_code: str | None,
+    contract_version: str,
+    limitations: list[str],
+    calculations: Sequence[PerformanceCalculationEvidenceView],
+    source_supportability: Sequence[PerformanceSourceSupportabilityView],
+) -> PerformanceEvidenceView:
+    source_services = sorted(
+        {service for service in ["lotus-performance"] if calculations}
+        | {
+            item.source_service
+            for item in source_supportability
+            if item.source_service is not None
+        }
+    )
+    upstream_dates = {
+        snapshot.as_of_date
+        for item in calculations
+        for snapshot in item.upstream_snapshots
+        if snapshot.as_of_date
+    }
+    performance_freshness = (
+        "fresh" if as_of_date in upstream_dates or not upstream_dates else "stale"
+    )
+    input_freshness = {"performance": performance_freshness}
+    if benchmark_code:
+        input_freshness["benchmark"] = input_freshness["performance"]
+
+    unsupported_dimensions = [
+        dimension
+        for dimension in ("issuer",)
+        if dimension not in SUPPORTED_CONTRIBUTION_DIMENSIONS
+        and dimension not in SUPPORTED_ATTRIBUTION_DIMENSIONS
+    ]
+    calculation_versions = {"gateway_contract": contract_version}
+    analytics_types = {
+        item.analytics_type for item in calculations if item.analytics_type is not None
+    }
+    if analytics_types:
+        calculation_versions["analytics_types"] = ",".join(sorted(analytics_types))
+
+    fallbacks = [
+        item.reason for item in calculations if item.reason is not None and item.reason.strip()
+    ]
+
+    return PerformanceEvidenceView(
+        state=state,
+        as_of_date=as_of_date,
+        period=period,
+        basis=basis,
+        benchmark_code=benchmark_code,
+        calculation_scope="performance_workspace",
+        source_services=source_services,
+        input_freshness=input_freshness,
+        methodology_references=["lotus-performance/docs/methodologies"],
+        calculation_versions=calculation_versions,
+        coverage={
+            "supported_dimensions": sorted(
+                set(SUPPORTED_CONTRIBUTION_DIMENSIONS) | set(SUPPORTED_ATTRIBUTION_DIMENSIONS)
+            ),
+            "unsupported_dimensions": unsupported_dimensions,
+        },
+        fallbacks=fallbacks,
+        limitations=limitations,
+        generated_at=None,
+        reason=reason,
+        calculations=list(calculations),
+        source_supportability=list(source_supportability),
+    )
+
+
+def build_source_supportability(
+    source_results: Sequence[GatheredResult | None],
+) -> list[PerformanceSourceSupportabilityView]:
+    items: list[PerformanceSourceSupportabilityView] = []
+    seen: set[tuple[str, str, str | None]] = set()
+    for result in source_results:
+        if result is None or isinstance(result, BaseException):
+            continue
+        status_code, payload = result
+        if status_code >= 400 or not isinstance(payload, Mapping):
+            continue
+        source_supportability = extract_calculation_supportability(payload)
+        if source_supportability is None:
+            continue
+        key = (
+            source_supportability.state,
+            source_supportability.reason or "",
+            source_supportability.freshness_bucket,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        items.append(
+            PerformanceSourceSupportabilityView(
+                key="source_calculation",
+                state=source_supportability.performance_evidence_state,
+                reason=source_supportability_reason(
+                    source_supportability,
+                    default_ready_reason=(
+                        "Source calculation supportability was confirmed upstream."
+                    ),
+                ),
+                freshness_bucket=source_supportability.freshness_bucket,
+                source_service=source_supportability.source_service or "lotus-performance",
+            )
+        )
+    return items
+
+
+def resolve_evidence_state(
+    *,
+    evidence_state: str,
+    source_supportability: Sequence[PerformanceSourceSupportabilityView],
+) -> str:
+    states = {item.state for item in source_supportability}
+    if states & {"unavailable"}:
+        return "unavailable"
+    if states - {"supported"}:
+        return "partial"
+    return evidence_state
+
+
+def resolve_evidence_reason(
+    *,
+    evidence_state: str,
+    supported_reason: str,
+    source_supportability: Sequence[PerformanceSourceSupportabilityView],
+) -> str:
+    if evidence_state == "supported":
+        return supported_reason
+    for item in source_supportability:
+        if item.state != "supported" and item.reason:
+            return item.reason
+    return "Source calculation supportability is partial or unavailable upstream."
+
+
+def execution_is_complete(execution_result: UpstreamResult) -> bool:
+    status_code, payload = execution_result
+    if status_code >= 400 or not isinstance(payload, Mapping):
+        return False
+    return str(payload.get("status", "")).lower() == "complete"
+
+
+def lineage_is_complete(lineage_result: UpstreamResult) -> bool:
+    status_code, payload = lineage_result
+    if status_code >= 400 or not isinstance(payload, Mapping):
+        return False
+    return str(payload.get("status", "")).lower() == "complete"
+
+
+def lineage_is_transient(lineage_result: UpstreamResult) -> bool:
+    status_code, payload = lineage_result
+    if status_code >= 400 or not isinstance(payload, Mapping):
+        return False
+    return str(payload.get("status", "")).lower() in {"pending", "in_progress"}
+
+
+def execution_lineage_stage_complete(execution_result: UpstreamResult) -> bool:
+    status_code, payload = execution_result
+    if status_code >= 400 or not isinstance(payload, Mapping):
+        return False
+    stages = payload.get("stages", [])
+    if not isinstance(stages, list):
+        return False
+    return any(
+        isinstance(stage, Mapping)
+        and str(stage.get("stage_name", "")).lower() == "lineage_materialization"
+        and str(stage.get("status", "")).lower() == "complete"
+        for stage in stages
+    )
+
+
+def build_calculation_evidence_view(
+    *,
+    portfolio_id: str,
+    calculation_role: str,
+    calculation_id: str,
+    execution_result: UpstreamResult,
+    lineage_result: UpstreamResult,
+) -> PerformanceCalculationEvidenceView:
+    execution_status_code, execution_payload = execution_result
+    lineage_status_code, lineage_payload = lineage_result
+
+    execution_data = execution_payload if isinstance(execution_payload, dict) else {}
+    lineage_data = lineage_payload if isinstance(lineage_payload, dict) else {}
+
+    execution_available = execution_status_code < 400 and bool(execution_data)
+    lineage_available = lineage_status_code < 400 and bool(lineage_data)
+    reason_parts: list[str] = []
+    if not execution_available:
+        reason_parts.append(
+            "Execution evidence unavailable "
+            f"({evidence_status_reason(execution_status_code, execution_data)})."
+        )
+    if not lineage_available:
+        reason_parts.append(
+            "Lineage evidence unavailable "
+            f"({evidence_status_reason(lineage_status_code, lineage_data)})."
+        )
+    elif str(lineage_data.get("status")) != "complete":
+        reason_parts.append(
+            f"Lineage is {str(lineage_data.get('status', 'unavailable'))} in lotus-performance."
+        )
+
+    stages_payload = execution_data.get("stages", [])
+    snapshots_payload = execution_data.get("upstream_snapshots", [])
+    artifacts_payload = lineage_data.get("artifacts", {})
+
+    stage_statuses = []
+    if isinstance(stages_payload, list):
+        stage_statuses = [
+            PerformanceEvidenceStageView(
+                stage_name=str(stage_payload.get("stage_name", "")),
+                status=str(stage_payload.get("status", "")),
+                completed_at_utc=_safe_str(stage_payload.get("completed_at_utc")),
+            )
+            for stage_payload in stages_payload
+            if isinstance(stage_payload, dict)
+        ]
+    upstream_snapshots = []
+    if isinstance(snapshots_payload, list):
+        upstream_snapshots = [
+            PerformanceEvidenceUpstreamSnapshotView(
+                upstream_endpoint=str(snapshot_payload.get("upstream_endpoint", "")),
+                source_identifier=str(snapshot_payload.get("source_identifier", "")),
+                as_of_date=str(snapshot_payload.get("as_of_date", "")),
+                retrieval_status=str(snapshot_payload.get("retrieval_status", "")),
+            )
+            for snapshot_payload in snapshots_payload
+            if isinstance(snapshot_payload, dict)
+        ]
+    artifacts = []
+    if isinstance(artifacts_payload, Mapping):
+        artifacts = [
+            PerformanceEvidenceArtifactView(
+                artifact_name=artifact_name,
+                url=gateway_evidence_artifact_url(
+                    portfolio_id=portfolio_id,
+                    calculation_id=calculation_id,
+                    artifact_name=artifact_name,
+                ),
+            )
+            for artifact_name in sorted(str(name) for name in artifacts_payload)
+        ]
+
+    return PerformanceCalculationEvidenceView(
+        calculation_role=calculation_role,
+        calculation_id=calculation_id,
+        analytics_type=_safe_str(execution_data.get("analytics_type")),
+        execution_status=_safe_str(execution_data.get("status")),
+        execution_mode=_safe_str(execution_data.get("execution_mode")),
+        lineage_status=_safe_str(lineage_data.get("status")),
+        stage_statuses=stage_statuses,
+        upstream_snapshots=upstream_snapshots,
+        artifacts=artifacts,
+        reason=" ".join(reason_parts) if reason_parts else None,
+    )
+
+
+def gateway_evidence_artifact_url(
+    *,
+    portfolio_id: str,
+    calculation_id: str,
+    artifact_name: str,
+) -> str:
+    return (
+        f"/api/v1/workbench/{portfolio_id}/performance/evidence/artifacts/"
+        f"{calculation_id}/{artifact_name}"
+    )
+
+
+def evidence_status_reason(status_code: int, payload: Mapping[str, Any]) -> str:
+    if status_code >= 400:
+        detail = payload.get("detail")
+        return str(detail) if detail is not None else f"HTTP_{status_code}"
+    return "missing payload"
+
+
+def _safe_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -28,14 +28,10 @@ from app.contracts.performance_workspace import (
     PerformanceCalculationEvidenceView,
     PerformanceChartPoint,
     PerformanceComparativeSummary,
-    PerformanceEvidenceArtifactView,
-    PerformanceEvidenceStageView,
-    PerformanceEvidenceUpstreamSnapshotView,
     PerformanceEvidenceView,
     PerformanceHorizonComparisonResponse,
     PerformanceHorizonComparisonRow,
     PerformanceModuleCapability,
-    PerformanceSourceSupportabilityView,
     PerformanceWorkspaceCapabilities,
     PerformanceWorkspaceDetailsResponse,
     PerformanceWorkspaceResponse,
@@ -72,9 +68,17 @@ from app.services.performance_workspace_controls import (
     resolve_workspace_summary_request,
     shift_years,
 )
-from app.services.source_supportability import (
-    extract_calculation_supportability,
-    source_supportability_reason,
+from app.services.performance_workspace_evidence import (
+    build_calculation_evidence_view,
+    build_performance_evidence_view,
+    build_source_supportability,
+    execution_is_complete,
+    execution_lineage_stage_complete,
+    extract_calculation_id_from_result,
+    lineage_is_complete,
+    lineage_is_transient,
+    resolve_evidence_reason,
+    resolve_evidence_state,
 )
 from app.services.workbench_service import WorkbenchService
 from app.services.workspace_client_protocols import (
@@ -693,15 +697,15 @@ class PerformanceWorkspaceService:
             calculations=[
                 (
                     "workspace_summary",
-                    self._extract_calculation_id_from_result(workspace_summary_result),
+                    extract_calculation_id_from_result(workspace_summary_result),
                 ),
                 (
                     "contribution",
-                    self._extract_calculation_id_from_result(contribution_detail_result),
+                    extract_calculation_id_from_result(contribution_detail_result),
                 ),
                 (
                     "attribution",
-                    self._extract_calculation_id_from_result(attribution_detail_result),
+                    extract_calculation_id_from_result(attribution_detail_result),
                 ),
             ],
             source_results=[
@@ -920,20 +924,6 @@ class PerformanceWorkspaceService:
             supported_frequencies=supported_frequencies,
         )
 
-    def _extract_calculation_id_from_result(
-        self,
-        result: GatheredResult | None,
-    ) -> str | None:
-        if result is None or isinstance(result, BaseException):
-            return None
-        _, payload = result
-        if not isinstance(payload, dict):
-            return None
-        calculation_id = payload.get("calculation_id")
-        if calculation_id is None:
-            return None
-        return str(calculation_id)
-
     async def _build_evidence_view(
         self,
         *,
@@ -949,14 +939,14 @@ class PerformanceWorkspaceService:
         warnings: list[str],
         partial_failures: list[WorkbenchPartialFailure],
     ) -> PerformanceEvidenceView | None:
-        source_supportability = self._build_source_supportability(source_results)
+        source_supportability = build_source_supportability(source_results)
         requested_items = [
             (role, calculation_id)
             for role, calculation_id in calculations
             if calculation_id is not None
         ]
         if not requested_items:
-            return self._build_performance_evidence_view(
+            return build_performance_evidence_view(
                 state="unavailable",
                 reason="No durable calculation evidence is available for the current selection.",
                 as_of_date=as_of_date,
@@ -993,7 +983,7 @@ class PerformanceWorkspaceService:
         )
         if backed_count == 0:
             warnings.append("PERFORMANCE_EVIDENCE_UNAVAILABLE")
-            return self._build_performance_evidence_view(
+            return build_performance_evidence_view(
                 state="unavailable",
                 reason=(
                     "Gateway could not resolve execution or lineage evidence "
@@ -1012,11 +1002,11 @@ class PerformanceWorkspaceService:
                 source_supportability=source_supportability,
             )
         if complete_count == len(evidence_items):
-            evidence_state = self._resolve_evidence_state(
+            evidence_state = resolve_evidence_state(
                 evidence_state="supported",
                 source_supportability=source_supportability,
             )
-            evidence_reason = self._resolve_evidence_reason(
+            evidence_reason = resolve_evidence_reason(
                 evidence_state=evidence_state,
                 supported_reason=(
                     "Execution status, upstream lineage, and artifact inventory "
@@ -1024,7 +1014,7 @@ class PerformanceWorkspaceService:
                 ),
                 source_supportability=source_supportability,
             )
-            return self._build_performance_evidence_view(
+            return build_performance_evidence_view(
                 state=evidence_state,
                 reason=evidence_reason,
                 as_of_date=as_of_date,
@@ -1048,7 +1038,7 @@ class PerformanceWorkspaceService:
                 ),
             )
         )
-        return self._build_performance_evidence_view(
+        return build_performance_evidence_view(
             state="partial",
             reason=(
                 "One or more performance calculations still have pending, failed, "
@@ -1066,149 +1056,6 @@ class PerformanceWorkspaceService:
             calculations=evidence_items,
             source_supportability=source_supportability,
         )
-
-    def _build_performance_evidence_view(
-        self,
-        *,
-        state: str,
-        reason: str,
-        as_of_date: str,
-        period: str,
-        basis: str,
-        benchmark_code: str | None,
-        contract_version: str,
-        limitations: list[str],
-        calculations: Sequence[PerformanceCalculationEvidenceView],
-        source_supportability: Sequence[PerformanceSourceSupportabilityView],
-    ) -> PerformanceEvidenceView:
-        source_services = sorted(
-            {service for service in ["lotus-performance"] if calculations}
-            | {
-                item.source_service
-                for item in source_supportability
-                if item.source_service is not None
-            }
-        )
-        upstream_dates = {
-            snapshot.as_of_date
-            for item in calculations
-            for snapshot in item.upstream_snapshots
-            if snapshot.as_of_date
-        }
-        performance_freshness = (
-            "fresh" if as_of_date in upstream_dates or not upstream_dates else "stale"
-        )
-        input_freshness = {"performance": performance_freshness}
-        if benchmark_code:
-            input_freshness["benchmark"] = input_freshness["performance"]
-
-        unsupported_dimensions = [
-            dimension
-            for dimension in ("issuer",)
-            if dimension not in SUPPORTED_CONTRIBUTION_DIMENSIONS
-            and dimension not in SUPPORTED_ATTRIBUTION_DIMENSIONS
-        ]
-        calculation_versions = {"gateway_contract": contract_version}
-        analytics_types = {
-            item.analytics_type for item in calculations if item.analytics_type is not None
-        }
-        if analytics_types:
-            calculation_versions["analytics_types"] = ",".join(sorted(analytics_types))
-
-        fallbacks = [
-            item.reason for item in calculations if item.reason is not None and item.reason.strip()
-        ]
-
-        return PerformanceEvidenceView(
-            state=state,
-            as_of_date=as_of_date,
-            period=period,
-            basis=basis,
-            benchmark_code=benchmark_code,
-            calculation_scope="performance_workspace",
-            source_services=source_services,
-            input_freshness=input_freshness,
-            methodology_references=["lotus-performance/docs/methodologies"],
-            calculation_versions=calculation_versions,
-            coverage={
-                "supported_dimensions": sorted(
-                    set(SUPPORTED_CONTRIBUTION_DIMENSIONS) | set(SUPPORTED_ATTRIBUTION_DIMENSIONS)
-                ),
-                "unsupported_dimensions": unsupported_dimensions,
-            },
-            fallbacks=fallbacks,
-            limitations=limitations,
-            generated_at=None,
-            reason=reason,
-            calculations=list(calculations),
-            source_supportability=list(source_supportability),
-        )
-
-    def _build_source_supportability(
-        self,
-        source_results: Sequence[GatheredResult | None],
-    ) -> list[PerformanceSourceSupportabilityView]:
-        items: list[PerformanceSourceSupportabilityView] = []
-        seen: set[tuple[str, str, str | None]] = set()
-        for result in source_results:
-            if result is None or isinstance(result, BaseException):
-                continue
-            status_code, payload = result
-            if status_code >= 400 or not isinstance(payload, Mapping):
-                continue
-            source_supportability = extract_calculation_supportability(payload)
-            if source_supportability is None:
-                continue
-            key = (
-                source_supportability.state,
-                source_supportability.reason or "",
-                source_supportability.freshness_bucket,
-            )
-            if key in seen:
-                continue
-            seen.add(key)
-            items.append(
-                PerformanceSourceSupportabilityView(
-                    key="source_calculation",
-                    state=source_supportability.performance_evidence_state,
-                    reason=source_supportability_reason(
-                        source_supportability,
-                        default_ready_reason=(
-                            "Source calculation supportability was confirmed upstream."
-                        ),
-                    ),
-                    freshness_bucket=source_supportability.freshness_bucket,
-                    source_service=source_supportability.source_service or "lotus-performance",
-                )
-            )
-        return items
-
-    def _resolve_evidence_state(
-        self,
-        *,
-        evidence_state: str,
-        source_supportability: Sequence[PerformanceSourceSupportabilityView],
-    ) -> str:
-        states = {item.state for item in source_supportability}
-        if states & {"unavailable"}:
-            return "unavailable"
-        if states - {"supported"}:
-            return "partial"
-        return evidence_state
-
-    def _resolve_evidence_reason(
-        self,
-        *,
-        evidence_state: str,
-        supported_reason: str,
-        source_supportability: Sequence[PerformanceSourceSupportabilityView],
-    ) -> str:
-        if evidence_state == "supported":
-            return supported_reason
-        for item in source_supportability:
-            if item.state != "supported" and item.reason:
-                return item.reason
-        return "Source calculation supportability is partial or unavailable upstream."
 
     async def _fetch_calculation_evidence(
         self,
@@ -1234,7 +1081,7 @@ class PerformanceWorkspaceService:
             execution_result=execution_result,
             lineage_result=lineage_result,
         )
-        return self._build_calculation_evidence_view(
+        return build_calculation_evidence_view(
             portfolio_id=portfolio_id,
             calculation_role=calculation_role,
             calculation_id=calculation_id,
@@ -1250,16 +1097,16 @@ class PerformanceWorkspaceService:
         execution_result: UpstreamResult,
         lineage_result: UpstreamResult,
     ) -> tuple[UpstreamResult, UpstreamResult]:
-        if not self._execution_is_complete(execution_result):
+        if not execution_is_complete(execution_result):
             return execution_result, lineage_result
-        if self._lineage_is_complete(lineage_result):
+        if lineage_is_complete(lineage_result):
             refreshed_execution = await self._refresh_execution_after_lineage_completion(
                 calculation_id=calculation_id,
                 correlation_id=correlation_id,
                 execution_result=execution_result,
             )
             return refreshed_execution, lineage_result
-        if not self._lineage_is_transient(lineage_result):
+        if not lineage_is_transient(lineage_result):
             return execution_result, lineage_result
 
         latest_result = lineage_result
@@ -1270,14 +1117,14 @@ class PerformanceWorkspaceService:
                 calculation_id=calculation_id,
                 correlation_id=correlation_id,
             )
-            if self._lineage_is_complete(latest_result):
+            if lineage_is_complete(latest_result):
                 refreshed_execution = await self._refresh_execution_after_lineage_completion(
                     calculation_id=calculation_id,
                     correlation_id=correlation_id,
                     execution_result=execution_result,
                 )
                 return refreshed_execution, latest_result
-            if not self._lineage_is_transient(latest_result):
+            if not lineage_is_transient(latest_result):
                 return execution_result, latest_result
         return execution_result, latest_result
 
@@ -1288,7 +1135,7 @@ class PerformanceWorkspaceService:
         correlation_id: str,
         execution_result: UpstreamResult,
     ) -> UpstreamResult:
-        if self._execution_lineage_stage_complete(execution_result):
+        if execution_lineage_stage_complete(execution_result):
             return execution_result
         refreshed_result = await self._analytics_client.get_execution(
             calculation_id=calculation_id,
@@ -1297,147 +1144,6 @@ class PerformanceWorkspaceService:
         if refreshed_result[0] >= 400:
             return execution_result
         return refreshed_result
-
-    def _execution_is_complete(self, execution_result: UpstreamResult) -> bool:
-        status_code, payload = execution_result
-        if status_code >= 400 or not isinstance(payload, Mapping):
-            return False
-        return str(payload.get("status", "")).lower() == "complete"
-
-    def _lineage_is_complete(self, lineage_result: UpstreamResult) -> bool:
-        status_code, payload = lineage_result
-        if status_code >= 400 or not isinstance(payload, Mapping):
-            return False
-        return str(payload.get("status", "")).lower() == "complete"
-
-    def _lineage_is_transient(self, lineage_result: UpstreamResult) -> bool:
-        status_code, payload = lineage_result
-        if status_code >= 400 or not isinstance(payload, Mapping):
-            return False
-        return str(payload.get("status", "")).lower() in {"pending", "in_progress"}
-
-    def _execution_lineage_stage_complete(self, execution_result: UpstreamResult) -> bool:
-        status_code, payload = execution_result
-        if status_code >= 400 or not isinstance(payload, Mapping):
-            return False
-        stages = payload.get("stages", [])
-        if not isinstance(stages, list):
-            return False
-        return any(
-            isinstance(stage, Mapping)
-            and str(stage.get("stage_name", "")).lower() == "lineage_materialization"
-            and str(stage.get("status", "")).lower() == "complete"
-            for stage in stages
-        )
-
-    def _build_calculation_evidence_view(
-        self,
-        *,
-        portfolio_id: str,
-        calculation_role: str,
-        calculation_id: str,
-        execution_result: UpstreamResult,
-        lineage_result: UpstreamResult,
-    ) -> PerformanceCalculationEvidenceView:
-        execution_status_code, execution_payload = execution_result
-        lineage_status_code, lineage_payload = lineage_result
-
-        execution_data = execution_payload if isinstance(execution_payload, dict) else {}
-        lineage_data = lineage_payload if isinstance(lineage_payload, dict) else {}
-
-        execution_available = execution_status_code < 400 and bool(execution_data)
-        lineage_available = lineage_status_code < 400 and bool(lineage_data)
-        reason_parts: list[str] = []
-        if not execution_available:
-            reason_parts.append(
-                "Execution evidence unavailable "
-                f"({self._evidence_status_reason(execution_status_code, execution_data)})."
-            )
-        if not lineage_available:
-            reason_parts.append(
-                "Lineage evidence unavailable "
-                f"({self._evidence_status_reason(lineage_status_code, lineage_data)})."
-            )
-        elif str(lineage_data.get("status")) != "complete":
-            reason_parts.append(
-                f"Lineage is {str(lineage_data.get('status', 'unavailable'))} in lotus-performance."
-            )
-
-        stages_payload = execution_data.get("stages", [])
-        snapshots_payload = execution_data.get("upstream_snapshots", [])
-        artifacts_payload = lineage_data.get("artifacts", {})
-
-        stage_statuses = []
-        if isinstance(stages_payload, list):
-            stage_statuses = [
-                PerformanceEvidenceStageView(
-                    stage_name=str(stage_payload.get("stage_name", "")),
-                    status=str(stage_payload.get("status", "")),
-                    completed_at_utc=self._safe_str(stage_payload.get("completed_at_utc")),
-                )
-                for stage_payload in stages_payload
-                if isinstance(stage_payload, dict)
-            ]
-        upstream_snapshots = []
-        if isinstance(snapshots_payload, list):
-            upstream_snapshots = [
-                PerformanceEvidenceUpstreamSnapshotView(
-                    upstream_endpoint=str(snapshot_payload.get("upstream_endpoint", "")),
-                    source_identifier=str(snapshot_payload.get("source_identifier", "")),
-                    as_of_date=str(snapshot_payload.get("as_of_date", "")),
-                    retrieval_status=str(snapshot_payload.get("retrieval_status", "")),
-                )
-                for snapshot_payload in snapshots_payload
-                if isinstance(snapshot_payload, dict)
-            ]
-        artifacts = []
-        if isinstance(artifacts_payload, Mapping):
-            artifacts = [
-                PerformanceEvidenceArtifactView(
-                    artifact_name=artifact_name,
-                    url=self._gateway_evidence_artifact_url(
-                        portfolio_id=portfolio_id,
-                        calculation_id=calculation_id,
-                        artifact_name=artifact_name,
-                    ),
-                )
-                for artifact_name in sorted(str(name) for name in artifacts_payload)
-            ]
-
-        return PerformanceCalculationEvidenceView(
-            calculation_role=calculation_role,
-            calculation_id=calculation_id,
-            analytics_type=self._safe_str(execution_data.get("analytics_type")),
-            execution_status=self._safe_str(execution_data.get("status")),
-            execution_mode=self._safe_str(execution_data.get("execution_mode")),
-            lineage_status=self._safe_str(lineage_data.get("status")),
-            stage_statuses=stage_statuses,
-            upstream_snapshots=upstream_snapshots,
-            artifacts=artifacts,
-            reason=" ".join(reason_parts) if reason_parts else None,
-        )
-
-    def _gateway_evidence_artifact_url(
-        self,
-        *,
-        portfolio_id: str,
-        calculation_id: str,
-        artifact_name: str,
-    ) -> str:
-        return (
-            f"/api/v1/workbench/{portfolio_id}/performance/evidence/artifacts/"
-            f"{calculation_id}/{artifact_name}"
-        )
-
-    def _evidence_status_reason(
-        self,
-        status_code: int,
-        payload: Mapping[str, Any],
-    ) -> str:
-        if status_code >= 400:
-            detail = payload.get("detail")
-            return str(detail) if detail is not None else f"HTTP_{status_code}"
-        return "missing payload"
 
     def _build_workspace_capabilities(
         self,

--- a/tests/unit/test_performance_workspace_evidence.py
+++ b/tests/unit/test_performance_workspace_evidence.py
@@ -216,11 +216,14 @@ def test_build_performance_evidence_view_marks_stale_source_dates():
 
 
 def test_artifact_url_and_status_reason_are_bounded():
-    assert gateway_evidence_artifact_url(
-        portfolio_id="PORT-1",
-        calculation_id="calc-1",
-        artifact_name="request.json",
-    ) == "/api/v1/workbench/PORT-1/performance/evidence/artifacts/calc-1/request.json"
+    assert (
+        gateway_evidence_artifact_url(
+            portfolio_id="PORT-1",
+            calculation_id="calc-1",
+            artifact_name="request.json",
+        )
+        == "/api/v1/workbench/PORT-1/performance/evidence/artifacts/calc-1/request.json"
+    )
     assert evidence_status_reason(503, {"detail": "upstream unavailable"}) == (
         "upstream unavailable"
     )

--- a/tests/unit/test_performance_workspace_evidence.py
+++ b/tests/unit/test_performance_workspace_evidence.py
@@ -1,0 +1,228 @@
+from app.contracts.performance_workspace import (
+    PerformanceCalculationEvidenceView,
+    PerformanceEvidenceUpstreamSnapshotView,
+    PerformanceSourceSupportabilityView,
+)
+from app.services.performance_workspace_evidence import (
+    build_calculation_evidence_view,
+    build_performance_evidence_view,
+    build_source_supportability,
+    evidence_status_reason,
+    execution_is_complete,
+    execution_lineage_stage_complete,
+    extract_calculation_id_from_result,
+    gateway_evidence_artifact_url,
+    lineage_is_complete,
+    lineage_is_transient,
+    resolve_evidence_reason,
+    resolve_evidence_state,
+)
+
+
+def test_extract_calculation_id_from_result_returns_stable_string_id():
+    assert extract_calculation_id_from_result((200, {"calculation_id": 42})) == "42"
+    assert extract_calculation_id_from_result((200, {})) is None
+    assert extract_calculation_id_from_result(ValueError("boom")) is None
+    assert extract_calculation_id_from_result(None) is None
+
+
+def test_build_source_supportability_deduplicates_upstream_posture():
+    source_results = [
+        (
+            200,
+            {
+                "metadata": {
+                    "calculation_supportability": {
+                        "state": "stale",
+                        "reason": "Source data window stale",
+                        "freshness_bucket": "stale",
+                        "source_service": "lotus-performance",
+                    }
+                }
+            },
+        ),
+        (
+            200,
+            {
+                "calculation_supportability": {
+                    "state": "stale",
+                    "reason": "Source data window stale",
+                    "freshness_bucket": "stale",
+                    "source_service": "lotus-performance",
+                }
+            },
+        ),
+        (503, {"detail": "ignored"}),
+    ]
+
+    items = build_source_supportability(source_results)
+
+    assert [item.model_dump() for item in items] == [
+        {
+            "key": "source_calculation",
+            "state": "partial",
+            "reason": "Source data window stale",
+            "freshness_bucket": "stale",
+            "source_service": "lotus-performance",
+        }
+    ]
+
+
+def test_resolve_evidence_state_and_reason_honor_source_supportability():
+    stale_item = PerformanceSourceSupportabilityView(
+        key="source_calculation",
+        state="partial",
+        reason="Source data window stale",
+        freshness_bucket="stale",
+        source_service="lotus-performance",
+    )
+
+    assert (
+        resolve_evidence_state(
+            evidence_state="supported",
+            source_supportability=[stale_item],
+        )
+        == "partial"
+    )
+    assert (
+        resolve_evidence_reason(
+            evidence_state="partial",
+            supported_reason="Supported",
+            source_supportability=[stale_item],
+        )
+        == "Source data window stale"
+    )
+
+
+def test_evidence_completion_helpers_fail_closed_for_bad_payloads():
+    complete_execution = (
+        200,
+        {
+            "status": "complete",
+            "stages": [
+                {
+                    "stage_name": "lineage_materialization",
+                    "status": "complete",
+                }
+            ],
+        },
+    )
+
+    assert execution_is_complete(complete_execution)
+    assert execution_lineage_stage_complete(complete_execution)
+    assert lineage_is_complete((200, {"status": "complete"}))
+    assert lineage_is_transient((200, {"status": "pending"}))
+    assert not execution_is_complete((500, {"status": "complete"}))
+    assert not lineage_is_complete((200, {"status": "pending"}))
+    assert not lineage_is_transient((404, {"status": "pending"}))
+
+
+def test_build_calculation_evidence_view_maps_artifacts_and_reason():
+    evidence = build_calculation_evidence_view(
+        portfolio_id="PORT-1",
+        calculation_role="workspace_summary",
+        calculation_id="calc-1",
+        execution_result=(
+            200,
+            {
+                "analytics_type": "TWR",
+                "execution_mode": "sync",
+                "status": "complete",
+                "stages": [
+                    {
+                        "stage_name": "execution",
+                        "status": "complete",
+                        "completed_at_utc": "2026-03-27T12:00:00Z",
+                    }
+                ],
+                "upstream_snapshots": [
+                    {
+                        "upstream_endpoint": "portfolio_timeseries",
+                        "source_identifier": "PORT-1",
+                        "as_of_date": "2026-03-27",
+                        "retrieval_status": "200",
+                    }
+                ],
+            },
+        ),
+        lineage_result=(
+            200,
+            {
+                "status": "pending",
+                "artifacts": {
+                    "response.json": {},
+                    "request.json": {},
+                },
+            },
+        ),
+    )
+
+    assert evidence.calculation_role == "workspace_summary"
+    assert evidence.analytics_type == "TWR"
+    assert evidence.lineage_status == "pending"
+    assert evidence.reason == "Lineage is pending in lotus-performance."
+    assert [artifact.artifact_name for artifact in evidence.artifacts] == [
+        "request.json",
+        "response.json",
+    ]
+    assert evidence.artifacts[0].url == (
+        "/api/v1/workbench/PORT-1/performance/evidence/artifacts/calc-1/request.json"
+    )
+
+
+def test_build_performance_evidence_view_marks_stale_source_dates():
+    calculation = PerformanceCalculationEvidenceView(
+        calculation_role="workspace_summary",
+        calculation_id="calc-1",
+        analytics_type="TWR",
+        execution_status="complete",
+        execution_mode="sync",
+        lineage_status="complete",
+        stage_statuses=[],
+        upstream_snapshots=[
+            PerformanceEvidenceUpstreamSnapshotView(
+                upstream_endpoint="portfolio_timeseries",
+                source_identifier="PORT-1",
+                as_of_date="2026-03-26",
+                retrieval_status="200",
+            )
+        ],
+        artifacts=[],
+        reason=None,
+    )
+
+    evidence = build_performance_evidence_view(
+        state="supported",
+        reason="Evidence ready",
+        as_of_date="2026-03-27",
+        period="YTD",
+        basis="NET",
+        benchmark_code="BMK-1",
+        contract_version="v1",
+        limitations=[],
+        calculations=[calculation],
+        source_supportability=[],
+    )
+
+    assert evidence.input_freshness == {
+        "performance": "stale",
+        "benchmark": "stale",
+    }
+    assert evidence.source_services == ["lotus-performance"]
+    assert evidence.calculation_versions == {
+        "gateway_contract": "v1",
+        "analytics_types": "TWR",
+    }
+
+
+def test_artifact_url_and_status_reason_are_bounded():
+    assert gateway_evidence_artifact_url(
+        portfolio_id="PORT-1",
+        calculation_id="calc-1",
+        artifact_name="request.json",
+    ) == "/api/v1/workbench/PORT-1/performance/evidence/artifacts/calc-1/request.json"
+    assert evidence_status_reason(503, {"detail": "upstream unavailable"}) == (
+        "upstream unavailable"
+    )
+    assert evidence_status_reason(503, {}) == "HTTP_503"
+    assert evidence_status_reason(200, {}) == "missing payload"


### PR DESCRIPTION
## Summary
- Extract performance workspace durable evidence mapping and supportability decisions into a reusable helper module.
- Centralize calculation-id extraction, evidence freshness, source supportability roll-up, lineage/execution status checks, artifact URL shaping, and calculation evidence view mapping.
- Keep async upstream orchestration in `PerformanceWorkspaceService` while reducing service-local mapping logic.
- Add focused unit coverage for performance evidence mapping and fail-closed evidence posture.

## Validation
- `python -m pytest tests/unit/test_performance_workspace_evidence.py -q`
- `python -m pytest tests/unit/test_performance_workspace_evidence.py tests/unit/test_performance_workspace_service.py -q`
- `make check`
- `make ci`

## Governance
- Experience API internal refactor only; no OpenAPI or route contract behavior changed.
- No docs/wiki publication required because product/operator truth did not change.
- Stranded truth baseline before work: no unmerged remote branches and no open PRs.