### PR TITLE
Extract Workbench rebalance snapshot parser

### DIFF
--- a/src/app/services/workbench_rebalance_snapshot.py
+++ b/src/app/services/workbench_rebalance_snapshot.py
@@ -1,0 +1,255 @@
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import status
+
+from app.contracts.portfolio import PortfolioRebalanceSupportabilitySummary
+from app.contracts.workbench import (
+    WorkbenchPartialFailure,
+    WorkbenchRebalanceRunSummary,
+    WorkbenchRebalanceSnapshot,
+)
+
+
+def parse_rebalance_snapshot(
+    result: object,
+    partial_failures: list[WorkbenchPartialFailure],
+    warnings: list[str],
+    supportability_result: object | None = None,
+) -> WorkbenchRebalanceSnapshot | None:
+    if isinstance(result, Exception):
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="lotus-manage",
+                error_code="UPSTREAM_EXCEPTION",
+                detail=str(result),
+            )
+        )
+        warnings.append("MANAGE_REBALANCE_UNAVAILABLE")
+        return None
+
+    if not isinstance(result, tuple) or len(result) != 2:
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="lotus-manage",
+                error_code="INVALID_UPSTREAM_RESPONSE",
+                detail=f"unexpected result type: {type(result)}",
+            )
+        )
+        warnings.append("MANAGE_REBALANCE_UNAVAILABLE")
+        return None
+
+    dpm_status, dpm_payload = result
+    if not isinstance(dpm_payload, dict):
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="lotus-manage",
+                error_code="INVALID_UPSTREAM_PAYLOAD",
+                detail=f"unexpected payload type: {type(dpm_payload)}",
+            )
+        )
+        warnings.append("MANAGE_REBALANCE_UNAVAILABLE")
+        return None
+
+    if dpm_status >= status.HTTP_400_BAD_REQUEST:
+        partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="lotus-manage",
+                error_code=f"HTTP_{dpm_status}",
+                detail=str(dpm_payload.get("detail", dpm_payload)),
+            )
+        )
+        warnings.append("MANAGE_REBALANCE_UNAVAILABLE")
+        return None
+
+    items = dpm_payload.get("items", [])
+    if not isinstance(items, list) or not items:
+        return WorkbenchRebalanceSnapshot(status="NOT_AVAILABLE")
+
+    latest = items[0]
+    if not isinstance(latest, dict):
+        return WorkbenchRebalanceSnapshot(status="NOT_AVAILABLE")
+
+    created_at = latest.get("created_at")
+    last_run_at_utc = None
+    if isinstance(created_at, str):
+        last_run_at_utc = created_at
+    elif isinstance(created_at, datetime):
+        last_run_at_utc = created_at.astimezone(UTC).isoformat()
+
+    return WorkbenchRebalanceSnapshot(
+        status=str(latest.get("status", "UNKNOWN")),
+        last_rebalance_run_id=_optional_str(latest.get("rebalance_run_id")),
+        last_run_at_utc=last_run_at_utc,
+        supportability=_parse_rebalance_supportability(
+            dpm_payload,
+            supportability_result=supportability_result,
+            partial_failures=partial_failures,
+            warnings=warnings,
+        ),
+        recent_runs=_parse_recent_dpm_runs(items),
+    )
+
+
+def _parse_recent_dpm_runs(items: list[Any]) -> list[WorkbenchRebalanceRunSummary]:
+    recent_runs: list[WorkbenchRebalanceRunSummary] = []
+    for item in items[:5]:
+        if not isinstance(item, dict):
+            continue
+        recent_runs.append(
+            WorkbenchRebalanceRunSummary(
+                rebalance_run_id=_optional_str(item.get("rebalance_run_id")),
+                status=str(item.get("status", "UNKNOWN")),
+                created_at_utc=_optional_datetime_str(item.get("created_at")),
+                error_code=_extract_dpm_run_error_code(item),
+                workflow_state=_optional_str(
+                    item.get("workflow_state")
+                    or item.get("workflow_decision_state")
+                    or item.get("review_state")
+                ),
+            )
+        )
+    return recent_runs
+
+
+def _parse_rebalance_supportability(
+    dpm_payload: dict[str, Any],
+    *,
+    supportability_result: object | None = None,
+    partial_failures: list[WorkbenchPartialFailure] | None = None,
+    warnings: list[str] | None = None,
+) -> PortfolioRebalanceSupportabilitySummary | None:
+    supportability_payload = _extract_rebalance_supportability_payload(
+        dpm_payload=dpm_payload,
+        supportability_result=supportability_result,
+        partial_failures=partial_failures,
+        warnings=warnings,
+    )
+    if not isinstance(supportability_payload, dict):
+        return None
+    return PortfolioRebalanceSupportabilitySummary(
+        feature_key=(
+            _optional_str(supportability_payload.get("feature_key"))
+            or "manage.observability.action_register_supportability"
+        ),
+        state=str(supportability_payload.get("state") or "unknown"),
+        reason=_optional_str(supportability_payload.get("reason")),
+        freshness_bucket=_optional_str(supportability_payload.get("freshness_bucket")),
+        run_count=_optional_int(supportability_payload.get("run_count")),
+        operation_count=_optional_int(supportability_payload.get("operation_count")),
+        workflow_decision_count=_optional_int(
+            supportability_payload.get("workflow_decision_count")
+        ),
+    )
+
+
+def _extract_rebalance_supportability_payload(
+    *,
+    dpm_payload: dict[str, Any],
+    supportability_result: object | None,
+    partial_failures: list[WorkbenchPartialFailure] | None,
+    warnings: list[str] | None,
+) -> dict[str, Any] | None:
+    supportability_payload = dpm_payload.get("supportability")
+    if isinstance(supportability_payload, dict):
+        return supportability_payload
+    if supportability_result is None:
+        return None
+    if isinstance(supportability_result, BaseException):
+        if partial_failures is not None:
+            partial_failures.append(
+                WorkbenchPartialFailure(
+                    source_service="lotus-manage",
+                    error_code="SUPPORTABILITY_SUMMARY_UNAVAILABLE",
+                    detail=str(supportability_result),
+                )
+            )
+        if warnings is not None:
+            warnings.append("MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
+        return None
+    if not isinstance(supportability_result, tuple) or len(supportability_result) != 2:
+        if partial_failures is not None:
+            partial_failures.append(
+                WorkbenchPartialFailure(
+                    source_service="lotus-manage",
+                    error_code="INVALID_SUPPORTABILITY_SUMMARY_RESULT",
+                    detail=f"unexpected supportability result: {type(supportability_result)}",
+                )
+            )
+        if warnings is not None:
+            warnings.append("MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
+        return None
+    supportability_status, supportability_summary = supportability_result
+    if not isinstance(supportability_status, int) or not isinstance(
+        supportability_summary,
+        dict,
+    ):
+        if partial_failures is not None:
+            partial_failures.append(
+                WorkbenchPartialFailure(
+                    source_service="lotus-manage",
+                    error_code="INVALID_SUPPORTABILITY_SUMMARY_PAYLOAD",
+                    detail=(
+                        "supportability summary result must include integer status "
+                        "and object payload"
+                    ),
+                )
+            )
+        if warnings is not None:
+            warnings.append("MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
+        return None
+    if supportability_status >= status.HTTP_400_BAD_REQUEST:
+        if partial_failures is not None:
+            partial_failures.append(
+                WorkbenchPartialFailure(
+                    source_service="lotus-manage",
+                    error_code=f"SUPPORTABILITY_HTTP_{supportability_status}",
+                    detail=str(supportability_summary.get("detail", supportability_summary)),
+                )
+            )
+        if warnings is not None:
+            warnings.append("MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
+        return None
+    supportability_payload = supportability_summary.get("supportability")
+    if isinstance(supportability_payload, dict):
+        merged_payload = dict(supportability_payload)
+        for summary_key in ("run_count", "operation_count", "workflow_decision_count"):
+            if summary_key not in merged_payload and summary_key in supportability_summary:
+                merged_payload[summary_key] = supportability_summary[summary_key]
+        return merged_payload
+    return None
+
+
+def _extract_dpm_run_error_code(item: dict[str, Any]) -> str | None:
+    for key in ("error_code", "failure_code", "reason_code"):
+        value = _optional_str(item.get(key))
+        if value:
+            return value
+    error_payload = item.get("error")
+    if isinstance(error_payload, dict):
+        return _optional_str(error_payload.get("code"))
+    return None
+
+
+def _optional_datetime_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, datetime):
+        return value.astimezone(UTC).isoformat()
+    return None
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -1,13 +1,12 @@
 import asyncio
 from collections.abc import Awaitable
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import date
 from typing import Any, cast
 
 from fastapi import HTTPException, status
 
 from app.config import settings
-from app.contracts.portfolio import PortfolioRebalanceSupportabilitySummary
 from app.contracts.workbench import (
     WorkbenchAnalyticsBucket,
     WorkbenchAnalyticsResponse,
@@ -21,7 +20,6 @@ from app.contracts.workbench import (
     WorkbenchPositionView,
     WorkbenchProjectedPositionView,
     WorkbenchProjectedSummary,
-    WorkbenchRebalanceRunSummary,
     WorkbenchRebalanceSnapshot,
     WorkbenchSandboxStateResponse,
     WorkbenchTopChange,
@@ -32,6 +30,7 @@ from app.precision_policy import (
     quantize_quantity,
 )
 from app.services.workbench_performance_snapshot import parse_performance_snapshot
+from app.services.workbench_rebalance_snapshot import parse_rebalance_snapshot
 from app.services.workspace_client_protocols import (
     WorkbenchAdviseClient,
     WorkbenchCoreClient,
@@ -569,7 +568,7 @@ class WorkbenchService:
                     warnings=warnings,
                 )
             if include_rebalance_snapshot:
-                rebalance_snapshot = self._parse_dpm_snapshot(
+                rebalance_snapshot = parse_rebalance_snapshot(
                     result=cast(object, gathered[1]),
                     supportability_result=cast(object, gathered[2]),
                     partial_failures=partial_failures,
@@ -900,251 +899,6 @@ class WorkbenchService:
             return None
         try:
             return float(quantize_performance(float(value) * 100.0))
-        except (TypeError, ValueError):
-            return None
-
-    def _parse_dpm_snapshot(
-        self,
-        result: object,
-        partial_failures: list[WorkbenchPartialFailure],
-        warnings: list[str],
-        supportability_result: object | None = None,
-    ) -> WorkbenchRebalanceSnapshot | None:
-        if isinstance(result, Exception):
-            partial_failures.append(
-                WorkbenchPartialFailure(
-                    source_service="lotus-manage",
-                    error_code="UPSTREAM_EXCEPTION",
-                    detail=str(result),
-                )
-            )
-            warnings.append("MANAGE_REBALANCE_UNAVAILABLE")
-            return None
-
-        if not isinstance(result, tuple) or len(result) != 2:
-            partial_failures.append(
-                WorkbenchPartialFailure(
-                    source_service="lotus-manage",
-                    error_code="INVALID_UPSTREAM_RESPONSE",
-                    detail=f"unexpected result type: {type(result)}",
-                )
-            )
-            warnings.append("MANAGE_REBALANCE_UNAVAILABLE")
-            return None
-
-        dpm_status, dpm_payload = result
-        if not isinstance(dpm_payload, dict):
-            partial_failures.append(
-                WorkbenchPartialFailure(
-                    source_service="lotus-manage",
-                    error_code="INVALID_UPSTREAM_PAYLOAD",
-                    detail=f"unexpected payload type: {type(dpm_payload)}",
-                )
-            )
-            warnings.append("MANAGE_REBALANCE_UNAVAILABLE")
-            return None
-
-        if dpm_status >= status.HTTP_400_BAD_REQUEST:
-            partial_failures.append(
-                WorkbenchPartialFailure(
-                    source_service="lotus-manage",
-                    error_code=f"HTTP_{dpm_status}",
-                    detail=str(dpm_payload.get("detail", dpm_payload)),
-                )
-            )
-            warnings.append("MANAGE_REBALANCE_UNAVAILABLE")
-            return None
-
-        items = dpm_payload.get("items", [])
-        if not isinstance(items, list) or not items:
-            return WorkbenchRebalanceSnapshot(status="NOT_AVAILABLE")
-
-        latest = items[0]
-        if not isinstance(latest, dict):
-            return WorkbenchRebalanceSnapshot(status="NOT_AVAILABLE")
-
-        created_at = latest.get("created_at")
-        last_run_at_utc = None
-        if isinstance(created_at, str):
-            last_run_at_utc = created_at
-        elif isinstance(created_at, datetime):
-            last_run_at_utc = created_at.astimezone(UTC).isoformat()
-
-        recent_runs = self._parse_recent_dpm_runs(items)
-        supportability = self._parse_rebalance_supportability(
-            dpm_payload,
-            supportability_result=supportability_result,
-            partial_failures=partial_failures,
-            warnings=warnings,
-        )
-
-        return WorkbenchRebalanceSnapshot(
-            status=str(latest.get("status", "UNKNOWN")),
-            last_rebalance_run_id=self._optional_str(latest.get("rebalance_run_id")),
-            last_run_at_utc=last_run_at_utc,
-            supportability=supportability,
-            recent_runs=recent_runs,
-        )
-
-    def _parse_recent_dpm_runs(
-        self,
-        items: list[Any],
-    ) -> list[WorkbenchRebalanceRunSummary]:
-        recent_runs: list[WorkbenchRebalanceRunSummary] = []
-        for item in items[:5]:
-            if not isinstance(item, dict):
-                continue
-            recent_runs.append(
-                WorkbenchRebalanceRunSummary(
-                    rebalance_run_id=self._optional_str(item.get("rebalance_run_id")),
-                    status=str(item.get("status", "UNKNOWN")),
-                    created_at_utc=self._optional_datetime_str(item.get("created_at")),
-                    error_code=self._extract_dpm_run_error_code(item),
-                    workflow_state=self._optional_str(
-                        item.get("workflow_state")
-                        or item.get("workflow_decision_state")
-                        or item.get("review_state")
-                    ),
-                )
-            )
-        return recent_runs
-
-    def _parse_rebalance_supportability(
-        self,
-        dpm_payload: dict[str, Any],
-        *,
-        supportability_result: object | None = None,
-        partial_failures: list[WorkbenchPartialFailure] | None = None,
-        warnings: list[str] | None = None,
-    ) -> PortfolioRebalanceSupportabilitySummary | None:
-        supportability_payload = self._extract_rebalance_supportability_payload(
-            dpm_payload=dpm_payload,
-            supportability_result=supportability_result,
-            partial_failures=partial_failures,
-            warnings=warnings,
-        )
-        if not isinstance(supportability_payload, dict):
-            return None
-        return PortfolioRebalanceSupportabilitySummary(
-            feature_key=(
-                self._optional_str(supportability_payload.get("feature_key"))
-                or "manage.observability.action_register_supportability"
-            ),
-            state=str(supportability_payload.get("state") or "unknown"),
-            reason=self._optional_str(supportability_payload.get("reason")),
-            freshness_bucket=self._optional_str(supportability_payload.get("freshness_bucket")),
-            run_count=self._optional_int(supportability_payload.get("run_count")),
-            operation_count=self._optional_int(supportability_payload.get("operation_count")),
-            workflow_decision_count=self._optional_int(
-                supportability_payload.get("workflow_decision_count")
-            ),
-        )
-
-    def _extract_rebalance_supportability_payload(
-        self,
-        *,
-        dpm_payload: dict[str, Any],
-        supportability_result: object | None,
-        partial_failures: list[WorkbenchPartialFailure] | None,
-        warnings: list[str] | None,
-    ) -> dict[str, Any] | None:
-        supportability_payload = dpm_payload.get("supportability")
-        if isinstance(supportability_payload, dict):
-            return supportability_payload
-        if supportability_result is None:
-            return None
-        if isinstance(supportability_result, BaseException):
-            if partial_failures is not None:
-                partial_failures.append(
-                    WorkbenchPartialFailure(
-                        source_service="lotus-manage",
-                        error_code="SUPPORTABILITY_SUMMARY_UNAVAILABLE",
-                        detail=str(supportability_result),
-                    )
-                )
-            if warnings is not None:
-                warnings.append("MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
-            return None
-        if not isinstance(supportability_result, tuple) or len(supportability_result) != 2:
-            if partial_failures is not None:
-                partial_failures.append(
-                    WorkbenchPartialFailure(
-                        source_service="lotus-manage",
-                        error_code="INVALID_SUPPORTABILITY_SUMMARY_RESULT",
-                        detail=f"unexpected supportability result: {type(supportability_result)}",
-                    )
-                )
-            if warnings is not None:
-                warnings.append("MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
-            return None
-        supportability_status, supportability_summary = supportability_result
-        if not isinstance(supportability_status, int) or not isinstance(
-            supportability_summary,
-            dict,
-        ):
-            if partial_failures is not None:
-                partial_failures.append(
-                    WorkbenchPartialFailure(
-                        source_service="lotus-manage",
-                        error_code="INVALID_SUPPORTABILITY_SUMMARY_PAYLOAD",
-                        detail=(
-                            "supportability summary result must include integer status "
-                            "and object payload"
-                        ),
-                    )
-                )
-            if warnings is not None:
-                warnings.append("MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
-            return None
-        if supportability_status >= status.HTTP_400_BAD_REQUEST:
-            if partial_failures is not None:
-                partial_failures.append(
-                    WorkbenchPartialFailure(
-                        source_service="lotus-manage",
-                        error_code=f"SUPPORTABILITY_HTTP_{supportability_status}",
-                        detail=str(supportability_summary.get("detail", supportability_summary)),
-                    )
-                )
-            if warnings is not None:
-                warnings.append("MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
-            return None
-        supportability_payload = supportability_summary.get("supportability")
-        if isinstance(supportability_payload, dict):
-            merged_payload = dict(supportability_payload)
-            for summary_key in ("run_count", "operation_count", "workflow_decision_count"):
-                if summary_key not in merged_payload and summary_key in supportability_summary:
-                    merged_payload[summary_key] = supportability_summary[summary_key]
-            return merged_payload
-        return None
-
-    def _extract_dpm_run_error_code(self, item: dict[str, Any]) -> str | None:
-        for key in ("error_code", "failure_code", "reason_code"):
-            value = self._optional_str(item.get(key))
-            if value:
-                return value
-        error_payload = item.get("error")
-        if isinstance(error_payload, dict):
-            return self._optional_str(error_payload.get("code"))
-        return None
-
-    def _optional_datetime_str(self, value: Any) -> str | None:
-        if isinstance(value, str):
-            return value
-        if isinstance(value, datetime):
-            return value.astimezone(UTC).isoformat()
-        return None
-
-    def _optional_str(self, value: Any) -> str | None:
-        if value is None:
-            return None
-        text = str(value).strip()
-        return text or None
-
-    def _optional_int(self, value: Any) -> int | None:
-        if value is None:
-            return None
-        try:
-            return int(value)
         except (TypeError, ValueError):
             return None
 

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.services.workbench_performance_snapshot import parse_performance_snapshot
+from app.services.workbench_rebalance_snapshot import parse_rebalance_snapshot
 from app.services.workbench_service import WorkbenchService
 
 
@@ -261,44 +262,39 @@ def test_parse_performance_snapshot_falls_back_to_first_period_key():
     ],
 )
 def test_parse_dpm_snapshot_handles_exception_and_invalid_result_shape(result, warning):
-    service, _, _, _ = _build_service()
     partial_failures = []
     warnings = []
-    parsed = service._parse_dpm_snapshot(result, partial_failures, warnings)
+    parsed = parse_rebalance_snapshot(result, partial_failures, warnings)
     assert parsed is None
     assert warning in warnings
     assert len(partial_failures) == 1
 
 
 def test_parse_dpm_snapshot_handles_invalid_payload_type():
-    service, _, _, _ = _build_service()
     partial_failures = []
     warnings = []
-    parsed = service._parse_dpm_snapshot((200, "bad-payload"), partial_failures, warnings)
+    parsed = parse_rebalance_snapshot((200, "bad-payload"), partial_failures, warnings)
     assert parsed is None
     assert partial_failures[0].error_code == "INVALID_UPSTREAM_PAYLOAD"
 
 
 def test_parse_dpm_snapshot_handles_http_error():
-    service, _, _, _ = _build_service()
     partial_failures = []
     warnings = []
-    parsed = service._parse_dpm_snapshot((500, {"detail": "dpm down"}), partial_failures, warnings)
+    parsed = parse_rebalance_snapshot((500, {"detail": "dpm down"}), partial_failures, warnings)
     assert parsed is None
     assert partial_failures[0].error_code == "HTTP_500"
 
 
 def test_parse_dpm_snapshot_with_no_items_returns_not_available():
-    service, _, _, _ = _build_service()
-    parsed = service._parse_dpm_snapshot((200, {"items": []}), [], [])
+    parsed = parse_rebalance_snapshot((200, {"items": []}), [], [])
     assert parsed is not None
     assert parsed.status == "NOT_AVAILABLE"
 
 
 def test_parse_dpm_snapshot_with_datetime_created_at_converts_to_utc():
-    service, _, _, _ = _build_service()
     created = datetime(2026, 2, 24, 10, 15, tzinfo=UTC)
-    parsed = service._parse_dpm_snapshot(
+    parsed = parse_rebalance_snapshot(
         (200, {"items": [{"status": "READY", "created_at": created, "rebalance_run_id": "rr-1"}]}),
         [],
         [],
@@ -310,8 +306,7 @@ def test_parse_dpm_snapshot_with_datetime_created_at_converts_to_utc():
 
 
 def test_parse_dpm_snapshot_uses_live_shape_supportability_summary():
-    service, _, _, _ = _build_service()
-    parsed = service._parse_dpm_snapshot(
+    parsed = parse_rebalance_snapshot(
         (
             200,
             {
@@ -349,6 +344,67 @@ def test_parse_dpm_snapshot_uses_live_shape_supportability_summary():
     assert parsed.supportability.state == "ready"
     assert parsed.supportability.freshness_bucket == "current"
     assert parsed.supportability.run_count == 82
+
+
+def test_parse_dpm_snapshot_records_supportability_summary_failure():
+    partial_failures = []
+    warnings = []
+    parsed = parse_rebalance_snapshot(
+        (200, {"items": [{"status": "READY"}]}),
+        partial_failures,
+        warnings,
+        supportability_result=(503, {"detail": "summary unavailable"}),
+    )
+    assert parsed is not None
+    assert parsed.supportability is None
+    assert warnings == ["MANAGE_REBALANCE_SUPPORTABILITY_UNAVAILABLE"]
+    assert partial_failures[0].error_code == "SUPPORTABILITY_HTTP_503"
+
+
+def test_parse_dpm_snapshot_merges_supportability_counts_from_summary_root():
+    parsed = parse_rebalance_snapshot(
+        (200, {"items": [{"status": "READY"}]}),
+        [],
+        [],
+        supportability_result=(
+            200,
+            {
+                "run_count": 3,
+                "operation_count": 2,
+                "workflow_decision_count": 1,
+                "supportability": {"state": "ready"},
+            },
+        ),
+    )
+    assert parsed is not None
+    assert parsed.supportability is not None
+    assert parsed.supportability.run_count == 3
+    assert parsed.supportability.operation_count == 2
+    assert parsed.supportability.workflow_decision_count == 1
+
+
+def test_parse_dpm_snapshot_preserves_recent_run_error_and_workflow_state():
+    parsed = parse_rebalance_snapshot(
+        (
+            200,
+            {
+                "items": [
+                    {
+                        "status": "FAILED",
+                        "rebalance_run_id": "rr-1",
+                        "created_at": "2026-02-24T00:00:00Z",
+                        "error": {"code": "SOURCE_GAP"},
+                        "workflow_decision_state": "NEEDS_REVIEW",
+                    }
+                ]
+            },
+        ),
+        [],
+        [],
+    )
+    assert parsed is not None
+    assert parsed.recent_runs[0].error_code == "SOURCE_GAP"
+    assert parsed.recent_runs[0].workflow_state == "NEEDS_REVIEW"
 
 
 @pytest.mark.parametrize(
@@ -665,15 +721,13 @@ def test_parse_performance_snapshot_none_period_key_returns_none():
 
 
 def test_parse_dpm_snapshot_non_dict_latest_returns_not_available():
-    service, _, _, _ = _build_service()
-    result = service._parse_dpm_snapshot((200, {"items": ["bad"]}), [], [])
+    result = parse_rebalance_snapshot((200, {"items": ["bad"]}), [], [])
     assert result is not None
     assert result.status == "NOT_AVAILABLE"
 
 
 def test_parse_dpm_snapshot_without_created_at_keeps_last_run_null():
-    service, _, _, _ = _build_service()
-    result = service._parse_dpm_snapshot((200, {"items": [{"status": "READY"}]}), [], [])
+    result = parse_rebalance_snapshot((200, {"items": [{"status": "READY"}]}), [], [])
     assert result is not None
     assert result.last_run_at_utc is None
 


### PR DESCRIPTION
## Summary
- Move Workbench manage/DPM rebalance snapshot parsing into a dedicated helper module.
- Keep WorkbenchService focused on orchestration and overview enrichment flow.
- Retarget parser tests to the extracted helper boundary and add supportability/recent-run branch coverage.

## Validation
- python -m ruff check src/app/services/workbench_service.py src/app/services/workbench_rebalance_snapshot.py tests/unit/test_workbench_service_additional.py
- python -m mypy src/app/services/workbench_service.py src/app/services/workbench_rebalance_snapshot.py
- python -m pytest tests/unit/test_workbench_service_additional.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API.
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal parser-boundary cleanup.
- Stranded truth: no governance-bearing paths changed and no unmerged remote branches were present after fetch.