### PR TITLE
Refactor performance workspace dependency fetches

### DIFF
--- a/src/app/services/performance_workspace_dependencies.py
+++ b/src/app/services/performance_workspace_dependencies.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, TypeAlias, cast
+
+from app.services.async_ttl_cache import AsyncTtlCache
+from app.services.workspace_client_protocols import PerformanceWorkspaceAnalyticsClient
+
+UpstreamPayload: TypeAlias = dict[str, Any]
+UpstreamResult: TypeAlias = tuple[int, UpstreamPayload]
+GatheredResult: TypeAlias = UpstreamResult | BaseException
+
+
+async def fetch_workspace_summary_result(
+    *,
+    cache: AsyncTtlCache[Any],
+    analytics_client: PerformanceWorkspaceAnalyticsClient,
+    portfolio_id: str,
+    correlation_id: str,
+    report_end_date: str,
+    report_start_date: str | None,
+    effective_period: str,
+    chart_frequency: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    portfolio_currency: str,
+    segment: str,
+    include_detail_blocks: bool = True,
+) -> GatheredResult:
+    effective_report_start_date = report_start_date if effective_period == "EXPLICIT" else None
+    return cast(
+        GatheredResult,
+        await cache.get_or_set(
+            key=(
+                "workspace_summary",
+                portfolio_id,
+                report_end_date,
+                effective_report_start_date,
+                effective_period,
+                chart_frequency,
+                detail_basis,
+                benchmark_code,
+                portfolio_currency,
+                segment,
+                include_detail_blocks,
+            ),
+            factory=lambda: analytics_client.get_workspace_summary(
+                portfolio_id=portfolio_id,
+                report_end_date=report_end_date,
+                report_start_date=effective_report_start_date,
+                period=effective_period,
+                chart_frequency=chart_frequency,
+                detail_basis=detail_basis,
+                benchmark_id=benchmark_code,
+                reporting_currency=portfolio_currency,
+                segment=segment,
+                correlation_id=correlation_id,
+                include_detail_blocks=include_detail_blocks,
+            ),
+        ),
+    )
+
+
+async def fetch_workspace_detail_results(
+    *,
+    cache: AsyncTtlCache[Any],
+    analytics_client: PerformanceWorkspaceAnalyticsClient,
+    portfolio_id: str,
+    correlation_id: str,
+    report_start_date: str,
+    report_end_date: str,
+    requested_period: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    contribution_dimension: str,
+    attribution_dimension: str,
+) -> tuple[GatheredResult, GatheredResult]:
+    return cast(
+        tuple[GatheredResult, GatheredResult],
+        await asyncio.gather(
+            cache.get_or_set(
+                key=(
+                    "workspace_contribution_detail",
+                    portfolio_id,
+                    report_start_date,
+                    report_end_date,
+                    requested_period,
+                    detail_basis,
+                    contribution_dimension,
+                ),
+                factory=lambda: analytics_client.get_contribution_analytics(
+                    portfolio_id=portfolio_id,
+                    report_start_date=report_start_date,
+                    report_end_date=report_end_date,
+                    period=requested_period,
+                    metric_basis=detail_basis,
+                    dimension=contribution_dimension,
+                    correlation_id=correlation_id,
+                ),
+            ),
+            cache.get_or_set(
+                key=(
+                    "workspace_attribution_detail",
+                    portfolio_id,
+                    report_start_date,
+                    report_end_date,
+                    requested_period,
+                    detail_basis,
+                    benchmark_code,
+                    attribution_dimension,
+                ),
+                factory=lambda: _fetch_attribution_detail(
+                    analytics_client=analytics_client,
+                    portfolio_id=portfolio_id,
+                    correlation_id=correlation_id,
+                    report_start_date=report_start_date,
+                    report_end_date=report_end_date,
+                    requested_period=requested_period,
+                    detail_basis=detail_basis,
+                    benchmark_code=benchmark_code,
+                    attribution_dimension=attribution_dimension,
+                ),
+            ),
+            return_exceptions=True,
+        ),
+    )
+
+
+async def _fetch_attribution_detail(
+    *,
+    analytics_client: PerformanceWorkspaceAnalyticsClient,
+    portfolio_id: str,
+    correlation_id: str,
+    report_start_date: str,
+    report_end_date: str,
+    requested_period: str,
+    detail_basis: str,
+    benchmark_code: str | None,
+    attribution_dimension: str,
+) -> GatheredResult:
+    if not benchmark_code:
+        return 204, {}
+    return await analytics_client.get_attribution_analytics(
+        portfolio_id=portfolio_id,
+        report_start_date=report_start_date,
+        report_end_date=report_end_date,
+        period=requested_period,
+        metric_basis=detail_basis,
+        benchmark_id=benchmark_code,
+        dimension=attribution_dimension,
+        correlation_id=correlation_id,
+    )

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -103,15 +103,6 @@ from app.services.workspace_client_protocols import (
     PerformanceWorkspaceCoreClient,
 )
 
