### PR TITLE
Extract advisor brief workflow pack adapter

### DIFF
--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -16,12 +16,7 @@ from app.contracts.advisor_brief import (
     AdvisorBriefStatus,
     AdvisorBriefSupportabilityItem,
     AdvisorBriefTone,
-    AdvisorBriefWorkflowPackRun,
-    AdvisorBriefWorkflowPackRunFinding,
     AdvisorBriefWorkflowPackRunReviewActionRequest,
-    AdvisorBriefWorkflowPackTaskFlow,
-    AdvisorBriefWorkflowPackTaskFlowHandoff,
-    AdvisorBriefWorkflowPackTaskFlowLineage,
 )
 from app.contracts.performance_workspace import (
     AttributionSummaryView,
@@ -32,12 +27,17 @@ from app.contracts.performance_workspace import (
 )
 from app.middleware.server_timing import server_timing_span
 from app.precision_policy import quantize_money, quantize_performance
+from app.services.advisor_brief_workflow_pack import (
+    assert_advisor_brief_review_action_allowed,
+    load_advisor_brief_workflow_pack_run,
+    load_advisor_brief_workflow_pack_task_flow,
+    resolve_advisor_brief_workflow_pack_run_id,
+)
 from app.services.advisory_client_protocols import AdvisorBriefAdviseClient, AdvisorBriefAiClient
 from app.services.async_ttl_cache import AsyncTtlCache
 
 _TASK_ID = "explain.v1"
 _EXPECTED_OUTPUT_LABEL = "EXPLANATION_ONLY"
-_ADVISOR_BRIEF_TASK_FLOW_LOOKUP_LIMIT = 100
 
 
 class AdvisorBriefPerformanceWorkspaceService(Protocol):
@@ -305,12 +305,12 @@ class AdvisorBriefService:
                         ],
                     )
                 )
-        workflow_pack_run = await _load_advisor_brief_workflow_pack_run(
+        workflow_pack_run = await load_advisor_brief_workflow_pack_run(
             lotus_ai_client=self._lotus_ai_client,
             ai_audit=ai_audit,
             correlation_id=correlation_id,
         )
-        workflow_pack_task_flow = await _load_advisor_brief_workflow_pack_task_flow(
+        workflow_pack_task_flow = await load_advisor_brief_workflow_pack_task_flow(
             lotus_ai_client=self._lotus_ai_client,
             ai_audit=ai_audit,
             correlation_id=correlation_id,
@@ -385,7 +385,7 @@ class AdvisorBriefService:
             explicit_start_date=explicit_start_date,
             explicit_end_date=explicit_end_date,
         )
-        run_id = _resolve_advisor_brief_workflow_pack_run_id(ai_audit=brief.ai_audit)
+        run_id = resolve_advisor_brief_workflow_pack_run_id(ai_audit=brief.ai_audit)
         if run_id is None:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -394,7 +394,7 @@ class AdvisorBriefService:
                     "actions."
                 ),
             )
-        _assert_advisor_brief_review_action_allowed(
+        assert_advisor_brief_review_action_allowed(
             workflow_pack_run=brief.workflow_pack_run,
             run_id=run_id,
             action_type=request.action_type.value,
@@ -420,12 +420,12 @@ class AdvisorBriefService:
                 detail=_safe_error_detail(review_payload),
             )
 
-        workflow_pack_run = await _load_advisor_brief_workflow_pack_run(
+        workflow_pack_run = await load_advisor_brief_workflow_pack_run(
             lotus_ai_client=self._lotus_ai_client,
             ai_audit=brief.ai_audit,
             correlation_id=correlation_id,
         )
-        workflow_pack_task_flow = await _load_advisor_brief_workflow_pack_task_flow(
+        workflow_pack_task_flow = await load_advisor_brief_workflow_pack_task_flow(
             lotus_ai_client=self._lotus_ai_client,
             ai_audit=brief.ai_audit,
             correlation_id=correlation_id,
@@ -446,33 +446,6 @@ class AdvisorBriefService:
                 "ai_surface_supportability": ai_surface_supportability,
                 "advisory_supportability": advisory_supportability,
             }
-        )
-
-
-def _assert_advisor_brief_review_action_allowed(
-    *,
-    workflow_pack_run: AdvisorBriefWorkflowPackRun | None,
-    run_id: str,
-    action_type: str,
-) -> None:
-    if workflow_pack_run is None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                f"Advisor brief workflow-pack run `{run_id}` has no inspectable review posture; "
-                "refresh the brief before recording a bounded review action."
-            ),
-        )
-    allowed_actions = set(workflow_pack_run.allowed_review_actions)
-    if action_type not in allowed_actions:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                f"Advisor brief workflow-pack run `{workflow_pack_run.run_id}` does not allow "
-                f"review action `{action_type}` from runtime state "
-                f"`{workflow_pack_run.runtime_state}` and review state "
-                f"`{workflow_pack_run.review_state}`."
-            ),
         )
 
 
