### PR TITLE
Refactor performance MWR helpers

### DIFF
--- a/src/app/services/performance_workspace_mwr.py
+++ b/src/app/services/performance_workspace_mwr.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.contracts.performance_workspace import MoneyWeightedReturnSummary
+from app.services.performance_workspace_parsing import (
+    quantize_optional,
+    safe_bool,
+    safe_str,
+    safe_str_list,
+)
+
+
+def build_workspace_mwr_summary(
+    period_payload: dict[str, Any],
+) -> MoneyWeightedReturnSummary | None:
+    mwr_payload = period_payload.get("money_weighted_return", {})
+    if not isinstance(mwr_payload, dict):
+        return None
+    economics_payload = mwr_payload.get("economics", {})
+    if not isinstance(economics_payload, dict):
+        economics_payload = {}
+    return MoneyWeightedReturnSummary(
+        money_weighted_return_pct=quantize_optional(mwr_payload.get("period_return")),
+        annualized_return_pct=quantize_optional(mwr_payload.get("annualized_return")),
+        holding_period_return_pct=quantize_optional(mwr_payload.get("holding_period_return")),
+        input_mode=safe_str(mwr_payload.get("input_mode")),
+        method=safe_str(mwr_payload.get("method")),
+        status=safe_str(mwr_payload.get("status")),
+        reason_codes=safe_str_list(mwr_payload.get("reason_codes")),
+        warnings=safe_str_list(mwr_payload.get("warnings")),
+        is_annualized_primary=safe_bool(mwr_payload.get("is_annualized_primary")),
+        fallback_from=safe_str(mwr_payload.get("fallback_from")),
+        fallback_reason=safe_str(mwr_payload.get("fallback_reason")),
+        is_approximation=safe_bool(mwr_payload.get("is_approximation")),
+        start_date=safe_str(mwr_payload.get("start_date")),
+        end_date=safe_str(mwr_payload.get("end_date")),
+        begin_market_value=quantize_optional(economics_payload.get("begin_market_value")),
+        end_market_value=quantize_optional(economics_payload.get("end_market_value")),
+        beginning_cash_flow=quantize_optional(economics_payload.get("beginning_cash_flow")),
+        ending_cash_flow=quantize_optional(economics_payload.get("ending_cash_flow")),
+        flow_adjusted_end_market_value=quantize_optional(
+            economics_payload.get("flow_adjusted_end_market_value")
+        ),
+        net_cash_flow=quantize_optional(economics_payload.get("net_cash_flow")),
+        fees=quantize_optional(economics_payload.get("fees")),
+        notes=_safe_notes(mwr_payload.get("notes", [])),
+    )
+
+
+def build_detail_mwr_summary(payload: dict[str, Any]) -> MoneyWeightedReturnSummary:
+    return MoneyWeightedReturnSummary(
+        money_weighted_return_pct=quantize_optional(payload.get("money_weighted_return")),
+        annualized_return_pct=quantize_optional(payload.get("mwr_annualized")),
+        holding_period_return_pct=quantize_optional(payload.get("holding_period_return")),
+        method=safe_str(payload.get("method")),
+        status=safe_str(payload.get("status")),
+        reason_codes=safe_str_list(payload.get("reason_codes")),
+        warnings=safe_str_list(payload.get("warnings")),
+        is_annualized_primary=safe_bool(payload.get("is_annualized_primary")),
+        fallback_from=safe_str(payload.get("fallback_from")),
+        fallback_reason=safe_str(payload.get("fallback_reason")),
+        is_approximation=safe_bool(payload.get("is_approximation")),
+        start_date=safe_str(payload.get("start_date")),
+        end_date=safe_str(payload.get("end_date")),
+        notes=_safe_notes(payload.get("notes", [])),
+    )
+
+
+def _safe_notes(payload: Any) -> list[str]:
+    return [str(note) for note in payload] if isinstance(payload, list) else []

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -87,11 +87,14 @@ from app.services.performance_workspace_evidence import (
     resolve_evidence_state,
 )
 from app.services.performance_workspace_horizon import fetch_workspace_horizon_dependencies
