### PR TITLE
Refactor performance chart point helpers

### DIFF
--- a/src/app/services/performance_workspace_chart_points.py
+++ b/src/app/services/performance_workspace_chart_points.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.contracts.performance_workspace import PerformanceChartPoint
+from app.precision_policy import quantize_performance
+from app.services.performance_workspace_parsing import extract_return, safe_str
+
+
+def build_workspace_chart_points(
+    *,
+    portfolio_block: dict[str, Any],
+    benchmark_block: dict[str, Any],
+    chart_frequency: str,
+) -> list[PerformanceChartPoint]:
+    normalized_frequency = chart_frequency.lower()
+    portfolio_breakdowns = portfolio_block.get("breakdowns", {})
+    benchmark_breakdowns = benchmark_block.get("breakdowns", {})
+    if not isinstance(portfolio_breakdowns, dict):
+        return []
+    portfolio_rows = portfolio_breakdowns.get(normalized_frequency, [])
+    benchmark_rows = (
+        benchmark_breakdowns.get(normalized_frequency, [])
+        if isinstance(benchmark_breakdowns, dict)
+        else []
+    )
+    if not isinstance(portfolio_rows, list):
+        return []
+    points: list[PerformanceChartPoint] = []
+    for index, portfolio_row in enumerate(portfolio_rows):
+        if not isinstance(portfolio_row, dict):
+            continue
+        benchmark_row = (
+            benchmark_rows[index]
+            if index < len(benchmark_rows) and isinstance(benchmark_rows[index], dict)
+            else {}
+        )
+        portfolio_period = extract_return(portfolio_row, "period_return", "base")
+        benchmark_period = extract_return(benchmark_row, "period_return", "base")
+        portfolio_cumulative = extract_return(portfolio_row, "cumulative_return", "base")
+        benchmark_cumulative = extract_return(benchmark_row, "cumulative_return", "base")
+        active_period = None
+        active_cumulative = None
+        if portfolio_period is not None and benchmark_period is not None:
+            active_period = float(quantize_performance(portfolio_period - benchmark_period))
+        if portfolio_cumulative is not None and benchmark_cumulative is not None:
+            active_cumulative = float(
+                quantize_performance(portfolio_cumulative - benchmark_cumulative)
+            )
+        points.append(
+            PerformanceChartPoint(
+                label=str(portfolio_row.get("period", f"point-{index + 1}")),
+                frequency=normalized_frequency,
+                period_start=safe_str(portfolio_row.get("period_start")),
+                period_end=safe_str(portfolio_row.get("period_end")),
+                portfolio_return_pct=portfolio_period,
+                benchmark_return_pct=benchmark_period,
+                active_return_pct=active_period,
+                cumulative_portfolio_return_pct=portfolio_cumulative,
+                cumulative_benchmark_return_pct=benchmark_cumulative,
+                cumulative_active_return_pct=active_cumulative,
+            )
+        )
+    return points
+
+
+def parse_chart_points(
+    *,
+    portfolio_block: dict[str, Any],
+    benchmark_block: dict[str, Any],
+    relative_block: dict[str, Any],
+    chart_frequency: str,
+) -> list[PerformanceChartPoint]:
+    normalized_frequency = chart_frequency.lower()
+    portfolio_breakdowns = portfolio_block.get("breakdowns", {})
+    benchmark_breakdowns = benchmark_block.get("breakdowns", {})
+    relative_breakdowns = relative_block.get("breakdowns", {})
+    if not isinstance(portfolio_breakdowns, dict):
+        return []
+    portfolio_rows = portfolio_breakdowns.get(normalized_frequency, [])
+    benchmark_rows = (
+        benchmark_breakdowns.get(normalized_frequency, [])
+        if isinstance(benchmark_breakdowns, dict)
+        else []
+    )
+    relative_rows = (
+        relative_breakdowns.get(normalized_frequency, [])
+        if isinstance(relative_breakdowns, dict)
+        else []
+    )
+    if not isinstance(portfolio_rows, list):
+        return []
+    points: list[PerformanceChartPoint] = []
+    for index, portfolio_row in enumerate(portfolio_rows):
+        if not isinstance(portfolio_row, dict):
+            continue
+        benchmark_row = benchmark_rows[index] if index < len(benchmark_rows) else {}
+        relative_row = relative_rows[index] if index < len(relative_rows) else {}
+        if not isinstance(benchmark_row, dict):
+            benchmark_row = {}
+        if not isinstance(relative_row, dict):
+            relative_row = {}
+        points.append(
+            PerformanceChartPoint(
+                label=str(portfolio_row.get("period", f"point-{index + 1}")),
+                frequency=normalized_frequency,
+                period_start=safe_str(portfolio_row.get("period_start")),
+                period_end=safe_str(portfolio_row.get("period_end")),
+                portfolio_return_pct=extract_return(portfolio_row, "period_return", "base"),
+                benchmark_return_pct=extract_return(benchmark_row, "period_return", "base"),
+                active_return_pct=extract_return(relative_row, "period_return", "base"),
+                cumulative_portfolio_return_pct=extract_return(
+                    portfolio_row, "cumulative_return", "base"
+                ),
+                cumulative_benchmark_return_pct=extract_return(
+                    benchmark_row, "cumulative_return", "base"
+                ),
+                cumulative_active_return_pct=extract_return(
+                    relative_row, "cumulative_return", "base"
+                ),
+            )
+        )
+    return points

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -54,6 +54,10 @@ from app.services.performance_workspace_capabilities import (
     build_module_capability,
     build_workspace_capabilities,
 )
