### PR TITLE
Extract Workbench policy feedback adapter

### DIFF
--- a/src/app/services/workbench_policy_feedback.py
+++ b/src/app/services/workbench_policy_feedback.py
@@ -1,0 +1,63 @@
+from typing import Any
+
+from app.contracts.workbench import WorkbenchPolicyFeedback, WorkbenchProjectedPositionView
+
+
+def build_policy_simulation_payload(
+    *,
+    portfolio_id: str,
+    base_currency: str,
+    projected_positions: list[WorkbenchProjectedPositionView],
+) -> dict[str, Any]:
+    return {
+        "portfolio_snapshot": {
+            "portfolio_id": portfolio_id,
+            "base_currency": base_currency,
+            "positions": [
+                {
+                    "instrument_id": row.security_id,
+                    "quantity": f"{row.proposed_quantity:.4f}",
+                }
+                for row in projected_positions
+                if row.proposed_quantity > 0
+            ],
+            "cash_balances": [],
+        },
+        "market_data_snapshot": {"prices": [], "fx_rates": []},
+        "shelf_entries": [],
+        "options": {
+            "enable_proposal_simulation": True,
+            "proposal_apply_cash_flows_first": True,
+            "proposal_block_negative_cash": True,
+        },
+        "proposed_cash_flows": [],
+        "proposed_trades": [],
+    }
+
+
+def build_policy_idempotency_key(*, session_id: str, session_version: int) -> str:
+    return f"sandbox-{session_id}-{session_version}"
+
+
+def parse_policy_feedback_success(payload: dict[str, Any]) -> WorkbenchPolicyFeedback:
+    gate_decision = payload.get("gate_decision")
+    if isinstance(gate_decision, dict):
+        gate_status = str(gate_decision.get("status", "UNKNOWN"))
+        return WorkbenchPolicyFeedback(
+            status=gate_status,
+            detail=str(gate_decision.get("reason_code", "")) or None,
+            raw=payload,
+        )
+    return WorkbenchPolicyFeedback(
+        status=str(payload.get("status", "AVAILABLE")),
+        detail=None,
+        raw=payload,
+    )
+
+
+def parse_policy_feedback_unavailable(payload: Any) -> WorkbenchPolicyFeedback:
+    return WorkbenchPolicyFeedback(
+        status="UNAVAILABLE",
+        detail="Proposal simulation unavailable",
+        raw=payload if isinstance(payload, dict) else None,
+    )

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -32,6 +32,12 @@ from app.services.workbench_core_snapshot import (
     parse_lotus_core_snapshot,
 )
 from app.services.workbench_performance_snapshot import parse_performance_snapshot
+from app.services.workbench_policy_feedback import (
+    build_policy_idempotency_key,
+    build_policy_simulation_payload,
+    parse_policy_feedback_success,
+    parse_policy_feedback_unavailable,
+)
 from app.services.workbench_projected_state import parse_projected_state
 from app.services.workbench_rebalance_snapshot import parse_rebalance_snapshot
 from app.services.workspace_client_protocols import (
@@ -514,31 +520,15 @@ class WorkbenchService:
             portfolio_id=portfolio_id,
             correlation_id=correlation_id,
         )
-        simulate_payload = {
-            "portfolio_snapshot": {
-                "portfolio_id": portfolio_id,
-                "base_currency": overview.portfolio.base_currency,
-                "positions": [
-                    {
-                        "instrument_id": row.security_id,
-                        "quantity": f"{row.proposed_quantity:.4f}",
-                    }
-                    for row in projected_positions
-                    if row.proposed_quantity > 0
-                ],
-                "cash_balances": [],
-            },
-            "market_data_snapshot": {"prices": [], "fx_rates": []},
-            "shelf_entries": [],
-            "options": {
-                "enable_proposal_simulation": True,
-                "proposal_apply_cash_flows_first": True,
-                "proposal_block_negative_cash": True,
-            },
-            "proposed_cash_flows": [],
-            "proposed_trades": [],
-        }
-        idempotency_key = f"sandbox-{session_id}-{session_version}"
+        simulate_payload = build_policy_simulation_payload(
+            portfolio_id=portfolio_id,
+            base_currency=overview.portfolio.base_currency,
+            projected_positions=projected_positions,
+        )
+        idempotency_key = build_policy_idempotency_key(
+            session_id=session_id,
+            session_version=session_version,
+        )
         advise_status, advise_payload = await self._advise_client.simulate_proposal(
             body=simulate_payload,
             idempotency_key=idempotency_key,
@@ -553,25 +543,9 @@ class WorkbenchService:
                     detail=str(advise_payload.get("detail", advise_payload)),
                 )
             )
