### PR TITLE
Extract attribution detail parser

### DIFF
--- a/src/app/services/performance_workspace_attribution.py
+++ b/src/app/services/performance_workspace_attribution.py
@@ -10,6 +10,8 @@ from app.contracts.performance_workspace import (
     AttributionSummaryView,
     AttributionSupportabilityEvidenceView,
 )
+from app.contracts.workbench import WorkbenchPartialFailure
+from app.services.performance_workspace_failures import build_performance_failure
 from app.services.performance_workspace_parsing import (
     format_key_label,
     quantize_optional,
@@ -18,6 +20,9 @@ from app.services.performance_workspace_parsing import (
     safe_str_list,
     weight_to_pct,
 )
+from app.services.performance_workspace_returns import resolve_results_period_key
+
+AttributionResult = tuple[int, dict[str, Any]] | BaseException
 
 
 def build_workspace_attribution_summary(
@@ -97,6 +102,56 @@ def build_detail_attribution_summary(
             row_key="groups",
             quantize_effects_with_policy=True,
         ),
+    )
+
+
+def parse_attribution_result(
+    *,
+    result: AttributionResult,
+    metric_basis: str,
+    requested_period: str,
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+) -> AttributionSummaryView | None:
+    if isinstance(result, BaseException):
+        warnings.append("ATTRIBUTION_UNAVAILABLE")
+        partial_failures.append(
+            build_performance_failure("lotus-performance", "UPSTREAM_EXCEPTION", str(result))
+        )
+        return None
+    status_code, payload = result
+    if not isinstance(payload, dict):
+        warnings.append("ATTRIBUTION_INVALID")
+        return None
+    if status_code >= 400:
+        warnings.append("ATTRIBUTION_UNAVAILABLE")
+        partial_failures.append(
+            build_performance_failure(
+                "lotus-performance",
+                f"HTTP_{status_code}",
+                str(payload.get("detail", payload)),
+            )
+        )
+        return None
+    results_by_period = payload.get("results_by_period", {})
+    if not isinstance(results_by_period, dict) or not results_by_period:
+        return None
+    period_key = resolve_results_period_key(
+        requested_period=requested_period,
+        results_by_period=results_by_period,
+    )
+    period_payload = results_by_period.get(period_key, {})
+    if not isinstance(period_payload, dict):
+        return None
+    benchmark_context = payload.get("benchmark_context", {})
+    if not isinstance(benchmark_context, dict):
+        benchmark_context = {}
+    return build_detail_attribution_summary(
+        period_payload=period_payload,
+        metric_basis=metric_basis,
+        benchmark_context=benchmark_context,
+        model=payload.get("model"),
+        linking=payload.get("linking"),
     )
 
 

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -30,9 +30,9 @@ from app.contracts.workbench import WorkbenchOverviewResponse, WorkbenchPartialF
 from app.middleware.server_timing import server_timing_span
 from app.services.async_ttl_cache import AsyncTtlCache
 from app.services.performance_workspace_attribution import (
-    build_detail_attribution_summary,
     build_workspace_attribution_summary,
     parse_attribution_residual_materiality,
+    parse_attribution_result,
     parse_attribution_supportability_evidence,
 )
 from app.services.performance_workspace_benchmarks import (
@@ -681,7 +681,7 @@ class PerformanceWorkspaceService:
                 ),
             )
             attribution = (
-                self._parse_attribution_result(
+                parse_attribution_result(
                     result=attribution_detail_result,
                     metric_basis=detail_basis,
                     requested_period=effective_period,
@@ -1269,56 +1269,6 @@ class PerformanceWorkspaceService:
             if resolved_benchmark_code is None:
                 resolved_benchmark_code = comparative.benchmark_id
         return rows, resolved_benchmark_code
-
-    def _parse_attribution_result(
-        self,
-        *,
-        result: GatheredResult,
-        metric_basis: str,
-        requested_period: str,
-        warnings: list[str],
-        partial_failures: list[WorkbenchPartialFailure],
-    ) -> AttributionSummaryView | None:
-        if isinstance(result, BaseException):
-            warnings.append("ATTRIBUTION_UNAVAILABLE")
-            partial_failures.append(
-                build_performance_failure("lotus-performance", "UPSTREAM_EXCEPTION", str(result))
-            )
-            return None
-        status_code, payload = result
-        if not isinstance(payload, dict):
-            warnings.append("ATTRIBUTION_INVALID")
-            return None
-        if status_code >= 400:
-            warnings.append("ATTRIBUTION_UNAVAILABLE")
-            partial_failures.append(
-                build_performance_failure(
-                    "lotus-performance",
-                    f"HTTP_{status_code}",
-                    str(payload.get("detail", payload)),
-                )
-            )
-            return None
-        results_by_period = payload.get("results_by_period", {})
-        if not isinstance(results_by_period, dict) or not results_by_period:
-            return None
-        period_key = resolve_results_period_key(
-            requested_period=requested_period,
-            results_by_period=results_by_period,
-        )
-        period_payload = results_by_period.get(period_key, {})
-        if not isinstance(period_payload, dict):
-            return None
-        benchmark_context = payload.get("benchmark_context", {})
-        if not isinstance(benchmark_context, dict):
-            benchmark_context = {}
-        return build_detail_attribution_summary(
-            period_payload=period_payload,
-            metric_basis=metric_basis,
-            benchmark_context=benchmark_context,
-            model=payload.get("model"),
-            linking=payload.get("linking"),
-        )
 
     def _parse_attribution_trend_results(
         self,

--- a/tests/unit/test_performance_workspace_attribution.py
+++ b/tests/unit/test_performance_workspace_attribution.py
@@ -3,6 +3,7 @@ from app.services.performance_workspace_attribution import (
     build_workspace_attribution_summary,
     parse_attribution_reasons,
     parse_attribution_residual_materiality,
+    parse_attribution_result,
     parse_attribution_supportability_evidence,
 )
 
@@ -131,6 +132,83 @@ def test_build_detail_attribution_summary_maps_group_payload():
     assert summary.levels[0].rows[0].total_effect_pct == 0.33333
     assert summary.supportability_evidence is not None
     assert summary.supportability_evidence.benchmark_only_group_count == 2
+
+
+def test_parse_attribution_result_selects_requested_period_and_benchmark_context():
+    warnings: list[str] = []
+    partial_failures = []
+
+    summary = parse_attribution_result(
+        result=(
+            200,
+            {
+                "model": "BF",
+                "linking": "carino",
+                "benchmark_context": {
+                    "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+                    "return_source": "assigned",
+                },
+                "results_by_period": {
+                    "YTD": {
+                        "status": "valid",
+                        "reconciliation": {
+                            "total_active_return": 0.31,
+                            "sum_of_effects": 0.3,
+                            "residual": 0.01,
+                        },
+                        "levels": [
+                            {
+                                "dimension": "asset_class",
+                                "groups": [
+                                    {
+                                        "key": {"asset_class": "Equity"},
+                                        "allocation": 0.1,
+                                        "selection": 0.2,
+                                        "interaction": 0.0,
+                                        "total_effect": 0.3,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                },
+            },
+        ),
+        metric_basis="NET",
+        requested_period="YTD",
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert summary is not None
+    assert summary.metric_basis == "NET"
+    assert summary.model == "BF"
+    assert summary.linking == "carino"
+    assert summary.benchmark_id == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert summary.benchmark_return_source == "assigned"
+    assert summary.active_return_pct == 0.31
+    assert summary.levels[0].rows[0].key_label == "Equity"
+    assert warnings == []
+    assert partial_failures == []
+
+
+def test_parse_attribution_result_records_upstream_failure():
+    warnings: list[str] = []
+    partial_failures = []
+
+    summary = parse_attribution_result(
+        result=RuntimeError("timeout"),
+        metric_basis="NET",
+        requested_period="YTD",
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert summary is None
+    assert warnings == ["ATTRIBUTION_UNAVAILABLE"]
+    assert len(partial_failures) == 1
+    assert partial_failures[0].source_service == "lotus-performance"
+    assert partial_failures[0].error_code == "UPSTREAM_EXCEPTION"
 
 
 def test_attribution_parsers_fail_closed_for_invalid_payloads():


### PR DESCRIPTION
## Summary
- Move performance workspace attribution detail result parsing into the attribution helper module
- Keep PerformanceWorkspaceService focused on orchestration instead of attribution upstream result mapping
- Add focused unit coverage for attribution period selection, benchmark context propagation, and upstream failure handling

## Validation
- python -m ruff check src/app/services/performance_workspace_attribution.py src/app/services/performance_workspace_service.py tests/unit/test_performance_workspace_attribution.py
- python -m mypy src/app/services/performance_workspace_attribution.py src/app/services/performance_workspace_service.py
- python -m pytest tests/unit/test_performance_workspace_attribution.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal parser-boundary cleanup.
- Stranded truth: no governance-bearing paths changed.