### PR TITLE
Refactor performance horizon fetch helpers

### DIFF
--- a/src/app/services/performance_workspace_horizon.py
+++ b/src/app/services/performance_workspace_horizon.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from typing import Any, TypeAlias, cast
+
+from app.services.workspace_client_protocols import PerformanceWorkspaceAnalyticsClient
+
+UpstreamPayload: TypeAlias = dict[str, Any]
+UpstreamResult: TypeAlias = tuple[int, UpstreamPayload]
+GatheredResult: TypeAlias = UpstreamResult | BaseException
+
+
+def build_horizon_comparison_frequencies(chart_frequency: str) -> list[str]:
+    frequencies: list[str] = []
+    for frequency in [chart_frequency, "monthly", "quarterly", "yearly"]:
+        if frequency not in frequencies:
+            frequencies.append(frequency)
+    return frequencies
+
+
+async def fetch_workspace_horizon_dependencies(
+    *,
+    analytics_client: PerformanceWorkspaceAnalyticsClient,
+    portfolio_id: str,
+    correlation_id: str,
+    report_end_date: str,
+    report_start_date: str | None,
+    period: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    portfolio_currency: str,
+    chart_frequency: str,
+) -> GatheredResult:
+    if period != "EXPLICIT":
+        return await fetch_standard_horizon_workspace_summary(
+            analytics_client=analytics_client,
+            portfolio_id=portfolio_id,
+            correlation_id=correlation_id,
+            report_end_date=report_end_date,
+            detail_basis=detail_basis,
+            benchmark_code=benchmark_code,
+            portfolio_currency=portfolio_currency,
+            chart_frequency=chart_frequency,
+        )
+
+    horizon_periods = [
+        {
+            "period": period,
+            "frequencies": build_horizon_comparison_frequencies(chart_frequency),
+        }
+    ]
+    return cast(
+        GatheredResult,
+        await analytics_client.get_workspace_summary(
+            portfolio_id=portfolio_id,
+            report_end_date=report_end_date,
+            report_start_date=report_start_date,
+            period=period,
+            chart_frequency=chart_frequency,
+            detail_basis=detail_basis,
+            benchmark_id=benchmark_code,
+            reporting_currency=portfolio_currency,
+            segment="asset_class",
+            correlation_id=correlation_id,
+            periods=horizon_periods,
+            include_detail_blocks=False,
+        ),
+    )
+
+
+async def fetch_standard_horizon_workspace_summary(
+    *,
+    analytics_client: PerformanceWorkspaceAnalyticsClient,
+    portfolio_id: str,
+    correlation_id: str,
+    report_end_date: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    portfolio_currency: str,
+    chart_frequency: str,
+) -> GatheredResult:
+    frequencies = build_horizon_comparison_frequencies(chart_frequency)
+    report_end = date.fromisoformat(report_end_date)
+    month_start = report_end.replace(day=1).isoformat()
+    quarter_start_month = ((report_end.month - 1) // 3) * 3 + 1
+    quarter_start = report_end.replace(month=quarter_start_month, day=1).isoformat()
+
+    gathered_results = await asyncio.gather(
+        analytics_client.get_workspace_summary(
+            portfolio_id=portfolio_id,
+            report_end_date=report_end_date,
+            report_start_date=month_start,
+            period="EXPLICIT",
+            chart_frequency=chart_frequency,
+            detail_basis=detail_basis,
+            benchmark_id=benchmark_code,
+            reporting_currency=portfolio_currency,
+            segment="asset_class",
+            correlation_id=correlation_id,
+            periods=[{"period": "EXPLICIT", "frequencies": frequencies}],
+            include_detail_blocks=False,
+        ),
+        analytics_client.get_workspace_summary(
+            portfolio_id=portfolio_id,
+            report_end_date=report_end_date,
+            report_start_date=quarter_start,
+            period="EXPLICIT",
+            chart_frequency=chart_frequency,
+            detail_basis=detail_basis,
+            benchmark_id=benchmark_code,
+            reporting_currency=portfolio_currency,
+            segment="asset_class",
+            correlation_id=correlation_id,
+            periods=[{"period": "EXPLICIT", "frequencies": frequencies}],
+            include_detail_blocks=False,
+        ),
+        analytics_client.get_workspace_summary(
+            portfolio_id=portfolio_id,
+            report_end_date=report_end_date,
+            report_start_date=None,
+            period="YTD",
+            chart_frequency=chart_frequency,
+            detail_basis=detail_basis,
+            benchmark_id=benchmark_code,
+            reporting_currency=portfolio_currency,
+            segment="asset_class",
+            correlation_id=correlation_id,
+            periods=[{"period": "YTD", "frequencies": frequencies}],
+            include_detail_blocks=False,
+        ),
+        return_exceptions=True,
+    )
+
+    return merge_standard_horizon_results(
+        gathered_results=gathered_results,
+        month_start=month_start,
+        quarter_start=quarter_start,
+        report_end_date=report_end_date,
+    )
+
+
+def merge_standard_horizon_results(
+    *,
+    gathered_results: list[UpstreamResult | BaseException],
+    month_start: str,
+    quarter_start: str,
+    report_end_date: str,
+) -> UpstreamResult:
+    result_labels = ("MTD", "QTD", "STANDARD")
+    merged_results: dict[str, Any] = {}
+    merged_warnings: list[str] = []
+    merged_failures: list[dict[str, str]] = []
+
+    for label, result in zip(result_labels, gathered_results, strict=True):
+        if isinstance(result, BaseException):
+            merged_warnings.append(f"PERFORMANCE_HORIZON_{label}_UNAVAILABLE")
+            merged_failures.append(
+                {
+                    "source_service": "lotus-performance",
+                    "error_code": "UPSTREAM_EXCEPTION",
+                    "detail": str(result),
+                }
+            )
+            continue
+
+        status_code, payload = result
+        if status_code >= 400 or not isinstance(payload, dict):
+            merged_warnings.append(f"PERFORMANCE_HORIZON_{label}_UNAVAILABLE")
+            merged_failures.append(
+                {
+                    "source_service": "lotus-performance",
+                    "error_code": (
+                        f"HTTP_{status_code}"
+                        if isinstance(status_code, int)
+                        else "INVALID_UPSTREAM_PAYLOAD"
+                    ),
+                    "detail": str(payload.get("detail", payload))
+                    if isinstance(payload, dict)
+                    else str(payload),
+                }
+            )
+            continue
+
+        results_by_period = payload.get("results_by_period", {})
+        if not isinstance(results_by_period, dict):
+            continue
+
+        if label in {"MTD", "QTD"}:
+            explicit_result = results_by_period.get("EXPLICIT")
+            if isinstance(explicit_result, dict):
+                merged_results[label] = {
+                    **explicit_result,
+                    "_gateway_requested_period_start": month_start
+                    if label == "MTD"
+                    else quarter_start,
+                    "_gateway_requested_period_end": report_end_date,
+                }
+            continue
+
+        period_payload = results_by_period.get("YTD")
+        if isinstance(period_payload, dict):
+            merged_results["YTD"] = period_payload
+
+    return 200, {
+        "results_by_period": merged_results,
+        "_gateway_warnings": merged_warnings,
+        "_gateway_partial_failures": merged_failures,
+    }

--- a/src/app/services/performance_workspace_horizon.py
+++ b/src/app/services/performance_workspace_horizon.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Sequence
 from datetime import date
 from typing import Any, TypeAlias, cast
 
@@ -142,7 +143,7 @@ async def fetch_standard_horizon_workspace_summary(
 
 def merge_standard_horizon_results(
     *,
-    gathered_results: list[UpstreamResult | BaseException],
+    gathered_results: Sequence[UpstreamResult | BaseException],
     month_start: str,
     quarter_start: str,
     report_end_date: str,

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -78,6 +78,7 @@ from app.services.performance_workspace_evidence import (
     resolve_evidence_reason,
     resolve_evidence_state,
 )
+from app.services.performance_workspace_horizon import fetch_workspace_horizon_dependencies
 from app.services.performance_workspace_parsing import (
     extract_return,
     format_attribution_trend_label,
@@ -341,7 +342,8 @@ class PerformanceWorkspaceService:
                 include_benchmark_catalog=True,
             )
         async with server_timing_span("perf-horizon"):
-            workspace_summary_result = await self._fetch_workspace_horizon_dependencies(
+            workspace_summary_result = await fetch_workspace_horizon_dependencies(
+                analytics_client=self._analytics_client,
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 report_end_date=resolved_report_end_date,
@@ -1458,185 +1460,6 @@ class PerformanceWorkspaceService:
             ),
         )
 
-    async def _fetch_workspace_horizon_dependencies(
-        self,
-        *,
-        portfolio_id: str,
-        correlation_id: str,
-        report_end_date: str,
-        report_start_date: str | None,
-        period: str,
-        detail_basis: str,
-        benchmark_code: str | None,
-        portfolio_currency: str,
-        chart_frequency: str,
-    ) -> GatheredResult:
-        if period != "EXPLICIT":
-            return await self._fetch_standard_horizon_workspace_summary(
-                portfolio_id=portfolio_id,
-                correlation_id=correlation_id,
-                report_end_date=report_end_date,
-                detail_basis=detail_basis,
-                benchmark_code=benchmark_code,
-                portfolio_currency=portfolio_currency,
-                chart_frequency=chart_frequency,
-            )
-
-        horizon_periods = (
-            [
-                {
-                    "period": period,
-                    "frequencies": self._build_horizon_comparison_frequencies(chart_frequency),
-                }
-            ]
-            if period == "EXPLICIT"
-            else []
-        )
-        return cast(
-            GatheredResult,
-            await self._analytics_client.get_workspace_summary(
-                portfolio_id=portfolio_id,
-                report_end_date=report_end_date,
-                report_start_date=report_start_date,
-                period=period,
-                chart_frequency=chart_frequency,
-                detail_basis=detail_basis,
-                benchmark_id=benchmark_code,
-                reporting_currency=portfolio_currency,
-                segment="asset_class",
-                correlation_id=correlation_id,
-                periods=horizon_periods,
-                include_detail_blocks=False,
-            ),
-        )
-
-    async def _fetch_standard_horizon_workspace_summary(
-        self,
-        *,
-        portfolio_id: str,
-        correlation_id: str,
-        report_end_date: str,
-        detail_basis: str,
-        benchmark_code: str | None,
-        portfolio_currency: str,
-        chart_frequency: str,
-    ) -> GatheredResult:
-        frequencies = self._build_horizon_comparison_frequencies(chart_frequency)
-        report_end = date.fromisoformat(report_end_date)
-        month_start = report_end.replace(day=1).isoformat()
-        quarter_start_month = ((report_end.month - 1) // 3) * 3 + 1
-        quarter_start = report_end.replace(month=quarter_start_month, day=1).isoformat()
-
-        result_labels = ("MTD", "QTD", "STANDARD")
-        gathered_results = await asyncio.gather(
-            self._analytics_client.get_workspace_summary(
-                portfolio_id=portfolio_id,
-                report_end_date=report_end_date,
-                report_start_date=month_start,
-                period="EXPLICIT",
-                chart_frequency=chart_frequency,
-                detail_basis=detail_basis,
-                benchmark_id=benchmark_code,
-                reporting_currency=portfolio_currency,
-                segment="asset_class",
-                correlation_id=correlation_id,
-                periods=[{"period": "EXPLICIT", "frequencies": frequencies}],
-                include_detail_blocks=False,
-            ),
-            self._analytics_client.get_workspace_summary(
-                portfolio_id=portfolio_id,
-                report_end_date=report_end_date,
-                report_start_date=quarter_start,
-                period="EXPLICIT",
-                chart_frequency=chart_frequency,
-                detail_basis=detail_basis,
-                benchmark_id=benchmark_code,
-                reporting_currency=portfolio_currency,
-                segment="asset_class",
-                correlation_id=correlation_id,
-                periods=[{"period": "EXPLICIT", "frequencies": frequencies}],
-                include_detail_blocks=False,
-            ),
-            self._analytics_client.get_workspace_summary(
-                portfolio_id=portfolio_id,
-                report_end_date=report_end_date,
-                report_start_date=None,
-                period="YTD",
-                chart_frequency=chart_frequency,
-                detail_basis=detail_basis,
-                benchmark_id=benchmark_code,
-                reporting_currency=portfolio_currency,
-                segment="asset_class",
-                correlation_id=correlation_id,
-                periods=[
-                    {"period": "YTD", "frequencies": frequencies},
-                ],
-                include_detail_blocks=False,
-            ),
-            return_exceptions=True,
-        )
-
-        merged_results: dict[str, Any] = {}
-        merged_warnings: list[str] = []
-        merged_failures: list[dict[str, str]] = []
-
-        for label, result in zip(result_labels, gathered_results, strict=True):
-            if isinstance(result, BaseException):
-                merged_warnings.append(f"PERFORMANCE_HORIZON_{label}_UNAVAILABLE")
-                merged_failures.append(
-                    {
-                        "source_service": "lotus-performance",
-                        "error_code": "UPSTREAM_EXCEPTION",
-                        "detail": str(result),
-                    }
-                )
-                continue
-
-            status_code, payload = result
-            if status_code >= 400 or not isinstance(payload, dict):
-                merged_warnings.append(f"PERFORMANCE_HORIZON_{label}_UNAVAILABLE")
-                merged_failures.append(
-                    {
-                        "source_service": "lotus-performance",
-                        "error_code": (
-                            f"HTTP_{status_code}"
-                            if isinstance(status_code, int)
-                            else "INVALID_UPSTREAM_PAYLOAD"
-                        ),
-                        "detail": str(payload.get("detail", payload))
-                        if isinstance(payload, dict)
-                        else str(payload),
-                    }
-                )
-                continue
-
-            results_by_period = payload.get("results_by_period", {})
-            if not isinstance(results_by_period, dict):
-                continue
-
-            if label in {"MTD", "QTD"}:
-                explicit_result = results_by_period.get("EXPLICIT")
-                if isinstance(explicit_result, dict):
-                    merged_results[label] = {
-                        **explicit_result,
-                        "_gateway_requested_period_start": month_start
-                        if label == "MTD"
-                        else quarter_start,
-                        "_gateway_requested_period_end": report_end_date,
-                    }
-                continue
-
-            for period_key in ("YTD",):
-                period_payload = results_by_period.get(period_key)
-                if isinstance(period_payload, dict):
-                    merged_results[period_key] = period_payload
-
-        return 200, {
-            "results_by_period": merged_results,
-            "_gateway_warnings": merged_warnings,
-            "_gateway_partial_failures": merged_failures,
-        }
-
     async def _empty_async_result(self) -> tuple[int, dict[str, Any]]:
         return 204, {}
 
@@ -1920,13 +1743,6 @@ class PerformanceWorkspaceService:
             if resolved_benchmark_code is None:
                 resolved_benchmark_code = comparative.benchmark_id
         return rows, resolved_benchmark_code
-
-    def _build_horizon_comparison_frequencies(self, chart_frequency: str) -> list[str]:
-        frequencies: list[str] = []
-        for frequency in [chart_frequency, "monthly", "quarterly", "yearly"]:
-            if frequency not in frequencies:
-                frequencies.append(frequency)
-        return frequencies
 
     def _extract_twr_workspace_block(
         self, period_payload: dict[str, Any], basis: str

--- a/tests/unit/test_performance_workspace_horizon.py
+++ b/tests/unit/test_performance_workspace_horizon.py
@@ -88,9 +88,7 @@ async def test_fetch_workspace_horizon_dependencies_calls_explicit_summary_once(
         "reporting_currency": "USD",
         "segment": "asset_class",
         "correlation_id": "corr-1",
-        "periods": [
-            {"period": "EXPLICIT", "frequencies": ["monthly", "quarterly", "yearly"]}
-        ],
+        "periods": [{"period": "EXPLICIT", "frequencies": ["monthly", "quarterly", "yearly"]}],
         "include_detail_blocks": False,
     }
 

--- a/tests/unit/test_performance_workspace_horizon.py
+++ b/tests/unit/test_performance_workspace_horizon.py
@@ -1,0 +1,180 @@
+from typing import Any
+
+import pytest
+
+from app.services.performance_workspace_horizon import (
+    build_horizon_comparison_frequencies,
+    fetch_workspace_horizon_dependencies,
+    merge_standard_horizon_results,
+)
+
+
+class FakeAnalyticsClient:
+    def __init__(self, results: list[tuple[int, dict[str, Any]]] | None = None) -> None:
+        self.results = results or [
+            (200, {"results_by_period": {"EXPLICIT": {"value": "MTD"}}}),
+            (200, {"results_by_period": {"EXPLICIT": {"value": "QTD"}}}),
+            (200, {"results_by_period": {"YTD": {"value": "YTD"}}}),
+        ]
+        self.workspace_summary_calls: list[dict[str, Any]] = []
+
+    async def get_workspace_summary(self, **kwargs):
+        self.workspace_summary_calls.append(kwargs)
+        return self.results.pop(0)
+
+    async def get_twr_analytics(self, *args, **kwargs):
+        raise AssertionError("not used by horizon helpers")
+
+    async def get_mwr_analytics(self, *args, **kwargs):
+        raise AssertionError("not used by horizon helpers")
+
+    async def get_contribution_analytics(self, *args, **kwargs):
+        raise AssertionError("not used by horizon helpers")
+
+    async def get_attribution_analytics(self, *args, **kwargs):
+        raise AssertionError("not used by horizon helpers")
+
+    async def get_execution(self, *args, **kwargs):
+        raise AssertionError("not used by horizon helpers")
+
+    async def get_lineage(self, *args, **kwargs):
+        raise AssertionError("not used by horizon helpers")
+
+    async def get_lineage_artifact(self, *args, **kwargs):
+        raise AssertionError("not used by horizon helpers")
+
+
+def test_build_horizon_comparison_frequencies_deduplicates_requested_frequency():
+    assert build_horizon_comparison_frequencies("monthly") == [
+        "monthly",
+        "quarterly",
+        "yearly",
+    ]
+    assert build_horizon_comparison_frequencies("daily") == [
+        "daily",
+        "monthly",
+        "quarterly",
+        "yearly",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_workspace_horizon_dependencies_calls_explicit_summary_once():
+    client = FakeAnalyticsClient(results=[(200, {"results_by_period": {"EXPLICIT": {}}})])
+
+    result = await fetch_workspace_horizon_dependencies(
+        analytics_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-1",
+        report_end_date="2026-03-27",
+        report_start_date="2026-01-01",
+        period="EXPLICIT",
+        detail_basis="NET",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+        portfolio_currency="USD",
+        chart_frequency="monthly",
+    )
+
+    assert result == (200, {"results_by_period": {"EXPLICIT": {}}})
+    assert len(client.workspace_summary_calls) == 1
+    assert client.workspace_summary_calls[0] == {
+        "portfolio_id": "DEMO_ADV_USD_001",
+        "report_end_date": "2026-03-27",
+        "report_start_date": "2026-01-01",
+        "period": "EXPLICIT",
+        "chart_frequency": "monthly",
+        "detail_basis": "NET",
+        "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+        "reporting_currency": "USD",
+        "segment": "asset_class",
+        "correlation_id": "corr-1",
+        "periods": [
+            {"period": "EXPLICIT", "frequencies": ["monthly", "quarterly", "yearly"]}
+        ],
+        "include_detail_blocks": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_workspace_horizon_dependencies_merges_standard_period_results():
+    client = FakeAnalyticsClient()
+
+    result = await fetch_workspace_horizon_dependencies(
+        analytics_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-1",
+        report_end_date="2026-03-27",
+        report_start_date=None,
+        period="YTD",
+        detail_basis="NET",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+        portfolio_currency="USD",
+        chart_frequency="daily",
+    )
+
+    assert result == (
+        200,
+        {
+            "results_by_period": {
+                "MTD": {
+                    "value": "MTD",
+                    "_gateway_requested_period_start": "2026-03-01",
+                    "_gateway_requested_period_end": "2026-03-27",
+                },
+                "QTD": {
+                    "value": "QTD",
+                    "_gateway_requested_period_start": "2026-01-01",
+                    "_gateway_requested_period_end": "2026-03-27",
+                },
+                "YTD": {"value": "YTD"},
+            },
+            "_gateway_warnings": [],
+            "_gateway_partial_failures": [],
+        },
+    )
+    assert [call["report_start_date"] for call in client.workspace_summary_calls] == [
+        "2026-03-01",
+        "2026-01-01",
+        None,
+    ]
+    assert [call["period"] for call in client.workspace_summary_calls] == [
+        "EXPLICIT",
+        "EXPLICIT",
+        "YTD",
+    ]
+
+
+def test_merge_standard_horizon_results_records_partial_failures():
+    result = merge_standard_horizon_results(
+        gathered_results=[
+            RuntimeError("mtd timeout"),
+            (503, {"detail": "qtd unavailable"}),
+            (200, {"results_by_period": {"YTD": {"value": "YTD"}}}),
+        ],
+        month_start="2026-03-01",
+        quarter_start="2026-01-01",
+        report_end_date="2026-03-27",
+    )
+
+    assert result == (
+        200,
+        {
+            "results_by_period": {"YTD": {"value": "YTD"}},
+            "_gateway_warnings": [
+                "PERFORMANCE_HORIZON_MTD_UNAVAILABLE",
+                "PERFORMANCE_HORIZON_QTD_UNAVAILABLE",
+            ],
+            "_gateway_partial_failures": [
+                {
+                    "source_service": "lotus-performance",
+                    "error_code": "UPSTREAM_EXCEPTION",
+                    "detail": "mtd timeout",
+                },
+                {
+                    "source_service": "lotus-performance",
+                    "error_code": "HTTP_503",
+                    "detail": "qtd unavailable",
+                },
+            ],
+        },
+    )


### PR DESCRIPTION
## Summary
- Extract performance workspace horizon comparison fan-out and merge shaping into a dedicated helper module
- Add focused unit coverage for frequency de-duplication, explicit horizon request shaping, standard MTD/QTD/YTD merge behavior, and partial failure preservation
- Wire PerformanceWorkspaceService to the helper and remove migrated private horizon methods

## Validation
- python -m ruff check src/app/services/performance_workspace_horizon.py src/app/services/performance_workspace_service.py tests/unit/test_performance_workspace_horizon.py tests/unit/test_performance_workspace_service.py
- python -m mypy src
- python -m pytest tests/unit/test_performance_workspace_horizon.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary refactor with unchanged API contracts and operator behavior.