### PR TITLE
Extract performance evidence retrieval

### DIFF
--- a/src/app/services/performance_workspace_evidence.py
+++ b/src/app/services/performance_workspace_evidence.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping, Sequence
 from typing import Any, TypeAlias
 
@@ -19,10 +20,14 @@ from app.services.source_supportability import (
     extract_calculation_supportability,
     source_supportability_reason,
 )
+from app.services.workspace_client_protocols import PerformanceWorkspaceAnalyticsClient
 
 UpstreamPayload: TypeAlias = dict[str, Any]
 UpstreamResult: TypeAlias = tuple[int, UpstreamPayload]
 GatheredResult: TypeAlias = UpstreamResult | BaseException
+
+DEFAULT_LINEAGE_COMPLETION_POLL_ATTEMPTS = 3
+DEFAULT_LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS = 0.25
 
 
 def extract_calculation_id_from_result(result: GatheredResult | None) -> str | None:
@@ -209,6 +214,106 @@ def execution_lineage_stage_complete(execution_result: UpstreamResult) -> bool:
         and str(stage.get("stage_name", "")).lower() == "lineage_materialization"
         and str(stage.get("status", "")).lower() == "complete"
         for stage in stages
+    )
+
+
+async def refresh_execution_after_lineage_completion(
+    *,
+    analytics_client: PerformanceWorkspaceAnalyticsClient,
+    calculation_id: str,
+    correlation_id: str,
+    execution_result: UpstreamResult,
+) -> UpstreamResult:
+    if execution_lineage_stage_complete(execution_result):
+        return execution_result
+    refreshed_result = await analytics_client.get_execution(
+        calculation_id=calculation_id,
+        correlation_id=correlation_id,
+    )
+    if refreshed_result[0] >= 400:
+        return execution_result
+    return refreshed_result
+
+
+async def await_recent_evidence_completion(
+    *,
+    analytics_client: PerformanceWorkspaceAnalyticsClient,
+    calculation_id: str,
+    correlation_id: str,
+    execution_result: UpstreamResult,
+    lineage_result: UpstreamResult,
+    poll_attempts: int = DEFAULT_LINEAGE_COMPLETION_POLL_ATTEMPTS,
+    poll_interval_seconds: float = DEFAULT_LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS,
+) -> tuple[UpstreamResult, UpstreamResult]:
+    if not execution_is_complete(execution_result):
+        return execution_result, lineage_result
+    if lineage_is_complete(lineage_result):
+        refreshed_execution = await refresh_execution_after_lineage_completion(
+            analytics_client=analytics_client,
+            calculation_id=calculation_id,
+            correlation_id=correlation_id,
+            execution_result=execution_result,
+        )
+        return refreshed_execution, lineage_result
+    if not lineage_is_transient(lineage_result):
+        return execution_result, lineage_result
+
+    latest_result = lineage_result
+    for _ in range(poll_attempts):
+        if poll_interval_seconds > 0:
+            await asyncio.sleep(poll_interval_seconds)
+        latest_result = await analytics_client.get_lineage(
+            calculation_id=calculation_id,
+            correlation_id=correlation_id,
+        )
+        if lineage_is_complete(latest_result):
+            refreshed_execution = await refresh_execution_after_lineage_completion(
+                analytics_client=analytics_client,
+                calculation_id=calculation_id,
+                correlation_id=correlation_id,
+                execution_result=execution_result,
+            )
+            return refreshed_execution, latest_result
+        if not lineage_is_transient(latest_result):
+            return execution_result, latest_result
+    return execution_result, latest_result
+
+
+async def fetch_calculation_evidence(
+    *,
+    analytics_client: PerformanceWorkspaceAnalyticsClient,
+    portfolio_id: str,
+    calculation_role: str,
+    calculation_id: str,
+    correlation_id: str,
+    poll_attempts: int = DEFAULT_LINEAGE_COMPLETION_POLL_ATTEMPTS,
+    poll_interval_seconds: float = DEFAULT_LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS,
+) -> PerformanceCalculationEvidenceView:
+    execution_result, lineage_result = await asyncio.gather(
+        analytics_client.get_execution(
+            calculation_id=calculation_id,
+            correlation_id=correlation_id,
+        ),
+        analytics_client.get_lineage(
+            calculation_id=calculation_id,
+            correlation_id=correlation_id,
+        ),
+    )
+    execution_result, lineage_result = await await_recent_evidence_completion(
+        analytics_client=analytics_client,
+        calculation_id=calculation_id,
+        correlation_id=correlation_id,
+        execution_result=execution_result,
+        lineage_result=lineage_result,
+        poll_attempts=poll_attempts,
+        poll_interval_seconds=poll_interval_seconds,
+    )
+    return build_calculation_evidence_view(
+        portfolio_id=portfolio_id,
+        calculation_role=calculation_role,
+        calculation_id=calculation_id,
+        execution_result=execution_result,
+        lineage_result=lineage_result,
     )
 
 

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -15,7 +15,6 @@ from app.contracts.performance_workspace import (
     PerformanceAttributionTrendResponse,
     PerformanceAttributionTrendRow,
     PerformanceBenchmarkOptionView,
-    PerformanceCalculationEvidenceView,
     PerformanceChartPoint,
     PerformanceComparativeSummary,
     PerformanceEvidenceView,
@@ -64,14 +63,10 @@ from app.services.performance_workspace_dependencies import (
     fetch_workspace_summary_result,
 )
 from app.services.performance_workspace_evidence import (
-    build_calculation_evidence_view,
     build_performance_evidence_view,
     build_source_supportability,
-    execution_is_complete,
-    execution_lineage_stage_complete,
     extract_calculation_id_from_result,
-    lineage_is_complete,
-    lineage_is_transient,
+    fetch_calculation_evidence,
     resolve_evidence_reason,
     resolve_evidence_state,
 )
@@ -105,7 +100,6 @@ from app.services.workspace_client_protocols import (
 )
 
 STANDARD_HORIZON_COMPARISON_PERIODS = ("MTD", "QTD", "YTD")
-LINEAGE_COMPLETION_POLL_ATTEMPTS = 3
 LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS = 0.25
 
 UpstreamPayload: TypeAlias = dict[str, Any]
@@ -837,11 +831,13 @@ class PerformanceWorkspaceService:
 
         evidence_items = await asyncio.gather(
             *[
-                self._fetch_calculation_evidence(
+                fetch_calculation_evidence(
+                    analytics_client=self._analytics_client,
                     portfolio_id=portfolio_id,
                     calculation_role=role,
                     calculation_id=calculation_id,
                     correlation_id=correlation_id,
+                    poll_interval_seconds=LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS,
                 )
                 for role, calculation_id in requested_items
             ]
@@ -932,94 +928,6 @@ class PerformanceWorkspaceService:
             calculations=evidence_items,
             source_supportability=source_supportability,
         )
-
-    async def _fetch_calculation_evidence(
-        self,
-        *,
-        portfolio_id: str,
-        calculation_role: str,
-        calculation_id: str,
-        correlation_id: str,
-    ) -> PerformanceCalculationEvidenceView:
-        execution_result, lineage_result = await asyncio.gather(
-            self._analytics_client.get_execution(
-                calculation_id=calculation_id,
-                correlation_id=correlation_id,
-            ),
-            self._analytics_client.get_lineage(
-                calculation_id=calculation_id,
-                correlation_id=correlation_id,
-            ),
-        )
-        execution_result, lineage_result = await self._await_recent_evidence_completion(
-            calculation_id=calculation_id,
-            correlation_id=correlation_id,
-            execution_result=execution_result,
-            lineage_result=lineage_result,
-        )
-        return build_calculation_evidence_view(
-            portfolio_id=portfolio_id,
-            calculation_role=calculation_role,
-            calculation_id=calculation_id,
-            execution_result=execution_result,
-            lineage_result=lineage_result,
-        )
-
-    async def _await_recent_evidence_completion(
-        self,
-        *,
-        calculation_id: str,
-        correlation_id: str,
-        execution_result: UpstreamResult,
-        lineage_result: UpstreamResult,
-    ) -> tuple[UpstreamResult, UpstreamResult]:
-        if not execution_is_complete(execution_result):
-            return execution_result, lineage_result
-        if lineage_is_complete(lineage_result):
-            refreshed_execution = await self._refresh_execution_after_lineage_completion(
-                calculation_id=calculation_id,
-                correlation_id=correlation_id,
-                execution_result=execution_result,
-            )
-            return refreshed_execution, lineage_result
-        if not lineage_is_transient(lineage_result):
-            return execution_result, lineage_result
-
-        latest_result = lineage_result
-        for _ in range(LINEAGE_COMPLETION_POLL_ATTEMPTS):
-            if LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS > 0:
-                await asyncio.sleep(LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS)
-            latest_result = await self._analytics_client.get_lineage(
-                calculation_id=calculation_id,
-                correlation_id=correlation_id,
-            )
-            if lineage_is_complete(latest_result):
-                refreshed_execution = await self._refresh_execution_after_lineage_completion(
-                    calculation_id=calculation_id,
-                    correlation_id=correlation_id,
-                    execution_result=execution_result,
-                )
-                return refreshed_execution, latest_result
-            if not lineage_is_transient(latest_result):
-                return execution_result, latest_result
-        return execution_result, latest_result
-
-    async def _refresh_execution_after_lineage_completion(
-        self,
-        *,
-        calculation_id: str,
-        correlation_id: str,
-        execution_result: UpstreamResult,
-    ) -> UpstreamResult:
-        if execution_lineage_stage_complete(execution_result):
-            return execution_result
-        refreshed_result = await self._analytics_client.get_execution(
-            calculation_id=calculation_id,
-            correlation_id=correlation_id,
-        )
-        if refreshed_result[0] >= 400:
-            return execution_result
-        return refreshed_result
 
     async def _determine_report_end_date(
         self,

--- a/tests/unit/test_performance_workspace_evidence.py
+++ b/tests/unit/test_performance_workspace_evidence.py
@@ -1,9 +1,12 @@
+import pytest
+
 from app.contracts.performance_workspace import (
     PerformanceCalculationEvidenceView,
     PerformanceEvidenceUpstreamSnapshotView,
     PerformanceSourceSupportabilityView,
 )
 from app.services.performance_workspace_evidence import (
+    await_recent_evidence_completion,
     build_calculation_evidence_view,
     build_performance_evidence_view,
     build_source_supportability,
@@ -11,12 +14,37 @@ from app.services.performance_workspace_evidence import (
     execution_is_complete,
     execution_lineage_stage_complete,
     extract_calculation_id_from_result,
+    fetch_calculation_evidence,
     gateway_evidence_artifact_url,
     lineage_is_complete,
     lineage_is_transient,
+    refresh_execution_after_lineage_completion,
     resolve_evidence_reason,
     resolve_evidence_state,
 )
+
+
+class _EvidenceAnalyticsClient:
+    def __init__(
+        self,
+        *,
+        execution_results: list[tuple[int, dict]],
+        lineage_results: list[tuple[int, dict]],
+    ) -> None:
+        self.execution_results = execution_results
+        self.lineage_results = lineage_results
+        self.execution_calls: list[str] = []
+        self.lineage_calls: list[str] = []
+
+    async def get_execution(self, *, calculation_id: str, correlation_id: str):
+        _ = correlation_id
+        self.execution_calls.append(calculation_id)
+        return self.execution_results.pop(0)
+
+    async def get_lineage(self, *, calculation_id: str, correlation_id: str):
+        _ = correlation_id
+        self.lineage_calls.append(calculation_id)
+        return self.lineage_results.pop(0)
 
 
 def test_extract_calculation_id_from_result_returns_stable_string_id():
@@ -115,6 +143,136 @@ def test_evidence_completion_helpers_fail_closed_for_bad_payloads():
     assert not execution_is_complete((500, {"status": "complete"}))
     assert not lineage_is_complete((200, {"status": "pending"}))
     assert not lineage_is_transient((404, {"status": "pending"}))
+
+
+@pytest.mark.asyncio
+async def test_refresh_execution_after_lineage_completion_keeps_complete_stage_result():
+    execution_result = (
+        200,
+        {
+            "status": "complete",
+            "stages": [
+                {
+                    "stage_name": "lineage_materialization",
+                    "status": "complete",
+                }
+            ],
+        },
+    )
+    client = _EvidenceAnalyticsClient(
+        execution_results=[(200, {"status": "complete"})],
+        lineage_results=[],
+    )
+
+    refreshed = await refresh_execution_after_lineage_completion(
+        analytics_client=client,
+        calculation_id="calc-1",
+        correlation_id="corr-1",
+        execution_result=execution_result,
+    )
+
+    assert refreshed == execution_result
+    assert client.execution_calls == []
+
+
+@pytest.mark.asyncio
+async def test_await_recent_evidence_completion_polls_and_refreshes_execution_stage():
+    execution_result = (
+        200,
+        {
+            "status": "complete",
+            "stages": [
+                {
+                    "stage_name": "lineage_materialization",
+                    "status": "in_progress",
+                }
+            ],
+        },
+    )
+    refreshed_execution = (
+        200,
+        {
+            "status": "complete",
+            "stages": [
+                {
+                    "stage_name": "lineage_materialization",
+                    "status": "complete",
+                }
+            ],
+        },
+    )
+    client = _EvidenceAnalyticsClient(
+        execution_results=[refreshed_execution],
+        lineage_results=[
+            (
+                200,
+                {
+                    "calculation_id": "calc-1",
+                    "status": "complete",
+                    "artifacts": {"response.json": {}},
+                },
+            )
+        ],
+    )
+
+    refreshed_execution_result, refreshed_lineage_result = await await_recent_evidence_completion(
+        analytics_client=client,
+        calculation_id="calc-1",
+        correlation_id="corr-1",
+        execution_result=execution_result,
+        lineage_result=(200, {"calculation_id": "calc-1", "status": "pending"}),
+        poll_attempts=2,
+        poll_interval_seconds=0,
+    )
+
+    assert refreshed_execution_result == refreshed_execution
+    assert refreshed_lineage_result[1]["status"] == "complete"
+    assert client.execution_calls == ["calc-1"]
+    assert client.lineage_calls == ["calc-1"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_calculation_evidence_returns_partial_lineage_evidence_after_poll_limit():
+    client = _EvidenceAnalyticsClient(
+        execution_results=[
+            (
+                200,
+                {
+                    "analytics_type": "WORKSPACE_SUMMARY",
+                    "execution_mode": "sync",
+                    "status": "complete",
+                    "stages": [
+                        {
+                            "stage_name": "lineage_materialization",
+                            "status": "in_progress",
+                        }
+                    ],
+                    "upstream_snapshots": [],
+                },
+            )
+        ],
+        lineage_results=[
+            (200, {"calculation_id": "calc-1", "status": "pending", "artifacts": {}}),
+            (200, {"calculation_id": "calc-1", "status": "pending", "artifacts": {}}),
+        ],
+    )
+
+    evidence = await fetch_calculation_evidence(
+        analytics_client=client,
+        portfolio_id="PORT-1",
+        calculation_role="workspace_summary",
+        calculation_id="calc-1",
+        correlation_id="corr-1",
+        poll_attempts=1,
+        poll_interval_seconds=0,
+    )
+
+    assert evidence.calculation_role == "workspace_summary"
+    assert evidence.execution_status == "complete"
+    assert evidence.lineage_status == "pending"
+    assert evidence.reason == "Lineage is pending in lotus-performance."
+    assert client.execution_calls == ["calc-1"]
+    assert client.lineage_calls == ["calc-1", "calc-1"]
 
 
 def test_build_calculation_evidence_view_maps_artifacts_and_reason():


### PR DESCRIPTION
## Summary
- Move performance workspace execution/lineage evidence retrieval into the dedicated evidence helper module
- Keep the service focused on evidence view orchestration instead of polling and refresh mechanics
- Add focused async unit coverage for lineage polling, execution refresh, and partial evidence fallback behavior

## Validation
- python -m ruff check src/app/services/performance_workspace_service.py src/app/services/performance_workspace_evidence.py tests/unit/test_performance_workspace_evidence.py tests/unit/test_performance_workspace_service.py
- python -m mypy src/app/services/performance_workspace_service.py src/app/services/performance_workspace_evidence.py
- python -m pytest tests/unit/test_performance_workspace_evidence.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal evidence-boundary cleanup.
- Stranded truth: no governance-bearing paths changed.