-            return WorkbenchPolicyFeedback(
-                status="UNAVAILABLE",
-                detail="Proposal simulation unavailable",
-                raw=advise_payload if isinstance(advise_payload, dict) else None,
-            )
+            return parse_policy_feedback_unavailable(advise_payload)
 
-        gate_decision = advise_payload.get("gate_decision")
-        if isinstance(gate_decision, dict):
-            gate_status = str(gate_decision.get("status", "UNKNOWN"))
-            return WorkbenchPolicyFeedback(
-                status=gate_status,
-                detail=str(gate_decision.get("reason_code", "")) or None,
-                raw=advise_payload,
-            )
-        return WorkbenchPolicyFeedback(
-            status=str(advise_payload.get("status", "AVAILABLE")),
-            detail=None,
-            raw=advise_payload,
-        )
+        return parse_policy_feedback_success(advise_payload)
 
 
 @dataclass(slots=True)

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -15,6 +15,12 @@ from app.services.workbench_core_snapshot import (
     parse_lotus_core_snapshot,
 )
 from app.services.workbench_performance_snapshot import parse_performance_snapshot
+from app.services.workbench_policy_feedback import (
+    build_policy_idempotency_key,
+    build_policy_simulation_payload,
+    parse_policy_feedback_success,
+    parse_policy_feedback_unavailable,
+)
 from app.services.workbench_projected_state import parse_projected_state
 from app.services.workbench_rebalance_snapshot import parse_rebalance_snapshot
 from app.services.workbench_service import WorkbenchService
@@ -680,6 +686,58 @@ async def test_evaluate_policy_feedback_uses_status_when_gate_decision_missing()
         partial_failures=[],
     )
     assert feedback.status == "PASS"
+
+
+def test_build_policy_simulation_payload_filters_non_positive_positions():
+    payload = build_policy_simulation_payload(
+        portfolio_id="P1",
+        base_currency="USD",
+        projected_positions=[
+            WorkbenchProjectedPositionView(
+                security_id="EQ_1",
+                instrument_name="Equity 1",
+                asset_class="Equity",
+                baseline_quantity=1.0,
+                proposed_quantity=2.34567,
+                delta_quantity=1.34567,
+            ),
+            WorkbenchProjectedPositionView(
+                security_id="CASH_1",
+                instrument_name="Cash 1",
+                asset_class="Cash",
+                baseline_quantity=1.0,
+                proposed_quantity=0.0,
+                delta_quantity=-1.0,
+            ),
+        ],
+    )
+
+    assert payload["portfolio_snapshot"]["portfolio_id"] == "P1"
+    assert payload["portfolio_snapshot"]["base_currency"] == "USD"
+    assert payload["portfolio_snapshot"]["positions"] == [
+        {"instrument_id": "EQ_1", "quantity": "2.3457"}
+    ]
+    assert payload["options"]["proposal_block_negative_cash"] is True
+
+
+def test_build_policy_idempotency_key_uses_session_version():
+    assert (
+        build_policy_idempotency_key(session_id="sess-1", session_version=3) == "sandbox-sess-1-3"
+    )
+
+
+def test_parse_policy_feedback_success_prefers_gate_decision():
+    feedback = parse_policy_feedback_success(
+        {"status": "COMPLETED", "gate_decision": {"status": "PASS", "reason_code": "OK"}}
+    )
+    assert feedback.status == "PASS"
+    assert feedback.detail == "OK"
+
+
+def test_parse_policy_feedback_unavailable_omits_non_dict_raw_payload():
+    feedback = parse_policy_feedback_unavailable("upstream unavailable")
+    assert feedback.status == "UNAVAILABLE"
+    assert feedback.raw is None
 
 
 def test_extract_current_positions_returns_empty_when_by_asset_class_not_dict():


### PR DESCRIPTION
## Summary
- Move Workbench policy simulation payload/idempotency construction and advise response parsing into a dedicated adapter module.
- Keep WorkbenchService focused on orchestration, upstream calls, and warning/partial-failure recording.
- Add direct tests for simulation payload shape, idempotency key generation, gate-decision parsing, and unavailable feedback mapping.

## Validation
- python -m ruff check src/app/services/workbench_service.py src/app/services/workbench_policy_feedback.py tests/unit/test_workbench_service_additional.py
- python -m mypy src/app/services/workbench_service.py src/app/services/workbench_policy_feedback.py
- python -m pytest tests/unit/test_workbench_service.py tests/unit/test_workbench_service_additional.py -q
- python scripts/check_monetary_float_usage.py
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API.
- Applicable lanes: Feature Lane and PR Merge Gate.
- Platform E2E is not required for this internal Workbench policy-feedback boundary cleanup.
- Stranded truth: no governance-bearing paths changed and no unmerged remote branches were present after fetch.