@@ -608,217 +581,6 @@ def _normalize_ai_surface_freshness_bucket(freshness: str) -> str:
     if normalized == "stale":
         return "stale"
     return "unknown"
-
-
-async def _load_advisor_brief_workflow_pack_run(
-    *,
-    lotus_ai_client: AdvisorBriefAiClient,
-    ai_audit: dict[str, Any],
-    correlation_id: str,
-) -> AdvisorBriefWorkflowPackRun | None:
-    run_id = _resolve_advisor_brief_workflow_pack_run_id(ai_audit=ai_audit)
-    if run_id is None:
-        return None
-
-    consumer_status, consumer_payload = await lotus_ai_client.get_workflow_pack_run_consumer_view(
-        run_id=run_id,
-        correlation_id=correlation_id,
-    )
-    if consumer_status != 200:
-        return None
-
-    (
-        operator_status,
-        operator_payload,
-    ) = await lotus_ai_client.get_workflow_pack_run_operator_profile(
-        run_id=run_id,
-        correlation_id=correlation_id,
-    )
-    if operator_status != 200:
-        return None
-
-    review = _safe_dict(consumer_payload.get("review"))
-    lineage = _safe_dict(consumer_payload.get("lineage"))
-    findings = [
-        finding
-        for finding in (
-            _parse_workflow_pack_run_finding(value=value)
-            for value in _safe_list(operator_payload.get("findings"))
-        )
-        if finding is not None
-    ]
-    return AdvisorBriefWorkflowPackRun(
-        run_id=_safe_str(operator_payload.get("run_id")) or run_id,
-        runtime_state=_safe_str(operator_payload.get("runtime_state")) or "UNKNOWN",
-        review_state=_safe_str(operator_payload.get("review_state")) or "UNKNOWN",
-        allowed_review_actions=[
-            action
-            for action in (_safe_str(value) for value in _safe_list(review.get("allowed_actions")))
-            if action is not None
-        ],
-        supportability_status=_safe_str(operator_payload.get("supportability_status")) or "UNKNOWN",
-        review_pending=bool(operator_payload.get("review_pending")),
-        superseded=bool(operator_payload.get("superseded")),
-        workflow_authority_owner=_safe_str(lineage.get("workflow_authority_owner"))
-        or "lotus-gateway",
-        current_summary_note=_safe_str(operator_payload.get("current_summary_note"))
-        or "Workflow-pack run posture is available without a current operator summary note.",
-        replacement_run_id=_safe_str(operator_payload.get("replacement_run_id")),
-        findings=findings,
-    )
-
-
-def _resolve_advisor_brief_workflow_pack_run_id(*, ai_audit: dict[str, Any]) -> str | None:
-    workflow_pack_run_id = _safe_str(ai_audit.get("workflow_pack_run_id"))
-    if workflow_pack_run_id is not None:
-        return workflow_pack_run_id
-    request_id = _safe_str(ai_audit.get("request_id"))
-    if request_id is None:
-        return None
-    return f"packrun_advisor_brief_{request_id}"
-
-
-async def _load_advisor_brief_workflow_pack_task_flow(
-    *,
-    lotus_ai_client: AdvisorBriefAiClient,
-    ai_audit: dict[str, Any],
-    correlation_id: str,
-) -> AdvisorBriefWorkflowPackTaskFlow | None:
-    run_id = _resolve_advisor_brief_workflow_pack_run_id(ai_audit=ai_audit)
-    if run_id is None:
-        return None
-
-    task_flow_status, task_flow_payload = await lotus_ai_client.list_workflow_pack_task_flows(
-        correlation_id=correlation_id,
-        workflow_pack_id="advisor_brief.pack",
-        caller="lotus-gateway",
-        workflow_surface="advisor-brief-workspace",
-        limit=_ADVISOR_BRIEF_TASK_FLOW_LOOKUP_LIMIT,
-    )
-    if task_flow_status != 200:
-        return None
-
-    for value in _safe_list(task_flow_payload.get("task_flows")):
-        task_flow = _parse_advisor_brief_workflow_pack_task_flow(value=value, run_id=run_id)
-        if task_flow is not None:
-            return task_flow
-    return None
-
-
-def _parse_advisor_brief_workflow_pack_task_flow(
-    *,
-    value: Any,
-    run_id: str,
-) -> AdvisorBriefWorkflowPackTaskFlow | None:
-    item = _safe_dict(value)
-    run_refs = [
-        ref for ref in (_safe_str(value) for value in _safe_list(item.get("run_refs"))) if ref
-    ]
-    if run_id not in run_refs:
-        return None
-
-    task_flow_id = _safe_str(item.get("task_flow_id"))
-    workflow_pack_id = _safe_str(item.get("workflow_pack_id"))
-    version = _safe_str(item.get("workflow_pack_version")) or _safe_str(item.get("version"))
-    flow_status = _safe_str(item.get("flow_status"))
-    supportability_status = _safe_str(item.get("supportability_status"))
-    updated_at = _safe_str(item.get("updated_at"))
-    if task_flow_id is None:
-        return None
-    if workflow_pack_id is None:
-        return None
-    if version is None:
-        return None
-    if flow_status is None:
-        return None
-    if supportability_status is None:
-        return None
-    if updated_at is None:
-        return None
-
-    lineage = [
-        lineage_item
-        for lineage_item in (
-            _parse_task_flow_lineage(value=value)
-            for value in _safe_list(item.get("replacement_lineage"))
-        )
-        if lineage_item is not None
-    ]
-    handoff_refs = [
-        handoff
-        for handoff in (
-            _parse_task_flow_handoff(value=value) for value in _safe_list(item.get("handoff_refs"))
-        )
-        if handoff is not None
-    ]
-    review_states = {
-        str(key): str(value)
-        for key, value in _safe_dict(item.get("review_states")).items()
-        if key and value
-    }
-    return AdvisorBriefWorkflowPackTaskFlow(
-        task_flow_id=task_flow_id,
-        workflow_pack_id=workflow_pack_id,
-        version=version,
-        flow_status=flow_status,
-        current_step_id=_safe_str(item.get("current_step_id")),
-        run_refs=run_refs,
-        review_states=review_states,
-        supportability_status=supportability_status,
-        replacement_lineage=lineage,
-        handoff_refs=handoff_refs,
-        updated_at=updated_at,
-    )
-
-
-def _parse_task_flow_lineage(*, value: Any) -> AdvisorBriefWorkflowPackTaskFlowLineage | None:
-    item = _safe_dict(value)
-    superseded_run_id = _safe_str(item.get("superseded_run_id"))
-    replacement_run_id = _safe_str(item.get("replacement_run_id"))
-    review_action_ref = _safe_str(item.get("review_action_ref"))
-    reason = _safe_str(item.get("reason"))
-    if (
-        superseded_run_id is None
-        or replacement_run_id is None
-        or review_action_ref is None
-        or reason is None
-    ):
-        return None
-    return AdvisorBriefWorkflowPackTaskFlowLineage(
-        superseded_run_id=superseded_run_id,
-        replacement_run_id=replacement_run_id,
-        review_action_ref=review_action_ref,
-        reason=reason,
-    )
-
-
-def _parse_task_flow_handoff(*, value: Any) -> AdvisorBriefWorkflowPackTaskFlowHandoff | None:
-    item = _safe_dict(value)
-    handoff_id = _safe_str(item.get("handoff_id"))
-    owner_service = _safe_str(item.get("owner_service"))
-    status = _safe_str(item.get("status"))
-    if handoff_id is None or owner_service is None or status is None:
-        return None
-    return AdvisorBriefWorkflowPackTaskFlowHandoff(
-        handoff_id=handoff_id,
-        owner_service=owner_service,
-        status=status,
-        domain_ref=_safe_str(item.get("domain_ref")),
-    )
-
-
-def _parse_workflow_pack_run_finding(*, value: Any) -> AdvisorBriefWorkflowPackRunFinding | None:
-    item = _safe_dict(value)
-    finding_id = _safe_str(item.get("finding_id"))
-    severity = _safe_str(item.get("severity"))
-    summary = _safe_str(item.get("summary"))
-    if finding_id is None or severity is None or summary is None:
-        return None
-    return AdvisorBriefWorkflowPackRunFinding(
-        finding_id=finding_id,
-        severity=severity,
-        summary=summary,
-    )
 
 
 def _normalize_ai_audit(audit: dict[str, Any]) -> dict[str, Any]:

