### PR TITLE
Extract workspace summary parser

### DIFF
--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -9,12 +9,7 @@ from fastapi import HTTPException
 
 from app.config import settings
 from app.contracts.performance_workspace import (
-    AttributionSummaryView,
-    ContributionSummaryView,
-    MoneyWeightedReturnSummary,
     PerformanceAttributionTrendResponse,
-    PerformanceChartPoint,
-    PerformanceComparativeSummary,
     PerformanceEvidenceView,
     PerformanceHorizonComparisonResponse,
     PerformanceWorkspaceDetailsResponse,
@@ -28,7 +23,6 @@ from app.contracts.workbench import WorkbenchOverviewResponse, WorkbenchPartialF
 from app.middleware.server_timing import server_timing_span
 from app.services.async_ttl_cache import AsyncTtlCache
 from app.services.performance_workspace_attribution import (
-    build_workspace_attribution_summary,
     parse_attribution_result,
     parse_attribution_trend_results,
 )
@@ -41,11 +35,7 @@ from app.services.performance_workspace_capabilities import (
     SUPPORTED_CONTRIBUTION_DIMENSIONS,
     build_workspace_capabilities,
 )
-from app.services.performance_workspace_chart_points import (
-    build_workspace_chart_points,
-)
 from app.services.performance_workspace_contribution import (
-    build_workspace_contribution_summary,
     merge_contribution_summary_views,
     parse_contribution_result,
 )
@@ -74,8 +64,6 @@ from app.services.performance_workspace_horizon import (
     fetch_workspace_horizon_dependencies,
     parse_horizon_comparison_result,
 )
-from app.services.performance_workspace_mwr import build_workspace_mwr_summary
-from app.services.performance_workspace_parsing import safe_str
 from app.services.performance_workspace_projection import (
     project_portfolio_performance_snapshot,
     project_workspace_details,
@@ -85,11 +73,7 @@ from app.services.performance_workspace_reference import (
     analytics_reference_cache_key,
     resolve_performance_report_end_date,
 )
-from app.services.performance_workspace_returns import (
-    build_workspace_comparative_summary,
-    extract_twr_workspace_block,
-    resolve_results_period_key,
-)
+from app.services.performance_workspace_summary import parse_workspace_summary_result
 from app.services.workbench_service import WorkbenchService
 from app.services.workspace_client_protocols import (
     PerformanceWorkspaceAnalyticsClient,
@@ -617,22 +601,21 @@ class PerformanceWorkspaceService:
                 include_detail_blocks=request_workspace_summary_detail_blocks,
             )
 
-        (
-            net_performance,
-            gross_performance,
-            net_chart,
-            gross_chart,
-            money_weighted_return,
-            contribution,
-            attribution,
-            resolved_benchmark_code,
-        ) = self._parse_workspace_summary_result(
+        parsed_workspace_summary = parse_workspace_summary_result(
             result=workspace_summary_result,
             requested_period=effective_period,
             chart_frequency=resolved_chart_frequency,
             warnings=warnings,
             partial_failures=partial_failures,
         )
+        net_performance = parsed_workspace_summary.net_performance
+        gross_performance = parsed_workspace_summary.gross_performance
+        net_chart = parsed_workspace_summary.net_chart
+        gross_chart = parsed_workspace_summary.gross_chart
+        money_weighted_return = parsed_workspace_summary.money_weighted_return
+        contribution = parsed_workspace_summary.contribution
+        attribution = parsed_workspace_summary.attribution
+        resolved_benchmark_code = parsed_workspace_summary.resolved_benchmark_code
         workspace_summary_available = (
             net_performance.portfolio_return_pct is not None
             or gross_performance.portfolio_return_pct is not None
@@ -984,101 +967,3 @@ class PerformanceWorkspaceService:
 
     async def _empty_async_scalar_result(self, value: str | None) -> str | None:
         return value
-
-    def _parse_workspace_summary_result(
-        self,
-        *,
-        result: GatheredResult,
-        requested_period: str,
-        chart_frequency: str,
-        warnings: list[str],
-        partial_failures: list[WorkbenchPartialFailure],
-    ) -> tuple[
-        PerformanceComparativeSummary,
-        PerformanceComparativeSummary,
-        list[PerformanceChartPoint],
-        list[PerformanceChartPoint],
-        MoneyWeightedReturnSummary | None,
-        ContributionSummaryView | None,
-        AttributionSummaryView | None,
-        str | None,
-    ]:
-        empty_summary = PerformanceComparativeSummary(metric_basis="NET")
-        empty_gross_summary = PerformanceComparativeSummary(metric_basis="GROSS")
-        if isinstance(result, BaseException):
-            warnings.append("PERFORMANCE_WORKSPACE_SUMMARY_UNAVAILABLE")
-            partial_failures.append(
-                build_performance_failure("lotus-performance", "UPSTREAM_EXCEPTION", str(result))
-            )
-            return empty_summary, empty_gross_summary, [], [], None, None, None, None
-
-        status_code, payload = result
-        if not isinstance(payload, dict):
-            warnings.append("PERFORMANCE_WORKSPACE_SUMMARY_INVALID")
-            return empty_summary, empty_gross_summary, [], [], None, None, None, None
-        if status_code >= 400:
-            warnings.append("PERFORMANCE_WORKSPACE_SUMMARY_UNAVAILABLE")
-            partial_failures.append(
-                build_performance_failure(
-                    "lotus-performance",
-                    f"HTTP_{status_code}",
-                    str(payload.get("detail", payload)),
-                )
-            )
-            return empty_summary, empty_gross_summary, [], [], None, None, None, None
-
-        results_by_period = payload.get("results_by_period", {})
-        if not isinstance(results_by_period, dict) or not results_by_period:
-            warnings.append("PERFORMANCE_WORKSPACE_SUMMARY_INVALID")
-            return empty_summary, empty_gross_summary, [], [], None, None, None, None
-
-        period_key = resolve_results_period_key(
-            requested_period=requested_period,
-            results_by_period=results_by_period,
-        )
-        period_payload = results_by_period.get(period_key, {})
-        if not isinstance(period_payload, dict):
-            return empty_summary, empty_gross_summary, [], [], None, None, None, None
-
-        benchmark_block = period_payload.get("benchmark", {})
-        active_block = period_payload.get("active", {})
-        net_block = extract_twr_workspace_block(period_payload, "net")
-        gross_block = extract_twr_workspace_block(period_payload, "gross")
-        money_weighted_return = build_workspace_mwr_summary(period_payload)
-        contribution = build_workspace_contribution_summary(period_payload)
-        attribution = build_workspace_attribution_summary(period_payload)
-
-        net_summary = build_workspace_comparative_summary(
-            metric_basis="NET",
-            portfolio_block=net_block,
-            benchmark_block=benchmark_block,
-            active_basis_block=active_block.get("net") if isinstance(active_block, dict) else {},
-        )
-        gross_summary = build_workspace_comparative_summary(
-            metric_basis="GROSS",
-            portfolio_block=gross_block,
-            benchmark_block=benchmark_block,
-            active_basis_block=active_block.get("gross") if isinstance(active_block, dict) else {},
-        )
-        net_chart = build_workspace_chart_points(
-            portfolio_block=net_block,
-            benchmark_block=benchmark_block,
-            chart_frequency=chart_frequency,
-        )
-        gross_chart = build_workspace_chart_points(
-            portfolio_block=gross_block,
-            benchmark_block=benchmark_block,
-            chart_frequency=chart_frequency,
-        )
-
-        resolved_benchmark_code = safe_str(benchmark_block.get("benchmark_id"))
-        return (
-            net_summary,
-            gross_summary,
-            net_chart,
-            gross_chart,
-            money_weighted_return,
-            contribution,
-            attribution,
-            resolved_benchmark_code,
-        )

--- a/src/app/services/performance_workspace_summary.py
+++ b/src/app/services/performance_workspace_summary.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+from app.contracts.performance_workspace import (
+    AttributionSummaryView,
+    ContributionSummaryView,
+    MoneyWeightedReturnSummary,
+    PerformanceChartPoint,
+    PerformanceComparativeSummary,
+)
+from app.contracts.workbench import WorkbenchPartialFailure
+from app.services.performance_workspace_attribution import build_workspace_attribution_summary
+from app.services.performance_workspace_chart_points import build_workspace_chart_points
+from app.services.performance_workspace_contribution import build_workspace_contribution_summary
+from app.services.performance_workspace_failures import build_performance_failure
+from app.services.performance_workspace_mwr import build_workspace_mwr_summary
+from app.services.performance_workspace_parsing import safe_str
+from app.services.performance_workspace_returns import (
+    build_workspace_comparative_summary,
+    extract_twr_workspace_block,
+    resolve_results_period_key,
+)
+
+UpstreamPayload: TypeAlias = dict[str, Any]
+UpstreamResult: TypeAlias = tuple[int, UpstreamPayload]
+GatheredResult: TypeAlias = UpstreamResult | BaseException
+
+
+@dataclass(frozen=True)
+class ParsedWorkspaceSummary:
+    net_performance: PerformanceComparativeSummary
+    gross_performance: PerformanceComparativeSummary
+    net_chart: list[PerformanceChartPoint]
+    gross_chart: list[PerformanceChartPoint]
+    money_weighted_return: MoneyWeightedReturnSummary | None
+    contribution: ContributionSummaryView | None
+    attribution: AttributionSummaryView | None
+    resolved_benchmark_code: str | None
+
+    @classmethod
+    def empty(cls) -> ParsedWorkspaceSummary:
+        return cls(
+            net_performance=PerformanceComparativeSummary(metric_basis="NET"),
+            gross_performance=PerformanceComparativeSummary(metric_basis="GROSS"),
+            net_chart=[],
+            gross_chart=[],
+            money_weighted_return=None,
+            contribution=None,
+            attribution=None,
+            resolved_benchmark_code=None,
+        )
+
+
+def parse_workspace_summary_result(
+    *,
+    result: GatheredResult,
+    requested_period: str,
+    chart_frequency: str,
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+) -> ParsedWorkspaceSummary:
+    empty_summary = ParsedWorkspaceSummary.empty()
+    if isinstance(result, BaseException):
+        warnings.append("PERFORMANCE_WORKSPACE_SUMMARY_UNAVAILABLE")
+        partial_failures.append(
+            build_performance_failure("lotus-performance", "UPSTREAM_EXCEPTION", str(result))
+        )
+        return empty_summary
+
+    status_code, payload = result
+    if not isinstance(payload, dict):
+        warnings.append("PERFORMANCE_WORKSPACE_SUMMARY_INVALID")
+        return empty_summary
+    if status_code >= 400:
+        warnings.append("PERFORMANCE_WORKSPACE_SUMMARY_UNAVAILABLE")
+        partial_failures.append(
+            build_performance_failure(
+                "lotus-performance",
+                f"HTTP_{status_code}",
+                str(payload.get("detail", payload)),
+            )
+        )
+        return empty_summary
+
+    results_by_period = payload.get("results_by_period", {})
+    if not isinstance(results_by_period, dict) or not results_by_period:
+        warnings.append("PERFORMANCE_WORKSPACE_SUMMARY_INVALID")
+        return empty_summary
+
+    period_key = resolve_results_period_key(
+        requested_period=requested_period,
+        results_by_period=results_by_period,
+    )
+    period_payload = results_by_period.get(period_key, {})
+    if not isinstance(period_payload, dict):
+        return empty_summary
+
+    benchmark_block = period_payload.get("benchmark", {})
+    active_block = period_payload.get("active", {})
+    net_block = extract_twr_workspace_block(period_payload, "net")
+    gross_block = extract_twr_workspace_block(period_payload, "gross")
+    money_weighted_return = build_workspace_mwr_summary(period_payload)
+    contribution = build_workspace_contribution_summary(period_payload)
+    attribution = build_workspace_attribution_summary(period_payload)
+
+    net_performance = build_workspace_comparative_summary(
+        metric_basis="NET",
+        portfolio_block=net_block,
+        benchmark_block=benchmark_block,
+        active_basis_block=active_block.get("net") if isinstance(active_block, dict) else {},
+    )
+    gross_performance = build_workspace_comparative_summary(
+        metric_basis="GROSS",
+        portfolio_block=gross_block,
+        benchmark_block=benchmark_block,
+        active_basis_block=active_block.get("gross") if isinstance(active_block, dict) else {},
+    )
+    net_chart = build_workspace_chart_points(
+        portfolio_block=net_block,
+        benchmark_block=benchmark_block,
+        chart_frequency=chart_frequency,
+    )
+    gross_chart = build_workspace_chart_points(
+        portfolio_block=gross_block,
+        benchmark_block=benchmark_block,
+        chart_frequency=chart_frequency,
+    )
+
+    return ParsedWorkspaceSummary(
+        net_performance=net_performance,
+        gross_performance=gross_performance,
+        net_chart=net_chart,
+        gross_chart=gross_chart,
+        money_weighted_return=money_weighted_return,
+        contribution=contribution,
+        attribution=attribution,
+        resolved_benchmark_code=safe_str(benchmark_block.get("benchmark_id")),
+    )

--- a/tests/unit/test_performance_workspace_summary.py
+++ b/tests/unit/test_performance_workspace_summary.py
@@ -1,0 +1,133 @@
+from app.services.performance_workspace_summary import parse_workspace_summary_result
+
+
+def test_parse_workspace_summary_result_returns_named_summary():
+    warnings: list[str] = []
+    partial_failures = []
+
+    parsed = parse_workspace_summary_result(
+        result=(
+            200,
+            {
+                "results_by_period": {
+                    "YTD": {
+                        "benchmark": {
+                            "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+                            "summary": {"period_return": {"base": 2.9}},
+                            "breakdowns": {
+                                "monthly": [
+                                    {
+                                        "period": "2026-03",
+                                        "period_return": {"base": 1.0},
+                                        "cumulative_return": {"base": 2.9},
+                                    }
+                                ],
+                            },
+                        },
+                        "active": {
+                            "net": {"period_return": {"base": 0.2}},
+                            "gross": {"period_return": {"base": 0.3}},
+                        },
+                        "portfolio_twr": {
+                            "net": {
+                                "summary": {
+                                    "period_return": {"base": 3.1},
+                                    "annualized_return": {"base": 6.3},
+                                },
+                                "breakdowns": {
+                                    "monthly": [
+                                        {
+                                            "period": "2026-03",
+                                            "period_return": {"base": 1.2},
+                                            "cumulative_return": {"base": 3.1},
+                                        }
+                                    ],
+                                },
+                            },
+                            "gross": {
+                                "summary": {
+                                    "period_return": {"base": 3.2},
+                                    "annualized_return": {"base": 6.4},
+                                },
+                                "breakdowns": {
+                                    "monthly": [
+                                        {
+                                            "period": "2026-03",
+                                            "period_return": {"base": 1.3},
+                                            "cumulative_return": {"base": 3.2},
+                                        }
+                                    ],
+                                },
+                            },
+                        },
+                        "money_weighted_return": {
+                            "period_return": 3.05,
+                            "input_mode": "stateful",
+                        },
+                        "contribution": {
+                            "metric_basis": "NET",
+                            "summary": {"portfolio_contribution": 3.1},
+                        },
+                        "attribution": {
+                            "metric_basis": "NET",
+                            "result": {
+                                "reconciliation": {
+                                    "total_active_return": 0.2,
+                                    "sum_of_effects": 0.19,
+                                },
+                            },
+                            "benchmark_context": {
+                                "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+                            },
+                        },
+                    },
+                },
+            },
+        ),
+        requested_period="YTD",
+        chart_frequency="monthly",
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert parsed.net_performance.portfolio_return_pct == 3.1
+    assert parsed.net_performance.benchmark_return_pct == 2.9
+    assert parsed.net_performance.active_return_pct == 0.2
+    assert parsed.gross_performance.portfolio_return_pct == 3.2
+    assert parsed.gross_performance.active_return_pct == 0.3
+    assert len(parsed.net_chart) == 1
+    assert parsed.net_chart[0].label == "2026-03"
+    assert parsed.net_chart[0].active_return_pct == 0.2
+    assert parsed.money_weighted_return is not None
+    assert parsed.money_weighted_return.money_weighted_return_pct == 3.05
+    assert parsed.contribution is not None
+    assert parsed.contribution.portfolio_contribution_pct == 3.1
+    assert parsed.attribution is not None
+    assert parsed.attribution.active_return_pct == 0.2
+    assert parsed.resolved_benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert warnings == []
+    assert partial_failures == []
+
+
+def test_parse_workspace_summary_result_records_upstream_failure():
+    warnings: list[str] = []
+    partial_failures = []
+
+    parsed = parse_workspace_summary_result(
+        result=(503, {"detail": "workspace summary unavailable"}),
+        requested_period="YTD",
+        chart_frequency="monthly",
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert parsed.net_performance.metric_basis == "NET"
+    assert parsed.net_performance.portfolio_return_pct is None
+    assert parsed.gross_performance.metric_basis == "GROSS"
+    assert parsed.net_chart == []
+    assert parsed.resolved_benchmark_code is None
+    assert warnings == ["PERFORMANCE_WORKSPACE_SUMMARY_UNAVAILABLE"]
+    assert len(partial_failures) == 1
+    assert partial_failures[0].source_service == "lotus-performance"
+    assert partial_failures[0].error_code == "HTTP_503"
+    assert partial_failures[0].detail == "workspace summary unavailable"


### PR DESCRIPTION
## Summary
- Move performance workspace summary parsing into a dedicated summary helper module.
- Replace the service-owned opaque parser tuple with a named ParsedWorkspaceSummary boundary object.
- Add focused unit coverage for successful summary parsing and upstream failure evidence.

## Validation
- python -m ruff check src/app/services/performance_workspace_service.py src/app/services/performance_workspace_summary.py tests/unit/test_performance_workspace_summary.py
- python -m mypy src/app/services/performance_workspace_service.py src/app/services/performance_workspace_summary.py
- python -m pytest tests/unit/test_performance_workspace_summary.py tests/unit/test_performance_workspace_service.py -q
- python -m pytest tests/unit/test_performance_workspace_summary.py tests/unit/test_performance_workspace_horizon.py tests/unit/test_performance_workspace_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API.
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal parser-boundary cleanup.
- Stranded truth: no governance-bearing paths changed and no unmerged remote branches were present after fetch.