-STANDARD_PERIOD_ANALYSES = (
-    {"period": "MTD", "frequencies": ["daily", "monthly", "quarterly", "yearly"]},
-    {"period": "QTD", "frequencies": ["daily", "monthly", "quarterly", "yearly"]},
-    {"period": "YTD", "frequencies": ["daily", "monthly", "quarterly", "yearly"]},
-    {"period": "1Y", "frequencies": ["daily", "monthly", "quarterly", "yearly"]},
-    {"period": "3Y", "frequencies": ["daily", "monthly", "quarterly", "yearly"]},
-    {"period": "5Y", "frequencies": ["daily", "monthly", "quarterly", "yearly"]},
-)
-
 STANDARD_HORIZON_COMPARISON_PERIODS = ("MTD", "QTD", "YTD")
 LINEAGE_COMPLETION_POLL_ATTEMPTS = 3
 LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS = 0.25
@@ -1149,103 +1140,6 @@ class PerformanceWorkspaceService:
             warnings=warnings,
             partial_failures=partial_failures,
         )
-
-    async def _fetch_analytics_results(
-        self,
-        *,
-        portfolio_id: str,
-        correlation_id: str,
-        report_end_date: str,
-        report_start_date: str,
-        effective_period: str,
-        requested_period: str,
-        detail_basis: str,
-        benchmark_code: str | None,
-        contribution_dimension: str,
-        attribution_dimension: str,
-    ) -> tuple[GatheredResult, GatheredResult, GatheredResult, GatheredResult, GatheredResult]:
-        twr_analyses = self._build_twr_analyses(effective_period)
-        twr_report_start_date = report_start_date if effective_period == "EXPLICIT" else None
-        analytics_tasks = (
-            self._analytics_client.get_twr_analytics(
-                portfolio_id=portfolio_id,
-                report_end_date=report_end_date,
-                report_start_date=twr_report_start_date,
-                period=effective_period,
-                metric_basis="NET",
-                benchmark_id=benchmark_code,
-                correlation_id=correlation_id,
-                analyses=twr_analyses,
-            ),
-            self._analytics_client.get_twr_analytics(
-                portfolio_id=portfolio_id,
-                report_end_date=report_end_date,
-                report_start_date=twr_report_start_date,
-                period=effective_period,
-                metric_basis="GROSS",
-                benchmark_id=benchmark_code,
-                correlation_id=correlation_id,
-                analyses=twr_analyses,
-            ),
-            self._analytics_client.get_mwr_analytics(
-                portfolio_id=portfolio_id,
-                as_of_date=report_end_date,
-                window_start_date=report_start_date,
-                correlation_id=correlation_id,
-            ),
-            self._analytics_client.get_contribution_analytics(
-                portfolio_id=portfolio_id,
-                report_start_date=report_start_date,
-                report_end_date=report_end_date,
-                period=requested_period,
-                metric_basis=detail_basis,
-                dimension=contribution_dimension,
-                correlation_id=correlation_id,
-            ),
-            (
-                self._analytics_client.get_attribution_analytics(
-                    portfolio_id=portfolio_id,
-                    report_start_date=report_start_date,
-                    report_end_date=report_end_date,
-                    period=requested_period,
-                    metric_basis=detail_basis,
-                    benchmark_id=benchmark_code,
-                    dimension=attribution_dimension,
-                    correlation_id=correlation_id,
-                )
-                if benchmark_code
-                else self._empty_async_result()
-            ),
-        )
-        return cast(
-            tuple[GatheredResult, GatheredResult, GatheredResult, GatheredResult, GatheredResult],
-            await asyncio.gather(*analytics_tasks, return_exceptions=True),
-        )
-
-    def _build_twr_analyses(self, period: str) -> list[dict[str, object]]:
-        if period == "EXPLICIT":
-            return [
-                {
-                    "period": "EXPLICIT",
-                    "frequencies": ["daily", "monthly", "quarterly", "yearly"],
-                }
-            ]
-        requested_period = period.upper()
-        analyses: list[dict[str, object]] = []
-        seen_periods: set[str] = set()
-        for analysis in (
-            {
-                "period": requested_period,
-                "frequencies": ["daily", "monthly", "quarterly", "yearly"],
-            },
-            *STANDARD_PERIOD_ANALYSES,
-        ):
-            period_key = str(analysis["period"]).upper()
-            if period_key in seen_periods:
-                continue
-            seen_periods.add(period_key)
-            analyses.append(dict(analysis))
-        return analyses
 
     async def _resolve_report_end_date(
         self,

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from datetime import date
 from typing import Any, TypeAlias, cast
 
@@ -65,6 +65,10 @@ from app.services.performance_workspace_controls import (
     resolve_requested_window,
     resolve_workspace_summary_request,
     shift_years,
+)
+from app.services.performance_workspace_dependencies import (
+    fetch_workspace_detail_results,
+    fetch_workspace_summary_result,
 )
 from app.services.performance_workspace_evidence import (
     build_calculation_evidence_view,
@@ -614,7 +618,9 @@ class PerformanceWorkspaceService:
                 period=effective_period,
                 report_start_date=report_start_date,
             )
-            workspace_summary_result = await self._fetch_workspace_summary_result(
+            workspace_summary_result = await fetch_workspace_summary_result(
+                cache=self._upstream_cache,
+                analytics_client=self._analytics_client,
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 report_end_date=report_end_date,
@@ -661,7 +667,9 @@ class PerformanceWorkspaceService:
             (
                 contribution_detail_result,
                 attribution_detail_result,
-            ) = await self._fetch_workspace_detail_results(
+            ) = await fetch_workspace_detail_results(
+                cache=self._upstream_cache,
+                analytics_client=self._analytics_client,
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 report_start_date=report_start_date.isoformat(),
@@ -1235,123 +1243,6 @@ class PerformanceWorkspaceService:
         return resolve_workspace_summary_request(
             period=period,
             report_start_date=report_start_date,
-        )
-
-    async def _fetch_workspace_summary_result(
-        self,
-        *,
-        portfolio_id: str,
-        correlation_id: str,
-        report_end_date: str,
-        report_start_date: str | None,
-        effective_period: str,
-        chart_frequency: str,
-        detail_basis: str,
-        benchmark_code: str | None,
-        portfolio_currency: str,
-        segment: str,
-        include_detail_blocks: bool = True,
-    ) -> GatheredResult:
-        return cast(
-            GatheredResult,
-            await self._get_cached_upstream_result(
-                (
-                    "workspace_summary",
-                    portfolio_id,
-                    report_end_date,
-                    report_start_date if effective_period == "EXPLICIT" else None,
-                    effective_period,
-                    chart_frequency,
-                    detail_basis,
-                    benchmark_code,
-                    portfolio_currency,
-                    segment,
-                    include_detail_blocks,
-                ),
-                lambda: self._analytics_client.get_workspace_summary(
-                    portfolio_id=portfolio_id,
-                    report_end_date=report_end_date,
-                    report_start_date=report_start_date if effective_period == "EXPLICIT" else None,
-                    period=effective_period,
-                    chart_frequency=chart_frequency,
-                    detail_basis=detail_basis,
-                    benchmark_id=benchmark_code,
-                    reporting_currency=portfolio_currency,
-                    segment=segment,
-                    correlation_id=correlation_id,
-                    include_detail_blocks=include_detail_blocks,
-                ),
-            ),
-        )
-
-    async def _fetch_workspace_detail_results(
-        self,
-        *,
-        portfolio_id: str,
-        correlation_id: str,
-        report_start_date: str,
-        report_end_date: str,
-        requested_period: str,
-        detail_basis: str,
-        benchmark_code: str | None,
-        contribution_dimension: str,
-        attribution_dimension: str,
-    ) -> tuple[GatheredResult, GatheredResult]:
-        def contribution_loader() -> Awaitable[GatheredResult]:
-            return self._analytics_client.get_contribution_analytics(
-                portfolio_id=portfolio_id,
-                report_start_date=report_start_date,
-                report_end_date=report_end_date,
-                period=requested_period,
-                metric_basis=detail_basis,
-                dimension=contribution_dimension,
-                correlation_id=correlation_id,
-            )
-
-        def attribution_loader() -> Awaitable[GatheredResult]:
-            if not benchmark_code:
-                return self._empty_async_result()
-            return self._analytics_client.get_attribution_analytics(
-                portfolio_id=portfolio_id,
-                report_start_date=report_start_date,
-                report_end_date=report_end_date,
-                period=requested_period,
-                metric_basis=detail_basis,
-                benchmark_id=benchmark_code,
-                dimension=attribution_dimension,
-                correlation_id=correlation_id,
-            )
-
-        return cast(
-            tuple[GatheredResult, GatheredResult],
-            await asyncio.gather(
-                self._get_cached_upstream_result(
-                    (
-                        "workspace_contribution_detail",
-                        portfolio_id,
-                        report_start_date,
-                        report_end_date,
-                        requested_period,
-                        detail_basis,
-                        contribution_dimension,
-                    ),
-                    contribution_loader,
-                ),
-                self._get_cached_upstream_result(
-                    (
-                        "workspace_attribution_detail",
-                        portfolio_id,
-                        report_start_date,
-                        report_end_date,
-                        requested_period,
-                        detail_basis,
-                        benchmark_code,
-                        attribution_dimension,
-                    ),
-                    attribution_loader,
-                ),
-                return_exceptions=True,
-            ),
         )
 
     async def _empty_async_result(self) -> tuple[int, dict[str, Any]]:

--- a/tests/unit/test_performance_workspace_dependencies.py
+++ b/tests/unit/test_performance_workspace_dependencies.py
@@ -1,0 +1,172 @@
+from typing import Any
+
+import pytest
+
+from app.services.async_ttl_cache import AsyncTtlCache
+from app.services.performance_workspace_dependencies import (
+    fetch_workspace_detail_results,
+    fetch_workspace_summary_result,
+)
+
+
+class FakeAnalyticsClient:
+    def __init__(self) -> None:
+        self.workspace_summary_calls: list[dict[str, Any]] = []
+        self.contribution_calls: list[dict[str, Any]] = []
+        self.attribution_calls: list[dict[str, Any]] = []
+
+    async def get_workspace_summary(self, **kwargs):
+        self.workspace_summary_calls.append(kwargs)
+        return 200, {"summary_call": len(self.workspace_summary_calls)}
+
+    async def get_contribution_analytics(self, **kwargs):
+        self.contribution_calls.append(kwargs)
+        return 200, {"contribution_call": len(self.contribution_calls)}
+
+    async def get_attribution_analytics(self, **kwargs):
+        self.attribution_calls.append(kwargs)
+        return 200, {"attribution_call": len(self.attribution_calls)}
+
+    async def get_twr_analytics(self, *args, **kwargs):
+        raise AssertionError("not used by dependency helpers")
+
+    async def get_mwr_analytics(self, *args, **kwargs):
+        raise AssertionError("not used by dependency helpers")
+
+    async def get_execution(self, *args, **kwargs):
+        raise AssertionError("not used by dependency helpers")
+
+    async def get_lineage(self, *args, **kwargs):
+        raise AssertionError("not used by dependency helpers")
+
+    async def get_lineage_artifact(self, *args, **kwargs):
+        raise AssertionError("not used by dependency helpers")
+
+
+@pytest.mark.asyncio
+async def test_fetch_workspace_summary_result_caches_request_shape():
+    cache = AsyncTtlCache[Any](ttl_seconds=30)
+    client = FakeAnalyticsClient()
+
+    first_result = await fetch_workspace_summary_result(
+        cache=cache,
+        analytics_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-1",
+        report_end_date="2026-03-27",
+        report_start_date="2026-01-01",
+        effective_period="EXPLICIT",
+        chart_frequency="monthly",
+        detail_basis="NET",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+        portfolio_currency="USD",
+        segment="asset_class",
+        include_detail_blocks=False,
+    )
+    second_result = await fetch_workspace_summary_result(
+        cache=cache,
+        analytics_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-2",
+        report_end_date="2026-03-27",
+        report_start_date="2026-01-01",
+        effective_period="EXPLICIT",
+        chart_frequency="monthly",
+        detail_basis="NET",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+        portfolio_currency="USD",
+        segment="asset_class",
+        include_detail_blocks=False,
+    )
+
+    assert first_result == second_result == (200, {"summary_call": 1})
+    assert client.workspace_summary_calls == [
+        {
+            "portfolio_id": "DEMO_ADV_USD_001",
+            "report_end_date": "2026-03-27",
+            "report_start_date": "2026-01-01",
+            "period": "EXPLICIT",
+            "chart_frequency": "monthly",
+            "detail_basis": "NET",
+            "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+            "reporting_currency": "USD",
+            "segment": "asset_class",
+            "correlation_id": "corr-1",
+            "include_detail_blocks": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_workspace_summary_result_omits_non_explicit_start_date():
+    cache = AsyncTtlCache[Any](ttl_seconds=30)
+    client = FakeAnalyticsClient()
+
+    result = await fetch_workspace_summary_result(
+        cache=cache,
+        analytics_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-1",
+        report_end_date="2026-03-27",
+        report_start_date="2026-01-01",
+        effective_period="YTD",
+        chart_frequency="monthly",
+        detail_basis="NET",
+        benchmark_code=None,
+        portfolio_currency="USD",
+        segment="asset_class",
+    )
+
+    assert result == (200, {"summary_call": 1})
+    assert client.workspace_summary_calls[0]["report_start_date"] is None
+    assert client.workspace_summary_calls[0]["period"] == "YTD"
+
+
+@pytest.mark.asyncio
+async def test_fetch_workspace_detail_results_fetches_contribution_and_attribution():
+    cache = AsyncTtlCache[Any](ttl_seconds=30)
+    client = FakeAnalyticsClient()
+
+    contribution_result, attribution_result = await fetch_workspace_detail_results(
+        cache=cache,
+        analytics_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-1",
+        report_start_date="2026-01-01",
+        report_end_date="2026-03-27",
+        requested_period="EXPLICIT",
+        detail_basis="NET",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+        contribution_dimension="sector",
+        attribution_dimension="currency",
+    )
+
+    assert contribution_result == (200, {"contribution_call": 1})
+    assert attribution_result == (200, {"attribution_call": 1})
+    assert client.contribution_calls[0]["dimension"] == "sector"
+    assert client.attribution_calls[0]["dimension"] == "currency"
+    assert client.attribution_calls[0]["benchmark_id"] == "BMK_PB_GLOBAL_BALANCED_60_40"
+
+
+@pytest.mark.asyncio
+async def test_fetch_workspace_detail_results_skips_attribution_without_benchmark():
+    cache = AsyncTtlCache[Any](ttl_seconds=30)
+    client = FakeAnalyticsClient()
+
+    contribution_result, attribution_result = await fetch_workspace_detail_results(
+        cache=cache,
+        analytics_client=client,
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-1",
+        report_start_date="2026-01-01",
+        report_end_date="2026-03-27",
+        requested_period="EXPLICIT",
+        detail_basis="NET",
+        benchmark_code=None,
+        contribution_dimension="sector",
+        attribution_dimension="currency",
+    )
+
+    assert contribution_result == (200, {"contribution_call": 1})
+    assert attribution_result == (204, {})
+    assert client.attribution_calls == []


### PR DESCRIPTION
## Summary
- Remove an unused performance analytics fan-out path and obsolete TWR analysis builder
- Extract performance workspace summary/detail dependency fetch and cache orchestration into a dedicated helper module
- Add focused unit coverage for summary cache shape, non-explicit start-date handling, detail fetches, and no-benchmark attribution skip

## Validation
- python -m ruff check src/app/services/performance_workspace_dependencies.py src/app/services/performance_workspace_service.py tests/unit/test_performance_workspace_dependencies.py tests/unit/test_performance_workspace_service.py
- python -m mypy src/app/services/performance_workspace_dependencies.py src/app/services/performance_workspace_service.py
- python -m pytest tests/unit/test_performance_workspace_dependencies.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary refactor and dead-code removal with unchanged API contracts and operator behavior.