### PR TITLE
Remove risk workspace request wrapper dead paths

### DIFF
--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -149,7 +149,7 @@ class RiskWorkspaceService:
         )
 
         async def _load() -> WorkbenchRiskSummaryResponse:
-            payload = _build_summary_request(
+            payload = build_summary_request(
                 portfolio_id=portfolio_id,
                 period=period,
                 detail_basis=detail_basis,
@@ -220,7 +220,7 @@ class RiskWorkspaceService:
         )
 
         async def _load() -> WorkbenchRiskConcentrationResponse:
-            payload = _build_concentration_request(
+            payload = build_concentration_request(
                 portfolio_id=portfolio_id,
                 as_of_date=resolved_as_of_date,
                 reporting_currency=reporting_currency,
@@ -291,7 +291,7 @@ class RiskWorkspaceService:
         )
 
         async def _load() -> WorkbenchRiskDrawdownResponse:
-            payload = _build_drawdown_request(
+            payload = build_drawdown_request(
                 portfolio_id=portfolio_id,
                 period=period,
                 detail_basis=detail_basis,
@@ -370,7 +370,7 @@ class RiskWorkspaceService:
         )
 
         async def _load() -> WorkbenchRiskRollingResponse:
-            initial_payload = _build_rolling_request(
+            initial_payload = build_rolling_request(
                 portfolio_id=portfolio_id,
                 period=period,
                 detail_basis=detail_basis,
@@ -392,7 +392,7 @@ class RiskWorkspaceService:
                 upstream_payload=upstream_payload,
             ):
                 sharpe_fallback_reason = _rolling_sharpe_failure_reason(upstream_payload)
-                fallback_payload = _build_rolling_request(
+                fallback_payload = build_rolling_request(
                     portfolio_id=portfolio_id,
                     period=period,
                     detail_basis=detail_basis,
@@ -494,7 +494,7 @@ class RiskWorkspaceService:
         )
 
         async def _load() -> WorkbenchRiskAttributionResponse:
-            payload = _build_attribution_request(
+            payload = build_attribution_request(
                 portfolio_id=portfolio_id,
                 period=period,
                 detail_basis=detail_basis,
@@ -549,119 +549,6 @@ class RiskWorkspaceService:
             },
             deep=True,
         )
-
-
-def _build_summary_request(
-    *,
-    portfolio_id: str,
-    period: str,
-    detail_basis: str,
-    as_of_date: str,
-    report_start_date: str | None,
-    report_end_date: str | None,
-    reporting_currency: str | None,
-) -> dict[str, Any]:
-    return build_summary_request(
-        portfolio_id=portfolio_id,
-        period=period,
-        detail_basis=detail_basis,
-        as_of_date=as_of_date,
-        report_start_date=report_start_date,
-        report_end_date=report_end_date,
-        reporting_currency=reporting_currency,
-    )
-
-
-def _build_concentration_request(
-    *,
-    portfolio_id: str,
-    as_of_date: str,
-    reporting_currency: str | None,
-) -> dict[str, Any]:
-    return build_concentration_request(
-        portfolio_id=portfolio_id,
-        as_of_date=as_of_date,
-        reporting_currency=reporting_currency,
-    )
-
-
-def _build_drawdown_request(
-    *,
-    portfolio_id: str,
-    period: str,
-    detail_basis: str,
-    benchmark_code: str | None,
-    as_of_date: str,
-    report_start_date: str | None,
-    report_end_date: str | None,
-    reporting_currency: str | None,
-    include_underwater_series: bool,
-) -> dict[str, Any]:
-    return build_drawdown_request(
-        portfolio_id=portfolio_id,
-        period=period,
-        detail_basis=detail_basis,
-        benchmark_code=benchmark_code,
-        as_of_date=as_of_date,
-        report_start_date=report_start_date,
-        report_end_date=report_end_date,
-        reporting_currency=reporting_currency,
-        include_underwater_series=include_underwater_series,
-    )
-
-
-def _build_rolling_request(
-    *,
-    portfolio_id: str,
-    period: str,
-    detail_basis: str,
-    benchmark_code: str | None,
-    as_of_date: str,
-    report_start_date: str | None,
-    report_end_date: str | None,
-    reporting_currency: str | None,
-    include_time_series: bool,
-    include_sharpe: bool,
-) -> dict[str, Any]:
-    return build_rolling_request(
-        portfolio_id=portfolio_id,
-        period=period,
-        detail_basis=detail_basis,
-        benchmark_code=benchmark_code,
-        as_of_date=as_of_date,
-        report_start_date=report_start_date,
-        report_end_date=report_end_date,
-        reporting_currency=reporting_currency,
-        include_time_series=include_time_series,
-        include_sharpe=include_sharpe,
-    )
-
-
-def _build_attribution_request(
-    *,
-    portfolio_id: str,
-    period: str,
-    detail_basis: str,
-    benchmark_code: str | None,
-    as_of_date: str,
-    report_start_date: str | None,
-    report_end_date: str | None,
-    reporting_currency: str | None,
-    attribution_type: str,
-    grouping_dimension: str,
-) -> dict[str, Any]:
-    return build_attribution_request(
-        portfolio_id=portfolio_id,
-        period=period,
-        detail_basis=detail_basis,
-        benchmark_code=benchmark_code,
-        as_of_date=as_of_date,
-        report_start_date=report_start_date,
-        report_end_date=report_end_date,
-        reporting_currency=reporting_currency,
-        attribution_type=attribution_type,
-        grouping_dimension=grouping_dimension,
-    )
 
 
 def _resolve_reporting_currency(value: str | None) -> str:

--- a/tests/unit/test_service_layer_boundaries.py
+++ b/tests/unit/test_service_layer_boundaries.py
@@ -114,6 +114,20 @@ def test_services_delegate_workflow_task_request_shape_to_shared_helper() -> Non
     assert offenders == {}
 
 
+def test_risk_workspace_service_uses_shared_request_builders_directly() -> None:
+    path = _SERVICE_ROOT / "risk_workspace_service.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    private_request_builders = sorted(
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and node.name.startswith("_build_")
+        and node.name.endswith("_request")
+    )
+
+    assert private_request_builders == []
+
+
 def test_service_tests_do_not_need_arg_type_suppressions() -> None:
     offenders: dict[str, int] = {}
     for path in _TEST_ROOT.glob("test_*_service.py"):


### PR DESCRIPTION
## Summary
- Remove private risk workspace request wrapper functions that only delegated to the shared request module.
- Wire RiskWorkspaceService directly to the existing risk_workspace_requests builders.
- Add a service-boundary regression test so risk request-shape ownership stays in the shared request module.

## Validation
- python -m ruff check src/app/services/risk_workspace_service.py tests/unit/test_service_layer_boundaries.py
- python -m mypy src/app/services/risk_workspace_service.py
- python -m pytest tests/unit/test_risk_workspace_requests.py tests/unit/test_risk_workspace_service.py tests/unit/test_service_layer_boundaries.py -q
- python scripts/check_monetary_float_usage.py
- make check
- make ci

## Docs/Wiki
- No docs or wiki change: internal dead-path removal with unchanged API contracts, upstream request payloads, and operator behavior.

## Governance
- Repo profile: Experience API.
- Applicable lanes: Feature Lane and PR Merge Gate.
- Platform E2E is not required for this internal risk workspace service-boundary cleanup.
- Stranded truth: no governance-bearing paths changed and no unmerged remote branches were present after fetch.