--- a/src/app/services/advisor_brief_workflow_pack.py
+++ b/src/app/services/advisor_brief_workflow_pack.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException, status
+
+from app.contracts.advisor_brief import (
+    AdvisorBriefWorkflowPackRun,
+    AdvisorBriefWorkflowPackRunFinding,
+    AdvisorBriefWorkflowPackTaskFlow,
+    AdvisorBriefWorkflowPackTaskFlowHandoff,
+    AdvisorBriefWorkflowPackTaskFlowLineage,
+)
+from app.services.advisory_client_protocols import AdvisorBriefAiClient
+
+_ADVISOR_BRIEF_TASK_FLOW_LOOKUP_LIMIT = 100
+
+
+def assert_advisor_brief_review_action_allowed(
+    *,
+    workflow_pack_run: AdvisorBriefWorkflowPackRun | None,
+    run_id: str,
+    action_type: str,
+) -> None:
+    if workflow_pack_run is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Advisor brief workflow-pack run `{run_id}` has no inspectable review posture; "
+                "refresh the brief before recording a bounded review action."
+            ),
+        )
+    allowed_actions = set(workflow_pack_run.allowed_review_actions)
+    if action_type not in allowed_actions:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Advisor brief workflow-pack run `{workflow_pack_run.run_id}` does not allow "
+                f"review action `{action_type}` from runtime state "
+                f"`{workflow_pack_run.runtime_state}` and review state "
+                f"`{workflow_pack_run.review_state}`."
+            ),
+        )
+
+
+async def load_advisor_brief_workflow_pack_run(
+    *,
+    lotus_ai_client: AdvisorBriefAiClient,
+    ai_audit: dict[str, Any],
+    correlation_id: str,
+) -> AdvisorBriefWorkflowPackRun | None:
+    run_id = resolve_advisor_brief_workflow_pack_run_id(ai_audit=ai_audit)
+    if run_id is None:
+        return None
+
+    consumer_status, consumer_payload = await lotus_ai_client.get_workflow_pack_run_consumer_view(
+        run_id=run_id,
+        correlation_id=correlation_id,
+    )
+    if consumer_status != 200:
+        return None
+
+    (
+        operator_status,
+        operator_payload,
+    ) = await lotus_ai_client.get_workflow_pack_run_operator_profile(
+        run_id=run_id,
+        correlation_id=correlation_id,
+    )
+    if operator_status != 200:
+        return None
+
+    review = _safe_dict(consumer_payload.get("review"))
+    lineage = _safe_dict(consumer_payload.get("lineage"))
+    findings = [
+        finding
+        for finding in (
+            _parse_workflow_pack_run_finding(value=value)
+            for value in _safe_list(operator_payload.get("findings"))
+        )
+        if finding is not None
+    ]
+    return AdvisorBriefWorkflowPackRun(
+        run_id=_safe_str(operator_payload.get("run_id")) or run_id,
+        runtime_state=_safe_str(operator_payload.get("runtime_state")) or "UNKNOWN",
+        review_state=_safe_str(operator_payload.get("review_state")) or "UNKNOWN",
+        allowed_review_actions=[
+            action
+            for action in (_safe_str(value) for value in _safe_list(review.get("allowed_actions")))
+            if action is not None
+        ],
+        supportability_status=_safe_str(operator_payload.get("supportability_status")) or "UNKNOWN",
+        review_pending=bool(operator_payload.get("review_pending")),
+        superseded=bool(operator_payload.get("superseded")),
+        workflow_authority_owner=_safe_str(lineage.get("workflow_authority_owner"))
+        or "lotus-gateway",
+        current_summary_note=_safe_str(operator_payload.get("current_summary_note"))
+        or "Workflow-pack run posture is available without a current operator summary note.",
+        replacement_run_id=_safe_str(operator_payload.get("replacement_run_id")),
+        findings=findings,
+    )
+
+
+def resolve_advisor_brief_workflow_pack_run_id(*, ai_audit: dict[str, Any]) -> str | None:
+    workflow_pack_run_id = _safe_str(ai_audit.get("workflow_pack_run_id"))
+    if workflow_pack_run_id is not None:
+        return workflow_pack_run_id
+    request_id = _safe_str(ai_audit.get("request_id"))
+    if request_id is None:
+        return None
+    return f"packrun_advisor_brief_{request_id}"
+
+
+async def load_advisor_brief_workflow_pack_task_flow(
+    *,
+    lotus_ai_client: AdvisorBriefAiClient,
+    ai_audit: dict[str, Any],
+    correlation_id: str,
+) -> AdvisorBriefWorkflowPackTaskFlow | None:
+    run_id = resolve_advisor_brief_workflow_pack_run_id(ai_audit=ai_audit)
+    if run_id is None:
+        return None
+
+    task_flow_status, task_flow_payload = await lotus_ai_client.list_workflow_pack_task_flows(
+        correlation_id=correlation_id,
+        workflow_pack_id="advisor_brief.pack",
+        caller="lotus-gateway",
+        workflow_surface="advisor-brief-workspace",
+        limit=_ADVISOR_BRIEF_TASK_FLOW_LOOKUP_LIMIT,
+    )
+    if task_flow_status != 200:
+        return None
+
+    for value in _safe_list(task_flow_payload.get("task_flows")):
+        task_flow = _parse_advisor_brief_workflow_pack_task_flow(value=value, run_id=run_id)
+        if task_flow is not None:
+            return task_flow
+    return None
+
+
+def _parse_advisor_brief_workflow_pack_task_flow(
+    *,
+    value: Any,
+    run_id: str,
+) -> AdvisorBriefWorkflowPackTaskFlow | None:
+    item = _safe_dict(value)
+    run_refs = [
+        ref for ref in (_safe_str(value) for value in _safe_list(item.get("run_refs"))) if ref
+    ]
+    if run_id not in run_refs:
+        return None
+
+    task_flow_id = _safe_str(item.get("task_flow_id"))
+    workflow_pack_id = _safe_str(item.get("workflow_pack_id"))
+    version = _safe_str(item.get("workflow_pack_version")) or _safe_str(item.get("version"))
+    flow_status = _safe_str(item.get("flow_status"))
+    supportability_status = _safe_str(item.get("supportability_status"))
+    updated_at = _safe_str(item.get("updated_at"))
+    if task_flow_id is None:
+        return None
+    if workflow_pack_id is None:
+        return None
+    if version is None:
+        return None
+    if flow_status is None:
+        return None
+    if supportability_status is None:
+        return None
+    if updated_at is None:
+        return None
+
+    lineage = [
+        lineage_item
+        for lineage_item in (
+            _parse_task_flow_lineage(value=value)
+            for value in _safe_list(item.get("replacement_lineage"))
+        )
+        if lineage_item is not None
+    ]
+    handoff_refs = [
+        handoff
+        for handoff in (
+            _parse_task_flow_handoff(value=value) for value in _safe_list(item.get("handoff_refs"))
+        )
+        if handoff is not None
+    ]
+    review_states = {
+        str(key): str(value)
+        for key, value in _safe_dict(item.get("review_states")).items()
+        if key and value
+    }
+    return AdvisorBriefWorkflowPackTaskFlow(
+        task_flow_id=task_flow_id,
+        workflow_pack_id=workflow_pack_id,
+        version=version,
+        flow_status=flow_status,
+        current_step_id=_safe_str(item.get("current_step_id")),
+        run_refs=run_refs,
+        review_states=review_states,
+        supportability_status=supportability_status,
+        replacement_lineage=lineage,
+        handoff_refs=handoff_refs,
+        updated_at=updated_at,
+    )
+
+
+def _parse_task_flow_lineage(*, value: Any) -> AdvisorBriefWorkflowPackTaskFlowLineage | None:
+    item = _safe_dict(value)
+    superseded_run_id = _safe_str(item.get("superseded_run_id"))
+    replacement_run_id = _safe_str(item.get("replacement_run_id"))
+    review_action_ref = _safe_str(item.get("review_action_ref"))
+    reason = _safe_str(item.get("reason"))
+    if (
+        superseded_run_id is None
+        or replacement_run_id is None
+        or review_action_ref is None
+        or reason is None
+    ):
+        return None
+    return AdvisorBriefWorkflowPackTaskFlowLineage(
+        superseded_run_id=superseded_run_id,
+        replacement_run_id=replacement_run_id,
+        review_action_ref=review_action_ref,
+        reason=reason,
+    )
+
+
+def _parse_task_flow_handoff(*, value: Any) -> AdvisorBriefWorkflowPackTaskFlowHandoff | None:
+    item = _safe_dict(value)
+    handoff_id = _safe_str(item.get("handoff_id"))
+    owner_service = _safe_str(item.get("owner_service"))
+    status = _safe_str(item.get("status"))
+    if handoff_id is None or owner_service is None or status is None:
+        return None
+    return AdvisorBriefWorkflowPackTaskFlowHandoff(
+        handoff_id=handoff_id,
+        owner_service=owner_service,
+        status=status,
+        domain_ref=_safe_str(item.get("domain_ref")),
+    )
+
+
+def _parse_workflow_pack_run_finding(*, value: Any) -> AdvisorBriefWorkflowPackRunFinding | None:
+    item = _safe_dict(value)
+    finding_id = _safe_str(item.get("finding_id"))
+    severity = _safe_str(item.get("severity"))
+    summary = _safe_str(item.get("summary"))
+    if finding_id is None or severity is None or summary is None:
+        return None
+    return AdvisorBriefWorkflowPackRunFinding(
+        finding_id=finding_id,
+        severity=severity,
+        summary=summary,
+    )
+
+
+def _safe_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _safe_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_str(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None

--- a/tests/unit/test_advisor_brief_workflow_pack.py
+++ b/tests/unit/test_advisor_brief_workflow_pack.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from app.contracts.advisor_brief import AdvisorBriefWorkflowPackRun
+from app.services.advisor_brief_workflow_pack import (
+    assert_advisor_brief_review_action_allowed,
+    load_advisor_brief_workflow_pack_run,
+    load_advisor_brief_workflow_pack_task_flow,
+    resolve_advisor_brief_workflow_pack_run_id,
+)
+
+
+class _AdvisorBriefAiClientStub:
+    async def execute_workflow_pack(
+        self,
+        *,
+        pack_id: str,
+        version: str,
+        environment: str,
+        caller_identity_class: str,
+        workflow_surface: str | None,
+        task_request: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        raise AssertionError("execute_workflow_pack is not used by workflow-pack mapping tests")
+
+    async def get_observability_runtime_status(
+        self,
+        *,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        raise AssertionError("get_observability_runtime_status is not used by these tests")
+
+    async def get_workflow_pack_run_consumer_view(
+        self,
+        *,
+        run_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return (
+            200,
+            {
+                "review": {"allowed_actions": ["ACCEPT"]},
+                "lineage": {"workflow_authority_owner": "lotus-ai"},
+            },
+        )
+
+    async def get_workflow_pack_run_operator_profile(
+        self,
+        *,
+        run_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return (
+            200,
+            {
+                "run_id": run_id,
+                "runtime_state": "WAITING_FOR_REVIEW",
+                "review_state": "AWAITING_REVIEW",
+                "supportability_status": "SUPPORTED",
+                "review_pending": True,
+                "superseded": False,
+                "current_summary_note": "Advisor brief is ready for review.",
+                "findings": [
+                    {
+                        "finding_id": "finding-1",
+                        "severity": "INFO",
+                        "summary": "Workflow-pack run is reviewable.",
+                    }
+                ],
+            },
+        )
+
+    async def list_workflow_pack_task_flows(
+        self,
+        *,
+        correlation_id: str,
+        workflow_pack_id: str | None = None,
+        caller: str | None = None,
+        workflow_surface: str | None = None,
+        limit: int = 25,
+    ) -> tuple[int, dict[str, Any]]:
+        return (
+            200,
+            {
+                "task_flows": [
+                    {
+                        "task_flow_id": "taskflow-ignored",
+                        "workflow_pack_id": "advisor_brief.pack",
+                        "workflow_pack_version": "v1",
+                        "flow_status": "COMPLETED",
+                        "supportability_status": "SUPPORTED",
+                        "updated_at": "2026-06-01T00:00:00Z",
+                        "run_refs": ["packrun-other"],
+                    },
+                    {
+                        "task_flow_id": "taskflow-advisor-brief-1",
+                        "workflow_pack_id": "advisor_brief.pack",
+                        "workflow_pack_version": "v1",
+                        "flow_status": "WAITING_FOR_REVIEW",
+                        "current_step_id": "review",
+                        "supportability_status": "SUPPORTED",
+                        "updated_at": "2026-06-01T00:00:00Z",
+                        "run_refs": ["packrun-advisor-brief-1"],
+                        "review_states": {"packrun-advisor-brief-1": "AWAITING_REVIEW"},
+                        "replacement_lineage": [
+                            {
+                                "superseded_run_id": "packrun-old",
+                                "replacement_run_id": "packrun-advisor-brief-1",
+                                "review_action_ref": "review-action-1",
+                                "reason": "Updated banker review.",
+                            }
+                        ],
+                        "handoff_refs": [
+                            {
+                                "handoff_id": "handoff-1",
+                                "owner_service": "lotus-advise",
+                                "status": "READY",
+                                "domain_ref": "proposal-1",
+                            }
+                        ],
+                    },
+                ]
+            },
+        )
+
+    async def apply_workflow_pack_run_review_action(
+        self,
+        *,
+        run_id: str,
+        correlation_id: str,
+        request_payload: dict[str, Any],
+    ) -> tuple[int, dict[str, Any]]:
+        raise AssertionError("apply_workflow_pack_run_review_action is not used by these tests")
+
+
+def test_resolve_advisor_brief_workflow_pack_run_id_prefers_source_identity() -> None:
+    assert (
+        resolve_advisor_brief_workflow_pack_run_id(
+            ai_audit={
+                "workflow_pack_run_id": "packrun-advisor-brief-1",
+                "request_id": "request-1",
+            }
+        )
+        == "packrun-advisor-brief-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_advisor_brief_workflow_pack_run_preserves_review_posture() -> None:
+    run = await load_advisor_brief_workflow_pack_run(
+        lotus_ai_client=_AdvisorBriefAiClientStub(),
+        ai_audit={"workflow_pack_run_id": "packrun-advisor-brief-1"},
+        correlation_id="corr-1",
+    )
+
+    assert run is not None
+    assert run.run_id == "packrun-advisor-brief-1"
+    assert run.allowed_review_actions == ["ACCEPT"]
+    assert run.workflow_authority_owner == "lotus-ai"
+    assert run.findings[0].finding_id == "finding-1"
+
+
+@pytest.mark.asyncio
+async def test_load_advisor_brief_workflow_pack_task_flow_matches_run_ref() -> None:
+    task_flow = await load_advisor_brief_workflow_pack_task_flow(
+        lotus_ai_client=_AdvisorBriefAiClientStub(),
+        ai_audit={"workflow_pack_run_id": "packrun-advisor-brief-1"},
+        correlation_id="corr-1",
+    )
+
+    assert task_flow is not None
+    assert task_flow.task_flow_id == "taskflow-advisor-brief-1"
+    assert task_flow.run_refs == ["packrun-advisor-brief-1"]
+    assert task_flow.review_states == {"packrun-advisor-brief-1": "AWAITING_REVIEW"}
+    assert task_flow.replacement_lineage[0].superseded_run_id == "packrun-old"
+    assert task_flow.handoff_refs[0].owner_service == "lotus-advise"
+
+
+def test_assert_advisor_brief_review_action_allowed_rejects_unavailable_posture() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        assert_advisor_brief_review_action_allowed(
+            workflow_pack_run=None,
+            run_id="packrun-advisor-brief-1",
+            action_type="ACCEPT",
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "has no inspectable review posture" in str(exc_info.value.detail)
+
+
+def test_assert_advisor_brief_review_action_allowed_rejects_disallowed_action() -> None:
+    run = AdvisorBriefWorkflowPackRun(
+        run_id="packrun-advisor-brief-1",
+        runtime_state="WAITING_FOR_REVIEW",
+        review_state="AWAITING_REVIEW",
+        allowed_review_actions=["REJECT"],
+        supportability_status="SUPPORTED",
+        review_pending=True,
+        superseded=False,
+        workflow_authority_owner="lotus-ai",
+        current_summary_note="Advisor brief is ready for review.",
+        replacement_run_id=None,
+        findings=[],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        assert_advisor_brief_review_action_allowed(
+            workflow_pack_run=run,
+            run_id="packrun-advisor-brief-1",
+            action_type="ACCEPT",
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "does not allow review action" in str(exc_info.value.detail)

--- a/tests/unit/test_service_layer_boundaries.py
+++ b/tests/unit/test_service_layer_boundaries.py
@@ -128,6 +128,23 @@ def test_risk_workspace_service_uses_shared_request_builders_directly() -> None:
     assert private_request_builders == []
 
 
+def test_advisor_brief_service_delegates_workflow_pack_runtime_mapping() -> None:
+    path = _SERVICE_ROOT / "advisor_brief_service.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    workflow_pack_helpers = sorted(
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and (
+            "workflow_pack_run" in node.name
+            or "workflow_pack_task_flow" in node.name
+            or node.name == "_assert_advisor_brief_review_action_allowed"
+        )
+    )
+
+    assert workflow_pack_helpers == []
+
+
 def test_service_tests_do_not_need_arg_type_suppressions() -> None:
     offenders: dict[str, int] = {}
     for path in _TEST_ROOT.glob("test_*_service.py"):


### PR DESCRIPTION
## Summary
- Extract advisor-brief workflow-pack run and task-flow hydration into a dedicated service adapter module.
- Keep AdvisorBriefService focused on orchestration and response composition.
- Add direct adapter tests and a service-layer boundary regression to prevent workflow-pack mapping from returning to the service monolith.

## Validation
- python -m ruff check src\\app\\services\\advisor_brief_service.py src\\app\\services\\advisor_brief_workflow_pack.py tests\\unit\\test_advisor_brief_workflow_pack.py tests\\unit\\test_service_layer_boundaries.py
- python -m mypy src\\app\\services\\advisor_brief_service.py src\\app\\services\\advisor_brief_workflow_pack.py tests\\unit\\test_advisor_brief_workflow_pack.py tests\\unit\\test_service_layer_boundaries.py
- python -m pytest tests\\unit\\test_advisor_brief_workflow_pack.py tests\\unit\\test_advisor_brief_service.py tests\\unit\\test_service_layer_boundaries.py -q
- make check
- make ci

## Documentation/Wiki
- No docs or wiki change: internal service-boundary refactor only; API contract and operator behavior unchanged.