### PR TITLE
Extract advisor brief supportability adapter

### DIFF
--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -6,9 +6,6 @@ from fastapi import HTTPException, status
 
 from app.contracts.advisor_brief import (
     AdvisorBriefActionItem,
-    AdvisorBriefAdvisorySupportability,
-    AdvisorBriefAiSurfaceSupportability,
-    AdvisorBriefAiSurfaceSupportabilityItem,
     AdvisorBriefEvidenceRef,
     AdvisorBriefNarrativeItem,
     AdvisorBriefResponse,
@@ -27,6 +24,10 @@ from app.contracts.performance_workspace import (
 )
 from app.middleware.server_timing import server_timing_span
 from app.precision_policy import quantize_money, quantize_performance
+from app.services.advisor_brief_supportability import (
+    load_advisory_supportability,
+    load_ai_surface_supportability,
+)
 from app.services.advisor_brief_workflow_pack import (
     assert_advisor_brief_review_action_allowed,
     load_advisor_brief_workflow_pack_run,
@@ -315,11 +316,11 @@ class AdvisorBriefService:
             ai_audit=ai_audit,
             correlation_id=correlation_id,
         )
-        ai_surface_supportability = await _load_ai_surface_supportability(
+        ai_surface_supportability = await load_ai_surface_supportability(
             lotus_ai_client=self._lotus_ai_client,
             correlation_id=correlation_id,
         )
-        advisory_supportability = await _load_advisory_supportability(
+        advisory_supportability = await load_advisory_supportability(
             advise_client=self._advise_client,
             correlation_id=correlation_id,
         )
@@ -430,11 +431,11 @@ class AdvisorBriefService:
             ai_audit=brief.ai_audit,
             correlation_id=correlation_id,
         )
-        ai_surface_supportability = await _load_ai_surface_supportability(
+        ai_surface_supportability = await load_ai_surface_supportability(
             lotus_ai_client=self._lotus_ai_client,
             correlation_id=correlation_id,
         )
-        advisory_supportability = await _load_advisory_supportability(
+        advisory_supportability = await load_advisory_supportability(
             advise_client=self._advise_client,
             correlation_id=correlation_id,
         )
@@ -447,140 +448,6 @@ class AdvisorBriefService:
                 "advisory_supportability": advisory_supportability,
             }
         )
-
-
-async def _load_advisory_supportability(
-    *,
-    advise_client: AdvisorBriefAdviseClient | None,
-    correlation_id: str,
-) -> AdvisorBriefAdvisorySupportability | None:
-    if advise_client is None:
-        return None
-    status_code, payload = await advise_client.get_platform_capabilities(
-        correlation_id=correlation_id
-    )
-    if status_code != 200:
-        return None
-    supportability = _safe_dict(payload.get("supportability"))
-    if not supportability:
-        return None
-    return AdvisorBriefAdvisorySupportability(
-        state=_safe_str(supportability.get("state")) or "unknown",
-        reason=_safe_str(supportability.get("reason")),
-        freshness_bucket=_safe_str(supportability.get("freshness_bucket")) or "unknown",
-        dependency_count=_safe_int(supportability.get("dependency_count")),
-        ready_dependency_count=_safe_int(supportability.get("ready_dependency_count")),
-        degraded_dependency_count=_safe_int(supportability.get("degraded_dependency_count")),
-        enabled_feature_count=_safe_int(supportability.get("enabled_feature_count")),
-        ready_feature_count=_safe_int(supportability.get("ready_feature_count")),
-    )
-
-
-async def _load_ai_surface_supportability(
-    *,
-    lotus_ai_client: AdvisorBriefAiClient,
-    correlation_id: str,
-) -> AdvisorBriefAiSurfaceSupportability | None:
-    runtime_status, runtime_payload = await lotus_ai_client.get_observability_runtime_status(
-        correlation_id=correlation_id
-    )
-    if runtime_status != 200:
-        return None
-    source = _safe_dict(runtime_payload.get("ai_surface_supportability"))
-    if not source:
-        return None
-    return _parse_ai_surface_supportability(source=source)
-
-
-def _parse_ai_surface_supportability(
-    *,
-    source: dict[str, Any],
-) -> AdvisorBriefAiSurfaceSupportability:
-    posture = _safe_str(source.get("posture")) or "unavailable"
-    freshness = _safe_str(source.get("freshness")) or "unknown"
-    return AdvisorBriefAiSurfaceSupportability(
-        state=_normalize_ai_surface_supportability_state(posture),
-        freshness_bucket=_normalize_ai_surface_freshness_bucket(freshness),
-        posture=posture,
-        freshness=freshness,
-        metric_name=_safe_str(source.get("metric_name")) or "lotus_ai_surface_supportability_state",
-        supported_surface_count=_safe_int(source.get("supported_surface_count")),
-        executable_workflow_pack_count=_safe_int(source.get("executable_workflow_pack_count")),
-        action_required_surface_count=_safe_int(source.get("action_required_surface_count")),
-        unavailable_surface_count=_safe_int(source.get("unavailable_surface_count")),
-        no_sensitive_content_telemetry=bool(source.get("no_sensitive_content_telemetry")),
-        surfaces=[
-            surface
-            for surface in (
-                _parse_ai_surface_supportability_item(value=value)
-                for value in _safe_list(source.get("surfaces"))
-            )
-            if surface is not None
-        ],
-        status_summary=[
-            summary
-            for summary in (_safe_str(item) for item in _safe_list(source.get("status_summary")))
-            if summary
-        ],
-    )
-
-
-def _parse_ai_surface_supportability_item(
-    *,
-    value: Any,
-) -> AdvisorBriefAiSurfaceSupportabilityItem | None:
-    item = _safe_dict(value)
-    surface_id = _safe_str(item.get("surface_id"))
-    owning_service = _safe_str(item.get("owning_service"))
-    workflow_authority_owner = _safe_str(item.get("workflow_authority_owner"))
-    workflow_pack_ref = _safe_str(item.get("workflow_pack_ref"))
-    supportability_status = _safe_str(item.get("supportability_status"))
-    model_posture = _safe_str(item.get("model_posture"))
-    if (
-        surface_id is None
-        or owning_service is None
-        or workflow_authority_owner is None
-        or workflow_pack_ref is None
-        or supportability_status is None
-        or model_posture is None
-    ):
-        return None
-    return AdvisorBriefAiSurfaceSupportabilityItem(
-        surface_id=surface_id,
-        owning_service=owning_service,
-        workflow_authority_owner=workflow_authority_owner,
-        workflow_pack_ref=workflow_pack_ref,
-        supportability_status=supportability_status,
-        model_posture=model_posture,
-        latest_ready_run_id=_safe_str(item.get("latest_ready_run_id")),
-        latest_action_required_run_id=_safe_str(item.get("latest_action_required_run_id")),
-        no_sensitive_content_telemetry=bool(item.get("no_sensitive_content_telemetry")),
-        status_summary=[
-            summary
-            for summary in (_safe_str(item) for item in _safe_list(item.get("status_summary")))
-            if summary
-        ],
-    )
-
-
-def _normalize_ai_surface_supportability_state(posture: str) -> str:
-    normalized = posture.strip().lower()
-    if normalized == "healthy":
-        return "ready"
-    if normalized == "degraded":
-        return "action_required"
-    if normalized == "unavailable":
-        return "unsupported"
-    return "unknown"
-
-
-def _normalize_ai_surface_freshness_bucket(freshness: str) -> str:
-    normalized = freshness.strip().lower()
-    if normalized in {"current", "fresh", "ready"}:
-        return "fresh"
-    if normalized == "stale":
-        return "stale"
-    return "unknown"
 
 
 def _normalize_ai_audit(audit: dict[str, Any]) -> dict[str, Any]:
@@ -1334,14 +1201,6 @@ def _safe_str(value: Any) -> str | None:
     if isinstance(value, str) and value.strip():
         return value.strip()
     return None
-
-
-def _safe_int(value: Any) -> int:
-    if isinstance(value, bool):
-        return 0
-    if isinstance(value, int):
-        return max(value, 0)
-    return 0
 
 
 def _safe_error_detail(payload: dict[str, Any]) -> str:

--- a/src/app/services/advisor_brief_supportability.py
+++ b/src/app/services/advisor_brief_supportability.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.contracts.advisor_brief import (
+    AdvisorBriefAdvisorySupportability,
+    AdvisorBriefAiSurfaceSupportability,
+    AdvisorBriefAiSurfaceSupportabilityItem,
+)
+from app.services.advisory_client_protocols import AdvisorBriefAdviseClient, AdvisorBriefAiClient
+
+
+async def load_advisory_supportability(
+    *,
+    advise_client: AdvisorBriefAdviseClient | None,
+    correlation_id: str,
+) -> AdvisorBriefAdvisorySupportability | None:
+    if advise_client is None:
+        return None
+    status_code, payload = await advise_client.get_platform_capabilities(
+        correlation_id=correlation_id
+    )
+    if status_code != 200:
+        return None
+    supportability = _safe_dict(payload.get("supportability"))
+    if not supportability:
+        return None
+    return AdvisorBriefAdvisorySupportability(
+        state=_safe_str(supportability.get("state")) or "unknown",
+        reason=_safe_str(supportability.get("reason")),
+        freshness_bucket=_safe_str(supportability.get("freshness_bucket")) or "unknown",
+        dependency_count=_safe_int(supportability.get("dependency_count")),
+        ready_dependency_count=_safe_int(supportability.get("ready_dependency_count")),
+        degraded_dependency_count=_safe_int(supportability.get("degraded_dependency_count")),
+        enabled_feature_count=_safe_int(supportability.get("enabled_feature_count")),
+        ready_feature_count=_safe_int(supportability.get("ready_feature_count")),
+    )
+
+
+async def load_ai_surface_supportability(
+    *,
+    lotus_ai_client: AdvisorBriefAiClient,
+    correlation_id: str,
+) -> AdvisorBriefAiSurfaceSupportability | None:
+    runtime_status, runtime_payload = await lotus_ai_client.get_observability_runtime_status(
+        correlation_id=correlation_id
+    )
+    if runtime_status != 200:
+        return None
+    source = _safe_dict(runtime_payload.get("ai_surface_supportability"))
+    if not source:
+        return None
+    return parse_ai_surface_supportability(source=source)
+
+
+def parse_ai_surface_supportability(
+    *,
+    source: dict[str, Any],
+) -> AdvisorBriefAiSurfaceSupportability:
+    posture = _safe_str(source.get("posture")) or "unavailable"
+    freshness = _safe_str(source.get("freshness")) or "unknown"
+    return AdvisorBriefAiSurfaceSupportability(
+        state=_normalize_ai_surface_supportability_state(posture),
+        freshness_bucket=_normalize_ai_surface_freshness_bucket(freshness),
+        posture=posture,
+        freshness=freshness,
+        metric_name=_safe_str(source.get("metric_name")) or "lotus_ai_surface_supportability_state",
+        supported_surface_count=_safe_int(source.get("supported_surface_count")),
+        executable_workflow_pack_count=_safe_int(source.get("executable_workflow_pack_count")),
+        action_required_surface_count=_safe_int(source.get("action_required_surface_count")),
+        unavailable_surface_count=_safe_int(source.get("unavailable_surface_count")),
+        no_sensitive_content_telemetry=bool(source.get("no_sensitive_content_telemetry")),
+        surfaces=[
+            surface
+            for surface in (
+                _parse_ai_surface_supportability_item(value=value)
+                for value in _safe_list(source.get("surfaces"))
+            )
+            if surface is not None
+        ],
+        status_summary=[
+            summary
+            for summary in (_safe_str(item) for item in _safe_list(source.get("status_summary")))
+            if summary
+        ],
+    )
+
+
+def _parse_ai_surface_supportability_item(
+    *,
+    value: Any,
+) -> AdvisorBriefAiSurfaceSupportabilityItem | None:
+    item = _safe_dict(value)
+    surface_id = _safe_str(item.get("surface_id"))
+    owning_service = _safe_str(item.get("owning_service"))
+    workflow_authority_owner = _safe_str(item.get("workflow_authority_owner"))
+    workflow_pack_ref = _safe_str(item.get("workflow_pack_ref"))
+    supportability_status = _safe_str(item.get("supportability_status"))
+    model_posture = _safe_str(item.get("model_posture"))
+    if (
+        surface_id is None
+        or owning_service is None
+        or workflow_authority_owner is None
+        or workflow_pack_ref is None
+        or supportability_status is None
+        or model_posture is None
+    ):
+        return None
+    return AdvisorBriefAiSurfaceSupportabilityItem(
+        surface_id=surface_id,
+        owning_service=owning_service,
+        workflow_authority_owner=workflow_authority_owner,
+        workflow_pack_ref=workflow_pack_ref,
+        supportability_status=supportability_status,
+        model_posture=model_posture,
+        latest_ready_run_id=_safe_str(item.get("latest_ready_run_id")),
+        latest_action_required_run_id=_safe_str(item.get("latest_action_required_run_id")),
+        no_sensitive_content_telemetry=bool(item.get("no_sensitive_content_telemetry")),
+        status_summary=[
+            summary
+            for summary in (_safe_str(item) for item in _safe_list(item.get("status_summary")))
+            if summary
+        ],
+    )
+
+
+def _normalize_ai_surface_supportability_state(posture: str) -> str:
+    normalized = posture.strip().lower()
+    if normalized == "healthy":
+        return "ready"
+    if normalized == "degraded":
+        return "action_required"
+    if normalized == "unavailable":
+        return "unsupported"
+    return "unknown"
+
+
+def _normalize_ai_surface_freshness_bucket(freshness: str) -> str:
+    normalized = freshness.strip().lower()
+    if normalized in {"current", "fresh", "ready"}:
+        return "fresh"
+    if normalized == "stale":
+        return "stale"
+    return "unknown"
+
+
+def _safe_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _safe_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_str(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _safe_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    return 0

--- a/tests/unit/test_advisor_brief_supportability.py
+++ b/tests/unit/test_advisor_brief_supportability.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.services.advisor_brief_supportability import (
+    load_advisory_supportability,
+    load_ai_surface_supportability,
+    parse_ai_surface_supportability,
+)
+
+
+class _AdvisorBriefAiClientStub:
+    def __init__(self, *, status_code: int = 200, payload: dict[str, Any] | None = None) -> None:
+        self.status_code = status_code
+        self.payload = payload or {
+            "ai_surface_supportability": {
+                "posture": "degraded",
+                "freshness": "current",
+                "metric_name": "lotus_ai_surface_supportability_state",
+                "supported_surface_count": 2,
+                "executable_workflow_pack_count": 1,
+                "action_required_surface_count": 1,
+                "unavailable_surface_count": 0,
+                "no_sensitive_content_telemetry": True,
+                "surfaces": [
+                    {
+                        "surface_id": "advisor_brief",
+                        "owning_service": "lotus-advise",
+                        "workflow_authority_owner": "lotus-advise",
+                        "workflow_pack_ref": "advisor_brief.pack@v1",
+                        "supportability_status": "ACTION_REQUIRED",
+                        "model_posture": "degraded",
+                        "latest_ready_run_id": "packrun-ready-1",
+                        "latest_action_required_run_id": "packrun-action-1",
+                        "no_sensitive_content_telemetry": True,
+                        "status_summary": ["Review required."],
+                    },
+                    {"surface_id": "incomplete"},
+                ],
+                "status_summary": ["One AI surface requires operator action."],
+            }
+        }
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute_workflow_pack(
+        self,
+        *,
+        pack_id: str,
+        version: str,
+        environment: str,
+        caller_identity_class: str,
+        workflow_surface: str | None,
+        task_request: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        raise AssertionError("execute_workflow_pack is not used by supportability tests")
+
+    async def get_observability_runtime_status(
+        self,
+        *,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        self.calls.append({"correlation_id": correlation_id})
+        return self.status_code, self.payload
+
+    async def get_workflow_pack_run_consumer_view(
+        self,
+        *,
+        run_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        raise AssertionError("get_workflow_pack_run_consumer_view is not used by these tests")
+
+    async def get_workflow_pack_run_operator_profile(
+        self,
+        *,
+        run_id: str,
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        raise AssertionError("get_workflow_pack_run_operator_profile is not used by these tests")
+
+    async def list_workflow_pack_task_flows(
+        self,
+        *,
+        correlation_id: str,
+        workflow_pack_id: str | None = None,
+        caller: str | None = None,
+        workflow_surface: str | None = None,
+        limit: int = 25,
+    ) -> tuple[int, dict[str, Any]]:
+        raise AssertionError("list_workflow_pack_task_flows is not used by these tests")
+
+    async def apply_workflow_pack_run_review_action(
+        self,
+        *,
+        run_id: str,
+        correlation_id: str,
+        request_payload: dict[str, Any],
+    ) -> tuple[int, dict[str, Any]]:
+        raise AssertionError("apply_workflow_pack_run_review_action is not used by these tests")
+
+
+class _AdvisorBriefAdviseClientStub:
+    def __init__(self, *, status_code: int = 200, payload: dict[str, Any] | None = None) -> None:
+        self.status_code = status_code
+        self.payload = payload or {
+            "supportability": {
+                "state": "ready",
+                "reason": "advisory_ready",
+                "freshness_bucket": "current",
+                "dependency_count": 5,
+                "ready_dependency_count": 5,
+                "degraded_dependency_count": 0,
+                "enabled_feature_count": 9,
+                "ready_feature_count": 9,
+            }
+        }
+        self.calls: list[dict[str, Any]] = []
+
+    async def get_platform_capabilities(
+        self,
+        *,
+        consumer_system: str = "lotus-gateway",
+        tenant_id: str = "default",
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        self.calls.append(
+            {
+                "consumer_system": consumer_system,
+                "tenant_id": tenant_id,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.status_code, self.payload
+
+
+@pytest.mark.asyncio
+async def test_load_ai_surface_supportability_preserves_bounded_source_posture() -> None:
+    ai_client = _AdvisorBriefAiClientStub()
+
+    supportability = await load_ai_surface_supportability(
+        lotus_ai_client=ai_client,
+        correlation_id="corr-ai-supportability",
+    )
+
+    assert supportability is not None
+    assert supportability.state == "action_required"
+    assert supportability.freshness_bucket == "fresh"
+    assert supportability.supported_surface_count == 2
+    assert len(supportability.surfaces) == 1
+    assert supportability.surfaces[0].surface_id == "advisor_brief"
+    assert supportability.surfaces[0].workflow_authority_owner == "lotus-advise"
+    assert supportability.status_summary == ["One AI surface requires operator action."]
+    assert ai_client.calls == [{"correlation_id": "corr-ai-supportability"}]
+
+
+@pytest.mark.asyncio
+async def test_load_ai_surface_supportability_omits_unavailable_source() -> None:
+    supportability = await load_ai_surface_supportability(
+        lotus_ai_client=_AdvisorBriefAiClientStub(status_code=503, payload={"detail": "paused"}),
+        correlation_id="corr-ai-down",
+    )
+
+    assert supportability is None
+
+
+def test_parse_ai_surface_supportability_clamps_non_integer_counts() -> None:
+    supportability = parse_ai_surface_supportability(
+        source={
+            "posture": "healthy",
+            "freshness": "ready",
+            "supported_surface_count": True,
+            "executable_workflow_pack_count": -1,
+            "action_required_surface_count": "3",
+            "unavailable_surface_count": 4,
+            "no_sensitive_content_telemetry": False,
+        }
+    )
+
+    assert supportability.state == "ready"
+    assert supportability.freshness_bucket == "fresh"
+    assert supportability.supported_surface_count == 0
+    assert supportability.executable_workflow_pack_count == 0
+    assert supportability.action_required_surface_count == 0
+    assert supportability.unavailable_surface_count == 4
+
+
+@pytest.mark.asyncio
+async def test_load_advisory_supportability_preserves_source_posture() -> None:
+    advise_client = _AdvisorBriefAdviseClientStub()
+
+    supportability = await load_advisory_supportability(
+        advise_client=advise_client,
+        correlation_id="corr-advisory-supportability",
+    )
+
+    assert supportability is not None
+    assert supportability.model_dump(mode="json") == {
+        "feature_key": "advise.observability.advisory_supportability",
+        "state": "ready",
+        "reason": "advisory_ready",
+        "freshness_bucket": "current",
+        "dependency_count": 5,
+        "ready_dependency_count": 5,
+        "degraded_dependency_count": 0,
+        "enabled_feature_count": 9,
+        "ready_feature_count": 9,
+        "metric_name": "lotus_advise_advisory_supportability_total",
+    }
+    assert advise_client.calls == [
+        {
+            "consumer_system": "lotus-gateway",
+            "tenant_id": "default",
+            "correlation_id": "corr-advisory-supportability",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_load_advisory_supportability_omits_absent_source() -> None:
+    assert (
+        await load_advisory_supportability(
+            advise_client=None,
+            correlation_id="corr-no-advise",
+        )
+        is None
+    )
+    assert (
+        await load_advisory_supportability(
+            advise_client=_AdvisorBriefAdviseClientStub(
+                status_code=503,
+                payload={"detail": "paused"},
+            ),
+            correlation_id="corr-advise-down",
+        )
+        is None
+    )

--- a/tests/unit/test_service_layer_boundaries.py
+++ b/tests/unit/test_service_layer_boundaries.py
@@ -145,6 +145,23 @@ def test_advisor_brief_service_delegates_workflow_pack_runtime_mapping() -> None
     assert workflow_pack_helpers == []
 
 
+def test_advisor_brief_service_delegates_supportability_runtime_mapping() -> None:
+    path = _SERVICE_ROOT / "advisor_brief_service.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    supportability_helpers = sorted(
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and (
+            node.name in {"_load_advisory_supportability", "_load_ai_surface_supportability"}
+            or node.name.startswith("_parse_ai_surface_supportability")
+            or node.name.startswith("_normalize_ai_surface_")
+        )
+    )
+
+    assert supportability_helpers == []
+
+
 def test_service_tests_do_not_need_arg_type_suppressions() -> None:
     offenders: dict[str, int] = {}
     for path in _TEST_ROOT.glob("test_*_service.py"):


### PR DESCRIPTION
## Summary
- Extract advisor-brief AI/advisory supportability loading and parsing into a dedicated service adapter module.
- Keep AdvisorBriefService focused on orchestration and response composition.
- Add direct supportability adapter tests and a service-layer boundary regression to prevent supportability mapping from returning to the service monolith.

## Validation
- python -m ruff check src\\app\\services\\advisor_brief_service.py src\\app\\services\\advisor_brief_supportability.py tests\\unit\\test_advisor_brief_supportability.py tests\\unit\\test_service_layer_boundaries.py
- python -m mypy src\\app\\services\\advisor_brief_service.py src\\app\\services\\advisor_brief_supportability.py tests\\unit\\test_advisor_brief_supportability.py tests\\unit\\test_service_layer_boundaries.py
- python -m pytest tests\\unit\\test_advisor_brief_supportability.py tests\\unit\\test_advisor_brief_service.py tests\\unit\\test_service_layer_boundaries.py -q
- make check
- make ci

## Documentation/Wiki
- No docs or wiki change: internal service-boundary refactor only; API contract and operator behavior unchanged.