### PR TITLE
Extract Workbench analytics response shaping

### DIFF
--- a/src/app/services/workbench_analytics_projection.py
+++ b/src/app/services/workbench_analytics_projection.py
@@ -2,11 +2,61 @@ from typing import Any
 
 from app.contracts.workbench import (
     WorkbenchAnalyticsBucket,
+    WorkbenchPartialFailure,
+    WorkbenchPerformanceSnapshot,
+    WorkbenchPortfolio360Response,
     WorkbenchPositionView,
     WorkbenchProjectedPositionView,
     WorkbenchTopChange,
 )
 from app.precision_policy import quantize_performance, quantize_quantity
+
+
+def with_controlled_risk_bff_gap(
+    portfolio_360: WorkbenchPortfolio360Response,
+) -> WorkbenchPortfolio360Response:
+    warnings = list(portfolio_360.warnings)
+    if "RISK_BFF_PENDING" not in warnings:
+        warnings.append("RISK_BFF_PENDING")
+
+    partial_failures = list(portfolio_360.partial_failures)
+    partial_failures.append(
+        WorkbenchPartialFailure(
+            source_service="risk",
+            error_code="RISK_BFF_NOT_IMPLEMENTED",
+            detail=(
+                "Legacy workbench risk proxy was removed. Stateful concentration risk "
+                "will be restored through the RFC-0022 Gateway Risk BFF."
+            ),
+        )
+    )
+    return portfolio_360.model_copy(
+        update={"warnings": warnings, "partial_failures": partial_failures}
+    )
+
+
+def build_workbench_return_metrics(
+    performance_snapshot: WorkbenchPerformanceSnapshot | None,
+) -> tuple[float | None, float | None, float | None]:
+    if performance_snapshot is None:
+        return None, None, None
+
+    portfolio_return = performance_snapshot.return_pct
+    benchmark_return = performance_snapshot.benchmark_return_pct
+    active_return = (
+        quantize_performance(portfolio_return) - quantize_performance(benchmark_return)
+        if portfolio_return is not None and benchmark_return is not None
+        else None
+    )
+    return (
+        _as_number(quantize_performance(portfolio_return))
+        if portfolio_return is not None
+        else None,
+        _as_number(quantize_performance(benchmark_return))
+        if benchmark_return is not None
+        else None,
+        _as_number(quantize_performance(active_return)) if active_return is not None else None,
+    )
 
 
 def build_workbench_allocation_buckets(

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -22,10 +22,11 @@ from app.contracts.workbench import (
     WorkbenchRebalanceSnapshot,
     WorkbenchSandboxStateResponse,
 )
-from app.precision_policy import quantize_performance
 from app.services.workbench_analytics_projection import (
     build_workbench_allocation_buckets,
+    build_workbench_return_metrics,
     build_workbench_top_changes,
+    with_controlled_risk_bff_gap,
 )
 from app.services.workbench_core_snapshot import (
     extract_current_positions,
@@ -284,37 +285,13 @@ class WorkbenchService:
                 projected_positions=portfolio_360.projected_positions,
             )
             top_changes = build_workbench_top_changes(portfolio_360.projected_positions)
-            warnings = list(portfolio_360.warnings)
-            if "RISK_BFF_PENDING" not in warnings:
-                warnings.append("RISK_BFF_PENDING")
-            partial_failures = list(portfolio_360.partial_failures)
-            partial_failures.append(
-                WorkbenchPartialFailure(
-                    source_service="risk",
-                    error_code="RISK_BFF_NOT_IMPLEMENTED",
-                    detail=(
-                        "Legacy workbench risk proxy was removed. Stateful concentration risk "
-                        "will be restored through the RFC-0022 Gateway Risk BFF."
-                    ),
-                )
-            )
-            portfolio_360 = portfolio_360.model_copy(
-                update={"warnings": warnings, "partial_failures": partial_failures}
-            )
-            portfolio_return = (
-                portfolio_360.performance_snapshot.return_pct
-                if portfolio_360.performance_snapshot is not None
-                else None
-            )
-            benchmark_return = (
-                portfolio_360.performance_snapshot.benchmark_return_pct
-                if portfolio_360.performance_snapshot is not None
-                else None
-            )
-            active_return = (
-                float(portfolio_return) - float(benchmark_return)
-                if portfolio_return is not None and benchmark_return is not None
-                else None
+            portfolio_360 = with_controlled_risk_bff_gap(portfolio_360)
+            (
+                portfolio_return_pct,
+                benchmark_return_pct,
+                active_return_pct,
+            ) = build_workbench_return_metrics(
+                portfolio_360.performance_snapshot,
             )
         except (TypeError, ValueError) as exc:
             raise HTTPException(
@@ -330,19 +307,9 @@ class WorkbenchService:
             period=period,
             group_by=group_by,
             benchmark_code=benchmark_code,
-            portfolio_return_pct=(
-                float(quantize_performance(portfolio_return))
-                if portfolio_return is not None
-                else None
-            ),
-            benchmark_return_pct=(
-                float(quantize_performance(benchmark_return))
-                if benchmark_return is not None
-                else None
-            ),
-            active_return_pct=(
-                float(quantize_performance(active_return)) if active_return is not None else None
-            ),
+            portfolio_return_pct=portfolio_return_pct,
+            benchmark_return_pct=benchmark_return_pct,
+            active_return_pct=active_return_pct,
             allocation_buckets=allocation_buckets,
             top_changes=top_changes,
             warnings=portfolio_360.warnings,

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -3,11 +3,21 @@ from datetime import UTC, datetime
 import pytest
 from fastapi import HTTPException
 
-from app.contracts.workbench import WorkbenchPositionView, WorkbenchProjectedPositionView
+from app.contracts.workbench import (
+    WorkbenchOverviewSummary,
+    WorkbenchPartialFailure,
+    WorkbenchPerformanceSnapshot,
+    WorkbenchPortfolio360Response,
+    WorkbenchPortfolioSummary,
+    WorkbenchPositionView,
+    WorkbenchProjectedPositionView,
+)
 from app.services.workbench_analytics_projection import (
     build_workbench_allocation_buckets,
+    build_workbench_return_metrics,
     build_workbench_top_changes,
     quantity_change_direction,
+    with_controlled_risk_bff_gap,
     workbench_position_bucket_key,
 )
 from app.services.workbench_core_snapshot import (
@@ -890,6 +900,56 @@ def test_build_workbench_top_changes_orders_limits_and_skips_unchanged_rows():
     assert "EQ_0" not in {change.security_id for change in top_changes}
     assert top_changes[1].security_id == "EQ_11"
     assert top_changes[1].direction == "INCREASE"
+
+
+def test_with_controlled_risk_bff_gap_appends_bounded_failure_once_per_projection():
+    portfolio_360 = WorkbenchPortfolio360Response(
+        correlation_id="corr-1",
+        contract_version="v1",
+        as_of_date="2026-02-24",
+        portfolio=WorkbenchPortfolioSummary(portfolio_id="P1", base_currency="USD"),
+        overview=WorkbenchOverviewSummary(
+            market_value_base=100.0,
+            cash_weight_pct=10.0,
+            position_count=1,
+        ),
+        warnings=["RISK_BFF_PENDING"],
+        partial_failures=[
+            WorkbenchPartialFailure(
+                source_service="lotus-performance",
+                error_code="HTTP_503",
+                detail="performance unavailable",
+            )
+        ],
+    )
+
+    projected = with_controlled_risk_bff_gap(portfolio_360)
+
+    assert projected is not portfolio_360
+    assert projected.warnings == ["RISK_BFF_PENDING"]
+    assert [failure.source_service for failure in projected.partial_failures] == [
+        "lotus-performance",
+        "risk",
+    ]
+    assert projected.partial_failures[-1].error_code == "RISK_BFF_NOT_IMPLEMENTED"
+
+
+def test_build_workbench_return_metrics_quantizes_active_return():
+    portfolio_return, benchmark_return, active_return = build_workbench_return_metrics(
+        WorkbenchPerformanceSnapshot(
+            period="YTD",
+            return_pct=1.23456,
+            benchmark_return_pct=0.11111,
+        )
+    )
+
+    assert portfolio_return == pytest.approx(1.23456)
+    assert benchmark_return == pytest.approx(0.11111)
+    assert active_return == pytest.approx(1.12345)
+
+
+def test_build_workbench_return_metrics_handles_missing_performance_snapshot():
+    assert build_workbench_return_metrics(None) == (None, None, None)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Move controlled Workbench analytics risk-gap annotation into the analytics projection module.
- Move Workbench portfolio, benchmark, and active return shaping into a direct helper.
- Keep WorkbenchService focused on orchestration and final contract assembly, with direct tests for the extracted behavior.

## Validation
- python -m ruff check src/app/services/workbench_service.py src/app/services/workbench_analytics_projection.py tests/unit/test_workbench_service_additional.py
- python -m mypy src/app/services/workbench_service.py src/app/services/workbench_analytics_projection.py
- python -m pytest tests/unit/test_workbench_service.py tests/unit/test_workbench_service_additional.py -q
- python scripts/check_monetary_float_usage.py
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal service-boundary cleanup with unchanged API contracts and operator behavior.

## Governance
- Repo profile: Experience API.
- Applicable lanes: Feature Lane and PR Merge Gate.
- Platform E2E is not required for this internal Workbench analytics response-shaping boundary cleanup.
- Stranded truth: no governance-bearing paths changed and no unmerged remote branches were present after fetch.