+from app.services.performance_workspace_chart_points import (
+    build_workspace_chart_points,
+    parse_chart_points,
+)
 from app.services.performance_workspace_controls import (
     build_attribution_trend_windows,
     last_day_of_month,
@@ -1330,12 +1334,12 @@ class PerformanceWorkspaceService:
             benchmark_block=benchmark_block,
             active_basis_block=active_block.get("gross") if isinstance(active_block, dict) else {},
         )
-        net_chart = self._build_workspace_chart_points(
+        net_chart = build_workspace_chart_points(
             portfolio_block=net_block,
             benchmark_block=benchmark_block,
             chart_frequency=chart_frequency,
         )
-        gross_chart = self._build_workspace_chart_points(
+        gross_chart = build_workspace_chart_points(
             portfolio_block=gross_block,
             benchmark_block=benchmark_block,
             chart_frequency=chart_frequency,
@@ -1532,63 +1536,6 @@ class PerformanceWorkspaceService:
             if resolved_benchmark_code is None:
                 resolved_benchmark_code = comparative.benchmark_id
         return rows, resolved_benchmark_code
-
-    def _build_workspace_chart_points(
-        self,
-        *,
-        portfolio_block: dict[str, Any],
-        benchmark_block: dict[str, Any],
-        chart_frequency: str,
-    ) -> list[PerformanceChartPoint]:
-        normalized_frequency = chart_frequency.lower()
-        portfolio_breakdowns = portfolio_block.get("breakdowns", {})
-        benchmark_breakdowns = benchmark_block.get("breakdowns", {})
-        if not isinstance(portfolio_breakdowns, dict):
-            return []
-        portfolio_rows = portfolio_breakdowns.get(normalized_frequency, [])
-        benchmark_rows = (
-            benchmark_breakdowns.get(normalized_frequency, [])
-            if isinstance(benchmark_breakdowns, dict)
-            else []
-        )
-        if not isinstance(portfolio_rows, list):
-            return []
-        points: list[PerformanceChartPoint] = []
-        for index, portfolio_row in enumerate(portfolio_rows):
-            if not isinstance(portfolio_row, dict):
-                continue
-            benchmark_row = (
-                benchmark_rows[index]
-                if index < len(benchmark_rows) and isinstance(benchmark_rows[index], dict)
-                else {}
-            )
-            portfolio_period = extract_return(portfolio_row, "period_return", "base")
-            benchmark_period = extract_return(benchmark_row, "period_return", "base")
-            portfolio_cumulative = extract_return(portfolio_row, "cumulative_return", "base")
-            benchmark_cumulative = extract_return(benchmark_row, "cumulative_return", "base")
-            active_period = None
-            active_cumulative = None
-            if portfolio_period is not None and benchmark_period is not None:
-                active_period = float(quantize_performance(portfolio_period - benchmark_period))
-            if portfolio_cumulative is not None and benchmark_cumulative is not None:
-                active_cumulative = float(
-                    quantize_performance(portfolio_cumulative - benchmark_cumulative)
-                )
-            points.append(
-                PerformanceChartPoint(
-                    label=str(portfolio_row.get("period", f"point-{index + 1}")),
-                    frequency=normalized_frequency,
-                    period_start=safe_str(portfolio_row.get("period_start")),
-                    period_end=safe_str(portfolio_row.get("period_end")),
-                    portfolio_return_pct=portfolio_period,
-                    benchmark_return_pct=benchmark_period,
-                    active_return_pct=active_period,
-                    cumulative_portfolio_return_pct=portfolio_cumulative,
-                    cumulative_benchmark_return_pct=benchmark_cumulative,
-                    cumulative_active_return_pct=active_cumulative,
-                )
-            )
-        return points
 
     def _build_workspace_mwr_summary(
         self, period_payload: dict[str, Any]
@@ -2018,7 +1965,7 @@ class PerformanceWorkspaceService:
                 benchmark_supportability.get("missing_benchmark_date_count")
             ),
         )
-        chart_points = self._parse_chart_points(
+        chart_points = parse_chart_points(
             portfolio_block=portfolio_block,
             benchmark_block=benchmark_block,
             relative_block=relative_block,
@@ -2045,65 +1992,6 @@ class PerformanceWorkspaceService:
         if normalized_requested_period == "EXPLICIT":
             return next(iter(results_by_period))
         return next(iter(results_by_period))
-
-    def _parse_chart_points(
-        self,
-        *,
-        portfolio_block: dict[str, Any],
-        benchmark_block: dict[str, Any],
-        relative_block: dict[str, Any],
-        chart_frequency: str,
-    ) -> list[PerformanceChartPoint]:
-        normalized_frequency = chart_frequency.lower()
-        portfolio_breakdowns = portfolio_block.get("breakdowns", {})
-        benchmark_breakdowns = benchmark_block.get("breakdowns", {})
-        relative_breakdowns = relative_block.get("breakdowns", {})
-        if not isinstance(portfolio_breakdowns, dict):
-            return []
-        portfolio_rows = portfolio_breakdowns.get(normalized_frequency, [])
-        benchmark_rows = (
-            benchmark_breakdowns.get(normalized_frequency, [])
-            if isinstance(benchmark_breakdowns, dict)
-            else []
-        )
-        relative_rows = (
-            relative_breakdowns.get(normalized_frequency, [])
-            if isinstance(relative_breakdowns, dict)
-            else []
-        )
-        if not isinstance(portfolio_rows, list):
-            return []
-        points: list[PerformanceChartPoint] = []
-        for index, portfolio_row in enumerate(portfolio_rows):
-            if not isinstance(portfolio_row, dict):
-                continue
-            benchmark_row = benchmark_rows[index] if index < len(benchmark_rows) else {}
-            relative_row = relative_rows[index] if index < len(relative_rows) else {}
-            if not isinstance(benchmark_row, dict):
-                benchmark_row = {}
-            if not isinstance(relative_row, dict):
-                relative_row = {}
-            points.append(
-                PerformanceChartPoint(
-                    label=str(portfolio_row.get("period", f"point-{index + 1}")),
-                    frequency=normalized_frequency,
-                    period_start=safe_str(portfolio_row.get("period_start")),
-                    period_end=safe_str(portfolio_row.get("period_end")),
-                    portfolio_return_pct=extract_return(portfolio_row, "period_return", "base"),
-                    benchmark_return_pct=extract_return(benchmark_row, "period_return", "base"),
-                    active_return_pct=extract_return(relative_row, "period_return", "base"),
-                    cumulative_portfolio_return_pct=extract_return(
-                        portfolio_row, "cumulative_return", "base"
-                    ),
-                    cumulative_benchmark_return_pct=extract_return(
-                        benchmark_row, "cumulative_return", "base"
-                    ),
-                    cumulative_active_return_pct=extract_return(
-                        relative_row, "cumulative_return", "base"
-                    ),
-                )
-            )
-        return points
 
     def _parse_mwr_result(
         self,

--- a/tests/unit/test_performance_workspace_chart_points.py
+++ b/tests/unit/test_performance_workspace_chart_points.py
@@ -1,0 +1,127 @@
+from app.services.performance_workspace_chart_points import (
+    build_workspace_chart_points,
+    parse_chart_points,
+)
+
+
+def test_build_workspace_chart_points_maps_active_returns_from_benchmark():
+    points = build_workspace_chart_points(
+        portfolio_block={
+            "breakdowns": {
+                "monthly": [
+                    {
+                        "period": "2026-01",
+                        "period_start": "2026-01-01",
+                        "period_end": "2026-01-31",
+                        "period_return": {"base": 2.34567},
+                        "cumulative_return": {"base": 4.56789},
+                    }
+                ]
+            }
+        },
+        benchmark_block={
+            "breakdowns": {
+                "monthly": [
+                    {
+                        "period_return": {"base": 1.11111},
+                        "cumulative_return": {"base": 3.22222},
+                    }
+                ]
+            }
+        },
+        chart_frequency="MONTHLY",
+    )
+
+    assert len(points) == 1
+    point = points[0]
+    assert point.label == "2026-01"
+    assert point.frequency == "monthly"
+    assert point.period_start == "2026-01-01"
+    assert point.period_end == "2026-01-31"
+    assert point.portfolio_return_pct == 2.34567
+    assert point.benchmark_return_pct == 1.11111
+    assert point.active_return_pct == 1.23456
+    assert point.cumulative_active_return_pct == 1.34567
+
+
+def test_build_workspace_chart_points_fails_closed_for_invalid_breakdowns():
+    assert (
+        build_workspace_chart_points(
+            portfolio_block={"breakdowns": []},
+            benchmark_block={},
+            chart_frequency="monthly",
+        )
+        == []
+    )
+    assert (
+        build_workspace_chart_points(
+            portfolio_block={"breakdowns": {"monthly": {}}},
+            benchmark_block={},
+            chart_frequency="monthly",
+        )
+        == []
+    )
+
+
+def test_parse_chart_points_uses_relative_active_returns_when_supplied():
+    points = parse_chart_points(
+        portfolio_block={
+            "breakdowns": {
+                "quarterly": [
+                    {
+                        "period": "2026-Q1",
+                        "period_return": {"base": 3.2},
+                        "cumulative_return": {"base": 3.2},
+                    }
+                ]
+            }
+        },
+        benchmark_block={
+            "breakdowns": {
+                "quarterly": [
+                    {
+                        "period_return": {"base": 2.5},
+                        "cumulative_return": {"base": 2.5},
+                    }
+                ]
+            }
+        },
+        relative_block={
+            "breakdowns": {
+                "quarterly": [
+                    {
+                        "period_return": {"base": 0.7},
+                        "cumulative_return": {"base": 0.7},
+                    }
+                ]
+            }
+        },
+        chart_frequency="QUARTERLY",
+    )
+
+    assert len(points) == 1
+    point = points[0]
+    assert point.label == "2026-Q1"
+    assert point.frequency == "quarterly"
+    assert point.portfolio_return_pct == 3.2
+    assert point.benchmark_return_pct == 2.5
+    assert point.active_return_pct == 0.7
+    assert point.cumulative_active_return_pct == 0.7
+
+
+def test_parse_chart_points_tolerates_missing_peer_rows():
+    points = parse_chart_points(
+        portfolio_block={
+            "breakdowns": {
+                "monthly": [{"period_return": {"base": 1.0}, "cumulative_return": {"base": 1.0}}]
+            }
+        },
+        benchmark_block={"breakdowns": {"monthly": []}},
+        relative_block={"breakdowns": {"monthly": []}},
+        chart_frequency="monthly",
+    )
+
+    assert len(points) == 1
+    assert points[0].label == "point-1"
+    assert points[0].benchmark_return_pct is None
+    assert points[0].active_return_pct is None


### PR DESCRIPTION
## Summary
- Extract performance workspace chart-point mapping into a dedicated helper module
- Add focused unit coverage for active return calculation, relative active return mapping, invalid breakdown handling, and missing peer rows
- Wire PerformanceWorkspaceService to the helper and remove migrated private chart parsing methods

## Validation
- python -m ruff check src/app/services/performance_workspace_chart_points.py src/app/services/performance_workspace_service.py tests/unit/test_performance_workspace_chart_points.py tests/unit/test_performance_workspace_service.py
- python -m mypy src/app/services/performance_workspace_chart_points.py src/app/services/performance_workspace_service.py
- python -m pytest tests/unit/test_performance_workspace_chart_points.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary refactor with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal mapping refactor.
- Stranded truth: no governance-bearing paths changed.