### PR TITLE
Extract Workbench core snapshot parser

### DIFF
--- a/src/app/services/workbench_core_snapshot.py
+++ b/src/app/services/workbench_core_snapshot.py
@@ -1,0 +1,167 @@
+from typing import Any
+
+from fastapi import HTTPException, status
+
+from app.contracts.workbench import (
+    WorkbenchOverviewSummary,
+    WorkbenchPortfolioSummary,
+    WorkbenchPositionView,
+)
+from app.precision_policy import quantize_money, quantize_performance, quantize_quantity
+
+
+def extract_current_positions(snapshot_payload: dict[str, Any]) -> list[WorkbenchPositionView]:
+    sections_payload = snapshot_payload.get("sections", {})
+    if not isinstance(sections_payload, dict):
+        return []
+    baseline_rows = sections_payload.get("positions_baseline", [])
+    enrichment_rows = sections_payload.get("instrument_enrichment", [])
+    totals_payload = sections_payload.get("portfolio_totals", {})
+
+    if not isinstance(baseline_rows, list):
+        return []
+    if not isinstance(enrichment_rows, list):
+        enrichment_rows = []
+    if not isinstance(totals_payload, dict):
+        totals_payload = {}
+
+    total_market_value = _optional_money(totals_payload.get("baseline_total_market_value_base"))
+    if total_market_value is None:
+        total_market_value = 0.0
+
+    enrichment_by_security_id = {
+        str(item.get("security_id", "")): item
+        for item in enrichment_rows
+        if isinstance(item, dict) and item.get("security_id") is not None
+    }
+    rows: list[WorkbenchPositionView] = []
+    for item in baseline_rows:
+        if not isinstance(item, dict):
+            continue
+        security_id = str(item.get("security_id", "UNKNOWN"))
+        enrichment = enrichment_by_security_id.get(security_id, {})
+        market_value_base = _optional_money(item.get("market_value_base"))
+        weight_ratio = item.get("weight")
+        weight_pct = _ratio_to_pct(weight_ratio)
+        if weight_pct is None and market_value_base is not None and total_market_value > 0:
+            weight_pct = _as_number(
+                quantize_performance((market_value_base / total_market_value) * 100.0)
+            )
+        rows.append(
+            WorkbenchPositionView(
+                security_id=security_id,
+                instrument_name=str(enrichment.get("instrument_name", security_id)),
+                asset_class=(
+                    str(enrichment["asset_class"])
+                    if enrichment.get("asset_class") is not None
+                    else None
+                ),
+                quantity=_as_number(quantize_quantity(item.get("quantity", 0.0))),
+                market_value_base=market_value_base,
+                weight_pct=weight_pct,
+            )
+        )
+    rows.sort(key=lambda row: row.security_id)
+    return rows
+
+
+def parse_lotus_core_snapshot(
+    fallback_portfolio_id: str,
+    portfolio_payload: dict[str, Any],
+    snapshot_payload: dict[str, Any],
+    fallback_as_of_date: str,
+) -> tuple[WorkbenchPortfolioSummary, WorkbenchOverviewSummary, str]:
+    if not isinstance(portfolio_payload, dict) or not isinstance(snapshot_payload, dict):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Invalid lotus-core core snapshot payload structure.",
+        )
+
+    sections_payload = snapshot_payload.get("sections", {})
+    if not isinstance(sections_payload, dict):
+        sections_payload = {}
+    baseline_rows = sections_payload.get("positions_baseline", [])
+    if not isinstance(baseline_rows, list):
+        baseline_rows = []
+    portfolio_totals = sections_payload.get("portfolio_totals", {})
+    if not isinstance(portfolio_totals, dict):
+        portfolio_totals = {}
+
+    total_market_value_value = portfolio_totals.get("baseline_total_market_value_base")
+    total_market_value = (
+        _as_number(quantize_money(total_market_value_value))
+        if total_market_value_value is not None
+        else _as_number(
+            quantize_money(
+                sum(
+                    _as_number(row.get("market_value_base", 0.0))
+                    for row in baseline_rows
+                    if isinstance(row, dict)
+                )
+            )
+        )
+    )
+    total_cash = _as_number(
+        quantize_money(
+            sum(
+                _as_number(row.get("market_value_base", 0.0))
+                for row in baseline_rows
+                if isinstance(row, dict) and str(row.get("security_id", "")).startswith("CASH")
+            )
+        )
+    )
+    cash_weight = 0.0
+    if total_market_value > 0:
+        cash_weight = _as_number(
+            quantize_performance(max(0.0, (total_cash / total_market_value) * 100.0))
+        )
+
+    as_of_date = str(snapshot_payload.get("as_of_date", fallback_as_of_date))
+    portfolio = WorkbenchPortfolioSummary(
+        portfolio_id=str(portfolio_payload.get("portfolio_id", fallback_portfolio_id)).strip()
+        or fallback_portfolio_id,
+        client_id=(
+            str(portfolio_payload["client_id"])
+            if portfolio_payload.get("client_id") is not None
+            else (
+                str(portfolio_payload["cif_id"])
+                if portfolio_payload.get("cif_id") is not None
+                else None
+            )
+        ),
+        base_currency=str(portfolio_payload.get("base_currency", "USD")),
+        booking_center_code=(
+            str(portfolio_payload["booking_center_code"])
+            if portfolio_payload.get("booking_center_code") is not None
+            else None
+        ),
+    )
+    overview = WorkbenchOverviewSummary(
+        market_value_base=total_market_value,
+        cash_weight_pct=cash_weight,
+        position_count=len(baseline_rows),
+    )
+    return portfolio, overview, as_of_date
+
+
+def _optional_money(raw: Any) -> float | None:
+    if raw is None:
+        return None
+    try:
+        return _as_number(quantize_money(raw))
+    except (TypeError, ValueError):
+        return None
+
+
+def _ratio_to_pct(raw: Any) -> float | None:
+    if raw is None:
+        return None
+    try:
+        return _as_number(quantize_performance(_as_number(raw) * 100.0))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_number(raw: Any) -> float:
+    converted = float(raw)
+    return converted

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -25,9 +25,12 @@ from app.contracts.workbench import (
     WorkbenchTopChange,
 )
 from app.precision_policy import (
-    quantize_money,
     quantize_performance,
     quantize_quantity,
+)
+from app.services.workbench_core_snapshot import (
+    extract_current_positions,
+    parse_lotus_core_snapshot,
 )
 from app.services.workbench_performance_snapshot import parse_performance_snapshot
 from app.services.workbench_rebalance_snapshot import parse_rebalance_snapshot
