### PR TITLE
Extract Workbench projected state parser

### DIFF
--- a/src/app/services/workbench_projected_state.py
+++ b/src/app/services/workbench_projected_state.py
@@ -1,0 +1,43 @@
+from typing import Any
+
+from app.contracts.workbench import WorkbenchProjectedPositionView, WorkbenchProjectedSummary
+from app.precision_policy import quantize_quantity
+
+
+def parse_projected_state(
+    *,
+    positions_payload: dict[str, Any],
+    summary_payload: dict[str, Any],
+) -> tuple[list[WorkbenchProjectedPositionView], WorkbenchProjectedSummary]:
+    rows_payload = positions_payload.get("positions", [])
+    rows: list[WorkbenchProjectedPositionView] = []
+    if isinstance(rows_payload, list):
+        for row in rows_payload:
+            if not isinstance(row, dict):
+                continue
+            rows.append(_parse_projected_position(row))
+
+    summary = WorkbenchProjectedSummary(
+        total_baseline_positions=int(summary_payload.get("total_baseline_positions", 0)),
+        total_proposed_positions=int(summary_payload.get("total_proposed_positions", 0)),
+        net_delta_quantity=_as_number(
+            quantize_quantity(summary_payload.get("net_delta_quantity", 0.0))
+        ),
+    )
+    return rows, summary
+
+
+def _parse_projected_position(row: dict[str, Any]) -> WorkbenchProjectedPositionView:
+    return WorkbenchProjectedPositionView(
+        security_id=str(row.get("security_id", "")),
+        instrument_name=str(row.get("instrument_name", row.get("security_id", "UNKNOWN"))),
+        asset_class=str(row["asset_class"]) if row.get("asset_class") is not None else None,
+        baseline_quantity=_as_number(quantize_quantity(row.get("baseline_quantity", 0.0))),
+        proposed_quantity=_as_number(quantize_quantity(row.get("proposed_quantity", 0.0))),
+        delta_quantity=_as_number(quantize_quantity(row.get("delta_quantity", 0.0))),
+    )
+
+
+def _as_number(raw: Any) -> float:
+    converted = float(raw)
+    return converted

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -22,7 +22,7 @@ from app.contracts.workbench import (
     WorkbenchRebalanceSnapshot,
     WorkbenchSandboxStateResponse,
 )
