### PR TITLE
Extract performance projection helpers

### DIFF
--- a/src/app/services/performance_workspace_projection.py
+++ b/src/app/services/performance_workspace_projection.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from app.contracts.performance_workspace import (
+    PerformanceChartPoint,
+    PerformanceWorkspaceDetailsResponse,
+    PerformanceWorkspaceResponse,
+    PerformanceWorkspaceSummaryResponse,
+)
+from app.contracts.portfolio import (
+    PortfolioPartialFailure,
+    PortfolioPerformanceSnapshotPoint,
+    PortfolioPerformanceSnapshotResponse,
+    PortfolioPerformanceSnapshotUnavailable,
+)
+
+
+def project_workspace_summary(
+    workspace: PerformanceWorkspaceResponse,
+) -> PerformanceWorkspaceSummaryResponse:
+    return PerformanceWorkspaceSummaryResponse(
+        correlation_id=workspace.correlation_id,
+        contract_version=workspace.contract_version,
+        portfolio_id=workspace.portfolio_id,
+        as_of_date=workspace.as_of_date,
+        period=workspace.period,
+        report_start_date=workspace.report_start_date,
+        report_end_date=workspace.report_end_date,
+        chart_frequency=workspace.chart_frequency,
+        detail_basis=workspace.detail_basis,
+        requested_chart_frequency_supported=workspace.requested_chart_frequency_supported,
+        requested_contribution_dimension_supported=(
+            workspace.requested_contribution_dimension_supported
+        ),
+        requested_attribution_dimension_supported=(
+            workspace.requested_attribution_dimension_supported
+        ),
+        benchmark_code=workspace.benchmark_code,
+        benchmark_options=workspace.benchmark_options,
+        capabilities=workspace.capabilities,
+        evidence_view=workspace.evidence_view,
+        portfolio=workspace.portfolio,
+        overview=workspace.overview,
+        net_performance=workspace.net_performance,
+        gross_performance=workspace.gross_performance,
+        money_weighted_return=workspace.money_weighted_return,
+        warnings=workspace.warnings,
+        partial_failures=workspace.partial_failures,
+    )
+
+
+def project_workspace_details(
+    workspace: PerformanceWorkspaceResponse,
+) -> PerformanceWorkspaceDetailsResponse:
+    return PerformanceWorkspaceDetailsResponse(
+        correlation_id=workspace.correlation_id,
+        contract_version=workspace.contract_version,
+        portfolio_id=workspace.portfolio_id,
+        as_of_date=workspace.as_of_date,
+        period=workspace.period,
+        report_start_date=workspace.report_start_date,
+        report_end_date=workspace.report_end_date,
+        chart_frequency=workspace.chart_frequency,
+        contribution_dimension=workspace.contribution_dimension,
+        attribution_dimension=workspace.attribution_dimension,
+        detail_basis=workspace.detail_basis,
+        requested_chart_frequency_supported=workspace.requested_chart_frequency_supported,
+        requested_contribution_dimension_supported=(
+            workspace.requested_contribution_dimension_supported
+        ),
+        requested_attribution_dimension_supported=(
+            workspace.requested_attribution_dimension_supported
+        ),
+        segment=workspace.segment,
+        benchmark_code=workspace.benchmark_code,
+        capabilities=workspace.capabilities,
+        evidence_view=workspace.evidence_view,
+        net_chart=workspace.net_chart,
+        gross_chart=workspace.gross_chart,
+        contribution=workspace.contribution,
+        attribution=workspace.attribution,
+        warnings=workspace.warnings,
+        partial_failures=workspace.partial_failures,
+    )
+
+
+def project_portfolio_performance_snapshot(
+    workspace: PerformanceWorkspaceResponse,
+) -> PortfolioPerformanceSnapshotResponse:
+    portfolio_return_pct = workspace.net_performance.portfolio_return_pct
+    benchmark_return_pct = workspace.net_performance.benchmark_return_pct
+    excess_return_pct = workspace.net_performance.active_return_pct
+    sparkline = [
+        PortfolioPerformanceSnapshotPoint(
+            as_of_date=snapshot_point_as_of_date(point),
+            portfolio_return_pct=point.portfolio_return_pct,
+            benchmark_return_pct=point.benchmark_return_pct,
+            excess_return_pct=point.active_return_pct,
+        )
+        for point in workspace.net_chart
+    ]
+    unavailable = None
+    if (
+        portfolio_return_pct is None
+        and benchmark_return_pct is None
+        and excess_return_pct is None
+        and not sparkline
+    ):
+        unavailable = PortfolioPerformanceSnapshotUnavailable(
+            title="Performance data unavailable",
+            detail=(
+                "Performance snapshot requires valuation history, cashflow history, "
+                "and a selected reporting period."
+            ),
+            requirements=[
+                "valuation history",
+                "cashflow history",
+                "selected reporting period",
+            ],
+        )
+    return PortfolioPerformanceSnapshotResponse(
+        correlation_id=workspace.correlation_id,
+        contract_version=workspace.contract_version,
+        portfolio_id=workspace.portfolio_id,
+        as_of_date=workspace.as_of_date,
+        report_start_date=workspace.report_start_date,
+        report_end_date=workspace.report_end_date,
+        period=workspace.period,
+        benchmark_code=workspace.benchmark_code,
+        portfolio_return_pct=portfolio_return_pct,
+        benchmark_return_pct=benchmark_return_pct,
+        excess_return_pct=excess_return_pct,
+        sparkline=sparkline,
+        unavailable=unavailable,
+        warnings=workspace.warnings,
+        partial_failures=[
+            PortfolioPartialFailure(**failure.model_dump())
+            for failure in workspace.partial_failures
+        ],
+    )
+
+
+def snapshot_point_as_of_date(point: PerformanceChartPoint) -> str:
+    return point.period_end or point.period_start or point.label

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -38,10 +38,7 @@ from app.contracts.performance_workspace import (
     PerformanceWorkspaceSummaryResponse,
 )
 from app.contracts.portfolio import (
-    PortfolioPartialFailure,
-    PortfolioPerformanceSnapshotPoint,
     PortfolioPerformanceSnapshotResponse,
-    PortfolioPerformanceSnapshotUnavailable,
 )
 from app.contracts.workbench import WorkbenchOverviewResponse, WorkbenchPartialFailure
 from app.middleware.server_timing import server_timing_span
