### PR TITLE
Remove performance projection wrappers

### DIFF
--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -98,7 +98,6 @@ from app.services.performance_workspace_projection import (
     project_portfolio_performance_snapshot,
     project_workspace_details,
     project_workspace_summary,
-    snapshot_point_as_of_date,
 )
 from app.services.performance_workspace_returns import (
     build_workspace_comparative_summary,
@@ -220,7 +219,7 @@ class PerformanceWorkspaceService:
             include_benchmark_catalog=True,
             include_detail_blocks=False,
         )
-        return self._project_workspace_summary(workspace)
+        return project_workspace_summary(workspace)
 
     async def get_performance_workspace_details(
         self,
@@ -251,7 +250,7 @@ class PerformanceWorkspaceService:
             include_detail_blocks=True,
             prefer_independent_detail_analytics=True,
         )
-        return self._project_workspace_details(workspace)
+        return project_workspace_details(workspace)
 
     async def get_portfolio_performance_snapshot(
         self,
@@ -279,7 +278,7 @@ class PerformanceWorkspaceService:
             include_benchmark_catalog=False,
             include_detail_blocks=False,
         )
-        return self._project_portfolio_performance_snapshot(workspace)
+        return project_portfolio_performance_snapshot(workspace)
 
     async def get_performance_horizon_comparison(
         self,
@@ -807,24 +806,6 @@ class PerformanceWorkspaceService:
                 detail=detail,
             )
         return content, content_type
-
-    def _project_workspace_summary(
-        self, workspace: PerformanceWorkspaceResponse
-    ) -> PerformanceWorkspaceSummaryResponse:
-        return project_workspace_summary(workspace)
-
-    def _project_workspace_details(
-        self, workspace: PerformanceWorkspaceResponse
-    ) -> PerformanceWorkspaceDetailsResponse:
-        return project_workspace_details(workspace)
-
-    def _project_portfolio_performance_snapshot(
-        self, workspace: PerformanceWorkspaceResponse
-    ) -> PortfolioPerformanceSnapshotResponse:
-        return project_portfolio_performance_snapshot(workspace)
-
-    def _snapshot_point_as_of_date(self, point: PerformanceChartPoint) -> str:
-        return snapshot_point_as_of_date(point)
 
     def _capability(
         self,

--- a/tests/unit/test_performance_workspace_service.py
+++ b/tests/unit/test_performance_workspace_service.py
@@ -3,7 +3,6 @@ import asyncio
 import pytest
 from fastapi import HTTPException
 
-from app.contracts.performance_workspace import PerformanceChartPoint
 from app.contracts.workbench import (
     WorkbenchOverviewResponse,
     WorkbenchOverviewSummary,
@@ -2021,33 +2020,6 @@ async def test_performance_workspace_service_projects_portfolio_performance_snap
     assert response.sparkline[0].as_of_date == "2026-01-31"
     assert response.sparkline[0].portfolio_return_pct == 2.0
     assert query_client.benchmark_catalog_calls == []
-
-
-@pytest.mark.asyncio
-async def test_performance_workspace_service_projects_snapshot_point_dates_from_fallback_fields():
-    service = PerformanceWorkspaceService(
-        workbench_service=_StubWorkbenchService(),
-        analytics_client=_StubAnalyticsClient(),
-        lotus_core_query_client=_StubLotusCoreQueryClient(),
-    )
-
-    point_with_period_start = PerformanceChartPoint(
-        label="2026-01-31",
-        frequency="monthly",
-        period_start="2026-01-01",
-        period_end=None,
-        portfolio_return_pct=2.0,
-    )
-    point_with_label_only = PerformanceChartPoint(
-        label="2026-02-28",
-        frequency="monthly",
-        period_start=None,
-        period_end=None,
-        portfolio_return_pct=4.1,
-    )
-
-    assert service._snapshot_point_as_of_date(point_with_period_start) == "2026-01-01"
-    assert service._snapshot_point_as_of_date(point_with_label_only) == "2026-02-28"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Wire performance workspace summary, detail, and snapshot projections directly to the projection helper module
- Remove redundant private projection wrapper methods from PerformanceWorkspaceService
- Drop duplicate service-level snapshot date fallback coverage now owned by performance workspace projection tests

## Validation
- python -m ruff check src/app/services/performance_workspace_service.py tests/unit/test_performance_workspace_service.py tests/unit/test_performance_workspace_projection.py
- python -m mypy src/app/services/performance_workspace_service.py
- python -m pytest tests/unit/test_performance_workspace_projection.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal projection cleanup.
- Stranded truth: no governance-bearing paths changed.