@@ -490,7 +493,7 @@ class WorkbenchService:
         self._raise_for_lotus_core_error(portfolio_status, portfolio_payload)
         self._raise_for_lotus_core_error(snapshot_status, snapshot_payload)
 
-        portfolio, overview, as_of_date = self._parse_lotus_core_snapshot(
+        portfolio, overview, as_of_date = parse_lotus_core_snapshot(
             fallback_portfolio_id=portfolio_id,
             portfolio_payload=portfolio_payload,
             snapshot_payload=snapshot_payload,
@@ -500,7 +503,7 @@ class WorkbenchService:
             portfolio=portfolio,
             overview=overview,
             as_of_date=as_of_date,
-            current_positions=self._extract_current_positions(snapshot_payload),
+            current_positions=extract_current_positions(snapshot_payload),
         )
 
     async def _load_overview_enrichment(
@@ -648,92 +651,6 @@ class WorkbenchService:
         )
         return rows, summary
 
-    def _extract_current_positions(
-        self, snapshot_payload: dict[str, Any]
-    ) -> list[WorkbenchPositionView]:
-        sections_payload = snapshot_payload.get("sections", {})
-        if not isinstance(sections_payload, dict):
-            return []
-        baseline_rows = sections_payload.get("positions_baseline", [])
-        enrichment_rows = sections_payload.get("instrument_enrichment", [])
-        totals_payload = sections_payload.get("portfolio_totals", {})
-
-        if not isinstance(baseline_rows, list):
-            return []
-        if not isinstance(enrichment_rows, list):
-            enrichment_rows = []
-        if not isinstance(totals_payload, dict):
-            totals_payload = {}
-
-        total_market_value = self._optional_money(
-            totals_payload.get("baseline_total_market_value_base")
-        )
-        if total_market_value is None:
-            total_market_value = 0.0
-
-        enrichment_by_security_id = {
-            str(item.get("security_id", "")): item
-            for item in enrichment_rows
-            if isinstance(item, dict) and item.get("security_id") is not None
-        }
-        rows: list[WorkbenchPositionView] = []
-        for item in baseline_rows:
-            if not isinstance(item, dict):
-                continue
-            security_id = str(item.get("security_id", "UNKNOWN"))
-            enrichment = enrichment_by_security_id.get(security_id, {})
-            market_value_base = self._optional_money(item.get("market_value_base"))
-            weight_ratio = item.get("weight")
-            weight_pct = self._ratio_to_pct(weight_ratio)
-            if weight_pct is None and market_value_base is not None and total_market_value > 0:
-                weight_pct = float(
-                    quantize_performance((market_value_base / total_market_value) * 100.0)
-                )
-            rows.append(
-                WorkbenchPositionView(
-                    security_id=security_id,
-                    instrument_name=str(enrichment.get("instrument_name", security_id)),
-                    asset_class=(
-                        str(enrichment["asset_class"])
-                        if enrichment.get("asset_class") is not None
-                        else None
-                    ),
-                    quantity=float(quantize_quantity(item.get("quantity", 0.0))),
-                    market_value_base=market_value_base,
-                    weight_pct=weight_pct,
-                )
-            )
-        rows.sort(key=lambda row: row.security_id)
-        return rows
-
-    def _parse_position_market_value(self, item: dict[str, Any]) -> float | None:
-        valuation_payload = item.get("valuation")
-        if isinstance(valuation_payload, dict):
-            for key in ("market_value_base", "market_value", "current_value_base", "current_value"):
-                value = valuation_payload.get(key)
-                if value is None:
-                    continue
-                try:
-                    return float(quantize_money(value))
-                except (TypeError, ValueError):
-                    continue
-        for key in (
-            "market_value_base",
-            "market_value",
-            "current_value_base",
-            "current_value",
-            "valuation_base",
-            "value_base",
-        ):
-            value = item.get(key)
-            if value is None:
-                continue
-            try:
-                return float(quantize_money(value))
-            except (TypeError, ValueError):
-                continue
-        return None
-
     async def _evaluate_policy_feedback(
         self,
         portfolio_id: str,
@@ -806,101 +723,6 @@ class WorkbenchService:
             detail=None,
             raw=advise_payload,
         )
-
-    def _parse_lotus_core_snapshot(
-        self,
-        fallback_portfolio_id: str,
-        portfolio_payload: dict[str, Any],
-        snapshot_payload: dict[str, Any],
-        fallback_as_of_date: str,
-    ) -> tuple[WorkbenchPortfolioSummary, WorkbenchOverviewSummary, str]:
-        if not isinstance(portfolio_payload, dict) or not isinstance(snapshot_payload, dict):
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail="Invalid lotus-core core snapshot payload structure.",
-            )
-
-        sections_payload = snapshot_payload.get("sections", {})
-        if not isinstance(sections_payload, dict):
-            sections_payload = {}
-        baseline_rows = sections_payload.get("positions_baseline", [])
-        if not isinstance(baseline_rows, list):
-            baseline_rows = []
-        portfolio_totals = sections_payload.get("portfolio_totals", {})
-        if not isinstance(portfolio_totals, dict):
-            portfolio_totals = {}
-
-        total_market_value_value = portfolio_totals.get("baseline_total_market_value_base")
-        total_market_value = (
-            float(quantize_money(total_market_value_value))
-            if total_market_value_value is not None
-            else float(
-                quantize_money(
-                    sum(
-                        float(row.get("market_value_base", 0.0))
-                        for row in baseline_rows
-                        if isinstance(row, dict)
-                    )
-                )
-            )
-        )
-        total_cash = float(
-            quantize_money(
-                sum(
-                    float(row.get("market_value_base", 0.0))
-                    for row in baseline_rows
-                    if isinstance(row, dict) and str(row.get("security_id", "")).startswith("CASH")
-                )
-            )
-        )
-        cash_weight = 0.0
-        if total_market_value > 0:
-            cash_weight = float(
-                quantize_performance(max(0.0, (total_cash / total_market_value) * 100.0))
-            )
-
-        as_of_date = str(snapshot_payload.get("as_of_date", fallback_as_of_date))
-        portfolio = WorkbenchPortfolioSummary(
-            portfolio_id=str(portfolio_payload.get("portfolio_id", fallback_portfolio_id)).strip()
-            or fallback_portfolio_id,
-            client_id=(
-                str(portfolio_payload["client_id"])
-                if portfolio_payload.get("client_id") is not None
-                else (
-                    str(portfolio_payload["cif_id"])
-                    if portfolio_payload.get("cif_id") is not None
-                    else None
-                )
-            ),
-            base_currency=str(portfolio_payload.get("base_currency", "USD")),
-            booking_center_code=(
-                str(portfolio_payload["booking_center_code"])
-                if portfolio_payload.get("booking_center_code") is not None
-                else None
-            ),
-        )
-        overview = WorkbenchOverviewSummary(
-            market_value_base=total_market_value,
-            cash_weight_pct=cash_weight,
-            position_count=len(baseline_rows),
-        )
-        return portfolio, overview, as_of_date
-
-    def _optional_money(self, value: Any) -> float | None:
-        if value is None:
-            return None
-        try:
-            return float(quantize_money(value))
-        except (TypeError, ValueError):
-            return None
-
-    def _ratio_to_pct(self, value: Any) -> float | None:
-        if value is None:
-            return None
-        try:
-            return float(quantize_performance(float(value) * 100.0))
-        except (TypeError, ValueError):
-            return None
 
 
 @dataclass(slots=True)

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -3,6 +3,10 @@ from datetime import UTC, datetime
 import pytest
 from fastapi import HTTPException
 