-from app.precision_policy import quantize_performance, quantize_quantity
+from app.precision_policy import quantize_performance
 from app.services.workbench_analytics_projection import (
     build_workbench_allocation_buckets,
     build_workbench_top_changes,
@@ -32,6 +32,7 @@ from app.services.workbench_core_snapshot import (
     parse_lotus_core_snapshot,
 )
 from app.services.workbench_performance_snapshot import parse_performance_snapshot
+from app.services.workbench_projected_state import parse_projected_state
 from app.services.workbench_rebalance_snapshot import parse_rebalance_snapshot
 from app.services.workspace_client_protocols import (
     WorkbenchAdviseClient,
@@ -494,39 +495,10 @@ class WorkbenchService:
                 detail=f"lotus-core projected summary unavailable: {summary_payload}",
             )
 
-        rows_payload = positions_payload.get("positions", [])
-        rows: list[WorkbenchProjectedPositionView] = []
-        if isinstance(rows_payload, list):
-            for row in rows_payload:
-                if not isinstance(row, dict):
-                    continue
-                rows.append(
-                    WorkbenchProjectedPositionView(
-                        security_id=str(row.get("security_id", "")),
-                        instrument_name=str(
-                            row.get("instrument_name", row.get("security_id", "UNKNOWN"))
-                        ),
-                        asset_class=(
-                            str(row["asset_class"]) if row.get("asset_class") is not None else None
-                        ),
-                        baseline_quantity=float(
-                            quantize_quantity(row.get("baseline_quantity", 0.0))
-                        ),
-                        proposed_quantity=float(
-                            quantize_quantity(row.get("proposed_quantity", 0.0))
-                        ),
-                        delta_quantity=float(quantize_quantity(row.get("delta_quantity", 0.0))),
-                    )
-                )
-
-        summary = WorkbenchProjectedSummary(
-            total_baseline_positions=int(summary_payload.get("total_baseline_positions", 0)),
-            total_proposed_positions=int(summary_payload.get("total_proposed_positions", 0)),
-            net_delta_quantity=float(
-                quantize_quantity(summary_payload.get("net_delta_quantity", 0.0))
-            ),
+        return parse_projected_state(
+            positions_payload=positions_payload,
+            summary_payload=summary_payload,
         )
-        return rows, summary
 
     async def _evaluate_policy_feedback(
         self,

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -15,6 +15,7 @@ from app.services.workbench_core_snapshot import (
     parse_lotus_core_snapshot,
 )
 from app.services.workbench_performance_snapshot import parse_performance_snapshot
+from app.services.workbench_projected_state import parse_projected_state
 from app.services.workbench_rebalance_snapshot import parse_rebalance_snapshot
 from app.services.workbench_service import WorkbenchService
 
@@ -471,6 +472,49 @@ async def test_load_projected_state_skips_non_dict_rows():
     assert len(rows) == 1
     assert rows[0].security_id == "EQ_1"
     assert summary.net_delta_quantity == 1.0
+
+
+def test_parse_projected_state_defaults_missing_fields_and_skips_invalid_rows():
+    rows, summary = parse_projected_state(
+        positions_payload={
+            "positions": [
+                "bad",
+                {
+                    "security_id": "EQ_1",
+                    "proposed_quantity": 1.23456,
+                    "delta_quantity": 1.23456,
+                },
+            ]
+        },
+        summary_payload={"net_delta_quantity": 1.23456},
+    )
+
+    assert len(rows) == 1
+    assert rows[0].security_id == "EQ_1"
+    assert rows[0].instrument_name == "EQ_1"
+    assert rows[0].asset_class is None
+    assert rows[0].baseline_quantity == pytest.approx(0.0)
+    assert rows[0].proposed_quantity == pytest.approx(1.23456)
+    assert rows[0].delta_quantity == pytest.approx(1.23456)
+    assert summary.total_baseline_positions == 0
+    assert summary.total_proposed_positions == 0
+    assert summary.net_delta_quantity == pytest.approx(1.23456)
+
+
+def test_parse_projected_state_handles_non_list_positions_payload():
+    rows, summary = parse_projected_state(
+        positions_payload={"positions": {"security_id": "EQ_1"}},
+        summary_payload={
+            "total_baseline_positions": 2,
+            "total_proposed_positions": 3,
+            "net_delta_quantity": -4.0,
+        },
+    )
+
+    assert rows == []
+    assert summary.total_baseline_positions == 2
+    assert summary.total_proposed_positions == 3
+    assert summary.net_delta_quantity == pytest.approx(-4.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Move Workbench projected-position and projected-summary payload parsing into a dedicated helper module.
- Keep WorkbenchService focused on lotus-core orchestration and upstream error handling.
- Add direct parser coverage for missing fields, invalid rows, non-list payloads, and quantity precision behavior.

## Validation
- python -m ruff check src/app/services/workbench_service.py src/app/services/workbench_projected_state.py tests/unit/test_workbench_service_additional.py
- python -m mypy src/app/services/workbench_service.py src/app/services/workbench_projected_state.py
- python -m pytest tests/unit/test_workbench_service.py tests/unit/test_workbench_service_additional.py -q
- python scripts/check_monetary_float_usage.py
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API.
- Applicable lanes: Feature Lane and PR Merge Gate.
- Platform E2E is not required for this internal Workbench parser-boundary cleanup.
- Stranded truth: no governance-bearing paths changed and no unmerged remote branches were present after fetch.