### PR TITLE
Refactor performance contribution helpers

### DIFF
--- a/src/app/services/performance_workspace_contribution.py
+++ b/src/app/services/performance_workspace_contribution.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.contracts.performance_workspace import (
+    ContributionLevelView,
+    ContributionPositionView,
+    ContributionRowView,
+    ContributionSmoothingEvidenceView,
+    ContributionSourceEconomicsEvidenceView,
+    ContributionSummaryView,
+)
+from app.precision_policy import quantize_performance
+from app.services.performance_workspace_parsing import (
+    format_key_label,
+    quantize_optional,
+    safe_int,
+    safe_str,
+    safe_str_list,
+    sum_optional,
+    weight_to_pct,
+)
+
+
+def build_workspace_contribution_summary(
+    period_payload: dict[str, Any],
+) -> ContributionSummaryView | None:
+    contribution_payload = period_payload.get("contribution", {})
+    if not isinstance(contribution_payload, dict):
+        return None
+    summary_payload = contribution_payload.get("summary", {})
+    if not isinstance(summary_payload, dict):
+        summary_payload = {}
+
+    return ContributionSummaryView(
+        metric_basis=safe_str(contribution_payload.get("metric_basis")) or "NET",
+        weighting_scheme=safe_str(summary_payload.get("weighting_scheme")),
+        portfolio_contribution_pct=quantize_optional(summary_payload.get("portfolio_contribution")),
+        total_portfolio_return_pct=quantize_optional(period_payload.get("total_portfolio_return")),
+        coverage_mv_pct=quantize_optional(summary_payload.get("coverage_mv_pct")),
+        portfolio_local_contribution_pct=quantize_optional(
+            summary_payload.get("local_contribution")
+        ),
+        portfolio_fx_contribution_pct=quantize_optional(summary_payload.get("fx_contribution")),
+        position_rows=_build_position_rows(
+            contribution_payload.get("position_contributions", []),
+            quantize_with_policy=False,
+        ),
+        levels=_build_workspace_contribution_levels(
+            levels_payload=contribution_payload.get("levels", []),
+            summary_payload=summary_payload,
+            period_payload=period_payload,
+        ),
+        smoothing_evidence=parse_contribution_smoothing_evidence(
+            period_payload.get("smoothing_evidence")
+        ),
+        source_economics_evidence=parse_contribution_source_economics_evidence(
+            contribution_payload.get("source_economics_evidence")
+        ),
+    )
+
+
+def build_detail_contribution_summary(
+    *,
+    period_payload: dict[str, Any],
+    metric_basis: str,
+    source_economics_payload: Any,
+) -> ContributionSummaryView | None:
+    summary_payload = period_payload.get("summary", {})
+    if not isinstance(summary_payload, dict):
+        summary_payload = {}
+
+    return ContributionSummaryView(
+        metric_basis=metric_basis,
+        weighting_scheme=safe_str(summary_payload.get("weighting_scheme")),
+        portfolio_contribution_pct=quantize_optional(summary_payload.get("portfolio_contribution")),
+        total_portfolio_return_pct=quantize_optional(period_payload.get("total_portfolio_return")),
+        coverage_mv_pct=quantize_optional(summary_payload.get("coverage_mv_pct")),
+        portfolio_local_contribution_pct=quantize_optional(
+            summary_payload.get("local_contribution")
+        ),
+        portfolio_fx_contribution_pct=quantize_optional(summary_payload.get("fx_contribution")),
+        position_rows=_build_position_rows(
+            period_payload.get("position_contributions", []),
+            quantize_with_policy=True,
+        ),
+        levels=_build_detail_contribution_levels(period_payload),
+        smoothing_evidence=parse_contribution_smoothing_evidence(
+            period_payload.get("smoothing_evidence")
+        ),
+        source_economics_evidence=parse_contribution_source_economics_evidence(
+            source_economics_payload
+        ),
+    )
+
+
+def merge_contribution_summary_views(
+    *,
+    summary_contribution: ContributionSummaryView | None,
+    detail_contribution: ContributionSummaryView | None,
+) -> ContributionSummaryView | None:
+    if detail_contribution is None:
+        return summary_contribution
+    if summary_contribution is None:
+        return detail_contribution
+
+    return ContributionSummaryView(
+        metric_basis=detail_contribution.metric_basis or summary_contribution.metric_basis,
+        weighting_scheme=(
+            detail_contribution.weighting_scheme or summary_contribution.weighting_scheme
+        ),
+        portfolio_contribution_pct=(
+            detail_contribution.portfolio_contribution_pct
+            if detail_contribution.portfolio_contribution_pct is not None
+            else summary_contribution.portfolio_contribution_pct
+        ),
+        total_portfolio_return_pct=(
+            detail_contribution.total_portfolio_return_pct
+            if detail_contribution.total_portfolio_return_pct is not None
+            else summary_contribution.total_portfolio_return_pct
+        ),
+        coverage_mv_pct=(
+            detail_contribution.coverage_mv_pct
+            if detail_contribution.coverage_mv_pct is not None
+            else summary_contribution.coverage_mv_pct
+        ),
+        portfolio_local_contribution_pct=(
+            detail_contribution.portfolio_local_contribution_pct
+            if detail_contribution.portfolio_local_contribution_pct is not None
+            else summary_contribution.portfolio_local_contribution_pct
+        ),
+        portfolio_fx_contribution_pct=(
+            detail_contribution.portfolio_fx_contribution_pct
+            if detail_contribution.portfolio_fx_contribution_pct is not None
+            else summary_contribution.portfolio_fx_contribution_pct
+        ),
+        position_rows=(
+            detail_contribution.position_rows
+            if detail_contribution.position_rows
+            else summary_contribution.position_rows
+        ),
+        levels=detail_contribution.levels or summary_contribution.levels,
+        smoothing_evidence=(
+            detail_contribution.smoothing_evidence or summary_contribution.smoothing_evidence
+        ),
+        source_economics_evidence=(
+            detail_contribution.source_economics_evidence
+            or summary_contribution.source_economics_evidence
+        ),
+    )
+
+
+def parse_contribution_smoothing_evidence(
+    payload: Any,
+) -> ContributionSmoothingEvidenceView | None:
+    if not isinstance(payload, dict):
+        return None
+    return ContributionSmoothingEvidenceView(
+        status=safe_str(payload.get("status")),
+        reason_codes=safe_str_list(payload.get("reason_codes")),
+        raw_contribution_pct=quantize_optional(payload.get("raw_contribution")),
+        final_contribution_pct=quantize_optional(payload.get("final_contribution")),
+        linked_return_pct=quantize_optional(payload.get("linked_return")),
+        smoothing_residual_pct=quantize_optional(payload.get("smoothing_residual")),
+    )
+
+
+def parse_contribution_source_economics_evidence(
+    payload: Any,
+) -> ContributionSourceEconomicsEvidenceView | None:
+    if not isinstance(payload, dict):
+        return None
+    return ContributionSourceEconomicsEvidenceView(
+        status=safe_str(payload.get("status")),
+        reason_codes=safe_str_list(payload.get("reason_codes")),
+        source_contracts=safe_str_list(payload.get("source_contracts")),
+        available_economics=safe_str_list(payload.get("available_economics")),
+        unsupported_economics=safe_str_list(payload.get("unsupported_economics")),
+        degraded_economics=safe_str_list(payload.get("degraded_economics")),
+        source_snapshot_count=safe_int(payload.get("source_snapshot_count")),
+    )
+
+
+def _build_workspace_contribution_levels(
+    *,
+    levels_payload: Any,
+    summary_payload: dict[str, Any],
+    period_payload: dict[str, Any],
+) -> list[ContributionLevelView]:
+    levels: list[ContributionLevelView] = []
+    if not isinstance(levels_payload, list):
+        return levels
+    for level_payload in levels_payload:
+        if not isinstance(level_payload, dict):
+            continue
+        rows = _build_contribution_rows(
+            level_payload.get("rows", []),
+            quantize_contribution_with_policy=False,
+            include_total_return=True,
+        )
+        source_level_return = quantize_optional(level_payload.get("total_portfolio_return"))
+        if source_level_return is None:
+            source_level_return = quantize_optional(period_payload.get("total_portfolio_return"))
+        levels.append(
+            ContributionLevelView(
+                level=int(level_payload.get("level", len(levels) + 1)),
+                name=str(level_payload.get("name", "Level")),
+                rows=rows,
+                total_contribution_pct=quantize_optional(
+                    summary_payload.get("portfolio_contribution")
+                ),
+                total_weight_avg_pct=sum_optional([row.weight_avg_pct for row in rows]),
+                total_portfolio_return_pct=source_level_return,
+            )
+        )
+    return levels
+
+
+def _build_detail_contribution_levels(
+    period_payload: dict[str, Any],
+) -> list[ContributionLevelView]:
+    levels_payload = period_payload.get("levels", [])
+    levels: list[ContributionLevelView] = []
+    if not isinstance(levels_payload, list):
+        return levels
+    for level_payload in levels_payload:
+        if not isinstance(level_payload, dict):
+            continue
+        rows = _build_contribution_rows(
+            level_payload.get("rows", []),
+            quantize_contribution_with_policy=True,
+            include_total_return=False,
+        )
+        source_level_total = quantize_optional(level_payload.get("total_contribution"))
+        if source_level_total is None:
+            source_level_total = quantize_optional(period_payload.get("total_contribution"))
+        source_level_return = quantize_optional(level_payload.get("total_portfolio_return"))
+        if source_level_return is None:
+            source_level_return = quantize_optional(period_payload.get("total_portfolio_return"))
+        levels.append(
+            ContributionLevelView(
+                level=int(level_payload.get("level", len(levels) + 1)),
+                name=str(level_payload.get("name", "Level")),
+                rows=rows,
+                total_contribution_pct=source_level_total
+                if source_level_total is not None
+                else (
+                    quantize_optional(sum(row.contribution_pct for row in rows)) if rows else None
+                ),
+                total_portfolio_return_pct=source_level_return,
+            )
+        )
+    return levels
+
+
+def _build_contribution_rows(
+    rows_payload: Any,
+    *,
+    quantize_contribution_with_policy: bool,
+    include_total_return: bool,
+) -> list[ContributionRowView]:
+    rows: list[ContributionRowView] = []
+    if not isinstance(rows_payload, list):
+        return rows
+    for row_payload in rows_payload:
+        if not isinstance(row_payload, dict):
+            continue
+        contribution = row_payload.get("contribution", 0.0)
+        contribution_pct = (
+            float(quantize_performance(contribution))
+            if quantize_contribution_with_policy
+            else quantize_optional(contribution) or 0.0
+        )
+        rows.append(
+            ContributionRowView(
+                key_label=format_key_label(row_payload.get("key")),
+                contribution_pct=contribution_pct,
+                weight_avg_pct=weight_to_pct(row_payload.get("weight_avg")),
+                total_return_pct=(
+                    quantize_optional(row_payload.get("return")) if include_total_return else None
+                ),
+                local_contribution_pct=quantize_optional(row_payload.get("local_contribution")),
+                fx_contribution_pct=quantize_optional(row_payload.get("fx_contribution")),
+                is_other=bool(row_payload.get("is_other", False)),
+            )
+        )
+    return rows
+
+
+def _build_position_rows(
+    position_payloads: Any,
+    *,
+    quantize_with_policy: bool,
+) -> list[ContributionPositionView]:
+    position_rows: list[ContributionPositionView] = []
+    if not isinstance(position_payloads, list):
+        return position_rows
+    for position_payload in position_payloads:
+        if not isinstance(position_payload, dict):
+            continue
+        total_contribution = position_payload.get("total_contribution", 0.0)
+        contribution_pct = (
+            float(quantize_performance(total_contribution))
+            if quantize_with_policy
+            else quantize_optional(total_contribution) or 0.0
+        )
+        position_rows.append(
+            ContributionPositionView(
+                position_id=str(position_payload.get("position_id", "Unknown Position")),
+                contribution_pct=contribution_pct,
+                weight_avg_pct=weight_to_pct(position_payload.get("average_weight")),
+                total_return_pct=quantize_optional(position_payload.get("total_return")),
+                local_contribution_pct=quantize_optional(
+                    position_payload.get("local_contribution")
+                ),
+                fx_contribution_pct=quantize_optional(position_payload.get("fx_contribution")),
+            )
+        )
+    return position_rows

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -15,11 +15,6 @@ from app.contracts.performance_workspace import (
     AttributionRowView,
     AttributionSummaryView,
     AttributionSupportabilityEvidenceView,
-    ContributionLevelView,
-    ContributionPositionView,
-    ContributionRowView,
-    ContributionSmoothingEvidenceView,
-    ContributionSourceEconomicsEvidenceView,
     ContributionSummaryView,
     MoneyWeightedReturnSummary,
     PerformanceAttributionTrendResponse,
@@ -57,6 +52,11 @@ from app.services.performance_workspace_capabilities import (
 from app.services.performance_workspace_chart_points import (
     build_workspace_chart_points,
     parse_chart_points,
+)
+from app.services.performance_workspace_contribution import (
+    build_detail_contribution_summary,
+    build_workspace_contribution_summary,
+    merge_contribution_summary_views,
 )
 from app.services.performance_workspace_controls import (
     build_attribution_trend_windows,
@@ -96,7 +96,6 @@ from app.services.performance_workspace_parsing import (
     safe_int,
     safe_str,
     safe_str_list,
-    sum_optional,
     weight_to_pct,
 )
 from app.services.performance_workspace_projection import (
@@ -688,7 +687,7 @@ class PerformanceWorkspaceService:
                 contribution_dimension=resolved_contribution_dimension,
                 attribution_dimension=resolved_attribution_dimension,
             )
-            contribution = self._merge_contribution_summary_views(
+            contribution = merge_contribution_summary_views(
                 summary_contribution=contribution,
                 detail_contribution=self._parse_contribution_result(
                     result=contribution_detail_result,
@@ -1319,7 +1318,7 @@ class PerformanceWorkspaceService:
         net_block = extract_twr_workspace_block(period_payload, "net")
         gross_block = extract_twr_workspace_block(period_payload, "gross")
         money_weighted_return = self._build_workspace_mwr_summary(period_payload)
-        contribution = self._build_workspace_contribution(period_payload)
+        contribution = build_workspace_contribution_summary(period_payload)
         attribution = self._build_workspace_attribution(period_payload)
 
         net_summary = build_workspace_comparative_summary(
@@ -1572,109 +1571,6 @@ class PerformanceWorkspaceService:
             net_cash_flow=quantize_optional(economics_payload.get("net_cash_flow")),
             fees=quantize_optional(economics_payload.get("fees")),
             notes=[str(note) for note in notes] if isinstance(notes, list) else [],
-        )
-
-    def _build_workspace_contribution(
-        self, period_payload: dict[str, Any]
-    ) -> ContributionSummaryView | None:
-        contribution_payload = period_payload.get("contribution", {})
-        if not isinstance(contribution_payload, dict):
-            return None
-        summary_payload = contribution_payload.get("summary", {})
-        if not isinstance(summary_payload, dict):
-            summary_payload = {}
-        smoothing_evidence = self._parse_contribution_smoothing_evidence(
-            period_payload.get("smoothing_evidence")
-        )
-        source_economics_evidence = self._parse_contribution_source_economics_evidence(
-            contribution_payload.get("source_economics_evidence")
-        )
-        levels_payload = contribution_payload.get("levels", [])
-        position_payloads = contribution_payload.get("position_contributions", [])
-        levels: list[ContributionLevelView] = []
-        if isinstance(levels_payload, list):
-            for level_payload in levels_payload:
-                if not isinstance(level_payload, dict):
-                    continue
-                rows_payload = level_payload.get("rows", [])
-                rows: list[ContributionRowView] = []
-                if isinstance(rows_payload, list):
-                    for row_payload in rows_payload:
-                        if not isinstance(row_payload, dict):
-                            continue
-                        rows.append(
-                            ContributionRowView(
-                                key_label=format_key_label(row_payload.get("key")),
-                                contribution_pct=quantize_optional(row_payload.get("contribution"))
-                                or 0.0,
-                                weight_avg_pct=weight_to_pct(row_payload.get("weight_avg")),
-                                total_return_pct=quantize_optional(row_payload.get("return")),
-                                local_contribution_pct=quantize_optional(
-                                    row_payload.get("local_contribution")
-                                ),
-                                fx_contribution_pct=quantize_optional(
-                                    row_payload.get("fx_contribution")
-                                ),
-                                is_other=bool(row_payload.get("is_other", False)),
-                            )
-                        )
-                source_level_return = quantize_optional(level_payload.get("total_portfolio_return"))
-                if source_level_return is None:
-                    source_level_return = quantize_optional(
-                        period_payload.get("total_portfolio_return")
-                    )
-                levels.append(
-                    ContributionLevelView(
-                        level=int(level_payload.get("level", len(levels) + 1)),
-                        name=str(level_payload.get("name", "Level")),
-                        rows=rows,
-                        total_contribution_pct=quantize_optional(
-                            summary_payload.get("portfolio_contribution")
-                        ),
-                        total_weight_avg_pct=sum_optional([row.weight_avg_pct for row in rows]),
-                        total_portfolio_return_pct=source_level_return,
-                    )
-                )
-        position_rows: list[ContributionPositionView] = []
-        if isinstance(position_payloads, list):
-            for position_payload in position_payloads:
-                if not isinstance(position_payload, dict):
-                    continue
-                position_rows.append(
-                    ContributionPositionView(
-                        position_id=str(position_payload.get("position_id", "Unknown Position")),
-                        contribution_pct=quantize_optional(
-                            position_payload.get("total_contribution")
-                        )
-                        or 0.0,
-                        weight_avg_pct=weight_to_pct(position_payload.get("average_weight")),
-                        total_return_pct=quantize_optional(position_payload.get("total_return")),
-                        local_contribution_pct=quantize_optional(
-                            position_payload.get("local_contribution")
-                        ),
-                        fx_contribution_pct=quantize_optional(
-                            position_payload.get("fx_contribution")
-                        ),
-                    )
-                )
-        return ContributionSummaryView(
-            metric_basis=safe_str(contribution_payload.get("metric_basis")) or "NET",
-            weighting_scheme=safe_str(summary_payload.get("weighting_scheme")),
-            portfolio_contribution_pct=quantize_optional(
-                summary_payload.get("portfolio_contribution")
-            ),
-            total_portfolio_return_pct=quantize_optional(
-                period_payload.get("total_portfolio_return")
-            ),
-            coverage_mv_pct=quantize_optional(summary_payload.get("coverage_mv_pct")),
-            portfolio_local_contribution_pct=quantize_optional(
-                summary_payload.get("local_contribution")
-            ),
-            portfolio_fx_contribution_pct=quantize_optional(summary_payload.get("fx_contribution")),
-            position_rows=position_rows,
-            levels=levels,
-            smoothing_evidence=smoothing_evidence,
-            source_economics_evidence=source_economics_evidence,
         )
 
     def _build_workspace_attribution(
@@ -2077,106 +1973,10 @@ class PerformanceWorkspaceService:
         period_payload = results_by_period.get(period_key, {})
         if not isinstance(period_payload, dict):
             return None
-        summary_payload = period_payload.get("summary", {})
-        levels_payload = period_payload.get("levels", [])
-        if not isinstance(summary_payload, dict):
-            summary_payload = {}
-        smoothing_evidence = self._parse_contribution_smoothing_evidence(
-            period_payload.get("smoothing_evidence")
-        )
-        source_economics_evidence = self._parse_contribution_source_economics_evidence(
-            payload.get("source_economics_evidence")
-        )
-        levels: list[ContributionLevelView] = []
-        if isinstance(levels_payload, list):
-            for level_payload in levels_payload:
-                if not isinstance(level_payload, dict):
-                    continue
-                rows: list[ContributionRowView] = []
-                row_payloads = level_payload.get("rows", [])
-                if isinstance(row_payloads, list):
-                    for row_payload in row_payloads:
-                        if not isinstance(row_payload, dict):
-                            continue
-                        rows.append(
-                            ContributionRowView(
-                                key_label=format_key_label(row_payload.get("key")),
-                                contribution_pct=float(
-                                    quantize_performance(row_payload.get("contribution", 0.0))
-                                ),
-                                weight_avg_pct=weight_to_pct(row_payload.get("weight_avg")),
-                                local_contribution_pct=quantize_optional(
-                                    row_payload.get("local_contribution")
-                                ),
-                                fx_contribution_pct=quantize_optional(
-                                    row_payload.get("fx_contribution")
-                                ),
-                                is_other=bool(row_payload.get("is_other", False)),
-                            )
-                        )
-                source_level_total = quantize_optional(level_payload.get("total_contribution"))
-                if source_level_total is None:
-                    source_level_total = quantize_optional(period_payload.get("total_contribution"))
-                source_level_return = quantize_optional(level_payload.get("total_portfolio_return"))
-                if source_level_return is None:
-                    source_level_return = quantize_optional(
-                        period_payload.get("total_portfolio_return")
-                    )
-                levels.append(
-                    ContributionLevelView(
-                        level=int(level_payload.get("level", len(levels) + 1)),
-                        name=str(level_payload.get("name", "Level")),
-                        rows=rows,
-                        total_contribution_pct=source_level_total
-                        if source_level_total is not None
-                        else (
-                            quantize_optional(sum(row.contribution_pct for row in rows))
-                            if rows
-                            else None
-                        ),
-                        total_portfolio_return_pct=source_level_return,
-                    )
-                )
-        position_rows: list[ContributionPositionView] = []
-        position_payloads = period_payload.get("position_contributions", [])
-        if isinstance(position_payloads, list):
-            for position_payload in position_payloads:
-                if not isinstance(position_payload, dict):
-                    continue
-                position_rows.append(
-                    ContributionPositionView(
-                        position_id=str(position_payload.get("position_id", "Unknown Position")),
-                        contribution_pct=float(
-                            quantize_performance(position_payload.get("total_contribution", 0.0))
-                        ),
-                        weight_avg_pct=weight_to_pct(position_payload.get("average_weight")),
-                        total_return_pct=quantize_optional(position_payload.get("total_return")),
-                        local_contribution_pct=quantize_optional(
-                            position_payload.get("local_contribution")
-                        ),
-                        fx_contribution_pct=quantize_optional(
-                            position_payload.get("fx_contribution")
-                        ),
-                    )
-                )
-        return ContributionSummaryView(
+        return build_detail_contribution_summary(
+            period_payload=period_payload,
             metric_basis=metric_basis,
-            weighting_scheme=safe_str(summary_payload.get("weighting_scheme")),
-            portfolio_contribution_pct=quantize_optional(
-                summary_payload.get("portfolio_contribution")
-            ),
-            total_portfolio_return_pct=quantize_optional(
-                period_payload.get("total_portfolio_return")
-            ),
-            coverage_mv_pct=quantize_optional(summary_payload.get("coverage_mv_pct")),
-            portfolio_local_contribution_pct=quantize_optional(
-                summary_payload.get("local_contribution")
-            ),
-            portfolio_fx_contribution_pct=quantize_optional(summary_payload.get("fx_contribution")),
-            position_rows=position_rows,
-            levels=levels,
-            smoothing_evidence=smoothing_evidence,
-            source_economics_evidence=source_economics_evidence,
+            source_economics_payload=payload.get("source_economics_evidence"),
         )
 
     def _parse_attribution_result(
@@ -2353,91 +2153,6 @@ class PerformanceWorkspaceService:
             currency_attribution_status=safe_str(payload.get("currency_attribution_status"))
             or "not_requested",
             linking_status=safe_str(payload.get("linking_status")) or "not_requested",
-        )
-
-    def _merge_contribution_summary_views(
-        self,
-        *,
-        summary_contribution: ContributionSummaryView | None,
-        detail_contribution: ContributionSummaryView | None,
-    ) -> ContributionSummaryView | None:
-        if detail_contribution is None:
-            return summary_contribution
-        if summary_contribution is None:
-            return detail_contribution
-
-        return ContributionSummaryView(
-            metric_basis=detail_contribution.metric_basis or summary_contribution.metric_basis,
-            weighting_scheme=(
-                detail_contribution.weighting_scheme or summary_contribution.weighting_scheme
-            ),
-            portfolio_contribution_pct=(
-                detail_contribution.portfolio_contribution_pct
-                if detail_contribution.portfolio_contribution_pct is not None
-                else summary_contribution.portfolio_contribution_pct
-            ),
-            total_portfolio_return_pct=(
-                detail_contribution.total_portfolio_return_pct
-                if detail_contribution.total_portfolio_return_pct is not None
-                else summary_contribution.total_portfolio_return_pct
-            ),
-            coverage_mv_pct=(
-                detail_contribution.coverage_mv_pct
-                if detail_contribution.coverage_mv_pct is not None
-                else summary_contribution.coverage_mv_pct
-            ),
-            portfolio_local_contribution_pct=(
-                detail_contribution.portfolio_local_contribution_pct
-                if detail_contribution.portfolio_local_contribution_pct is not None
-                else summary_contribution.portfolio_local_contribution_pct
-            ),
-            portfolio_fx_contribution_pct=(
-                detail_contribution.portfolio_fx_contribution_pct
-                if detail_contribution.portfolio_fx_contribution_pct is not None
-                else summary_contribution.portfolio_fx_contribution_pct
-            ),
-            position_rows=(
-                detail_contribution.position_rows
-                if detail_contribution.position_rows
-                else summary_contribution.position_rows
-            ),
-            levels=detail_contribution.levels or summary_contribution.levels,
-            smoothing_evidence=(
-                detail_contribution.smoothing_evidence or summary_contribution.smoothing_evidence
-            ),
-            source_economics_evidence=(
-                detail_contribution.source_economics_evidence
-                or summary_contribution.source_economics_evidence
-            ),
-        )
-
-    def _parse_contribution_smoothing_evidence(
-        self, payload: Any
-    ) -> ContributionSmoothingEvidenceView | None:
-        if not isinstance(payload, dict):
-            return None
-        return ContributionSmoothingEvidenceView(
-            status=safe_str(payload.get("status")),
-            reason_codes=safe_str_list(payload.get("reason_codes")),
-            raw_contribution_pct=quantize_optional(payload.get("raw_contribution")),
-            final_contribution_pct=quantize_optional(payload.get("final_contribution")),
-            linked_return_pct=quantize_optional(payload.get("linked_return")),
-            smoothing_residual_pct=quantize_optional(payload.get("smoothing_residual")),
-        )
-
-    def _parse_contribution_source_economics_evidence(
-        self, payload: Any
-    ) -> ContributionSourceEconomicsEvidenceView | None:
-        if not isinstance(payload, dict):
-            return None
-        return ContributionSourceEconomicsEvidenceView(
-            status=safe_str(payload.get("status")),
-            reason_codes=safe_str_list(payload.get("reason_codes")),
-            source_contracts=safe_str_list(payload.get("source_contracts")),
-            available_economics=safe_str_list(payload.get("available_economics")),
-            unsupported_economics=safe_str_list(payload.get("unsupported_economics")),
-            degraded_economics=safe_str_list(payload.get("degraded_economics")),
-            source_snapshot_count=safe_int(payload.get("source_snapshot_count")),
         )
 
     def _parse_attribution_trend_results(

--- a/tests/unit/test_performance_workspace_contribution.py
+++ b/tests/unit/test_performance_workspace_contribution.py
@@ -1,0 +1,155 @@
+from app.services.performance_workspace_contribution import (
+    build_detail_contribution_summary,
+    build_workspace_contribution_summary,
+    merge_contribution_summary_views,
+    parse_contribution_smoothing_evidence,
+    parse_contribution_source_economics_evidence,
+)
+
+
+def test_build_workspace_contribution_summary_maps_period_payload():
+    summary = build_workspace_contribution_summary(
+        {
+            "total_portfolio_return": 3.25,
+            "smoothing_evidence": {
+                "status": "smoothed",
+                "reason_codes": ["LINKING_RESIDUAL"],
+                "raw_contribution": 3.24999,
+                "final_contribution": 3.25,
+                "linked_return": 3.25,
+                "smoothing_residual": 0.00001,
+            },
+            "contribution": {
+                "metric_basis": "GROSS",
+                "summary": {
+                    "weighting_scheme": "beginning_market_value",
+                    "portfolio_contribution": 3.25,
+                    "coverage_mv_pct": 98.5,
+                    "local_contribution": 3.0,
+                    "fx_contribution": 0.25,
+                },
+                "levels": [
+                    {
+                        "level": 1,
+                        "name": "Asset Class",
+                        "total_portfolio_return": 3.25,
+                        "rows": [
+                            {
+                                "key": {"asset_class": "Equity"},
+                                "contribution": 2.5,
+                                "weight_avg": 0.6,
+                                "return": 4.1,
+                                "local_contribution": 2.4,
+                                "fx_contribution": 0.1,
+                            }
+                        ],
+                    }
+                ],
+                "position_contributions": [
+                    {
+                        "position_id": "POS_1",
+                        "total_contribution": 1.2,
+                        "average_weight": 0.2,
+                        "total_return": 6.0,
+                    }
+                ],
+                "source_economics_evidence": {
+                    "status": "complete",
+                    "source_contracts": ["lotus-performance.contribution.v1"],
+                    "available_economics": ["local_contribution"],
+                    "source_snapshot_count": 2,
+                },
+            },
+        }
+    )
+
+    assert summary is not None
+    assert summary.metric_basis == "GROSS"
+    assert summary.portfolio_contribution_pct == 3.25
+    assert summary.total_portfolio_return_pct == 3.25
+    assert summary.coverage_mv_pct == 98.5
+    assert summary.levels[0].name == "Asset Class"
+    assert summary.levels[0].rows[0].key_label == "Equity"
+    assert summary.levels[0].rows[0].weight_avg_pct == 60.0
+    assert summary.position_rows[0].position_id == "POS_1"
+    assert summary.smoothing_evidence is not None
+    assert summary.smoothing_evidence.status == "smoothed"
+    assert summary.source_economics_evidence is not None
+    assert summary.source_economics_evidence.source_snapshot_count == 2
+
+
+def test_build_detail_contribution_summary_maps_independent_payload():
+    summary = build_detail_contribution_summary(
+        metric_basis="NET",
+        source_economics_payload={
+            "status": "partial",
+            "reason_codes": ["MISSING_FX"],
+            "unsupported_economics": ["fx_contribution"],
+        },
+        period_payload={
+            "total_contribution": 1.23456,
+            "total_portfolio_return": 2.34567,
+            "summary": {"portfolio_contribution": 1.23456},
+            "levels": [
+                {
+                    "level": 2,
+                    "name": "Sector",
+                    "rows": [{"key": {"sector": "Technology"}, "contribution": 1.23456}],
+                }
+            ],
+            "position_contributions": [{"position_id": "POS_2", "total_contribution": 0.22222}],
+        },
+    )
+
+    assert summary is not None
+    assert summary.metric_basis == "NET"
+    assert summary.portfolio_contribution_pct == 1.23456
+    assert summary.levels[0].total_contribution_pct == 1.23456
+    assert summary.levels[0].rows[0].contribution_pct == 1.23456
+    assert summary.position_rows[0].contribution_pct == 0.22222
+    assert summary.source_economics_evidence is not None
+    assert summary.source_economics_evidence.reason_codes == ["MISSING_FX"]
+
+
+def test_merge_contribution_summary_views_prefers_detail_when_present():
+    summary = build_workspace_contribution_summary(
+        {
+            "total_portfolio_return": 3.0,
+            "contribution": {
+                "metric_basis": "NET",
+                "summary": {"portfolio_contribution": 3.0, "coverage_mv_pct": 90.0},
+                "levels": [
+                    {
+                        "name": "Summary",
+                        "rows": [{"key": {"asset_class": "Cash"}, "contribution": 3.0}],
+                    }
+                ],
+            },
+        }
+    )
+    detail = build_detail_contribution_summary(
+        metric_basis="NET",
+        source_economics_payload={},
+        period_payload={
+            "summary": {"portfolio_contribution": 3.1},
+            "levels": [
+                {"name": "Detail", "rows": [{"key": {"asset_class": "Cash"}, "contribution": 3.1}]}
+            ],
+        },
+    )
+
+    merged = merge_contribution_summary_views(
+        summary_contribution=summary,
+        detail_contribution=detail,
+    )
+
+    assert merged is not None
+    assert merged.portfolio_contribution_pct == 3.1
+    assert merged.coverage_mv_pct == 90.0
+    assert merged.levels[0].name == "Detail"
+
+
+def test_contribution_evidence_parsers_fail_closed_for_invalid_payloads():
+    assert parse_contribution_smoothing_evidence([]) is None
+    assert parse_contribution_source_economics_evidence([]) is None
+    assert build_workspace_contribution_summary({"contribution": []}) is None


### PR DESCRIPTION
## Summary
- Extract performance workspace contribution mapping and contribution evidence parsing into a dedicated helper module
- Add focused unit coverage for workspace contribution payloads, independent detail contribution payloads, merge precedence, and fail-closed evidence parsing
- Wire PerformanceWorkspaceService to the helper and remove migrated private contribution mapping methods

## Validation
- python -m ruff check src/app/services/performance_workspace_contribution.py src/app/services/performance_workspace_service.py tests/unit/test_performance_workspace_contribution.py tests/unit/test_performance_workspace_service.py
- python -m mypy src/app/services/performance_workspace_contribution.py src/app/services/performance_workspace_service.py
- python -m pytest tests/unit/test_performance_workspace_contribution.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary refactor with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal mapping refactor.
- Stranded truth: no governance-bearing paths changed.