+from app.services.performance_workspace_mwr import (
+    build_detail_mwr_summary,
+    build_workspace_mwr_summary,
+)
 from app.services.performance_workspace_parsing import (
     extract_return,
     format_attribution_trend_label,
     quantize_optional,
-    safe_bool,
     safe_int,
     safe_str,
     safe_str_list,
@@ -1315,7 +1318,7 @@ class PerformanceWorkspaceService:
         active_block = period_payload.get("active", {})
         net_block = extract_twr_workspace_block(period_payload, "net")
         gross_block = extract_twr_workspace_block(period_payload, "gross")
-        money_weighted_return = self._build_workspace_mwr_summary(period_payload)
+        money_weighted_return = build_workspace_mwr_summary(period_payload)
         contribution = build_workspace_contribution_summary(period_payload)
         attribution = build_workspace_attribution_summary(period_payload)
 
@@ -1533,43 +1536,6 @@ class PerformanceWorkspaceService:
             if resolved_benchmark_code is None:
                 resolved_benchmark_code = comparative.benchmark_id
         return rows, resolved_benchmark_code
-
-    def _build_workspace_mwr_summary(
-        self, period_payload: dict[str, Any]
-    ) -> MoneyWeightedReturnSummary | None:
-        mwr_payload = period_payload.get("money_weighted_return", {})
-        if not isinstance(mwr_payload, dict):
-            return None
-        economics_payload = mwr_payload.get("economics", {})
-        if not isinstance(economics_payload, dict):
-            economics_payload = {}
-        notes = mwr_payload.get("notes", [])
-        return MoneyWeightedReturnSummary(
-            money_weighted_return_pct=quantize_optional(mwr_payload.get("period_return")),
-            annualized_return_pct=quantize_optional(mwr_payload.get("annualized_return")),
-            holding_period_return_pct=quantize_optional(mwr_payload.get("holding_period_return")),
-            input_mode=safe_str(mwr_payload.get("input_mode")),
-            method=safe_str(mwr_payload.get("method")),
-            status=safe_str(mwr_payload.get("status")),
-            reason_codes=safe_str_list(mwr_payload.get("reason_codes")),
-            warnings=safe_str_list(mwr_payload.get("warnings")),
-            is_annualized_primary=safe_bool(mwr_payload.get("is_annualized_primary")),
-            fallback_from=safe_str(mwr_payload.get("fallback_from")),
-            fallback_reason=safe_str(mwr_payload.get("fallback_reason")),
-            is_approximation=safe_bool(mwr_payload.get("is_approximation")),
-            start_date=safe_str(mwr_payload.get("start_date")),
-            end_date=safe_str(mwr_payload.get("end_date")),
-            begin_market_value=quantize_optional(economics_payload.get("begin_market_value")),
-            end_market_value=quantize_optional(economics_payload.get("end_market_value")),
-            beginning_cash_flow=quantize_optional(economics_payload.get("beginning_cash_flow")),
-            ending_cash_flow=quantize_optional(economics_payload.get("ending_cash_flow")),
-            flow_adjusted_end_market_value=quantize_optional(
-                economics_payload.get("flow_adjusted_end_market_value")
-            ),
-            net_cash_flow=quantize_optional(economics_payload.get("net_cash_flow")),
-            fees=quantize_optional(economics_payload.get("fees")),
-            notes=[str(note) for note in notes] if isinstance(notes, list) else [],
-        )
 
     def _parse_benchmark_catalog_result(
         self,
@@ -1826,23 +1792,7 @@ class PerformanceWorkspaceService:
                 )
             )
             return None
