### PR TITLE
Extract Workbench performance snapshot parser

### DIFF
--- a/src/app/services/workbench_performance_snapshot.py
+++ b/src/app/services/workbench_performance_snapshot.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from fastapi import status
+
+from app.contracts.workbench import WorkbenchPartialFailure, WorkbenchPerformanceSnapshot
+
+
+def parse_performance_snapshot(
+    result: object,
+    partial_failures: list[WorkbenchPartialFailure],
+    warnings: list[str],
+) -> WorkbenchPerformanceSnapshot | None:
+    if isinstance(result, Exception):
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="lotus-performance",
+                error_code="UPSTREAM_EXCEPTION",
+                detail=str(result),
+            )
+        )
+        warnings.append("PERFORMANCE_SNAPSHOT_UNAVAILABLE")
+        return None
+
+    if not isinstance(result, tuple) or len(result) != 2:
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="lotus-performance",
+                error_code="INVALID_UPSTREAM_RESPONSE",
+                detail=f"unexpected result type: {type(result)}",
+            )
+        )
+        warnings.append("PERFORMANCE_SNAPSHOT_UNAVAILABLE")
+        return None
+
+    performance_status, performance_payload = result
+    if not isinstance(performance_payload, dict):
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="lotus-performance",
+                error_code="INVALID_UPSTREAM_PAYLOAD",
+                detail=f"unexpected payload type: {type(performance_payload)}",
+            )
+        )
+        warnings.append("PERFORMANCE_SNAPSHOT_UNAVAILABLE")
+        return None
+
+    if performance_status >= status.HTTP_400_BAD_REQUEST:
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="lotus-performance",
+                error_code=f"HTTP_{performance_status}",
+                detail=str(performance_payload.get("detail", performance_payload)),
+            )
+        )
+        warnings.append("PERFORMANCE_SNAPSHOT_UNAVAILABLE")
+        return None
+
+    results_by_period = performance_payload.get(
+        "results_by_period",
+        performance_payload.get("resultsByPeriod", {}),
+    )
+    if not isinstance(results_by_period, dict):
+        warnings.append("PERFORMANCE_SNAPSHOT_INVALID")
+        return None
+
+    if "YTD" in results_by_period:
+        period_key = "YTD"
+    else:
+        keys = iter(results_by_period)
+        try:
+            period_key = next(keys)
+        except StopIteration:
+            return None
+
+    if period_key is None:
+        return None
+
+    period_payload = results_by_period.get(period_key, {})
+    if not isinstance(period_payload, dict):
+        return None
+    portfolio_payload = period_payload.get("portfolio", {})
+    if not isinstance(portfolio_payload, dict):
+        return None
+    summary_payload = portfolio_payload.get("summary", {})
+    if not isinstance(summary_payload, dict):
+        return None
+    period_return_payload = summary_payload.get("period_return", {})
+    if not isinstance(period_return_payload, dict):
+        return None
+
+    return WorkbenchPerformanceSnapshot(
+        period=period_key,
+        return_pct=period_return_payload.get("base"),
+        benchmark_return_pct=None,
+    )

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -31,6 +31,7 @@ from app.precision_policy import (
     quantize_performance,
     quantize_quantity,
 )
+from app.services.workbench_performance_snapshot import parse_performance_snapshot
 from app.services.workspace_client_protocols import (
     WorkbenchAdviseClient,
     WorkbenchCoreClient,
@@ -562,7 +563,7 @@ class WorkbenchService:
                 return_exceptions=True,
             )
             if include_performance_snapshot:
-                performance_snapshot = self._parse_performance_snapshot(
+                performance_snapshot = parse_performance_snapshot(
                     result=cast(object, gathered[0]),
                     partial_failures=partial_failures,
                     warnings=warnings,
@@ -885,96 +886,6 @@ class WorkbenchService:
             position_count=len(baseline_rows),
         )
         return portfolio, overview, as_of_date
-
-    def _parse_performance_snapshot(
-        self,
-        result: object,
-        partial_failures: list[WorkbenchPartialFailure],
-        warnings: list[str],
-    ) -> WorkbenchPerformanceSnapshot | None:
-        if isinstance(result, Exception):
-            partial_failures.append(
-                WorkbenchPartialFailure(
-                    source_service="lotus-performance",
-                    error_code="UPSTREAM_EXCEPTION",
-                    detail=str(result),
-                )
-            )
-            warnings.append("PERFORMANCE_SNAPSHOT_UNAVAILABLE")
-            return None
-
-        if not isinstance(result, tuple) or len(result) != 2:
-            partial_failures.append(
-                WorkbenchPartialFailure(
-                    source_service="lotus-performance",
-                    error_code="INVALID_UPSTREAM_RESPONSE",
-                    detail=f"unexpected result type: {type(result)}",
-                )
-            )
-            warnings.append("PERFORMANCE_SNAPSHOT_UNAVAILABLE")
-            return None
-
-        performance_status, performance_payload = result
-        if not isinstance(performance_payload, dict):
-            partial_failures.append(
-                WorkbenchPartialFailure(
-                    source_service="lotus-performance",
-                    error_code="INVALID_UPSTREAM_PAYLOAD",
-                    detail=f"unexpected payload type: {type(performance_payload)}",
-                )
-            )
-            warnings.append("PERFORMANCE_SNAPSHOT_UNAVAILABLE")
-            return None
-
-        if performance_status >= status.HTTP_400_BAD_REQUEST:
-            partial_failures.append(
-                WorkbenchPartialFailure(
-                    source_service="lotus-performance",
-                    error_code=f"HTTP_{performance_status}",
-                    detail=str(performance_payload.get("detail", performance_payload)),
-                )
-            )
-            warnings.append("PERFORMANCE_SNAPSHOT_UNAVAILABLE")
-            return None
-
-        results_by_period = performance_payload.get(
-            "results_by_period",
-            performance_payload.get("resultsByPeriod", {}),
-        )
-        if not isinstance(results_by_period, dict):
-            warnings.append("PERFORMANCE_SNAPSHOT_INVALID")
-            return None
-
-        if "YTD" in results_by_period:
-            period_key = "YTD"
-        else:
-            keys = iter(results_by_period)
-            try:
-                period_key = next(keys)
-            except StopIteration:
-                return None
-
-        if period_key is None:
-            return None
-
-        period_payload = results_by_period.get(period_key, {})
-        if not isinstance(period_payload, dict):
-            return None
-        portfolio_payload = period_payload.get("portfolio", {})
-        if not isinstance(portfolio_payload, dict):
-            return None
-        summary_payload = portfolio_payload.get("summary", {})
-        if not isinstance(summary_payload, dict):
-            return None
-        period_return_payload = summary_payload.get("period_return", {})
-        if not isinstance(period_return_payload, dict):
-            return None
-
-        return WorkbenchPerformanceSnapshot(
-            period=period_key,
-            return_pct=period_return_payload.get("base"),
-            benchmark_return_pct=None,
-        )
 
     def _optional_money(self, value: Any) -> float | None:
         if value is None:

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 import pytest
 from fastapi import HTTPException
 
+from app.services.workbench_performance_snapshot import parse_performance_snapshot
 from app.services.workbench_service import WorkbenchService
 
 
@@ -192,29 +193,26 @@ def test_parse_lotus_core_snapshot_uses_fallback_defaults():
     ],
 )
 def test_parse_performance_snapshot_handles_exception_and_invalid_result_shape(result, warning):
