### PR TITLE
Extract contribution detail parser

### DIFF
--- a/src/app/services/performance_workspace_contribution.py
+++ b/src/app/services/performance_workspace_contribution.py
@@ -10,7 +10,9 @@ from app.contracts.performance_workspace import (
     ContributionSourceEconomicsEvidenceView,
     ContributionSummaryView,
 )
+from app.contracts.workbench import WorkbenchPartialFailure
 from app.precision_policy import quantize_performance
+from app.services.performance_workspace_failures import build_performance_failure
 from app.services.performance_workspace_parsing import (
     format_key_label,
     quantize_optional,
@@ -20,6 +22,9 @@ from app.services.performance_workspace_parsing import (
     sum_optional,
     weight_to_pct,
 )
+from app.services.performance_workspace_returns import resolve_results_period_key
+
+ContributionResult = tuple[int, dict[str, Any]] | BaseException
 
 
 def build_workspace_contribution_summary(
@@ -91,6 +96,51 @@ def build_detail_contribution_summary(
         source_economics_evidence=parse_contribution_source_economics_evidence(
             source_economics_payload
         ),
+    )
+
+
+def parse_contribution_result(
+    *,
+    result: ContributionResult,
+    metric_basis: str,
+    requested_period: str,
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+) -> ContributionSummaryView | None:
+    if isinstance(result, BaseException):
+        warnings.append("CONTRIBUTION_UNAVAILABLE")
+        partial_failures.append(
+            build_performance_failure("lotus-performance", "UPSTREAM_EXCEPTION", str(result))
+        )
+        return None
+    status_code, payload = result
+    if not isinstance(payload, dict):
+        warnings.append("CONTRIBUTION_INVALID")
+        return None
+    if status_code >= 400:
+        warnings.append("CONTRIBUTION_UNAVAILABLE")
+        partial_failures.append(
+            build_performance_failure(
+                "lotus-performance",
+                f"HTTP_{status_code}",
+                str(payload.get("detail", payload)),
+            )
+        )
+        return None
+    results_by_period = payload.get("results_by_period", {})
+    if not isinstance(results_by_period, dict) or not results_by_period:
+        return None
+    period_key = resolve_results_period_key(
+        requested_period=requested_period,
+        results_by_period=results_by_period,
+    )
+    period_payload = results_by_period.get(period_key, {})
+    if not isinstance(period_payload, dict):
+        return None
+    return build_detail_contribution_summary(
+        period_payload=period_payload,
+        metric_basis=metric_basis,
+        source_economics_payload=payload.get("source_economics_evidence"),
     )
 
 

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -48,9 +48,9 @@ from app.services.performance_workspace_chart_points import (
     build_workspace_chart_points,
 )
 from app.services.performance_workspace_contribution import (
-    build_detail_contribution_summary,
     build_workspace_contribution_summary,
     merge_contribution_summary_views,
+    parse_contribution_result,
 )
 from app.services.performance_workspace_controls import (
     build_attribution_trend_windows,
@@ -672,7 +672,7 @@ class PerformanceWorkspaceService:
             )
             contribution = merge_contribution_summary_views(
                 summary_contribution=contribution,
-                detail_contribution=self._parse_contribution_result(
+                detail_contribution=parse_contribution_result(
                     result=contribution_detail_result,
                     metric_basis=detail_basis,
                     requested_period=effective_period,
@@ -1269,51 +1269,6 @@ class PerformanceWorkspaceService:
             if resolved_benchmark_code is None:
                 resolved_benchmark_code = comparative.benchmark_id
         return rows, resolved_benchmark_code
-
-    def _parse_contribution_result(
-        self,
-        *,
-        result: GatheredResult,
-        metric_basis: str,
-        requested_period: str,
-        warnings: list[str],
-        partial_failures: list[WorkbenchPartialFailure],
-    ) -> ContributionSummaryView | None:
-        if isinstance(result, BaseException):
-            warnings.append("CONTRIBUTION_UNAVAILABLE")
-            partial_failures.append(
-                build_performance_failure("lotus-performance", "UPSTREAM_EXCEPTION", str(result))
-            )
-            return None
-        status_code, payload = result
-        if not isinstance(payload, dict):
-            warnings.append("CONTRIBUTION_INVALID")
-            return None
-        if status_code >= 400:
-            warnings.append("CONTRIBUTION_UNAVAILABLE")
-            partial_failures.append(
-                build_performance_failure(
-                    "lotus-performance",
-                    f"HTTP_{status_code}",
-                    str(payload.get("detail", payload)),
-                )
-            )
-            return None
-        results_by_period = payload.get("results_by_period", {})
-        if not isinstance(results_by_period, dict) or not results_by_period:
-            return None
-        period_key = resolve_results_period_key(
-            requested_period=requested_period,
-            results_by_period=results_by_period,
-        )
-        period_payload = results_by_period.get(period_key, {})
-        if not isinstance(period_payload, dict):
-            return None
-        return build_detail_contribution_summary(
-            period_payload=period_payload,
-            metric_basis=metric_basis,
-            source_economics_payload=payload.get("source_economics_evidence"),
-        )
 
     def _parse_attribution_result(
         self,

--- a/tests/unit/test_performance_workspace_contribution.py
+++ b/tests/unit/test_performance_workspace_contribution.py
@@ -2,6 +2,7 @@ from app.services.performance_workspace_contribution import (
     build_detail_contribution_summary,
     build_workspace_contribution_summary,
     merge_contribution_summary_views,
+    parse_contribution_result,
     parse_contribution_smoothing_evidence,
     parse_contribution_source_economics_evidence,
 )
@@ -109,6 +110,73 @@ def test_build_detail_contribution_summary_maps_independent_payload():
     assert summary.position_rows[0].contribution_pct == 0.22222
     assert summary.source_economics_evidence is not None
     assert summary.source_economics_evidence.reason_codes == ["MISSING_FX"]
+
+
+def test_parse_contribution_result_selects_requested_period_and_source_economics():
+    warnings: list[str] = []
+    partial_failures = []
+
+    summary = parse_contribution_result(
+        result=(
+            200,
+            {
+                "source_economics_evidence": {
+                    "status": "partial",
+                    "reason_codes": ["MISSING_LOCAL_ECONOMICS"],
+                },
+                "results_by_period": {
+                    "YTD": {
+                        "summary": {"portfolio_contribution": 2.5},
+                        "total_portfolio_return": 2.9,
+                        "levels": [
+                            {
+                                "name": "Asset Class",
+                                "rows": [
+                                    {
+                                        "key": {"asset_class": "Equity"},
+                                        "contribution": 2.5,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                },
+            },
+        ),
+        metric_basis="NET",
+        requested_period="YTD",
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert summary is not None
+    assert summary.metric_basis == "NET"
+    assert summary.portfolio_contribution_pct == 2.5
+    assert summary.total_portfolio_return_pct == 2.9
+    assert summary.levels[0].rows[0].key_label == "Equity"
+    assert summary.source_economics_evidence is not None
+    assert summary.source_economics_evidence.reason_codes == ["MISSING_LOCAL_ECONOMICS"]
+    assert warnings == []
+    assert partial_failures == []
+
+
+def test_parse_contribution_result_records_upstream_failure():
+    warnings: list[str] = []
+    partial_failures = []
+
+    summary = parse_contribution_result(
+        result=RuntimeError("timeout"),
+        metric_basis="NET",
+        requested_period="YTD",
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert summary is None
+    assert warnings == ["CONTRIBUTION_UNAVAILABLE"]
+    assert len(partial_failures) == 1
+    assert partial_failures[0].source_service == "lotus-performance"
+    assert partial_failures[0].error_code == "UPSTREAM_EXCEPTION"
 
 
 def test_merge_contribution_summary_views_prefers_detail_when_present():


### PR DESCRIPTION
## Summary
- Move performance workspace contribution detail result parsing into the contribution helper module
- Keep PerformanceWorkspaceService focused on orchestration instead of contribution upstream result mapping
- Add focused unit coverage for contribution period selection, source-economics propagation, and upstream failure handling

## Validation
- python -m ruff check src/app/services/performance_workspace_contribution.py src/app/services/performance_workspace_service.py tests/unit/test_performance_workspace_contribution.py
- python -m mypy src/app/services/performance_workspace_contribution.py src/app/services/performance_workspace_service.py
- python -m pytest tests/unit/test_performance_workspace_contribution.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal parser-boundary cleanup.
- Stranded truth: no governance-bearing paths changed.