-        notes = payload.get("notes", [])
-        return MoneyWeightedReturnSummary(
-            money_weighted_return_pct=quantize_optional(payload.get("money_weighted_return")),
-            annualized_return_pct=quantize_optional(payload.get("mwr_annualized")),
-            holding_period_return_pct=quantize_optional(payload.get("holding_period_return")),
-            method=safe_str(payload.get("method")),
-            status=safe_str(payload.get("status")),
-            reason_codes=safe_str_list(payload.get("reason_codes")),
-            warnings=safe_str_list(payload.get("warnings")),
-            is_annualized_primary=safe_bool(payload.get("is_annualized_primary")),
-            fallback_from=safe_str(payload.get("fallback_from")),
-            fallback_reason=safe_str(payload.get("fallback_reason")),
-            is_approximation=safe_bool(payload.get("is_approximation")),
-            start_date=safe_str(payload.get("start_date")),
-            end_date=safe_str(payload.get("end_date")),
-            notes=[str(note) for note in notes] if isinstance(notes, list) else [],
-        )
+        return build_detail_mwr_summary(payload)
 
     def _parse_contribution_result(
         self,

--- a/tests/unit/test_performance_workspace_mwr.py
+++ b/tests/unit/test_performance_workspace_mwr.py
@@ -1,0 +1,99 @@
+from app.services.performance_workspace_mwr import (
+    build_detail_mwr_summary,
+    build_workspace_mwr_summary,
+)
+
+
+def test_build_workspace_mwr_summary_maps_economics_and_notes():
+    summary = build_workspace_mwr_summary(
+        {
+            "money_weighted_return": {
+                "period_return": 14.05,
+                "annualized_return": 16.1,
+                "holding_period_return": 3.05,
+                "input_mode": "stateful",
+                "method": "XIRR",
+                "status": "CALCULATED",
+                "reason_codes": ["STATEFUL_CASH_FLOWS"],
+                "warnings": ["FLOW_TIMING_APPROXIMATED"],
+                "is_annualized_primary": True,
+                "fallback_from": "DAILY_MWR",
+                "fallback_reason": "INSUFFICIENT_DAILY_POINTS",
+                "is_approximation": False,
+                "start_date": "2026-01-01",
+                "end_date": "2026-03-27",
+                "economics": {
+                    "begin_market_value": 450000.0,
+                    "end_market_value": 508870.0,
+                    "beginning_cash_flow": 30000.0,
+                    "ending_cash_flow": -7500.0,
+                    "flow_adjusted_end_market_value": 486370.0,
+                    "net_cash_flow": 22500.0,
+                    "fees": 0.0,
+                },
+                "notes": ["client contribution included"],
+            }
+        }
+    )
+
+    assert summary is not None
+    assert summary.money_weighted_return_pct == 14.05
+    assert summary.annualized_return_pct == 16.1
+    assert summary.holding_period_return_pct == 3.05
+    assert summary.input_mode == "stateful"
+    assert summary.method == "XIRR"
+    assert summary.reason_codes == ["STATEFUL_CASH_FLOWS"]
+    assert summary.warnings == ["FLOW_TIMING_APPROXIMATED"]
+    assert summary.is_annualized_primary is True
+    assert summary.is_approximation is False
+    assert summary.begin_market_value == 450000.0
+    assert summary.end_market_value == 508870.0
+    assert summary.beginning_cash_flow == 30000.0
+    assert summary.ending_cash_flow == -7500.0
+    assert summary.flow_adjusted_end_market_value == 486370.0
+    assert summary.net_cash_flow == 22500.0
+    assert summary.fees == 0.0
+    assert summary.notes == ["client contribution included"]
+
+
+def test_build_detail_mwr_summary_maps_independent_payload():
+    summary = build_detail_mwr_summary(
+        {
+            "money_weighted_return": 7.25,
+            "mwr_annualized": 9.1,
+            "holding_period_return": 2.2,
+            "method": "MODIFIED_DIETZ",
+            "status": "APPROXIMATED",
+            "reason_codes": ["DAILY_CASH_FLOW_MISSING"],
+            "warnings": ["USING_PERIOD_FLOWS"],
+            "is_annualized_primary": False,
+            "fallback_from": "XIRR",
+            "fallback_reason": "NO_ROOT",
+            "is_approximation": True,
+            "start_date": "2026-02-01",
+            "end_date": "2026-02-28",
+            "notes": ["fallback applied"],
+        }
+    )
+
+    assert summary.money_weighted_return_pct == 7.25
+    assert summary.annualized_return_pct == 9.1
+    assert summary.method == "MODIFIED_DIETZ"
+    assert summary.status == "APPROXIMATED"
+    assert summary.reason_codes == ["DAILY_CASH_FLOW_MISSING"]
+    assert summary.warnings == ["USING_PERIOD_FLOWS"]
+    assert summary.is_annualized_primary is False
+    assert summary.is_approximation is True
+    assert summary.notes == ["fallback applied"]
+
+
+def test_mwr_summary_builders_fail_closed_for_invalid_nested_payloads():
+    assert build_workspace_mwr_summary({"money_weighted_return": []}) is None
+
+    summary = build_workspace_mwr_summary(
+        {"money_weighted_return": {"economics": [], "notes": "not-a-list"}}
+    )
+
+    assert summary is not None
+    assert summary.begin_market_value is None
+    assert summary.notes == []


### PR DESCRIPTION
## Summary
- Extract performance workspace money-weighted return mapping into a dedicated helper module
- Add focused unit coverage for embedded workspace MWR economics, independent MWR payloads, and fail-closed invalid nested payloads
- Wire PerformanceWorkspaceService to the helper and remove migrated private MWR mapping methods

## Validation
- python -m ruff check src/app/services/performance_workspace_mwr.py src/app/services/performance_workspace_service.py tests/unit/test_performance_workspace_mwr.py tests/unit/test_performance_workspace_service.py
- python -m mypy src/app/services/performance_workspace_mwr.py src/app/services/performance_workspace_service.py
- python -m pytest tests/unit/test_performance_workspace_mwr.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary refactor with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal mapping refactor.
- Stranded truth: no governance-bearing paths changed.