-    service, _, _, _ = _build_service()
     partial_failures = []
     warnings = []
-    parsed = service._parse_performance_snapshot(result, partial_failures, warnings)
+    parsed = parse_performance_snapshot(result, partial_failures, warnings)
     assert parsed is None
     assert warning in warnings
     assert len(partial_failures) == 1
 
 
 def test_parse_performance_snapshot_handles_invalid_payload_types():
-    service, _, _, _ = _build_service()
     partial_failures = []
     warnings = []
-    parsed = service._parse_performance_snapshot((200, "bad-payload"), partial_failures, warnings)
+    parsed = parse_performance_snapshot((200, "bad-payload"), partial_failures, warnings)
     assert parsed is None
     assert "PERFORMANCE_SNAPSHOT_UNAVAILABLE" in warnings
 
 
 def test_parse_performance_snapshot_handles_http_error_payload():
-    service, _, _, _ = _build_service()
     partial_failures = []
     warnings = []
-    parsed = service._parse_performance_snapshot(
+    parsed = parse_performance_snapshot(
         (503, {"detail": "lotus-performance down"}),
         partial_failures,
         warnings,
@@ -224,10 +222,9 @@ def test_parse_performance_snapshot_handles_http_error_payload():
 
 
 def test_parse_performance_snapshot_handles_non_dict_period_map():
-    service, _, _, _ = _build_service()
     partial_failures = []
     warnings = []
-    parsed = service._parse_performance_snapshot(
+    parsed = parse_performance_snapshot(
         (200, {"results_by_period": []}),
         partial_failures,
         warnings,
@@ -237,10 +234,9 @@ def test_parse_performance_snapshot_handles_non_dict_period_map():
 
 
 def test_parse_performance_snapshot_falls_back_to_first_period_key():
-    service, _, _, _ = _build_service()
     partial_failures = []
     warnings = []
-    parsed = service._parse_performance_snapshot(
+    parsed = parse_performance_snapshot(
         (
             200,
             {
@@ -643,20 +639,17 @@ def test_parse_lotus_core_snapshot_handles_non_dict_overview_and_holdings_shapes
 
 
 def test_parse_performance_snapshot_empty_results_by_period_returns_none():
-    service, _, _, _ = _build_service()
-    result = service._parse_performance_snapshot((200, {"results_by_period": {}}), [], [])
+    result = parse_performance_snapshot((200, {"results_by_period": {}}), [], [])
     assert result is None
 
 
 def test_parse_performance_snapshot_non_dict_period_payload_returns_none():
-    service, _, _, _ = _build_service()
-    result = service._parse_performance_snapshot((200, {"results_by_period": {"YTD": []}}), [], [])
+    result = parse_performance_snapshot((200, {"results_by_period": {"YTD": []}}), [], [])
     assert result is None
 
 
 def test_parse_performance_snapshot_none_period_key_returns_none():
-    service, _, _, _ = _build_service()
-    result = service._parse_performance_snapshot(
+    result = parse_performance_snapshot(
         (
             200,
             {


### PR DESCRIPTION
## Summary
- Move Workbench performance snapshot parsing into a dedicated helper module.
- Keep WorkbenchService focused on orchestration and overview enrichment flow.
- Retarget existing parser tests to the extracted helper boundary.

## Validation
- python -m ruff check src/app/services/workbench_service.py src/app/services/workbench_performance_snapshot.py tests/unit/test_workbench_service_additional.py
- python -m mypy src/app/services/workbench_service.py src/app/services/workbench_performance_snapshot.py
- python -m pytest tests/unit/test_workbench_service.py tests/unit/test_workbench_service_additional.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API.
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal parser-boundary cleanup.
- Stranded truth: no governance-bearing paths changed and no unmerged remote branches were present after fetch.