### PR TITLE
Refactor performance return mapping helpers

### DIFF
--- a/src/app/services/performance_workspace_returns.py
+++ b/src/app/services/performance_workspace_returns.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.contracts.performance_workspace import PerformanceComparativeSummary
+from app.services.performance_workspace_parsing import extract_return, quantize_optional, safe_str
+
+
+def extract_twr_workspace_block(period_payload: dict[str, Any], basis: str) -> dict[str, Any]:
+    portfolio_twr = period_payload.get("portfolio_twr", {})
+    if not isinstance(portfolio_twr, dict):
+        return {}
+    block = portfolio_twr.get(basis.lower(), {})
+    return block if isinstance(block, dict) else {}
+
+
+def build_workspace_comparative_summary(
+    *,
+    metric_basis: str,
+    portfolio_block: dict[str, Any],
+    benchmark_block: dict[str, Any],
+    active_basis_block: Any,
+) -> PerformanceComparativeSummary:
+    active_payload = active_basis_block if isinstance(active_basis_block, dict) else {}
+    economics = (
+        portfolio_block.get("summary", {}).get("economics", {})
+        if isinstance(portfolio_block.get("summary"), dict)
+        else {}
+    )
+    return PerformanceComparativeSummary(
+        metric_basis=metric_basis,
+        portfolio_return_pct=extract_return(portfolio_block, "summary", "period_return", "base"),
+        benchmark_return_pct=extract_return(benchmark_block, "summary", "period_return", "base"),
+        active_return_pct=extract_return(active_payload, "period_return", "base"),
+        annualized_return_pct=extract_return(
+            portfolio_block, "summary", "annualized_return", "base"
+        ),
+        benchmark_id=safe_str(benchmark_block.get("benchmark_id")),
+        benchmark_return_source=safe_str(benchmark_block.get("return_source")),
+        benchmark_input_mode=safe_str(benchmark_block.get("input_mode")),
+        begin_market_value=quantize_optional(economics.get("begin_market_value"))
+        if isinstance(economics, dict)
+        else None,
+        end_market_value=quantize_optional(economics.get("end_market_value"))
+        if isinstance(economics, dict)
+        else None,
+        beginning_cash_flow=quantize_optional(economics.get("beginning_cash_flow"))
+        if isinstance(economics, dict)
+        else None,
+        ending_cash_flow=quantize_optional(economics.get("ending_cash_flow"))
+        if isinstance(economics, dict)
+        else None,
+        flow_adjusted_end_market_value=quantize_optional(
+            economics.get("flow_adjusted_end_market_value")
+        )
+        if isinstance(economics, dict)
+        else None,
+        net_cash_flow=quantize_optional(economics.get("net_cash_flow"))
+        if isinstance(economics, dict)
+        else None,
+        fees=quantize_optional(economics.get("fees")) if isinstance(economics, dict) else None,
+    )

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -101,6 +101,10 @@ from app.services.performance_workspace_projection import (
     project_workspace_summary,
     snapshot_point_as_of_date,
 )