+from app.services.workbench_core_snapshot import (
+    extract_current_positions,
+    parse_lotus_core_snapshot,
+)
 from app.services.workbench_performance_snapshot import parse_performance_snapshot
 from app.services.workbench_rebalance_snapshot import parse_rebalance_snapshot
 from app.services.workbench_service import WorkbenchService
@@ -166,15 +170,13 @@ def test_raise_for_lotus_core_error_includes_upstream_detail():
 
 
 def test_parse_lotus_core_snapshot_invalid_structure_raises():
-    service, _, _, _ = _build_service()
     with pytest.raises(HTTPException) as exc:
-        service._parse_lotus_core_snapshot("P1", [], {}, "2026-02-24")
+        parse_lotus_core_snapshot("P1", [], {}, "2026-02-24")
     assert exc.value.status_code == 502
 
 
 def test_parse_lotus_core_snapshot_uses_fallback_defaults():
-    service, _, _, _ = _build_service()
-    portfolio, overview, as_of_date = service._parse_lotus_core_snapshot(
+    portfolio, overview, as_of_date = parse_lotus_core_snapshot(
         fallback_portfolio_id="P1",
         portfolio_payload={},
         snapshot_payload={"sections": {}},
@@ -407,28 +409,11 @@ def test_parse_dpm_snapshot_preserves_recent_run_error_and_workflow_state():
     assert parsed.recent_runs[0].workflow_state == "NEEDS_REVIEW"
 
 
-@pytest.mark.parametrize(
-    ("payload", "expected"),
-    [
-        ({"valuation": {"market_value_base": 100}}, 100.0),
-        ({"valuation": {"market_value": 101}}, 101.0),
-        ({"current_value_base": 102}, 102.0),
-        ({"value_base": 103}, 103.0),
-        ({"valuation": {"market_value_base": "bad"}}, None),
-    ],
-)
-def test_parse_position_market_value_variants(payload, expected):
-    service, _, _, _ = _build_service()
-    assert service._parse_position_market_value(payload) == expected
-
-
 def test_extract_current_positions_handles_non_dict_holdings():
-    service, _, _, _ = _build_service()
-    assert service._extract_current_positions({"sections": []}) == []
+    assert extract_current_positions({"sections": []}) == []
 
 
 def test_extract_current_positions_computes_weight_and_sorts():
-    service, _, _, _ = _build_service()
     payload = {
         "sections": {
             "positions_baseline": [
@@ -442,7 +427,7 @@ def test_extract_current_positions_computes_weight_and_sorts():
             ],
         },
     }
-    rows = service._extract_current_positions(payload)
+    rows = extract_current_positions(payload)
     assert [row.security_id for row in rows] == ["A", "B"]
     assert rows[0].weight_pct == pytest.approx(10.0)
     assert rows[1].weight_pct == pytest.approx(20.0)
@@ -647,13 +632,11 @@ async def test_evaluate_policy_feedback_uses_status_when_gate_decision_missing()
 
 
 def test_extract_current_positions_returns_empty_when_by_asset_class_not_dict():
-    service, _, _, _ = _build_service()
     payload = {"sections": {"positions_baseline": [], "instrument_enrichment": []}}
-    assert service._extract_current_positions(payload) == []
+    assert extract_current_positions(payload) == []
 
 
 def test_extract_current_positions_skips_invalid_item_shapes():
-    service, _, _, _ = _build_service()
     payload = {
         "sections": {
             "positions_baseline": ["bad", {"security_id": "EQ_1", "quantity": 1}],
@@ -661,29 +644,19 @@ def test_extract_current_positions_skips_invalid_item_shapes():
             "instrument_enrichment": [{"security_id": "EQ_1", "instrument_name": "EQ 1"}],
         },
     }
-    rows = service._extract_current_positions(payload)
+    rows = extract_current_positions(payload)
     assert len(rows) == 1
     assert rows[0].security_id == "EQ_1"
 
 
 def test_extract_current_positions_skips_asset_class_with_non_list_items():
-    service, _, _, _ = _build_service()
     payload = {"sections": {"positions_baseline": {"security_id": "EQ_1"}}}
-    rows = service._extract_current_positions(payload)
+    rows = extract_current_positions(payload)
     assert rows == []
 
 
-def test_parse_position_market_value_skips_non_numeric_in_flat_keys():
-    service, _, _, _ = _build_service()
-    assert (
-        service._parse_position_market_value({"market_value_base": "bad", "value_base": "bad"})
-        is None
-    )
-
-
 def test_parse_lotus_core_snapshot_handles_non_dict_overview_and_holdings_shapes():
-    service, _, _, _ = _build_service()
-    portfolio, overview, _ = service._parse_lotus_core_snapshot(
+    portfolio, overview, _ = parse_lotus_core_snapshot(
         fallback_portfolio_id="P1",
         portfolio_payload={"portfolio_id": "P1"},
         snapshot_payload={"sections": []},


### PR DESCRIPTION
## Summary
- Move Workbench lotus-core snapshot and current-position parsing into a dedicated helper module.
- Keep WorkbenchService focused on orchestration and enrichment flow.
- Remove the stale private market-value parser that was only test-referenced after current-position parsing stopped using it.

## Validation
- python -m ruff check src/app/services/workbench_service.py src/app/services/workbench_core_snapshot.py tests/unit/test_workbench_service_additional.py
- python -m mypy src/app/services/workbench_service.py src/app/services/workbench_core_snapshot.py
- python -m pytest tests/unit/test_workbench_service_additional.py tests/unit/test_workbench_service.py -q
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API.
- Tiering: Feature Lane and PR Merge Gate are applicable; Platform E2E is not required for this internal parser-boundary cleanup.
- Stranded truth: no governance-bearing paths changed and no unmerged remote branches were present after fetch.