### PR TITLE
Extract performance reference resolver

### DIFF
--- a/src/app/services/performance_workspace_reference.py
+++ b/src/app/services/performance_workspace_reference.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any, TypeAlias
+
+from app.contracts.workbench import WorkbenchPartialFailure
+from app.services.performance_workspace_failures import build_performance_failure
+
+UpstreamPayload: TypeAlias = dict[str, Any]
+UpstreamResult: TypeAlias = tuple[int, UpstreamPayload]
+
+
+def analytics_reference_cache_key(
+    *,
+    portfolio_id: str,
+    as_of_date: str,
+) -> tuple[str, str, str]:
+    return ("analytics_reference", portfolio_id, as_of_date)
+
+
+def resolve_performance_report_end_date(
+    *,
+    result: UpstreamResult,
+    fallback_as_of_date: str,
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+) -> str:
+    status_code, payload = result
+    if status_code >= 400 or not isinstance(payload, dict):
+        warnings.append("PERFORMANCE_REFERENCE_UNAVAILABLE")
+        partial_failures.append(
+            build_performance_failure(
+                "lotus-core",
+                (f"HTTP_{status_code}" if isinstance(status_code, int) else "INVALID_RESPONSE"),
+                str(payload.get("detail", payload)) if isinstance(payload, dict) else str(payload),
+            )
+        )
+        return fallback_as_of_date
+
+    performance_end_date = payload.get("performance_end_date")
+    if not isinstance(performance_end_date, str) or not performance_end_date:
+        warnings.append("PERFORMANCE_REFERENCE_MISSING_END_DATE")
+        return fallback_as_of_date
+    return performance_end_date

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -88,6 +88,10 @@ from app.services.performance_workspace_projection import (
     project_workspace_details,
     project_workspace_summary,
 )
+from app.services.performance_workspace_reference import (
+    analytics_reference_cache_key,
+    resolve_performance_report_end_date,
+)
 from app.services.performance_workspace_returns import (
     build_workspace_comparative_summary,
     extract_twr_workspace_block,
@@ -964,7 +968,10 @@ class PerformanceWorkspaceService:
         ) = cast(
             UpstreamResult,
             await self._get_cached_upstream_result(
-                ("analytics_reference", portfolio_id, as_of_date),
+                analytics_reference_cache_key(
+                    portfolio_id=portfolio_id,
+                    as_of_date=as_of_date,
+                ),
                 lambda: self._lotus_core_query_client.get_portfolio_analytics_reference(
                     portfolio_id=portfolio_id,
                     as_of_date=as_of_date,
@@ -973,26 +980,12 @@ class PerformanceWorkspaceService:
                 ),
             ),
         )
-        if status_code >= 400 or not isinstance(payload, dict):
-            warnings.append("PERFORMANCE_REFERENCE_UNAVAILABLE")
-            partial_failures.append(
-                build_performance_failure(
-                    "lotus-core",
-                    (f"HTTP_{status_code}" if isinstance(status_code, int) else "INVALID_RESPONSE"),
-                    (
-                        str(payload.get("detail", payload))
-                        if isinstance(payload, dict)
-                        else str(payload)
-                    ),
-                )
-            )
-            return as_of_date
-
-        performance_end_date = payload.get("performance_end_date")
-        if not isinstance(performance_end_date, str) or not performance_end_date:
-            warnings.append("PERFORMANCE_REFERENCE_MISSING_END_DATE")
-            return as_of_date
-        return performance_end_date
+        return resolve_performance_report_end_date(
+            result=(status_code, payload),
+            fallback_as_of_date=as_of_date,
+            warnings=warnings,
+            partial_failures=partial_failures,
+        )
 
     async def _empty_async_result(self) -> tuple[int, dict[str, Any]]:
         return 204, {}

--- a/tests/unit/test_performance_workspace_reference.py
+++ b/tests/unit/test_performance_workspace_reference.py
@@ -1,0 +1,62 @@
+from app.services.performance_workspace_reference import (
+    analytics_reference_cache_key,
+    resolve_performance_report_end_date,
+)
+
+
+def test_analytics_reference_cache_key_is_stable() -> None:
+    assert analytics_reference_cache_key(
+        portfolio_id="DEMO_ADV_USD_001",
+        as_of_date="2026-03-27",
+    ) == ("analytics_reference", "DEMO_ADV_USD_001", "2026-03-27")
+
+
+def test_resolve_performance_report_end_date_uses_upstream_reference_date() -> None:
+    warnings: list[str] = []
+    partial_failures = []
+
+    report_end_date = resolve_performance_report_end_date(
+        result=(200, {"performance_end_date": "2026-03-26"}),
+        fallback_as_of_date="2026-03-27",
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert report_end_date == "2026-03-26"
+    assert warnings == []
+    assert partial_failures == []
+
+
+def test_resolve_performance_report_end_date_falls_back_for_http_failure() -> None:
+    warnings: list[str] = []
+    partial_failures = []
+
+    report_end_date = resolve_performance_report_end_date(
+        result=(503, {"detail": "analytics reference unavailable"}),
+        fallback_as_of_date="2026-03-27",
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert report_end_date == "2026-03-27"
+    assert warnings == ["PERFORMANCE_REFERENCE_UNAVAILABLE"]
+    assert len(partial_failures) == 1
+    assert partial_failures[0].source_service == "lotus-core"
+    assert partial_failures[0].error_code == "HTTP_503"
+    assert partial_failures[0].detail == "analytics reference unavailable"
+
+
+def test_resolve_performance_report_end_date_falls_back_for_missing_date() -> None:
+    warnings: list[str] = []
+    partial_failures = []
+
+    report_end_date = resolve_performance_report_end_date(
+        result=(200, {"performance_end_date": ""}),
+        fallback_as_of_date="2026-03-27",
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert report_end_date == "2026-03-27"
+    assert warnings == ["PERFORMANCE_REFERENCE_MISSING_END_DATE"]
+    assert partial_failures == []


### PR DESCRIPTION
## Summary
- Extract performance analytics reference cache-key and report-end-date fallback policy into a dedicated helper module
- Keep PerformanceWorkspaceService focused on upstream fetch orchestration instead of interpreting reference payloads inline
- Add focused unit coverage for reference date resolution, HTTP fallback, and missing-date warnings

## Validation
- python -m ruff check src/app/services/performance_workspace_service.py src/app/services/performance_workspace_reference.py tests/unit/test_performance_workspace_reference.py tests/unit/test_performance_workspace_service.py
- python -m mypy src/app/services/performance_workspace_service.py src/app/services/performance_workspace_reference.py
- python -m pytest tests/unit/test_performance_workspace_reference.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal reference-boundary cleanup.
- Stranded truth: no governance-bearing paths changed.