### PR TITLE
Refactor performance benchmark context helpers

### DIFF
--- a/src/app/services/performance_workspace_benchmarks.py
+++ b/src/app/services/performance_workspace_benchmarks.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, TypeAlias, cast
+
+from app.services.async_ttl_cache import AsyncTtlCache
+from app.services.performance_workspace_parsing import safe_str
+from app.services.workspace_client_protocols import PerformanceWorkspaceCoreClient
+
+UpstreamPayload: TypeAlias = dict[str, Any]
+UpstreamResult: TypeAlias = tuple[int, UpstreamPayload]
+GatheredResult: TypeAlias = UpstreamResult | BaseException
+
+
+def benchmark_assignment_cache_key(
+    *,
+    portfolio_id: str,
+    as_of_date: str,
+    portfolio_currency: str,
+) -> tuple[str, str, str, str]:
+    return (
+        "benchmark_assignment",
+        portfolio_id,
+        as_of_date,
+        portfolio_currency,
+    )
+
+
+def benchmark_catalog_cache_key(
+    *,
+    report_end_date: str,
+    portfolio_currency: str,
+) -> tuple[str, str, str]:
+    return ("benchmark_catalog", report_end_date, portfolio_currency)
+
+
+async def fetch_assigned_benchmark_code(
+    *,
+    core_client: PerformanceWorkspaceCoreClient,
+    portfolio_id: str,
+    as_of_date: str,
+    portfolio_currency: str,
+    correlation_id: str,
+) -> str | None:
+    status_code, payload = await core_client.get_benchmark_assignment(
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        reporting_currency=portfolio_currency,
+        correlation_id=correlation_id,
+    )
+    if status_code >= 400 or not isinstance(payload, dict):
+        return None
+    return safe_str(payload.get("benchmark_id"))
+
+
+async def resolve_benchmark_code(
+    *,
+    cache: AsyncTtlCache[Any],
+    core_client: PerformanceWorkspaceCoreClient,
+    portfolio_id: str,
+    correlation_id: str,
+    as_of_date: str,
+    portfolio_currency: str,
+    benchmark_code: str | None,
+) -> str | None:
+    if benchmark_code:
+        return benchmark_code
+
+    cache_key = benchmark_assignment_cache_key(
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        portfolio_currency=portfolio_currency,
+    )
+    resolved_benchmark_code, cache_hit = await cache.get_or_set_with_status(
+        key=cache_key,
+        factory=lambda: fetch_assigned_benchmark_code(
+            core_client=core_client,
+            portfolio_id=portfolio_id,
+            as_of_date=as_of_date,
+            portfolio_currency=portfolio_currency,
+            correlation_id=correlation_id,
+        ),
+    )
+    if resolved_benchmark_code:
+        return cast(str, resolved_benchmark_code)
+
+    cache.discard(cache_key)
+    if not cache_hit:
+        return None
+
+    refreshed_benchmark_code = await fetch_assigned_benchmark_code(
+        core_client=core_client,
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        portfolio_currency=portfolio_currency,
+        correlation_id=correlation_id,
+    )
+    if refreshed_benchmark_code:
+        cache.set(cache_key, refreshed_benchmark_code)
+    return refreshed_benchmark_code
+
+
+async def fetch_benchmark_context(
+    *,
+    cache: AsyncTtlCache[Any],
+    core_client: PerformanceWorkspaceCoreClient,
+    portfolio_id: str,
+    correlation_id: str,
+    report_end_date: str,
+    portfolio_currency: str,
+    benchmark_code: str | None,
+    include_benchmark_catalog: bool,
+) -> tuple[str | None, GatheredResult]:
+    assignment_task = (
+        resolve_benchmark_code(
+            cache=cache,
+            core_client=core_client,
+            portfolio_id=portfolio_id,
+            correlation_id=correlation_id,
+            as_of_date=report_end_date,
+            portfolio_currency=portfolio_currency,
+            benchmark_code=benchmark_code,
+        )
+        if not benchmark_code
+        else _empty_async_scalar_result(None)
+    )
+    benchmark_catalog_task = (
+        cache.get_or_set(
+            key=benchmark_catalog_cache_key(
+                report_end_date=report_end_date,
+                portfolio_currency=portfolio_currency,
+            ),
+            factory=lambda: core_client.get_benchmark_catalog(
+                as_of_date=report_end_date,
+                benchmark_currency=portfolio_currency,
+                benchmark_status="active",
+                benchmark_type="composite",
+                correlation_id=correlation_id,
+            ),
+        )
+        if include_benchmark_catalog
+        else _empty_async_result()
+    )
+    benchmark_context_results = await asyncio.gather(
+        assignment_task,
+        benchmark_catalog_task,
+        return_exceptions=True,
+    )
+    resolved_benchmark_code_result = cast(
+        str | None | BaseException,
+        benchmark_context_results[0],
+    )
+    benchmark_catalog_result_value = cast(GatheredResult, benchmark_context_results[1])
+    if isinstance(resolved_benchmark_code_result, BaseException):
+        return benchmark_code, benchmark_catalog_result_value
+    return benchmark_code or cast(str | None, resolved_benchmark_code_result), (
+        benchmark_catalog_result_value
+    )
+
+
+async def _empty_async_result() -> tuple[int, dict[str, Any]]:
+    return 200, {}
+
+
+async def _empty_async_scalar_result(value: str | None) -> str | None:
+    return value

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -44,6 +44,7 @@ from app.contracts.workbench import WorkbenchOverviewResponse, WorkbenchPartialF
 from app.middleware.server_timing import server_timing_span
 from app.precision_policy import quantize_performance
 from app.services.async_ttl_cache import AsyncTtlCache
