### PR TITLE
Remove dead performance MWR detail parser

### DIFF
--- a/src/app/services/performance_workspace_mwr.py
+++ b/src/app/services/performance_workspace_mwr.py
@@ -48,24 +48,5 @@ def build_workspace_mwr_summary(
     )
 
 
-def build_detail_mwr_summary(payload: dict[str, Any]) -> MoneyWeightedReturnSummary:
-    return MoneyWeightedReturnSummary(
-        money_weighted_return_pct=quantize_optional(payload.get("money_weighted_return")),
-        annualized_return_pct=quantize_optional(payload.get("mwr_annualized")),
-        holding_period_return_pct=quantize_optional(payload.get("holding_period_return")),
-        method=safe_str(payload.get("method")),
-        status=safe_str(payload.get("status")),
-        reason_codes=safe_str_list(payload.get("reason_codes")),
-        warnings=safe_str_list(payload.get("warnings")),
-        is_annualized_primary=safe_bool(payload.get("is_annualized_primary")),
-        fallback_from=safe_str(payload.get("fallback_from")),
-        fallback_reason=safe_str(payload.get("fallback_reason")),
-        is_approximation=safe_bool(payload.get("is_approximation")),
-        start_date=safe_str(payload.get("start_date")),
-        end_date=safe_str(payload.get("end_date")),
-        notes=_safe_notes(payload.get("notes", [])),
-    )
-
-
 def _safe_notes(payload: Any) -> list[str]:
     return [str(note) for note in payload] if isinstance(payload, list) else []

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -74,10 +74,7 @@ from app.services.performance_workspace_evidence import (
 )
 from app.services.performance_workspace_failures import build_performance_failure
 from app.services.performance_workspace_horizon import fetch_workspace_horizon_dependencies
-from app.services.performance_workspace_mwr import (
-    build_detail_mwr_summary,
-    build_workspace_mwr_summary,
-)
+from app.services.performance_workspace_mwr import build_workspace_mwr_summary
 from app.services.performance_workspace_parsing import (
     extract_return,
     format_attribution_trend_label,
@@ -1272,35 +1269,6 @@ class PerformanceWorkspaceService:
             if resolved_benchmark_code is None:
                 resolved_benchmark_code = comparative.benchmark_id
         return rows, resolved_benchmark_code
-
-    def _parse_mwr_result(
-        self,
-        *,
-        result: GatheredResult,
-        warnings: list[str],
-        partial_failures: list[WorkbenchPartialFailure],
-    ) -> MoneyWeightedReturnSummary | None:
-        if isinstance(result, BaseException):
-            warnings.append("MWR_UNAVAILABLE")
-            partial_failures.append(
-                build_performance_failure("lotus-performance", "UPSTREAM_EXCEPTION", str(result))
-            )
-            return None
-        status_code, payload = result
-        if not isinstance(payload, dict):
-            warnings.append("MWR_INVALID")
-            return None
-        if status_code >= 400:
-            warnings.append("MWR_UNAVAILABLE")
-            partial_failures.append(
-                build_performance_failure(
-                    "lotus-performance",
-                    f"HTTP_{status_code}",
-                    str(payload.get("detail", payload)),
-                )
-            )
-            return None
-        return build_detail_mwr_summary(payload)
 
     def _parse_contribution_result(
         self,

--- a/tests/unit/test_performance_workspace_mwr.py
+++ b/tests/unit/test_performance_workspace_mwr.py
@@ -1,7 +1,4 @@
-from app.services.performance_workspace_mwr import (
-    build_detail_mwr_summary,
-    build_workspace_mwr_summary,
-)
+from app.services.performance_workspace_mwr import build_workspace_mwr_summary
 
 
 def test_build_workspace_mwr_summary_maps_economics_and_notes():
@@ -54,37 +51,6 @@ def test_build_workspace_mwr_summary_maps_economics_and_notes():
     assert summary.net_cash_flow == 22500.0
     assert summary.fees == 0.0
     assert summary.notes == ["client contribution included"]
-
-
-def test_build_detail_mwr_summary_maps_independent_payload():
-    summary = build_detail_mwr_summary(
-        {
-            "money_weighted_return": 7.25,
-            "mwr_annualized": 9.1,
-            "holding_period_return": 2.2,
-            "method": "MODIFIED_DIETZ",
-            "status": "APPROXIMATED",
-            "reason_codes": ["DAILY_CASH_FLOW_MISSING"],
-            "warnings": ["USING_PERIOD_FLOWS"],
-            "is_annualized_primary": False,
-            "fallback_from": "XIRR",
-            "fallback_reason": "NO_ROOT",
-            "is_approximation": True,
-            "start_date": "2026-02-01",
-            "end_date": "2026-02-28",
-            "notes": ["fallback applied"],
-        }
-    )
-
-    assert summary.money_weighted_return_pct == 7.25
-    assert summary.annualized_return_pct == 9.1
-    assert summary.method == "MODIFIED_DIETZ"
-    assert summary.status == "APPROXIMATED"
-    assert summary.reason_codes == ["DAILY_CASH_FLOW_MISSING"]
-    assert summary.warnings == ["USING_PERIOD_FLOWS"]
-    assert summary.is_annualized_primary is False
-    assert summary.is_approximation is True
-    assert summary.notes == ["fallback applied"]
 
 
 def test_mwr_summary_builders_fail_closed_for_invalid_nested_payloads():


### PR DESCRIPTION
## Summary
- Remove the unused performance workspace MWR detail parser from PerformanceWorkspaceService
- Remove the now-unused detail MWR summary builder and implementation-only test
- Keep the active workspace MWR summary path intact while reducing dead parsing surface

## Validation
- python -m ruff check src/app/services/performance_workspace_service.py src/app/services/performance_workspace_mwr.py tests/unit/test_performance_workspace_mwr.py
- python -m mypy src/app/services/performance_workspace_service.py src/app/services/performance_workspace_mwr.py
- python -m pytest tests/unit/test_performance_workspace_mwr.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal dead-code cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal dead-code cleanup.
- Stranded truth: no governance-bearing paths changed.