@@ -91,6 +88,12 @@ from app.services.performance_workspace_parsing import (
     safe_str_list,
     sum_optional,
     weight_to_pct,
+)
+from app.services.performance_workspace_projection import (
+    project_portfolio_performance_snapshot,
+    project_workspace_details,
+    project_workspace_summary,
+    snapshot_point_as_of_date,
 )
 from app.services.workbench_service import WorkbenchService
 from app.services.workspace_client_protocols import (
@@ -799,119 +802,20 @@ class PerformanceWorkspaceService:
     def _project_workspace_summary(
         self, workspace: PerformanceWorkspaceResponse
     ) -> PerformanceWorkspaceSummaryResponse:
-        return PerformanceWorkspaceSummaryResponse(
-            correlation_id=workspace.correlation_id,
-            contract_version=workspace.contract_version,
-            portfolio_id=workspace.portfolio_id,
-            as_of_date=workspace.as_of_date,
-            period=workspace.period,
-            report_start_date=workspace.report_start_date,
-            report_end_date=workspace.report_end_date,
-            chart_frequency=workspace.chart_frequency,
-            detail_basis=workspace.detail_basis,
-            requested_chart_frequency_supported=workspace.requested_chart_frequency_supported,
-            requested_contribution_dimension_supported=workspace.requested_contribution_dimension_supported,
-            requested_attribution_dimension_supported=workspace.requested_attribution_dimension_supported,
-            benchmark_code=workspace.benchmark_code,
-            benchmark_options=workspace.benchmark_options,
-            capabilities=workspace.capabilities,
-            evidence_view=workspace.evidence_view,
-            portfolio=workspace.portfolio,
-            overview=workspace.overview,
-            net_performance=workspace.net_performance,
-            gross_performance=workspace.gross_performance,
-            money_weighted_return=workspace.money_weighted_return,
-            warnings=workspace.warnings,
-            partial_failures=workspace.partial_failures,
-        )
+        return project_workspace_summary(workspace)
 
     def _project_workspace_details(
         self, workspace: PerformanceWorkspaceResponse
     ) -> PerformanceWorkspaceDetailsResponse:
-        return PerformanceWorkspaceDetailsResponse(
-            correlation_id=workspace.correlation_id,
-            contract_version=workspace.contract_version,
-            portfolio_id=workspace.portfolio_id,
-            as_of_date=workspace.as_of_date,
-            period=workspace.period,
-            report_start_date=workspace.report_start_date,
-            report_end_date=workspace.report_end_date,
-            chart_frequency=workspace.chart_frequency,
-            contribution_dimension=workspace.contribution_dimension,
-            attribution_dimension=workspace.attribution_dimension,
-            detail_basis=workspace.detail_basis,
-            requested_chart_frequency_supported=workspace.requested_chart_frequency_supported,
-            requested_contribution_dimension_supported=workspace.requested_contribution_dimension_supported,
-            requested_attribution_dimension_supported=workspace.requested_attribution_dimension_supported,
-            segment=workspace.segment,
-            benchmark_code=workspace.benchmark_code,
-            capabilities=workspace.capabilities,
-            evidence_view=workspace.evidence_view,
-            net_chart=workspace.net_chart,
-            gross_chart=workspace.gross_chart,
-            contribution=workspace.contribution,
-            attribution=workspace.attribution,
-            warnings=workspace.warnings,
-            partial_failures=workspace.partial_failures,
-        )
+        return project_workspace_details(workspace)
 
     def _project_portfolio_performance_snapshot(
         self, workspace: PerformanceWorkspaceResponse
     ) -> PortfolioPerformanceSnapshotResponse:
-        portfolio_return_pct = workspace.net_performance.portfolio_return_pct
-        benchmark_return_pct = workspace.net_performance.benchmark_return_pct
-        excess_return_pct = workspace.net_performance.active_return_pct
-        sparkline = [
-            PortfolioPerformanceSnapshotPoint(
-                as_of_date=self._snapshot_point_as_of_date(point),
-                portfolio_return_pct=point.portfolio_return_pct,
-                benchmark_return_pct=point.benchmark_return_pct,
-                excess_return_pct=point.active_return_pct,
-            )
-            for point in workspace.net_chart
-        ]
-        unavailable = None
-        if (
-            portfolio_return_pct is None
-            and benchmark_return_pct is None
-            and excess_return_pct is None
-            and not sparkline
-        ):
-            unavailable = PortfolioPerformanceSnapshotUnavailable(
-                title="Performance data unavailable",
-                detail=(
-                    "Performance snapshot requires valuation history, cashflow history, "
-                    "and a selected reporting period."
-                ),
-                requirements=[
-                    "valuation history",
-                    "cashflow history",
-                    "selected reporting period",
-                ],
-            )
-        return PortfolioPerformanceSnapshotResponse(
-            correlation_id=workspace.correlation_id,
-            contract_version=workspace.contract_version,
-            portfolio_id=workspace.portfolio_id,
-            as_of_date=workspace.as_of_date,
-            report_start_date=workspace.report_start_date,
-            report_end_date=workspace.report_end_date,
-            period=workspace.period,
-            benchmark_code=workspace.benchmark_code,
-            portfolio_return_pct=portfolio_return_pct,
-            benchmark_return_pct=benchmark_return_pct,
-            excess_return_pct=excess_return_pct,
-            sparkline=sparkline,
-            unavailable=unavailable,
-            warnings=workspace.warnings,
-            partial_failures=[
-                PortfolioPartialFailure(**failure.model_dump())
-                for failure in workspace.partial_failures
-            ],
-        )
+        return project_portfolio_performance_snapshot(workspace)
 
     def _snapshot_point_as_of_date(self, point: PerformanceChartPoint) -> str:
-        return point.period_end or point.period_start or point.label
+        return snapshot_point_as_of_date(point)
 
     def _capability(
         self,

--- a/tests/unit/test_performance_workspace_projection.py
+++ b/tests/unit/test_performance_workspace_projection.py
@@ -103,9 +103,7 @@ def test_snapshot_point_as_of_date_prefers_period_end_then_start_then_label():
         == "2026-03-01"
     )
     assert (
-        snapshot_point_as_of_date(
-            PerformanceChartPoint(label="Fallback", frequency="monthly")
-        )
+        snapshot_point_as_of_date(PerformanceChartPoint(label="Fallback", frequency="monthly"))
         == "Fallback"
     )
 

--- a/tests/unit/test_performance_workspace_projection.py
+++ b/tests/unit/test_performance_workspace_projection.py
@@ -1,0 +1,187 @@
+from app.contracts.performance_workspace import (
+    PerformanceChartPoint,
+    PerformanceComparativeSummary,
+    PerformanceWorkspaceCapabilities,
+    PerformanceWorkspaceResponse,
+)
+from app.contracts.workbench import (
+    WorkbenchOverviewSummary,
+    WorkbenchPartialFailure,
+    WorkbenchPortfolioSummary,
+)
+from app.services.performance_workspace_capabilities import build_module_capability
+from app.services.performance_workspace_projection import (
+    project_portfolio_performance_snapshot,
+    project_workspace_details,
+    project_workspace_summary,
+    snapshot_point_as_of_date,
+)
+
+
+def test_project_workspace_summary_keeps_summary_contract_fields_only():
+    workspace = _workspace_response()
+
+    summary = project_workspace_summary(workspace)
+
+    assert summary.portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert summary.period == "YTD"
+    assert summary.detail_basis == "NET"
+    assert summary.benchmark_options == []
+    assert summary.net_performance.portfolio_return_pct == 4.2
+    assert summary.warnings == ["PERFORMANCE_EVIDENCE_PARTIAL"]
+    assert summary.partial_failures[0].error_code == "UPSTREAM_PARTIAL"
+    assert not hasattr(summary, "net_chart")
+    assert not hasattr(summary, "contribution")
+
+
+def test_project_workspace_details_keeps_detail_modules_without_portfolio_header():
+    workspace = _workspace_response()
+
+    details = project_workspace_details(workspace)
+
+    assert details.portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert details.segment == "asset_class"
+    assert details.net_chart[0].period_end == "2026-03-31"
+    assert details.gross_chart == []
+    assert details.warnings == ["PERFORMANCE_EVIDENCE_PARTIAL"]
+    assert not hasattr(details, "portfolio")
+    assert not hasattr(details, "overview")
+
+
+def test_project_portfolio_performance_snapshot_maps_sparkline_and_failures():
+    workspace = _workspace_response()
+
+    snapshot = project_portfolio_performance_snapshot(workspace)
+
+    assert snapshot.portfolio_return_pct == 4.2
+    assert snapshot.benchmark_return_pct == 3.9
+    assert snapshot.excess_return_pct == 0.3
+    assert snapshot.sparkline[0].as_of_date == "2026-03-31"
+    assert snapshot.sparkline[0].excess_return_pct == 0.3
+    assert snapshot.unavailable is None
+    assert snapshot.partial_failures[0].source_service == "lotus-performance"
+
+
+def test_project_portfolio_performance_snapshot_exposes_unavailable_state():
+    workspace = _workspace_response(
+        net_performance=PerformanceComparativeSummary(metric_basis="NET"),
+        net_chart=[],
+    )
+
+    snapshot = project_portfolio_performance_snapshot(workspace)
+
+    assert snapshot.portfolio_return_pct is None
+    assert snapshot.sparkline == []
+    assert snapshot.unavailable is not None
+    assert snapshot.unavailable.requirements == [
+        "valuation history",
+        "cashflow history",
+        "selected reporting period",
+    ]
+
+
+def test_snapshot_point_as_of_date_prefers_period_end_then_start_then_label():
+    assert (
+        snapshot_point_as_of_date(
+            PerformanceChartPoint(
+                label="Fallback",
+                frequency="monthly",
+                period_start="2026-03-01",
+                period_end="2026-03-31",
+            )
+        )
+        == "2026-03-31"
+    )
+    assert (
+        snapshot_point_as_of_date(
+            PerformanceChartPoint(
+                label="Fallback",
+                frequency="monthly",
+                period_start="2026-03-01",
+            )
+        )
+        == "2026-03-01"
+    )
+    assert (
+        snapshot_point_as_of_date(
+            PerformanceChartPoint(label="Fallback", frequency="monthly")
+        )
+        == "Fallback"
+    )
+
+
+def _workspace_response(
+    *,
+    net_performance: PerformanceComparativeSummary | None = None,
+    net_chart: list[PerformanceChartPoint] | None = None,
+) -> PerformanceWorkspaceResponse:
+    capability = build_module_capability(state="supported")
+    capabilities = PerformanceWorkspaceCapabilities(
+        summary_kpis=capability,
+        return_path=capability,
+        benchmark_comparison=capability,
+        multi_horizon_returns=capability,
+        contribution_ranking=capability,
+        attribution_detail=capability,
+        contribution_detail=capability,
+        evidence=capability,
+    )
+    return PerformanceWorkspaceResponse(
+        correlation_id="corr-performance",
+        contract_version="v1",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        as_of_date="2026-03-31",
+        period="YTD",
+        report_start_date="2026-01-01",
+        report_end_date="2026-03-31",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        segment="asset_class",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+        capabilities=capabilities,
+        portfolio=WorkbenchPortfolioSummary(
+            portfolio_id="PB_SG_GLOBAL_BAL_001",
+            client_id="CIF_1001",
+            base_currency="USD",
+            booking_center_code="SG",
+        ),
+        overview=WorkbenchOverviewSummary(
+            market_value_base=1_000_000.0,
+            cash_weight_pct=5.0,
+            position_count=12,
+        ),
+        net_performance=net_performance
+        or PerformanceComparativeSummary(
+            metric_basis="NET",
+            portfolio_return_pct=4.2,
+            benchmark_return_pct=3.9,
+            active_return_pct=0.3,
+        ),
+        gross_performance=PerformanceComparativeSummary(
+            metric_basis="GROSS",
+            portfolio_return_pct=4.5,
+        ),
+        net_chart=net_chart
+        if net_chart is not None
+        else [
+            PerformanceChartPoint(
+                label="Mar 2026",
+                frequency="monthly",
+                period_start="2026-03-01",
+                period_end="2026-03-31",
+                portfolio_return_pct=4.2,
+                benchmark_return_pct=3.9,
+                active_return_pct=0.3,
+            )
+        ],
+        warnings=["PERFORMANCE_EVIDENCE_PARTIAL"],
+        partial_failures=[
+            WorkbenchPartialFailure(
+                source_service="lotus-performance",
+                error_code="UPSTREAM_PARTIAL",
+                detail="Lineage is still materializing.",
+            )
+        ],
+    )


### PR DESCRIPTION
## Summary
- Extract performance workspace projection helpers into a reusable module.
- Centralize full-workspace to summary/details/snapshot projection, snapshot sparkline date selection, and unavailable snapshot metadata.
- Keep thin service wrappers for existing call sites while removing service-local projection bodies.
- Add focused unit coverage for summary, details, snapshot, unavailable, and date fallback projection behavior.

## Validation
- `python -m pytest tests/unit/test_performance_workspace_projection.py -q`
- `python -m pytest tests/unit/test_performance_workspace_projection.py tests/unit/test_performance_workspace_service.py -q`
- `make check`
- `make ci`

## Governance
- Experience API internal refactor only; no OpenAPI or route contract behavior changed.
- No docs/wiki publication required because product/operator truth did not change.
- Stranded truth baseline before work: no unmerged remote branches and no open PRs.