+from app.services.performance_workspace_benchmarks import fetch_benchmark_context
 from app.services.performance_workspace_capabilities import (
     SUPPORTED_ATTRIBUTION_DIMENSIONS,
     SUPPORTED_CONTRIBUTION_DIMENSIONS,
@@ -329,7 +330,9 @@ class PerformanceWorkspaceService:
             (
                 resolved_benchmark_code,
                 benchmark_catalog_result,
-            ) = await self._fetch_benchmark_context(
+            ) = await fetch_benchmark_context(
+                cache=self._upstream_cache,
+                core_client=self._lotus_core_query_client,
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 report_end_date=resolved_report_end_date,
@@ -443,7 +446,9 @@ class PerformanceWorkspaceService:
         )
 
         async with server_timing_span("perf-benchmark"):
-            resolved_benchmark_code, _ = await self._fetch_benchmark_context(
+            resolved_benchmark_code, _ = await fetch_benchmark_context(
+                cache=self._upstream_cache,
+                core_client=self._lotus_core_query_client,
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 report_end_date=report_end_date,
@@ -595,7 +600,9 @@ class PerformanceWorkspaceService:
             (
                 resolved_benchmark_code,
                 benchmark_catalog_result,
-            ) = await self._fetch_benchmark_context(
+            ) = await fetch_benchmark_context(
+                cache=self._upstream_cache,
+                core_client=self._lotus_core_query_client,
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 report_end_date=report_end_date,
@@ -1139,118 +1146,6 @@ class PerformanceWorkspaceService:
             correlation_id=correlation_id,
             warnings=warnings,
             partial_failures=partial_failures,
-        )
-
-    async def _resolve_benchmark_code(
-        self,
-        *,
-        portfolio_id: str,
-        correlation_id: str,
-        as_of_date: str,
-        portfolio_currency: str,
-        benchmark_code: str | None,
-    ) -> str | None:
-        if benchmark_code:
-            return benchmark_code
-        cache_key = (
-            "benchmark_assignment",
-            portfolio_id,
-            as_of_date,
-            portfolio_currency,
-        )
-        resolved_benchmark_code, cache_hit = await self._upstream_cache.get_or_set_with_status(
-            key=cache_key,
-            factory=lambda: self._fetch_assigned_benchmark_code(
-                portfolio_id=portfolio_id,
-                as_of_date=as_of_date,
-                portfolio_currency=portfolio_currency,
-                correlation_id=correlation_id,
-            ),
-        )
-        if resolved_benchmark_code:
-            return cast(str, resolved_benchmark_code)
-
-        self._upstream_cache.discard(cache_key)
-        if not cache_hit:
-            return None
-
-        refreshed_benchmark_code = await self._fetch_assigned_benchmark_code(
-            portfolio_id=portfolio_id,
-            as_of_date=as_of_date,
-            portfolio_currency=portfolio_currency,
-            correlation_id=correlation_id,
-        )
-        if refreshed_benchmark_code:
-            self._upstream_cache.set(cache_key, refreshed_benchmark_code)
-        return refreshed_benchmark_code
-
-    async def _fetch_assigned_benchmark_code(
-        self,
-        *,
-        portfolio_id: str,
-        as_of_date: str,
-        portfolio_currency: str,
-        correlation_id: str,
-    ) -> str | None:
-        status_code, payload = await self._lotus_core_query_client.get_benchmark_assignment(
-            portfolio_id=portfolio_id,
-            as_of_date=as_of_date,
-            reporting_currency=portfolio_currency,
-            correlation_id=correlation_id,
-        )
-        if status_code >= 400 or not isinstance(payload, dict):
-            return None
-        return safe_str(payload.get("benchmark_id"))
-
-    async def _fetch_benchmark_context(
-        self,
-        *,
-        portfolio_id: str,
-        correlation_id: str,
-        report_end_date: str,
-        portfolio_currency: str,
-        benchmark_code: str | None,
-        include_benchmark_catalog: bool,
-    ) -> tuple[str | None, GatheredResult]:
-        assignment_task = (
-            self._resolve_benchmark_code(
-                portfolio_id=portfolio_id,
-                correlation_id=correlation_id,
-                as_of_date=report_end_date,
-                portfolio_currency=portfolio_currency,
-                benchmark_code=benchmark_code,
-            )
-            if not benchmark_code
-            else self._empty_async_scalar_result(None)
-        )
-        benchmark_catalog_task = (
-            self._get_cached_upstream_result(
-                ("benchmark_catalog", report_end_date, portfolio_currency),
-                lambda: self._lotus_core_query_client.get_benchmark_catalog(
-                    as_of_date=report_end_date,
-                    benchmark_currency=portfolio_currency,
-                    benchmark_status="active",
-                    benchmark_type="composite",
-                    correlation_id=correlation_id,
-                ),
-            )
-            if include_benchmark_catalog
-            else self._empty_async_result()
-        )
-        benchmark_context_results = await asyncio.gather(
-            assignment_task,
-            benchmark_catalog_task,
-            return_exceptions=True,
-        )
-        resolved_benchmark_code_result = cast(
-            str | None | BaseException,
-            benchmark_context_results[0],
-        )
-        benchmark_catalog_result_value = cast(GatheredResult, benchmark_context_results[1])
-        if isinstance(resolved_benchmark_code_result, BaseException):
-            return benchmark_code, cast(GatheredResult, benchmark_catalog_result_value)
-        return benchmark_code or cast(str | None, resolved_benchmark_code_result), cast(
-            GatheredResult, benchmark_catalog_result_value
         )
 
     async def _fetch_analytics_results(

--- a/tests/unit/test_performance_workspace_benchmarks.py
+++ b/tests/unit/test_performance_workspace_benchmarks.py
@@ -1,0 +1,193 @@
+import asyncio
+from typing import Any
+
+import pytest
+
+from app.services.async_ttl_cache import AsyncTtlCache
+from app.services.performance_workspace_benchmarks import (
+    fetch_assigned_benchmark_code,
+    fetch_benchmark_context,
+    resolve_benchmark_code,
+)
+
+
+class FakeCoreClient:
+    def __init__(self) -> None:
+        self.assignment_payloads: list[tuple[int, dict[str, Any]]] = [
+            (200, {"benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40"})
+        ]
+        self.catalog_payload: tuple[int, dict[str, Any]] = (
+            200,
+            {"benchmarks": [{"benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40"}]},
+        )
+        self.assignment_calls: list[dict[str, Any]] = []
+        self.catalog_calls: list[dict[str, Any]] = []
+
+    async def get_benchmark_assignment(self, **kwargs):
+        self.assignment_calls.append(kwargs)
+        if self.assignment_payloads:
+            return self.assignment_payloads.pop(0)
+        return 200, {"benchmark_id": None}
+
+    async def get_benchmark_catalog(self, **kwargs):
+        self.catalog_calls.append(kwargs)
+        return self.catalog_payload
+
+    async def get_portfolio_analytics_reference(self, *args, **kwargs):
+        raise AssertionError("not used by benchmark helpers")
+
+
+@pytest.mark.asyncio
+async def test_fetch_assigned_benchmark_code_returns_assignment_id():
+    client = FakeCoreClient()
+
+    benchmark_code = await fetch_assigned_benchmark_code(
+        core_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        as_of_date="2026-03-27",
+        portfolio_currency="USD",
+        correlation_id="corr-1",
+    )
+
+    assert benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert client.assignment_calls == [
+        {
+            "portfolio_id": "DEMO_ADV_USD_001",
+            "as_of_date": "2026-03-27",
+            "reporting_currency": "USD",
+            "correlation_id": "corr-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_assigned_benchmark_code_fails_closed_for_upstream_failure():
+    client = FakeCoreClient()
+    client.assignment_payloads = [(503, {"detail": "core unavailable"})]
+
+    benchmark_code = await fetch_assigned_benchmark_code(
+        core_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        as_of_date="2026-03-27",
+        portfolio_currency="USD",
+        correlation_id="corr-1",
+    )
+
+    assert benchmark_code is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_benchmark_code_keeps_explicit_code_local():
+    client = FakeCoreClient()
+    cache = AsyncTtlCache[Any](ttl_seconds=30)
+
+    benchmark_code = await resolve_benchmark_code(
+        cache=cache,
+        core_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-1",
+        as_of_date="2026-03-27",
+        portfolio_currency="USD",
+        benchmark_code="BMK_EXPLICIT",
+    )
+
+    assert benchmark_code == "BMK_EXPLICIT"
+    assert client.assignment_calls == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_benchmark_code_refreshes_cached_missing_assignment():
+    client = FakeCoreClient()
+    client.assignment_payloads = [
+        (200, {"benchmark_id": None, "assignment_status": "not_found"}),
+        (200, {"benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40"}),
+    ]
+    cache = AsyncTtlCache[Any](ttl_seconds=30)
+
+    first_benchmark_code = await resolve_benchmark_code(
+        cache=cache,
+        core_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-1",
+        as_of_date="2026-03-27",
+        portfolio_currency="USD",
+        benchmark_code=None,
+    )
+    second_benchmark_code = await resolve_benchmark_code(
+        cache=cache,
+        core_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-1",
+        as_of_date="2026-03-27",
+        portfolio_currency="USD",
+        benchmark_code=None,
+    )
+
+    assert first_benchmark_code is None
+    assert second_benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert len(client.assignment_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_benchmark_context_fetches_assignment_and_catalog_concurrently():
+    assignment_started = asyncio.Event()
+    catalog_started = asyncio.Event()
+    release = asyncio.Event()
+
+    class CoordinatedCoreClient(FakeCoreClient):
+        async def get_benchmark_assignment(self, **kwargs):
+            self.assignment_calls.append(kwargs)
+            assignment_started.set()
+            await catalog_started.wait()
+            release.set()
+            return 200, {"benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40"}
+
+        async def get_benchmark_catalog(self, **kwargs):
+            self.catalog_calls.append(kwargs)
+            catalog_started.set()
+            await assignment_started.wait()
+            await release.wait()
+            return self.catalog_payload
+
+    client = CoordinatedCoreClient()
+    cache = AsyncTtlCache[Any](ttl_seconds=30)
+
+    benchmark_code, catalog_result = await asyncio.wait_for(
+        fetch_benchmark_context(
+            cache=cache,
+            core_client=client,
+            portfolio_id="DEMO_ADV_USD_001",
+            correlation_id="corr-1",
+            report_end_date="2026-03-27",
+            portfolio_currency="USD",
+            benchmark_code=None,
+            include_benchmark_catalog=True,
+        ),
+        timeout=1,
+    )
+
+    assert benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert catalog_result == client.catalog_payload
+    assert len(client.assignment_calls) == 1
+    assert len(client.catalog_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_benchmark_context_skips_catalog_when_not_requested():
+    client = FakeCoreClient()
+    cache = AsyncTtlCache[Any](ttl_seconds=30)
+
+    benchmark_code, catalog_result = await fetch_benchmark_context(
+        cache=cache,
+        core_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-1",
+        report_end_date="2026-03-27",
+        portfolio_currency="USD",
+        benchmark_code=None,
+        include_benchmark_catalog=False,
+    )
+
+    assert benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert catalog_result == (200, {})
+    assert client.catalog_calls == []


### PR DESCRIPTION
## Summary
- Extract performance workspace benchmark assignment and catalog resolution into a dedicated helper module
- Add focused unit coverage for explicit benchmark handling, fail-closed assignment lookup, negative-cache refresh, catalog skip, and concurrent assignment/catalog fetch
- Wire PerformanceWorkspaceService to the helper and remove migrated private methods

## Validation
- python -m ruff check src/app/services/performance_workspace_benchmarks.py src/app/services/performance_workspace_service.py tests/unit/test_performance_workspace_benchmarks.py tests/unit/test_performance_workspace_service.py
- python -m pytest tests/unit/test_performance_workspace_benchmarks.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary refactor with unchanged API contracts and operator behavior.