+from app.services.performance_workspace_returns import (
+    build_workspace_comparative_summary,
+    extract_twr_workspace_block,
+)
 from app.services.workbench_service import WorkbenchService
 from app.services.workspace_client_protocols import (
     PerformanceWorkspaceAnalyticsClient,
@@ -1308,19 +1312,19 @@ class PerformanceWorkspaceService:
 
         benchmark_block = period_payload.get("benchmark", {})
         active_block = period_payload.get("active", {})
-        net_block = self._extract_twr_workspace_block(period_payload, "net")
-        gross_block = self._extract_twr_workspace_block(period_payload, "gross")
+        net_block = extract_twr_workspace_block(period_payload, "net")
+        gross_block = extract_twr_workspace_block(period_payload, "gross")
         money_weighted_return = self._build_workspace_mwr_summary(period_payload)
         contribution = self._build_workspace_contribution(period_payload)
         attribution = self._build_workspace_attribution(period_payload)
 
-        net_summary = self._build_workspace_comparative_summary(
+        net_summary = build_workspace_comparative_summary(
             metric_basis="NET",
             portfolio_block=net_block,
             benchmark_block=benchmark_block,
             active_basis_block=active_block.get("net") if isinstance(active_block, dict) else {},
         )
-        gross_summary = self._build_workspace_comparative_summary(
+        gross_summary = build_workspace_comparative_summary(
             metric_basis="GROSS",
             portfolio_block=gross_block,
             benchmark_block=benchmark_block,
@@ -1419,8 +1423,8 @@ class PerformanceWorkspaceService:
                 continue
             benchmark_block = period_payload.get("benchmark", {})
             active_block = period_payload.get("active", {})
-            net_block = self._extract_twr_workspace_block(period_payload, "net")
-            gross_block = self._extract_twr_workspace_block(period_payload, "gross")
+            net_block = extract_twr_workspace_block(period_payload, "net")
+            gross_block = extract_twr_workspace_block(period_payload, "gross")
             net_summary_payload = (
                 net_block.get("summary", {}) if isinstance(net_block, dict) else {}
             )
@@ -1430,7 +1434,7 @@ class PerformanceWorkspaceService:
                 if isinstance(net_summary_payload, dict)
                 else {}
             )
-            comparative = self._build_workspace_comparative_summary(
+            comparative = build_workspace_comparative_summary(
                 metric_basis=detail_basis.upper(),
                 portfolio_block=net_block,
                 benchmark_block=benchmark_block if isinstance(benchmark_block, dict) else {},
@@ -1528,67 +1532,6 @@ class PerformanceWorkspaceService:
             if resolved_benchmark_code is None:
                 resolved_benchmark_code = comparative.benchmark_id
         return rows, resolved_benchmark_code
-
-    def _extract_twr_workspace_block(
-        self, period_payload: dict[str, Any], basis: str
-    ) -> dict[str, Any]:
-        portfolio_twr = period_payload.get("portfolio_twr", {})
-        if not isinstance(portfolio_twr, dict):
-            return {}
-        block = portfolio_twr.get(basis.lower(), {})
-        return block if isinstance(block, dict) else {}
-
-    def _build_workspace_comparative_summary(
-        self,
-        *,
-        metric_basis: str,
-        portfolio_block: dict[str, Any],
-        benchmark_block: dict[str, Any],
-        active_basis_block: Any,
-    ) -> PerformanceComparativeSummary:
-        active_payload = active_basis_block if isinstance(active_basis_block, dict) else {}
-        economics = (
-            portfolio_block.get("summary", {}).get("economics", {})
-            if isinstance(portfolio_block.get("summary"), dict)
-            else {}
-        )
-        return PerformanceComparativeSummary(
-            metric_basis=metric_basis,
-            portfolio_return_pct=extract_return(
-                portfolio_block, "summary", "period_return", "base"
-            ),
-            benchmark_return_pct=extract_return(
-                benchmark_block, "summary", "period_return", "base"
-            ),
-            active_return_pct=extract_return(active_payload, "period_return", "base"),
-            annualized_return_pct=extract_return(
-                portfolio_block, "summary", "annualized_return", "base"
-            ),
-            benchmark_id=safe_str(benchmark_block.get("benchmark_id")),
-            benchmark_return_source=safe_str(benchmark_block.get("return_source")),
-            benchmark_input_mode=safe_str(benchmark_block.get("input_mode")),
-            begin_market_value=quantize_optional(economics.get("begin_market_value"))
-            if isinstance(economics, dict)
-            else None,
-            end_market_value=quantize_optional(economics.get("end_market_value"))
-            if isinstance(economics, dict)
-            else None,
-            beginning_cash_flow=quantize_optional(economics.get("beginning_cash_flow"))
-            if isinstance(economics, dict)
-            else None,
-            ending_cash_flow=quantize_optional(economics.get("ending_cash_flow"))
-            if isinstance(economics, dict)
-            else None,
-            flow_adjusted_end_market_value=quantize_optional(
-                economics.get("flow_adjusted_end_market_value")
-            )
-            if isinstance(economics, dict)
-            else None,
-            net_cash_flow=quantize_optional(economics.get("net_cash_flow"))
-            if isinstance(economics, dict)
-            else None,
-            fees=quantize_optional(economics.get("fees")) if isinstance(economics, dict) else None,
-        )
 
     def _build_workspace_chart_points(
         self,

--- a/tests/unit/test_performance_workspace_returns.py
+++ b/tests/unit/test_performance_workspace_returns.py
@@ -1,0 +1,85 @@
+from app.services.performance_workspace_returns import (
+    build_workspace_comparative_summary,
+    extract_twr_workspace_block,
+)
+
+
+def test_extract_twr_workspace_block_returns_requested_basis_block():
+    period_payload = {
+        "portfolio_twr": {
+            "net": {"summary": {"period_return": {"base": 4.2}}},
+            "gross": {"summary": {"period_return": {"base": 4.6}}},
+        }
+    }
+
+    assert extract_twr_workspace_block(period_payload, "NET") == {
+        "summary": {"period_return": {"base": 4.2}}
+    }
+    assert extract_twr_workspace_block(period_payload, "gross") == {
+        "summary": {"period_return": {"base": 4.6}}
+    }
+
+
+def test_extract_twr_workspace_block_fails_closed_for_invalid_payloads():
+    assert extract_twr_workspace_block({"portfolio_twr": []}, "net") == {}
+    assert extract_twr_workspace_block({"portfolio_twr": {"net": []}}, "net") == {}
+    assert extract_twr_workspace_block({}, "net") == {}
+
+
+def test_build_workspace_comparative_summary_maps_returns_and_economics():
+    summary = build_workspace_comparative_summary(
+        metric_basis="NET",
+        portfolio_block={
+            "summary": {
+                "period_return": {"base": 5.4321},
+                "annualized_return": {"base": 8.7654},
+                "economics": {
+                    "begin_market_value": 1000000,
+                    "end_market_value": 1050000,
+                    "beginning_cash_flow": 10000,
+                    "ending_cash_flow": 5000,
+                    "flow_adjusted_end_market_value": 1045000,
+                    "net_cash_flow": 15000,
+                    "fees": 250,
+                },
+            }
+        },
+        benchmark_block={
+            "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+            "return_source": "calculated",
+            "input_mode": "stateful",
+            "summary": {"period_return": {"base": 4.25}},
+        },
+        active_basis_block={"period_return": {"base": 1.1821}},
+    )
+
+    assert summary.metric_basis == "NET"
+    assert summary.portfolio_return_pct == 5.4321
+    assert summary.benchmark_return_pct == 4.25
+    assert summary.active_return_pct == 1.1821
+    assert summary.annualized_return_pct == 8.7654
+    assert summary.benchmark_id == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert summary.benchmark_return_source == "calculated"
+    assert summary.benchmark_input_mode == "stateful"
+    assert summary.begin_market_value == 1000000
+    assert summary.end_market_value == 1050000
+    assert summary.beginning_cash_flow == 10000
+    assert summary.ending_cash_flow == 5000
+    assert summary.flow_adjusted_end_market_value == 1045000
+    assert summary.net_cash_flow == 15000
+    assert summary.fees == 250
+
+
+def test_build_workspace_comparative_summary_tolerates_missing_nested_blocks():
+    summary = build_workspace_comparative_summary(
+        metric_basis="NET",
+        portfolio_block={"summary": []},
+        benchmark_block={},
+        active_basis_block=[],
+    )
+
+    assert summary.metric_basis == "NET"
+    assert summary.portfolio_return_pct is None
+    assert summary.benchmark_return_pct is None
+    assert summary.active_return_pct is None
+    assert summary.begin_market_value is None


### PR DESCRIPTION
## Summary
- Extract performance workspace TWR block extraction and comparative return summary mapping into a dedicated helper module
- Add focused unit coverage for basis block extraction, fail-closed malformed payload handling, return/economics mapping, and missing nested payload tolerance
- Wire PerformanceWorkspaceService to the helper and remove migrated private mapping methods

## Validation
- python -m ruff check src/app/services/performance_workspace_returns.py src/app/services/performance_workspace_service.py tests/unit/test_performance_workspace_returns.py tests/unit/test_performance_workspace_service.py
- python -m mypy src/app/services/performance_workspace_returns.py src/app/services/performance_workspace_service.py
- python -m pytest tests/unit/test_performance_workspace_returns.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary refactor with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal mapping refactor.
- Stranded truth: checked before PR; no unmerged remote branches were present.