### PR TITLE
Extract Workbench analytics projection

### DIFF
--- a/src/app/services/workbench_analytics_projection.py
+++ b/src/app/services/workbench_analytics_projection.py
@@ -1,0 +1,138 @@
+from typing import Any
+
+from app.contracts.workbench import (
+    WorkbenchAnalyticsBucket,
+    WorkbenchPositionView,
+    WorkbenchProjectedPositionView,
+    WorkbenchTopChange,
+)
+from app.precision_policy import quantize_performance, quantize_quantity
+
+
+def build_workbench_allocation_buckets(
+    *,
+    group_by: str,
+    current_positions: list[WorkbenchPositionView],
+    projected_positions: list[WorkbenchProjectedPositionView],
+) -> list[WorkbenchAnalyticsBucket]:
+    bucket_quantities: dict[str, dict[str, float]] = {}
+
+    if projected_positions:
+        for projected_row in projected_positions:
+            bucket_key = workbench_position_bucket_key(
+                group_by=group_by,
+                security_id=projected_row.security_id,
+                instrument_name=projected_row.instrument_name,
+                asset_class=projected_row.asset_class,
+            )
+            bucket = bucket_quantities.setdefault(
+                bucket_key,
+                {"current": 0.0, "proposed": 0.0},
+            )
+            bucket["current"] += _as_number(projected_row.baseline_quantity)
+            bucket["proposed"] += _as_number(projected_row.proposed_quantity)
+
+        projected_security_ids = {
+            projected_row.security_id for projected_row in projected_positions
+        }
+        for current_row in current_positions:
+            if current_row.security_id in projected_security_ids:
+                continue
+            bucket_key = workbench_position_bucket_key(
+                group_by=group_by,
+                security_id=current_row.security_id,
+                instrument_name=current_row.instrument_name,
+                asset_class=current_row.asset_class,
+            )
+            bucket = bucket_quantities.setdefault(
+                bucket_key,
+                {"current": 0.0, "proposed": 0.0},
+            )
+            bucket["current"] += _as_number(current_row.quantity)
+            bucket["proposed"] += _as_number(current_row.quantity)
+    else:
+        for current_row in current_positions:
+            bucket_key = workbench_position_bucket_key(
+                group_by=group_by,
+                security_id=current_row.security_id,
+                instrument_name=current_row.instrument_name,
+                asset_class=current_row.asset_class,
+            )
+            bucket = bucket_quantities.setdefault(
+                bucket_key,
+                {"current": 0.0, "proposed": 0.0},
+            )
+            bucket["current"] += _as_number(current_row.quantity)
+            bucket["proposed"] += _as_number(current_row.quantity)
+
+    total_current = sum(abs(bucket["current"]) for bucket in bucket_quantities.values())
+    total_proposed = sum(abs(bucket["proposed"]) for bucket in bucket_quantities.values())
+
+    return [
+        WorkbenchAnalyticsBucket(
+            bucket_key=bucket_key,
+            bucket_label=bucket_key,
+            current_quantity=_as_number(quantize_quantity(values["current"])),
+            proposed_quantity=_as_number(quantize_quantity(values["proposed"])),
+            delta_quantity=_as_number(quantize_quantity(values["proposed"] - values["current"])),
+            current_weight_pct=allocation_pct(values["current"], total_current),
+            proposed_weight_pct=allocation_pct(values["proposed"], total_proposed),
+        )
+        for bucket_key, values in sorted(bucket_quantities.items())
+    ]
+
+
+def build_workbench_top_changes(
+    projected_positions: list[WorkbenchProjectedPositionView],
+) -> list[WorkbenchTopChange]:
+    sorted_changes = sorted(
+        projected_positions,
+        key=lambda row: abs(_as_number(row.delta_quantity)),
+        reverse=True,
+    )
+    return [
+        WorkbenchTopChange(
+            security_id=row.security_id,
+            instrument_name=row.instrument_name,
+            delta_quantity=_as_number(quantize_quantity(row.delta_quantity)),
+            direction=quantity_change_direction(_as_number(row.delta_quantity)),
+        )
+        for row in sorted_changes
+        if _as_number(row.delta_quantity) != 0.0
+    ][:10]
+
+
+def workbench_position_bucket_key(
+    *,
+    group_by: str,
+    security_id: str,
+    instrument_name: str,
+    asset_class: str | None,
+) -> str:
+    normalized_group = group_by.upper()
+    if normalized_group == "ASSET_CLASS":
+        return str(asset_class or "UNCLASSIFIED").upper()
+    if normalized_group == "SECURITY":
+        return security_id
+    if normalized_group == "INSTRUMENT":
+        return instrument_name
+    return str(asset_class or "UNCLASSIFIED").upper()
+
+
+def allocation_pct(quantity: float, total_abs_quantity: float) -> float:
+    if total_abs_quantity <= 0:
+        return 0.0
+    return _as_number(quantize_performance((abs(quantity) / total_abs_quantity) * 100.0))
+
+
+def quantity_change_direction(delta_quantity: float) -> str:
+    if delta_quantity > 0:
+        return "INCREASE"
+    if delta_quantity < 0:
+        return "DECREASE"
+    return "UNCHANGED"
+
+
+def _as_number(raw: Any) -> float:
+    converted = float(raw)
+    return converted

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -8,7 +8,6 @@ from fastapi import HTTPException, status
 
 from app.config import settings
 from app.contracts.workbench import (
-    WorkbenchAnalyticsBucket,
     WorkbenchAnalyticsResponse,
     WorkbenchOverviewResponse,
     WorkbenchOverviewSummary,
@@ -22,11 +21,11 @@ from app.contracts.workbench import (
     WorkbenchProjectedSummary,
     WorkbenchRebalanceSnapshot,
     WorkbenchSandboxStateResponse,
-    WorkbenchTopChange,
 )
-from app.precision_policy import (
-    quantize_performance,
-    quantize_quantity,
+from app.precision_policy import quantize_performance, quantize_quantity
+from app.services.workbench_analytics_projection import (
+    build_workbench_allocation_buckets,
+    build_workbench_top_changes,
 )
 from app.services.workbench_core_snapshot import (
     extract_current_positions,
@@ -272,12 +271,12 @@ class WorkbenchService:
         )
 
         try:
-            allocation_buckets = self._build_workbench_allocation_buckets(
+            allocation_buckets = build_workbench_allocation_buckets(
                 group_by=group_by,
                 current_positions=portfolio_360.current_positions,
                 projected_positions=portfolio_360.projected_positions,
             )
-            top_changes = self._build_workbench_top_changes(portfolio_360.projected_positions)
+            top_changes = build_workbench_top_changes(portfolio_360.projected_positions)
             warnings = list(portfolio_360.warnings)
             if "RISK_BFF_PENDING" not in warnings:
                 warnings.append("RISK_BFF_PENDING")
@@ -342,128 +341,6 @@ class WorkbenchService:
             warnings=portfolio_360.warnings,
             partial_failures=portfolio_360.partial_failures,
         )
-
-    def _build_workbench_allocation_buckets(
-        self,
-        *,
-        group_by: str,
-        current_positions: list[WorkbenchPositionView],
-        projected_positions: list[WorkbenchProjectedPositionView],
-    ) -> list[WorkbenchAnalyticsBucket]:
-        bucket_quantities: dict[str, dict[str, float]] = {}
-
-        if projected_positions:
-            for projected_row in projected_positions:
-                bucket_key = self._workbench_position_bucket_key(
-                    group_by=group_by,
-                    security_id=projected_row.security_id,
-                    instrument_name=projected_row.instrument_name,
-                    asset_class=projected_row.asset_class,
-                )
-                bucket = bucket_quantities.setdefault(
-                    bucket_key,
-                    {"current": 0.0, "proposed": 0.0},
-                )
-                bucket["current"] += float(projected_row.baseline_quantity)
-                bucket["proposed"] += float(projected_row.proposed_quantity)
-
-            projected_security_ids = {
-                projected_row.security_id for projected_row in projected_positions
-            }
-            for current_row in current_positions:
-                if current_row.security_id in projected_security_ids:
-                    continue
-                bucket_key = self._workbench_position_bucket_key(
-                    group_by=group_by,
-                    security_id=current_row.security_id,
-                    instrument_name=current_row.instrument_name,
-                    asset_class=current_row.asset_class,
-                )
-                bucket = bucket_quantities.setdefault(
-                    bucket_key,
-                    {"current": 0.0, "proposed": 0.0},
-                )
-                bucket["current"] += float(current_row.quantity)
-                bucket["proposed"] += float(current_row.quantity)
-        else:
-            for current_row in current_positions:
-                bucket_key = self._workbench_position_bucket_key(
-                    group_by=group_by,
-                    security_id=current_row.security_id,
-                    instrument_name=current_row.instrument_name,
-                    asset_class=current_row.asset_class,
-                )
-                bucket = bucket_quantities.setdefault(
-                    bucket_key,
-                    {"current": 0.0, "proposed": 0.0},
-                )
-                bucket["current"] += float(current_row.quantity)
-                bucket["proposed"] += float(current_row.quantity)
-
-        total_current = sum(abs(bucket["current"]) for bucket in bucket_quantities.values())
-        total_proposed = sum(abs(bucket["proposed"]) for bucket in bucket_quantities.values())
-
-        return [
-            WorkbenchAnalyticsBucket(
-                bucket_key=bucket_key,
-                bucket_label=bucket_key,
-                current_quantity=float(quantize_quantity(values["current"])),
-                proposed_quantity=float(quantize_quantity(values["proposed"])),
-                delta_quantity=float(quantize_quantity(values["proposed"] - values["current"])),
-                current_weight_pct=self._quantity_weight_pct(values["current"], total_current),
-                proposed_weight_pct=self._quantity_weight_pct(values["proposed"], total_proposed),
-            )
-            for bucket_key, values in sorted(bucket_quantities.items())
-        ]
-
-    def _build_workbench_top_changes(
-        self,
-        projected_positions: list[WorkbenchProjectedPositionView],
-    ) -> list[WorkbenchTopChange]:
-        sorted_changes = sorted(
-            projected_positions,
-            key=lambda row: abs(float(row.delta_quantity)),
-            reverse=True,
-        )
-        return [
-            WorkbenchTopChange(
-                security_id=row.security_id,
-                instrument_name=row.instrument_name,
-                delta_quantity=float(quantize_quantity(row.delta_quantity)),
-                direction=self._quantity_change_direction(float(row.delta_quantity)),
-            )
-            for row in sorted_changes
-            if float(row.delta_quantity) != 0.0
-        ][:10]
-
-    def _workbench_position_bucket_key(
-        self,
-        *,
-        group_by: str,
-        security_id: str,
-        instrument_name: str,
-        asset_class: str | None,
-    ) -> str:
-        normalized_group = group_by.upper()
-        if normalized_group == "ASSET_CLASS":
-            return str(asset_class or "UNCLASSIFIED").upper()
-        if normalized_group == "SECURITY":
-            return security_id
-        if normalized_group == "INSTRUMENT":
-            return instrument_name
-        return str(asset_class or "UNCLASSIFIED").upper()
-
-    def _quantity_weight_pct(self, quantity: float, total_abs_quantity: float) -> float:
-        if total_abs_quantity <= 0:
-            return 0.0
-        return float(quantize_performance((abs(quantity) / total_abs_quantity) * 100.0))
-
-    def _quantity_change_direction(self, delta_quantity: float) -> str:
-        if delta_quantity > 0:
-            return "INCREASE"
-        if delta_quantity < 0:
-            return "DECREASE"
-        return "UNCHANGED"
 
     async def _load_workbench_snapshot_context(
         self,

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -3,6 +3,13 @@ from datetime import UTC, datetime
 import pytest
 from fastapi import HTTPException
 
+from app.contracts.workbench import WorkbenchPositionView, WorkbenchProjectedPositionView
+from app.services.workbench_analytics_projection import (
+    build_workbench_allocation_buckets,
+    build_workbench_top_changes,
+    quantity_change_direction,
+    workbench_position_bucket_key,
+)
 from app.services.workbench_core_snapshot import (
     extract_current_positions,
     parse_lotus_core_snapshot,
@@ -703,6 +710,113 @@ def test_parse_dpm_snapshot_without_created_at_keeps_last_run_null():
     result = parse_rebalance_snapshot((200, {"items": [{"status": "READY"}]}), [], [])
     assert result is not None
     assert result.last_run_at_utc is None
+
+
+def test_build_workbench_allocation_buckets_merges_projected_and_unchanged_rows():
+    current_positions = [
+        WorkbenchPositionView(
+            security_id="EQ_1",
+            instrument_name="Equity 1",
+            asset_class="Equity",
+            quantity=10.0,
+            market_value_base=100.0,
+            weight=1.0,
+        ),
+        WorkbenchPositionView(
+            security_id="BOND_1",
+            instrument_name="Bond 1",
+            asset_class="Fixed Income",
+            quantity=30.0,
+            market_value_base=300.0,
+            weight=1.0,
+        ),
+    ]
+    projected_positions = [
+        WorkbenchProjectedPositionView(
+            security_id="EQ_1",
+            instrument_name="Equity 1",
+            asset_class="Equity",
+            baseline_quantity=10.0,
+            proposed_quantity=20.0,
+            delta_quantity=10.0,
+        )
+    ]
+
+    buckets = build_workbench_allocation_buckets(
+        group_by="ASSET_CLASS",
+        current_positions=current_positions,
+        projected_positions=projected_positions,
+    )
+
+    assert [bucket.bucket_key for bucket in buckets] == ["EQUITY", "FIXED INCOME"]
+    assert buckets[0].current_quantity == pytest.approx(10.0)
+    assert buckets[0].proposed_quantity == pytest.approx(20.0)
+    assert buckets[0].current_weight_pct == pytest.approx(25.0)
+    assert buckets[0].proposed_weight_pct == pytest.approx(40.0)
+    assert buckets[1].current_quantity == pytest.approx(30.0)
+    assert buckets[1].proposed_quantity == pytest.approx(30.0)
+
+
+def test_build_workbench_top_changes_orders_limits_and_skips_unchanged_rows():
+    projected_positions = [
+        WorkbenchProjectedPositionView(
+            security_id=f"EQ_{index}",
+            instrument_name=f"Equity {index}",
+            asset_class="Equity",
+            baseline_quantity=100.0,
+            proposed_quantity=100.0 + index,
+            delta_quantity=float(index),
+        )
+        for index in range(12)
+    ]
+    projected_positions.append(
+        WorkbenchProjectedPositionView(
+            security_id="BOND_REDUCE",
+            instrument_name="Bond Reduce",
+            asset_class="Fixed Income",
+            baseline_quantity=50.0,
+            proposed_quantity=25.0,
+            delta_quantity=-25.0,
+        )
+    )
+
+    top_changes = build_workbench_top_changes(projected_positions)
+
+    assert len(top_changes) == 10
+    assert top_changes[0].security_id == "BOND_REDUCE"
+    assert top_changes[0].direction == "DECREASE"
+    assert "EQ_0" not in {change.security_id for change in top_changes}
+    assert top_changes[1].security_id == "EQ_11"
+    assert top_changes[1].direction == "INCREASE"
+
+
+@pytest.mark.parametrize(
+    ("group_by", "expected"),
+    [
+        ("ASSET_CLASS", "UNCLASSIFIED"),
+        ("SECURITY", "SEC_1"),
+        ("INSTRUMENT", "Instrument 1"),
+        ("UNKNOWN", "UNCLASSIFIED"),
+    ],
+)
+def test_workbench_position_bucket_key_supports_expected_groupings(group_by, expected):
+    assert (
+        workbench_position_bucket_key(
+            group_by=group_by,
+            security_id="SEC_1",
+            instrument_name="Instrument 1",
+            asset_class=None,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("delta_quantity", "expected"),
+    [(1.0, "INCREASE"), (-1.0, "DECREASE"), (0.0, "UNCHANGED")],
+)
+def test_quantity_change_direction(delta_quantity, expected):
+    assert quantity_change_direction(delta_quantity) == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Move Workbench allocation bucket and top-change projection into a dedicated helper module.
- Keep WorkbenchService focused on orchestration, upstream calls, and response assembly.
- Add direct unit coverage for projected plus unchanged rows, top-change ranking, grouping keys, and direction classification.

## Validation
- python -m ruff check src/app/services/workbench_service.py src/app/services/workbench_analytics_projection.py tests/unit/test_workbench_service_additional.py
- python -m mypy src/app/services/workbench_service.py src/app/services/workbench_analytics_projection.py
- python -m pytest tests/unit/test_workbench_service.py tests/unit/test_workbench_service_additional.py -q
- python scripts/check_monetary_float_usage.py
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API.
- Applicable lanes: Feature Lane and PR Merge Gate.
- Platform E2E is not required for this internal Workbench projection-boundary cleanup.
- Stranded truth: no governance-bearing paths changed and no unmerged remote branches were present after fetch.