### PR TITLE
Extract benchmark catalog parser

### DIFF
--- a/src/app/services/performance_workspace_benchmarks.py
+++ b/src/app/services/performance_workspace_benchmarks.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import asyncio
 from typing import Any, TypeAlias, cast
 
+from app.contracts.performance_workspace import PerformanceBenchmarkOptionView
+from app.contracts.workbench import WorkbenchPartialFailure
 from app.services.async_ttl_cache import AsyncTtlCache
+from app.services.performance_workspace_failures import build_performance_failure
 from app.services.performance_workspace_parsing import safe_str
 from app.services.workspace_client_protocols import PerformanceWorkspaceCoreClient
 
@@ -155,6 +158,61 @@ async def fetch_benchmark_context(
         return benchmark_code, benchmark_catalog_result_value
     return benchmark_code or cast(str | None, resolved_benchmark_code_result), (
         benchmark_catalog_result_value
+    )
+
+
+def parse_benchmark_catalog_result(
+    *,
+    result: GatheredResult,
+    assigned_benchmark_code: str | None,
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+) -> list[PerformanceBenchmarkOptionView]:
+    if isinstance(result, BaseException):
+        warnings.append("BENCHMARK_CATALOG_UNAVAILABLE")
+        partial_failures.append(
+            build_performance_failure("lotus-core", "UPSTREAM_EXCEPTION", str(result))
+        )
+        return []
+    status_code, payload = result
+    if status_code >= 400 or not isinstance(payload, dict):
+        warnings.append("BENCHMARK_CATALOG_UNAVAILABLE")
+        partial_failures.append(
+            build_performance_failure(
+                "lotus-core",
+                f"HTTP_{status_code}"
+                if isinstance(status_code, int)
+                else "INVALID_UPSTREAM_PAYLOAD",
+                str(payload),
+            )
+        )
+        return []
+    records = payload.get("records", [])
+    if not isinstance(records, list):
+        return []
+    options_by_code: dict[str, PerformanceBenchmarkOptionView] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        benchmark_code_value = safe_str(record.get("benchmark_id"))
+        benchmark_name = safe_str(record.get("benchmark_name"))
+        if not benchmark_code_value or not benchmark_name:
+            continue
+        option = PerformanceBenchmarkOptionView(
+            benchmark_code=benchmark_code_value,
+            benchmark_name=benchmark_name,
+            benchmark_currency=safe_str(record.get("benchmark_currency")),
+            benchmark_type=safe_str(record.get("benchmark_type")),
+            benchmark_family=safe_str(record.get("benchmark_family")),
+            benchmark_provider=safe_str(record.get("benchmark_provider")),
+            is_assigned=benchmark_code_value == assigned_benchmark_code,
+        )
+        existing = options_by_code.get(benchmark_code_value)
+        if existing is None or (option.is_assigned and not existing.is_assigned):
+            options_by_code[benchmark_code_value] = option
+    return sorted(
+        options_by_code.values(),
+        key=lambda option: (not option.is_assigned, option.benchmark_name),
     )
 
 

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -14,7 +14,6 @@ from app.contracts.performance_workspace import (
     MoneyWeightedReturnSummary,
     PerformanceAttributionTrendResponse,
     PerformanceAttributionTrendRow,
-    PerformanceBenchmarkOptionView,
     PerformanceChartPoint,
     PerformanceComparativeSummary,
     PerformanceEvidenceView,
@@ -36,7 +35,10 @@ from app.services.performance_workspace_attribution import (
     parse_attribution_residual_materiality,
     parse_attribution_supportability_evidence,
 )
-from app.services.performance_workspace_benchmarks import fetch_benchmark_context
+from app.services.performance_workspace_benchmarks import (
+    fetch_benchmark_context,
+    parse_benchmark_catalog_result,
+)
 from app.services.performance_workspace_capabilities import (
     SUPPORTED_ATTRIBUTION_DIMENSIONS,
     SUPPORTED_CONTRIBUTION_DIMENSIONS,
@@ -357,7 +359,7 @@ class PerformanceWorkspaceService:
             warnings=warnings,
             partial_failures=partial_failures,
         )
-        benchmark_options = self._parse_benchmark_catalog_result(
+        benchmark_options = parse_benchmark_catalog_result(
             result=benchmark_catalog_result,
             assigned_benchmark_code=resolved_benchmark_code or benchmark_code,
             warnings=warnings,
@@ -694,7 +696,7 @@ class PerformanceWorkspaceService:
         else:
             contribution_detail_result = None
             attribution_detail_result = None
-        benchmark_options = self._parse_benchmark_catalog_result(
+        benchmark_options = parse_benchmark_catalog_result(
             result=benchmark_catalog_result,
             assigned_benchmark_code=resolved_benchmark_code or benchmark_code,
             warnings=warnings,
@@ -1270,61 +1272,6 @@ class PerformanceWorkspaceService:
             if resolved_benchmark_code is None:
                 resolved_benchmark_code = comparative.benchmark_id
         return rows, resolved_benchmark_code
-
-    def _parse_benchmark_catalog_result(
-        self,
-        *,
-        result: GatheredResult,
-        assigned_benchmark_code: str | None,
-        warnings: list[str],
-        partial_failures: list[WorkbenchPartialFailure],
-    ) -> list[PerformanceBenchmarkOptionView]:
-        if isinstance(result, BaseException):
-            warnings.append("BENCHMARK_CATALOG_UNAVAILABLE")
-            partial_failures.append(
-                build_performance_failure("lotus-core", "UPSTREAM_EXCEPTION", str(result))
-            )
-            return []
-        status_code, payload = result
-        if status_code >= 400 or not isinstance(payload, dict):
-            warnings.append("BENCHMARK_CATALOG_UNAVAILABLE")
-            partial_failures.append(
-                build_performance_failure(
-                    "lotus-core",
-                    f"HTTP_{status_code}"
-                    if isinstance(status_code, int)
-                    else "INVALID_UPSTREAM_PAYLOAD",
-                    str(payload),
-                )
-            )
-            return []
-        records = payload.get("records", [])
-        if not isinstance(records, list):
-            return []
-        options_by_code: dict[str, PerformanceBenchmarkOptionView] = {}
-        for record in records:
-            if not isinstance(record, dict):
-                continue
-            benchmark_code = safe_str(record.get("benchmark_id"))
-            benchmark_name = safe_str(record.get("benchmark_name"))
-            if not benchmark_code or not benchmark_name:
-                continue
-            option = PerformanceBenchmarkOptionView(
-                benchmark_code=benchmark_code,
-                benchmark_name=benchmark_name,
-                benchmark_currency=safe_str(record.get("benchmark_currency")),
-                benchmark_type=safe_str(record.get("benchmark_type")),
-                benchmark_family=safe_str(record.get("benchmark_family")),
-                benchmark_provider=safe_str(record.get("benchmark_provider")),
-                is_assigned=benchmark_code == assigned_benchmark_code,
-            )
-            existing = options_by_code.get(benchmark_code)
-            if existing is None or (option.is_assigned and not existing.is_assigned):
-                options_by_code[benchmark_code] = option
-        return sorted(
-            options_by_code.values(),
-            key=lambda option: (not option.is_assigned, option.benchmark_name),
-        )
 
     def _parse_mwr_result(
         self,

--- a/tests/unit/test_performance_workspace_benchmarks.py
+++ b/tests/unit/test_performance_workspace_benchmarks.py
@@ -7,6 +7,7 @@ from app.services.async_ttl_cache import AsyncTtlCache
 from app.services.performance_workspace_benchmarks import (
     fetch_assigned_benchmark_code,
     fetch_benchmark_context,
+    parse_benchmark_catalog_result,
     resolve_benchmark_code,
 )
 
@@ -191,3 +192,72 @@ async def test_fetch_benchmark_context_skips_catalog_when_not_requested():
     assert benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert catalog_result == (200, {})
     assert client.catalog_calls == []
+
+
+def test_parse_benchmark_catalog_result_deduplicates_and_marks_assigned_option():
+    warnings: list[str] = []
+    partial_failures = []
+
+    options = parse_benchmark_catalog_result(
+        result=(
+            200,
+            {
+                "records": [
+                    {
+                        "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+                        "benchmark_name": "Global Balanced 60/40",
+                        "benchmark_currency": "USD",
+                        "benchmark_type": "composite",
+                        "benchmark_family": "Balanced",
+                        "benchmark_provider": "Lotus",
+                    },
+                    {
+                        "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+                        "benchmark_name": "Global Balanced 60/40",
+                        "benchmark_currency": "USD",
+                        "benchmark_type": "composite",
+                        "benchmark_family": "Balanced",
+                        "benchmark_provider": "Lotus",
+                    },
+                    {
+                        "benchmark_id": "BMK_GLOBAL_GROWTH_80_20",
+                        "benchmark_name": "Global Growth 80/20",
+                        "benchmark_currency": "USD",
+                        "benchmark_type": "composite",
+                        "benchmark_family": "Growth",
+                        "benchmark_provider": "Lotus",
+                    },
+                ]
+            },
+        ),
+        assigned_benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert [option.benchmark_code for option in options] == [
+        "BMK_PB_GLOBAL_BALANCED_60_40",
+        "BMK_GLOBAL_GROWTH_80_20",
+    ]
+    assert options[0].is_assigned is True
+    assert warnings == []
+    assert partial_failures == []
+
+
+def test_parse_benchmark_catalog_result_records_upstream_failure():
+    warnings: list[str] = []
+    partial_failures = []
+
+    options = parse_benchmark_catalog_result(
+        result=(503, {"detail": "catalog unavailable"}),
+        assigned_benchmark_code=None,
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert options == []
+    assert warnings == ["BENCHMARK_CATALOG_UNAVAILABLE"]
+    assert len(partial_failures) == 1
+    assert partial_failures[0].source_service == "lotus-core"
+    assert partial_failures[0].error_code == "HTTP_503"
+    assert partial_failures[0].detail == "{'detail': 'catalog unavailable'}"

--- a/tests/unit/test_performance_workspace_service.py
+++ b/tests/unit/test_performance_workspace_service.py
@@ -1088,62 +1088,6 @@ def _many_attribution_groups_payload(*, dimension: str) -> dict:
 
 
 @pytest.mark.asyncio
-async def test_performance_workspace_service_deduplicates_benchmark_catalog_options():
-    service = PerformanceWorkspaceService(
-        workbench_service=_StubWorkbenchService(),
-        analytics_client=_StubAnalyticsClient(),
-        lotus_core_query_client=_StubLotusCoreQueryClient(),
-    )
-
-    warnings: list[str] = []
-    partial_failures: list[WorkbenchPartialFailure] = []
-    options = service._parse_benchmark_catalog_result(
-        result=(
-            200,
-            {
-                "records": [
-                    {
-                        "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
-                        "benchmark_name": "Global Balanced 60/40",
-                        "benchmark_currency": "USD",
-                        "benchmark_type": "composite",
-                        "benchmark_family": "Balanced",
-                        "benchmark_provider": "Lotus",
-                    },
-                    {
-                        "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
-                        "benchmark_name": "Global Balanced 60/40",
-                        "benchmark_currency": "USD",
-                        "benchmark_type": "composite",
-                        "benchmark_family": "Balanced",
-                        "benchmark_provider": "Lotus",
-                    },
-                    {
-                        "benchmark_id": "BMK_GLOBAL_GROWTH_80_20",
-                        "benchmark_name": "Global Growth 80/20",
-                        "benchmark_currency": "USD",
-                        "benchmark_type": "composite",
-                        "benchmark_family": "Growth",
-                        "benchmark_provider": "Lotus",
-                    },
-                ]
-            },
-        ),
-        assigned_benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
-        warnings=warnings,
-        partial_failures=partial_failures,
-    )
-
-    assert [option.benchmark_code for option in options] == [
-        "BMK_PB_GLOBAL_BALANCED_60_40",
-        "BMK_GLOBAL_GROWTH_80_20",
-    ]
-    assert options[0].is_assigned is True
-    assert warnings == []
-    assert partial_failures == []
-
-
-@pytest.mark.asyncio
 async def test_performance_workspace_service_returns_workspace_summary_contract():
     analytics_client = _StubAnalyticsClient()
     query_client = _StubLotusCoreQueryClient()


### PR DESCRIPTION
## Summary
- Move performance workspace benchmark catalog parsing into the dedicated benchmark helper module
- Keep PerformanceWorkspaceService focused on orchestration instead of benchmark option mapping
- Add focused unit coverage for benchmark catalog deduplication, assigned-option ordering, and upstream failure handling

## Validation
- python -m ruff check src/app/services/performance_workspace_service.py src/app/services/performance_workspace_benchmarks.py tests/unit/test_performance_workspace_benchmarks.py tests/unit/test_performance_workspace_service.py
- python -m mypy src/app/services/performance_workspace_service.py src/app/services/performance_workspace_benchmarks.py
- python -m pytest tests/unit/test_performance_workspace_benchmarks.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal benchmark-parser cleanup.
- Stranded truth: no governance-bearing paths changed.