### PR TITLE
Add gateway quality baseline governance

### DIFF
--- a/.github/workflows/quality-baseline.yml
+++ b/.github/workflows/quality-baseline.yml
@@ -1,0 +1,107 @@
+name: Quality Baseline
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches-ignore:
+      - "main"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  report-only:
+    name: Quality Baseline / Report Only
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Python Quality Tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,quality]"
+          python -m pip check
+
+      - name: Install Spectral
+        run: npm install -g @stoplight/spectral-cli
+
+      - name: Ruff
+        continue-on-error: true
+        run: |
+          mkdir -p output/quality-baseline
+          python -m ruff check . 2>&1 | tee output/quality-baseline/ruff.txt
+
+      - name: Mypy
+        continue-on-error: true
+        run: python -m mypy src 2>&1 | tee output/quality-baseline/mypy.txt
+
+      - name: Coverage
+        continue-on-error: true
+        run: make test-coverage 2>&1 | tee output/quality-baseline/coverage.txt
+
+      - name: Architecture Import Rules
+        continue-on-error: true
+        run: lint-imports --config .importlinter 2>&1 | tee output/quality-baseline/import-linter.txt
+
+      - name: Complexity Baseline
+        continue-on-error: true
+        run: |
+          {
+            radon cc src/app -s -a
+            radon mi src/app -s
+            xenon --max-absolute C --max-modules B --max-average A src/app
+          } 2>&1 | tee output/quality-baseline/complexity.txt
+
+      - name: Dead Code Baseline
+        continue-on-error: true
+        run: vulture src/app tests --min-confidence 80 2>&1 | tee output/quality-baseline/vulture.txt
+
+      - name: Dependency Baseline
+        continue-on-error: true
+        run: deptry . 2>&1 | tee output/quality-baseline/deptry.txt
+
+      - name: Security Baseline
+        continue-on-error: true
+        run: |
+          {
+            bandit -q -r src/app -c pyproject.toml
+            make security-audit
+          } 2>&1 | tee output/quality-baseline/security.txt
+
+      - name: Documentation Baseline
+        continue-on-error: true
+        run: interrogate src/app 2>&1 | tee output/quality-baseline/interrogate.txt
+
+      - name: OpenAPI Spectral Baseline
+        continue-on-error: true
+        run: |
+          python - <<'PY' > openapi.json
+          import json
+          from app.main import app
+          print(json.dumps(app.openapi(), indent=2))
+          PY
+          spectral lint openapi.json --ruleset .spectral.yaml 2>&1 | tee output/quality-baseline/spectral.txt
+
+      - name: Upload Quality Baseline Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-baseline
+          path: |
+            output/quality-baseline/
+            openapi.json
+          if-no-files-found: warn

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,57 @@
+[importlinter]
+root_package = app
+
+[importlinter:contract:routers_do_not_import_concrete_clients]
+name = Routers depend on service layer, not concrete upstream clients
+type = forbidden
+source_modules =
+    app.routers
+forbidden_modules =
+    app.clients
+
+[importlinter:contract:middleware_stays_out_of_services_and_clients]
+name = Middleware stays framework/cross-cutting only
+type = forbidden
+source_modules =
+    app.middleware
+forbidden_modules =
+    app.clients
+    app.services
+
+[importlinter:contract:contracts_do_not_depend_on_runtime_layers]
+name = Contracts do not depend on routers, services, clients, or middleware
+type = forbidden
+source_modules =
+    app.contracts
+forbidden_modules =
+    app.routers
+    app.services
+    app.clients
+    app.middleware
+
+[importlinter:contract:services_do_not_depend_on_routers]
+name = Services do not depend on routers
+type = forbidden
+source_modules =
+    app.services
+forbidden_modules =
+    app.routers
+
+[importlinter:contract:services_use_factories_for_concrete_clients]
+name = Services use factory modules for concrete upstream clients
+type = forbidden
+source_modules =
+    app.services
+forbidden_modules =
+    app.clients
+unmatched_ignore_imports_alerting = none
+ignore_imports =
+    app.services.advise_client_factory -> app.clients.advise_client
+    app.services.analytics_client_factory -> app.clients.lotus_analytics_client
+    app.services.archive_client_factory -> app.clients.archive_client
+    app.services.dpm_service_factory -> app.clients.dpm_client
+    app.services.dpm_service_factory -> app.clients.lotus_ai_client
+    app.services.lotus_core_client_factory -> app.clients.lotus_core_ingestion_client
+    app.services.lotus_core_client_factory -> app.clients.lotus_core_query_client
+    app.services.reporting_client_factory -> app.clients.render_client
+    app.services.reporting_client_factory -> app.clients.reporting_client

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,62 @@
+extends:
+  - spectral:oas
+
+rules:
+  lotus-operation-operation-id:
+    description: Every public operation must expose a stable operationId.
+    message: "Operation must define operationId."
+    severity: warn
+    given: "$.paths[*][get,post,put,patch,delete]"
+    then:
+      field: operationId
+      function: truthy
+
+  lotus-operation-summary:
+    description: Every operation must have a concise summary.
+    message: "Operation must define summary."
+    severity: warn
+    given: "$.paths[*][get,post,put,patch,delete]"
+    then:
+      field: summary
+      function: truthy
+
+  lotus-operation-description:
+    description: Every operation must explain behavior, ownership, and degraded posture.
+    message: "Operation must define description."
+    severity: warn
+    given: "$.paths[*][get,post,put,patch,delete]"
+    then:
+      field: description
+      function: truthy
+
+  lotus-operation-tags:
+    description: Every operation must be assigned to at least one route-family tag.
+    message: "Operation must define tags."
+    severity: warn
+    given: "$.paths[*][get,post,put,patch,delete]"
+    then:
+      field: tags
+      function: truthy
+
+  lotus-standard-error-response:
+    description: Every operation should document at least one 4xx or 5xx response.
+    message: "Operation should define standard error responses."
+    severity: warn
+    given: "$.paths[*][get,post,put,patch,delete]"
+    then:
+      field: responses
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          anyOf:
+            - required: ["400"]
+            - required: ["401"]
+            - required: ["403"]
+            - required: ["404"]
+            - required: ["409"]
+            - required: ["422"]
+            - required: ["429"]
+            - required: ["500"]
+            - required: ["502"]
+            - required: ["503"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Experience-API blueprint:
 Upstream contract-family map:
 [docs/standards/RFC-0082-upstream-contract-family-map.md](docs/standards/RFC-0082-upstream-contract-family-map.md)
 
+Quality and enterprise-readiness baseline:
+[quality/baseline_report.md](quality/baseline_report.md),
+[quality/quality_scorecard.md](quality/quality_scorecard.md),
+[docs/architecture.md](docs/architecture.md),
+[docs/api-governance.md](docs/api-governance.md),
+[docs/observability.md](docs/observability.md),
+[docs/security.md](docs/security.md), and
+[docs/operations-runbook.md](docs/operations-runbook.md)
+
 ## Purpose And Scope
 
 `lotus-gateway` owns product-facing API composition for Lotus.
@@ -259,6 +268,11 @@ Repo-native gate mapping:
   local feature-lane style validation
 - `make ci-local-docker`
   Docker parity for the live integration boundary
+
+The Quality Baseline workflow is intentionally report-only. It publishes complexity,
+maintainability, dead-code, dependency, security, import-boundary, documentation, coverage, and
+OpenAPI governance evidence without weakening the existing blocking lanes. Promote individual
+checks only after baseline findings are classified and no-new-regression thresholds are agreed.
 
 ## API Contract Notes
 

--- a/docs/api-governance.md
+++ b/docs/api-governance.md
@@ -1,0 +1,48 @@
+# API Governance
+
+`lotus-gateway` exposes the governed product API contract for Lotus front-office and operating
+surfaces.
+
+## API Shape
+
+Public APIs should:
+
+1. live under `/api/v1` unless a governed version change is approved,
+2. use typed request and response contracts,
+3. include summaries, descriptions, tags, operation IDs, examples, and standard errors,
+4. preserve correlation IDs,
+5. document degraded and partial-readiness behavior,
+6. avoid leaking upstream-only DTOs when a product contract is required.
+
+## OpenAPI Baseline
+
+Current generated OpenAPI baseline:
+
+1. 170 paths,
+2. 170 operations,
+3. 0 missing summaries,
+4. 3 missing descriptions,
+5. 0 missing generated operation IDs,
+6. 4 missing tags,
+7. 4 missing documented 4xx/5xx responses,
+8. 186 Spectral warnings and 0 Spectral errors in the first report-only smoke.
+
+`.spectral.yaml` captures report-only rules for operation ID, summary, description, tags, and
+standard error responses.
+
+## Error Governance
+
+Gateway should converge on RFC 7807/problem-details for platform errors where applicable. Existing
+unhandled exceptions return `application/problem+json`; route-specific upstream error mapping
+remains a baseline improvement area.
+
+## Versioning And Deprecation
+
+1. Current public APIs use `/api/v1`.
+2. Breaking changes require docs, tests, and migration posture.
+3. Deprecated routes must be marked in OpenAPI and referenced in supported-features material.
+
+## Pagination, Filtering, Sorting
+
+Collection routes should use explicit, bounded query parameters. New collection routes should
+document pagination, filtering, sorting, and default ordering behavior in OpenAPI descriptions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,65 @@
+# Architecture
+
+`lotus-gateway` is the Lotus experience API and composition boundary. It is consumed primarily by
+`lotus-workbench` and mediates product-facing access to domain-authoritative services.
+
+## Role
+
+Gateway owns:
+
+1. product-facing API composition,
+2. partial-readiness-aware aggregation,
+3. route contract governance,
+4. product-safe response shaping,
+5. correlation, supportability, degraded-state, and evidence mediation.
+
+Gateway does not own portfolio source truth, performance methodology, risk methodology, advisory
+workflow truth, management workflow truth, reporting truth, archive truth, or AI output truth.
+
+## Runtime Layers
+
+1. `src/app/routers/`
+   FastAPI route handlers. Routers should validate request shape, call services, and return typed
+   contracts. They should not construct concrete downstream clients.
+2. `src/app/services/`
+   Experience orchestration, upstream composition, supportability mapping, partial-failure mapping,
+   and product response shaping.
+3. `src/app/clients/`
+   Concrete upstream HTTP client implementations.
+4. `src/app/contracts/`
+   Product-facing DTOs for Workbench and external consumers.
+5. `src/app/middleware/`
+   Cross-cutting middleware for correlation and HTTP behavior.
+
+## Integration Boundaries
+
+Gateway integrates with:
+
+1. `lotus-core` for portfolio, booking, lookup, ingestion, and supportability inputs,
+2. `lotus-performance` for performance analytics and evidence,
+3. `lotus-risk` for risk workspace analytics,
+4. `lotus-advise` for proposals, advisory policy, advisor cockpit, and bank-demo proof,
+5. `lotus-manage` for DPM command-center and discretionary management workflows,
+6. `lotus-report` for reporting and report-batch workflows,
+7. `lotus-archive` for generated-document metadata and controlled download,
+8. `lotus-ai` for governed workflow-pack execution seams,
+9. `lotus-platform` for generated data-product catalog and trust evidence.
+
+## Boundary Rules
+
+1. Domain authority remains upstream.
+2. Gateway preserves upstream supportability and lineage instead of recomputing truth.
+3. Gateway routes should expose product-oriented contracts, not uncontrolled upstream mirrors.
+4. Concrete clients are constructed in service factory modules.
+5. Service modules should depend on typed protocols where possible.
+6. Public API behavior must be pinned by contract or integration tests.
+
+## Quality Baseline
+
+The current architecture baseline is documented in:
+
+1. `quality/baseline_report.md`,
+2. `quality/architecture_rules.md`,
+3. `.importlinter`,
+4. `tests/unit/test_service_layer_boundaries.py`,
+5. `tests/unit/test_router_layer_boundaries.py`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,44 @@
+# Observability
+
+`lotus-gateway` observability must support product users, operations, support engineers, and
+enterprise adoption without exposing sensitive portfolio, client, prompt, model-output, or
+entitlement detail.
+
+## Current Surfaces
+
+1. `/health`
+2. `/health/live`
+3. `/health/ready`
+4. `/metrics`
+5. `X-Correlation-Id` propagation
+6. analytics UI fan-out logs and metrics
+7. protected analytics diagnostics lookup
+8. bounded audit records for selected analytics reads and denial paths
+
+## Logging Rules
+
+1. Logs should be structured.
+2. Logs must not include raw portfolio holdings, client PII, prompts, model outputs, transaction
+   payloads, entitlement payloads, or generated report content.
+3. Audit records should use bounded fields and explicit route/operation/panel/state/reason labels.
+4. Correlation IDs should be present on ingress and propagated to upstream clients.
+
+## Metrics Rules
+
+1. Metrics labels must be low-cardinality.
+2. Do not use portfolio, client, transaction, document, prompt, model-output, or entitlement IDs as
+   metric labels.
+3. Degraded upstream posture should be counted with bounded service and reason labels.
+
+## Traceability
+
+Current traceability relies primarily on correlation IDs, support references, evidence references,
+and upstream lineage payloads. Distributed tracing is a future hardening track and should preserve
+the same sensitive-data constraints.
+
+## Baseline Gaps
+
+1. No blocking static check yet verifies structured log field allowlists.
+2. No blocking gate verifies metric label cardinality.
+3. Trace propagation beyond correlation IDs is not yet governed.
+4. Diagnostics authorization and masking should get dedicated security regression tests.

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -1,0 +1,70 @@
+# Operations Runbook
+
+This runbook summarizes local and CI operations for `lotus-gateway`.
+
+## Local Startup
+
+Use the canonical app-dir startup path:
+
+```powershell
+make run-canonical
+```
+
+The canonical local route is `http://gateway.dev.lotus` when platform ingress is active.
+
+## Health And Metrics
+
+1. `/health`
+2. `/health/live`
+3. `/health/ready`
+4. `/metrics`
+
+Readiness should fail when the process is draining and should remain product-safe.
+
+## Local Validation
+
+```powershell
+make check
+make ci
+```
+
+`make check` covers lint, formatting, monetary-float guard, typecheck, Workbench OpenAPI contract
+smoke, and unit/contract tests.
+
+`make ci` adds migration smoke, integration tests, coverage, and security audit.
+
+## Docker Parity
+
+```powershell
+make ci-local-docker
+make ci-local-docker-down
+```
+
+Docker parity is required because gateway is a live integration boundary.
+
+## Quality Baseline
+
+The report-only quality workflow installs optional quality tooling and runs:
+
+1. ruff,
+2. mypy,
+3. coverage,
+4. import-linter,
+5. radon/xenon,
+6. vulture,
+7. deptry,
+8. bandit,
+9. pip-audit,
+10. interrogate,
+11. spectral.
+
+The workflow is intentionally `continue-on-error` during baseline classification.
+
+## Incident Notes
+
+1. Preserve correlation IDs when escalating gateway issues.
+2. Capture upstream service, route family, status class, degraded reason, and support reference.
+3. Do not paste raw client, holding, prompt, model-output, entitlement, or document payloads into
+   tickets or chat.
+4. Verify whether the failure is gateway composition, upstream domain truth, ingress, or platform
+   runtime before changing code.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,40 @@
+# Security
+
+`lotus-gateway` is an API entry point and must protect downstream services, client data, and
+operator surfaces.
+
+## Current Controls
+
+1. `pip-audit` runs in repo-native CI.
+2. A governed temporary exception exists for `PYSEC-2026-161` because FastAPI constrains Starlette
+   below the fixed line.
+3. Correlation middleware avoids leaking raw payloads.
+4. Analytics audit and diagnostics paths use bounded product-safe fields.
+5. CORS, downstream HTTP resilience, and error handling are covered by existing tests.
+
+## Security Baseline Additions
+
+This slice adds report-only baseline tooling for:
+
+1. `bandit`,
+2. `deptry`,
+3. `vulture`,
+4. `import-linter`,
+5. `spectral` OpenAPI checks.
+
+## Required Security Posture
+
+1. Secrets must come from environment/configuration, not source code.
+2. Logs and metrics must not expose sensitive client, portfolio, holding, transaction, prompt,
+   model-output, entitlement, or document content.
+3. Downstream errors must be product-safe and should not leak raw upstream stack traces or internal
+   topology beyond governed service names.
+4. Protected diagnostics must be auditable and role-aware.
+5. Mutating operations should define idempotency and audit behavior.
+
+## Future Blocking Gates
+
+1. No new high-severity Bandit findings.
+2. No new dependency vulnerabilities outside governed exceptions.
+3. No new route that logs or returns sensitive raw downstream payloads.
+4. Dedicated regression tests for auth, diagnostics, data masking, and problem-details errors.

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -1,0 +1,61 @@
+# Supported Features
+
+`lotus-gateway` currently supports the following product-facing route families.
+
+## Platform And Foundation
+
+1. health, liveness, readiness, metrics, and docs,
+2. foundation workspace composition,
+3. platform capability aggregation,
+4. source-product execution acknowledgement.
+
+## Workbench
+
+1. Workbench overview and sandbox surfaces,
+2. performance workspace summary, detail, evidence, attribution trend, modules, and advisor brief,
+3. risk workspace summary, concentration, drawdown, rolling risk, and attribution,
+4. portfolio 360 composition.
+
+## Advisory And Proposals
+
+1. proposal simulation, lifecycle, workflow, approval, lineage, replay, report request, delivery
+   posture, and execution updates,
+2. advisory workspace create, draft, save, resume, compare, rationale, review, and handoff,
+3. advisory policy packs, evaluations, review queue, workflow, sign-off, report package, lineage,
+   replay, event, and AI evidence,
+4. advisor cockpit actions, preparation packets, snapshot, supportability, acknowledgements, and
+   house-view cohorts,
+5. bank-demo proof scenario contract, supported-claim register, and proof-pack capture.
+
+## DPM Command Center
+
+1. command-center summary, monitoring, exceptions, mandates, and mandate drill-down,
+2. construction alternative-set generation, retrieval, and selection,
+3. proof-pack generation/read/Markdown/report-input/AI-evidence/AI PM memo,
+4. portfolio memory,
+5. outcome-review preview/create/search/detail/source-refresh/supportability/report-input,
+   AI-evidence, AI narrative, and handoff,
+6. PM operating quality policy, score-run, fairness, review-action, and summary-invocation route
+   families,
+7. wave campaign definitions, queues, approval inbox, workflow board, assignment plan,
+   automation, wave report input, AI PM memo, and operations handoff summary.
+
+## Reporting And Archive
+
+1. portfolio-review report job submission,
+2. report-job search/status/event-history/cancellation,
+3. RFC-0104 report-batch materialization/status/control/retry/recovery/bounded operator-run,
+4. report-batch scheduler list and run-due,
+5. archived generated-document metadata and controlled binary download.
+
+## Data Products
+
+1. domain-product catalog,
+2. product detail,
+3. dependency graph,
+4. live trust certification discovery.
+
+## Boundaries
+
+Supported does not mean gateway owns source truth. Domain authority remains with the upstream
+services listed in `docs/architecture.md` and `REPOSITORY-ENGINEERING-CONTEXT.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,16 @@ dev = [
   "mypy>=1.13.0",
   "pip-audit>=2.9.0"
 ]
+quality = [
+  "bandit[toml]>=1.7.10",
+  "deptry>=0.23.0",
+  "import-linter>=2.1",
+  "interrogate>=1.7.0",
+  "pip-audit>=2.9.0",
+  "radon>=6.0.1",
+  "vulture>=2.14",
+  "xenon>=0.9.3"
+]
 
 [build-system]
 requires = ["setuptools>=61.0"]
@@ -54,4 +64,23 @@ python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
+
+[tool.bandit]
+exclude_dirs = ["tests", ".venv-codex", ".venv", "output"]
+skips = []
+
+[tool.interrogate]
+ignore-init-method = true
+ignore-init-module = true
+ignore-magic = true
+ignore-module = true
+ignore-nested-functions = true
+ignore-private = true
+ignore-property-decorators = true
+fail-under = 45
+exclude = ["tests", "output", ".venv", ".venv-codex"]
+
+[tool.deptry]
+known_first_party = ["app"]
+exclude = [".venv", ".venv-codex", "output"]
 

--- a/quality/api_governance_rules.md
+++ b/quality/api_governance_rules.md
@@ -1,0 +1,44 @@
+# API Governance Rules
+
+`lotus-gateway` is the product-facing experience API for Lotus. API governance focuses on
+truthful contracts, stable documentation, consistent error behavior, and gateway-first
+consumption by product clients.
+
+## Required Operation Shape
+
+Every public operation should define:
+
+1. route-family tags,
+2. summary,
+3. description,
+4. stable operation ID,
+5. request model or typed query parameters,
+6. response model,
+7. examples where the route is non-trivial,
+8. standard error responses.
+
+`.spectral.yaml` records these expectations as warning-level baseline checks. The current FastAPI
+OpenAPI export contains 170 paths and 170 operations. Current generated OpenAPI has no missing
+summaries or operation IDs, but it has baseline gaps for 3 descriptions, 4 tags, and 4 documented
+4xx/5xx responses. A Spectral smoke using `.spectral.yaml` plus the inherited `spectral:oas`
+rules reports 186 warnings and no errors; most warnings are missing global tag declarations.
+
+## Error Model
+
+Gateway errors should converge on RFC 7807/problem-details where applicable. The current app has a
+`ProblemDetails` model and an unhandled-exception handler that returns
+`application/problem+json`; route-specific upstream error mapping remains mixed and should be
+normalized incrementally.
+
+## Pagination, Filtering, Sorting, Versioning
+
+1. New collection endpoints should use consistent pagination naming and explicit limit bounds.
+2. Filtering and sorting parameters should be enumerated and documented in OpenAPI descriptions.
+3. Public routes remain under `/api/v1` until a governed version change is approved.
+4. Deprecation must be explicit in OpenAPI and documented in the API catalog or supported-features
+   material.
+
+## Gateway Authority Boundary
+
+Gateway may compose and shape product payloads. It must not recompute domain-source truth or
+invent readiness, entitlement, advisory, report, archive, or AI posture that belongs upstream.

--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -1,0 +1,54 @@
+# Architecture Rules
+
+This document records the baseline architecture rules for the `lotus-gateway` enterprise
+hardening program. The first implementation phase is report-only; later phases should fail only
+new regressions, then enforce agreed thresholds.
+
+## Layering
+
+1. Routers call gateway services or use-case modules only.
+2. Routers must not import or instantiate concrete downstream clients, HTTP clients, database
+   clients, Kafka, Redis, or persistence adapters.
+3. Middleware remains cross-cutting and thin. It must not contain portfolio, advisory, reporting,
+   analytics, or workflow business logic.
+4. Contracts define product-facing DTOs and must not depend on routers, services, clients, or
+   middleware.
+5. Service modules may orchestrate upstream calls through typed protocol surfaces and factories.
+6. Only service factory modules may construct concrete upstream clients.
+7. Gateway must not become the authority for portfolio source data, analytics methodology, advisory
+   workflow truth, management workflow truth, reporting truth, archive truth, or AI output truth.
+
+## Import-Linter Contracts
+
+`.importlinter` defines report-only contracts for:
+
+1. routers not importing `app.clients`,
+2. middleware not importing `app.clients` or `app.services`,
+3. contracts not importing runtime layers,
+4. services not importing routers.
+
+Existing AST-based unit boundary tests remain the blocking local protection for the currently
+validated rules. Import-linter expands the governed baseline and will become blocking after the
+report-only baseline is reviewed.
+
+## Baseline Findings
+
+The largest current modularity risks are:
+
+1. `src/app/services/portfolio_service.py` at 2,882 lines,
+2. `src/app/services/risk_workspace_service.py` at 1,781 lines,
+3. `src/app/services/advisor_brief_service.py` at 1,144 lines,
+4. `src/app/services/dpm_command_center_service.py` at 966 lines,
+5. `src/app/services/performance_workspace_service.py` at 937 lines.
+
+The longest current function is `register_routers` in `src/app/router_registry.py` at 298 lines.
+That function should be split into route-family registration groups without changing route
+contract behavior.
+
+## Progressive Enforcement
+
+1. Phase 1: report-only quality baseline.
+2. Phase 2: fail only new architecture regressions.
+3. Phase 3: enforce thresholds for largest modules, function length, complexity, and import rules.
+4. Phase 4: enterprise-readiness gate requiring architecture, API, security, observability, and
+   docs scorecard targets to pass.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,0 +1,165 @@
+# Quality Baseline Report
+
+Date: 2026-06-02  
+Repository: `lotus-gateway`  
+Baseline phase: report-only
+
+## Scope
+
+This baseline covers the current `main` state after PR #311. It is intended to make quality debt
+visible before introducing stricter CI gates. Findings are not yet enforced unless they are already
+covered by existing repo-native gates.
+
+## Repository Size
+
+| Measure | Current value |
+| --- | ---: |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 645 |
+| Python source files under `src/app` | 431 |
+| Python test files under `tests` | 150 |
+| OpenAPI paths | 170 |
+| OpenAPI operations | 170 |
+
+## Largest Source Files
+
+| Rank | Lines | File |
+| ---: | ---: | --- |
+| 1 | 2,882 | `src/app/services/portfolio_service.py` |
+| 2 | 2,123 | `src/app/contracts/portfolio.py` |
+| 3 | 1,940 | `src/app/contracts/risk_workspace.py` |
+| 4 | 1,781 | `src/app/services/risk_workspace_service.py` |
+| 5 | 1,731 | `src/app/contracts/reporting.py` |
+| 6 | 1,539 | `src/app/contracts/performance_workspace.py` |
+| 7 | 1,258 | `src/app/clients/dpm_client.py` |
+| 8 | 1,144 | `src/app/services/advisor_brief_service.py` |
+| 9 | 1,012 | `src/app/clients/advise_client.py` |
+| 10 | 966 | `src/app/services/dpm_command_center_service.py` |
+
+## Largest Functions
+
+| Rank | Lines | Function | File |
+| ---: | ---: | --- | --- |
+| 1 | 298 | `register_routers` | `src/app/router_registry.py` |
+| 2 | 253 | `_build_performance_workspace_response` | `src/app/services/performance_workspace_service.py` |
+| 3 | 241 | `_build_performance_advisor_brief` | `src/app/services/advisor_brief_service.py` |
+| 4 | 196 | `_map_drawdown_response` | `src/app/services/risk_workspace_service.py` |
+| 5 | 195 | `_build_normalized_capabilities` | `src/app/services/platform_capabilities_service.py` |
+| 6 | 191 | `_build_workspace_control_capabilities` | `src/app/services/portfolio_service.py` |
+| 7 | 184 | `_map_rolling_response` | `src/app/services/risk_workspace_service.py` |
+| 8 | 172 | `parse_horizon_comparison_result` | `src/app/services/performance_workspace_horizon.py` |
+| 9 | 153 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
+| 10 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
+
+## Existing Blocking Gates
+
+Current repo-native gates already cover:
+
+1. ruff lint and format check,
+2. monetary-float governance,
+3. mypy on `src`,
+4. Workbench OpenAPI contract smoke,
+5. migration contract smoke,
+6. unit and contract tests,
+7. integration tests,
+8. coverage with an 84% floor,
+9. `pip-audit` with one governed FastAPI/Starlette exception,
+10. Docker build and local Docker parity in the PR Merge Gate.
+
+Most recent local evidence from PR #311:
+
+1. `make check`: 932 unit/contract tests passed.
+2. `make ci`: 207 integration tests passed.
+3. `make ci`: 1,139 coverage tests passed.
+4. Coverage: 92.60%.
+5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
+
+## Tooling Availability Baseline
+
+The local shell did not expose `radon`, `xenon`, `vulture`, `deptry`, `bandit`, `spectral`,
+`lint-imports`, `interrogate`, or `pyright` as commands before this slice. `pyproject.toml` now
+declares a `quality` optional dependency group for Python quality tools, and the new Quality
+Baseline workflow installs Python and Node quality tooling explicitly.
+
+## Complexity And Maintainability Gaps
+
+Report-only complexity tools are being introduced now. Current manual size evidence already shows
+large-file and long-function hotspots in service, contract, client, and router registration code.
+The first enforcement candidates should be:
+
+1. no new service file above the current largest-file baseline,
+2. no new function above the current longest-function baseline,
+3. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
+4. no new architecture import-linter violations after contracts are reviewed.
+
+## Dead Code Gaps
+
+`vulture` is not yet part of existing blocking CI. The new workflow runs it report-only with
+`--min-confidence 80`. Findings must be triaged before enforcement because routers, FastAPI
+dependency injection, Pydantic models, and test fixtures can produce false positives.
+
+## Dependency And Security Gaps
+
+`pip-audit` is already blocking through `make security-audit`. `bandit` and `deptry` are added as
+report-only quality checks. Baseline findings should be triaged before making them blocking.
+
+## OpenAPI Gaps
+
+Current generated OpenAPI evidence:
+
+| Check | Count |
+| --- | ---: |
+| Paths | 170 |
+| Operations | 170 |
+| Missing summary | 0 |
+| Missing description | 3 |
+| Missing operation ID | 0 |
+| Missing tags | 4 |
+| Missing 4xx/5xx response | 4 |
+| Spectral warnings from `.spectral.yaml` plus `spectral:oas` | 186 |
+
+Important nuance: operation IDs are present in generated OpenAPI, but only two explicit router
+`operation_id=` declarations were found. Future governance should decide whether generated IDs are
+acceptable or whether stable explicit operation IDs are required for all public endpoints.
+
+The first Spectral smoke found no errors. Most warnings are generated by the inherited
+`spectral:oas` baseline for missing global tag declarations; the custom Lotus rules highlight the
+same health and metrics documentation gaps listed above.
+
+## Architecture Violations And Watchlist
+
+Existing unit tests already enforce several service-layer boundaries. `.importlinter` expands the
+report-only baseline for routers, middleware, contracts, and services. A text scan found router
+references matching downstream-client patterns; many may be type hints, dependency injection, or
+service imports rather than concrete client construction. These must be classified before
+enforcement.
+
+## Documentation Gaps
+
+Existing README, wiki, RFCs, and standards are substantial. Gaps now addressed by new baseline docs:
+
+1. consolidated architecture overview at `docs/architecture.md`,
+2. API governance at `docs/api-governance.md`,
+3. observability at `docs/observability.md`,
+4. security at `docs/security.md`,
+5. operations runbook at `docs/operations-runbook.md`,
+6. supported-features summary at `docs/supported-features.md`,
+7. quality scorecard and health reports under `quality/`.
+
+## Observability Gaps
+
+Current code and docs include health, readiness, metrics, correlation, selected analytics audit
+logs, and diagnostics lookup. Remaining baseline gaps:
+
+1. no central observability runbook existed at `docs/observability.md`,
+2. structured logging/audit field allowlists are documented in repository context but not yet
+   scored in CI,
+3. tracing propagation beyond correlation IDs is not yet governed by a blocking test,
+4. metrics label-cardinality rules are not yet enforced by a static gate.
+
+## Next Gates
+
+1. Keep Quality Baseline workflow report-only.
+2. Classify baseline findings and false positives.
+3. Review uploaded quality log artifacts from GitHub Actions.
+4. Fail only new regressions.
+5. Promote agreed thresholds into blocking Feature Lane and PR Merge Gate checks.

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,0 +1,59 @@
+# Quality Scorecard
+
+Date: 2026-06-02  
+Mode: baseline/report-only
+
+| Dimension | Score | Baseline status | Next action |
+| --- | ---: | --- | --- |
+| Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
+| Coverage | 4/5 | 92.60% total coverage | Add targeted middleware/security/error tests |
+| Modularity | 2/5 | Large services and contracts remain | Continue extraction slices |
+| Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
+| API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |
+| Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |
+| Observability | 3/5 | Health/readiness/metrics/correlation/audit present | Enforce structured log and metric label rules |
+| Security | 3/5 | `pip-audit` blocking; no bandit baseline yet | Triage bandit and sensitive-data handling checks |
+| Documentation | 3/5 | Strong README/wiki/RFC base; quality docs newly added | Keep wiki synced and add diagrams over time |
+| Operations readiness | 3/5 | Existing CI/runbook docs; operational runbook now consolidated | Add incident playbooks and SLO checks |
+
+## Phase Gates
+
+### Phase 1: Baseline/Report-Only
+
+Status: active.
+
+Required evidence:
+
+1. baseline reports exist under `quality/`,
+2. architecture and API governance rules are documented,
+3. report-only CI workflow exists,
+4. existing Feature Lane and PR Merge Gate remain unchanged.
+
+### Phase 2: Fail Only New Regressions
+
+Candidate thresholds:
+
+1. no new missing OpenAPI summary, description, tag, or standard error response,
+2. no new forbidden imports,
+3. no new high-confidence dead-code findings,
+4. no new high-severity bandit findings,
+5. no new file/function above the current baseline maxima.
+
+### Phase 3: Enforce Agreed Thresholds
+
+Candidate targets:
+
+1. no service file above 1,500 lines,
+2. no function above 150 lines without an explicit exception,
+3. coverage floor moves from 84% to a governed target,
+4. Spectral and import-linter become blocking.
+
+### Phase 4: Enterprise-Readiness Gate
+
+Candidate release checks:
+
+1. scorecard average at least 4/5,
+2. no unclassified security or architecture findings,
+3. OpenAPI quality gate fully green,
+4. docs/wiki/runbooks current and published,
+5. operational diagnostics and SLO evidence available.

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,0 +1,51 @@
+# Refactor Health Report
+
+Date: 2026-06-02  
+Phase: baseline/report-only
+
+## Current Direction
+
+Recent gateway hardening has reduced monolithic Workbench and advisor-brief responsibilities by
+extracting focused service adapters while preserving public behavior and keeping CI green. The
+remaining work is still substantial: large portfolio, risk workspace, contract, client, and router
+registration modules remain.
+
+## Health Signals
+
+| Area | Current posture | Evidence |
+| --- | --- | --- |
+| Branch hygiene | Healthy | `main` only after PR #311 cleanup |
+| Unit/contract coverage | Healthy | 932 tests passed in `make check` on PR #311 |
+| Integration coverage | Healthy | 207 integration tests passed in `make ci` on PR #311 |
+| Total coverage | Healthy | 92.60%, above the 84% floor |
+| Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
+| Modularity | Improving, incomplete | Multiple service files remain above 900 lines |
+| API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |
+| Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
+| Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
+
+## Primary Refactor Backlog
+
+1. Split `portfolio_service.py` into source-readiness, transaction/activity, income, workspace,
+   and workflow-cue adapters.
+2. Split `risk_workspace_service.py` response mappers by risk surface.
+3. Split `router_registry.py` registration into route-family groups.
+4. Split large contract modules only when contract ownership boundaries are clear and tests remain
+   stable.
+5. Normalize route-specific upstream errors toward shared problem-details mapping.
+6. Add explicit API governance tests for missing operation descriptions, tags, standard errors, and
+   deprecation posture.
+
+## Quality-Gate Roadmap
+
+1. Report-only workflow introduced in this slice.
+2. Report-only workflow uploads quality logs for baseline classification.
+3. Then enforce no-new-regression thresholds for:
+   - ruff/mypy,
+   - coverage,
+   - import-linter,
+   - OpenAPI spectral warnings,
+   - largest-file and longest-function thresholds,
+   - `pip-audit` and high-confidence `bandit` findings.
+4. Enterprise-readiness gates should require docs, API, security, observability, and architecture
+   scorecard sections to be green before release promotion.

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -7,6 +7,9 @@
 - composition logic under `src/app/services/`
 - upstream integrations under `src/app/clients/`
 - workbench-facing contracts under `src/app/contracts/`
+- consolidated architecture and quality-baseline docs under
+  [docs/architecture.md](../docs/architecture.md) and
+  [quality/architecture_rules.md](../quality/architecture_rules.md)
 
 ## Route-family map
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -10,6 +10,10 @@
   [docs/documentation/experience-api-foundation-blueprint.md](../docs/documentation/experience-api-foundation-blueprint.md)
 - Upstream contract-family map:
   [docs/standards/RFC-0082-upstream-contract-family-map.md](../docs/standards/RFC-0082-upstream-contract-family-map.md)
+- Quality and enterprise-readiness baseline:
+  [quality/baseline_report.md](../quality/baseline_report.md),
+  [quality/quality_scorecard.md](../quality/quality_scorecard.md), and
+  [docs/architecture.md](../docs/architecture.md)
 
 ## Current phase
 

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -6,6 +6,10 @@
 - if Windows startup looks healthy but routes fail, verify `--app-dir src`
 - treat partial-failure and supportability signals as contract data, not as noise to suppress
 - use repo-native gates before inventing custom checks
+- use [docs/operations-runbook.md](../docs/operations-runbook.md),
+  [docs/observability.md](../docs/observability.md), and
+  [docs/security.md](../docs/security.md) as the consolidated root-doc entry points for
+  operators and enterprise-readiness reviews
 
 ## Health and readiness surfaces
 

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -8,6 +8,8 @@
 2. `Pull Request Merge Gate`
 3. `Main Releasability Gate`
 4. platform-facing validation for cross-app experience changes
+5. `Quality Baseline`
+   report-only evidence for progressive enterprise-readiness gates
 
 ## Local command mapping
 
@@ -26,3 +28,27 @@
 - startup and migration truth
 - upstream composition safety
 - live integration-boundary parity
+
+## Quality baseline lane
+
+The Quality Baseline workflow is report-only. It installs the optional `quality` dependency group
+and records evidence for:
+
+- complexity and maintainability through `radon` and `xenon`
+- high-confidence dead-code candidates through `vulture`
+- dependency hygiene through `deptry`
+- security findings through `bandit` and `pip-audit`
+- import-boundary contracts through `import-linter`
+- docstring baseline through `interrogate`
+- OpenAPI governance through Spectral and `.spectral.yaml`
+
+The lane must not replace `make check` or `make ci`. It exists to classify current baseline
+findings, then promote only agreed no-new-regression checks into blocking Feature Lane and PR Merge
+Gate enforcement.
+
+Current baseline truth lives in:
+
+- [quality/baseline_report.md](../quality/baseline_report.md)
+- [quality/quality_scorecard.md](../quality/quality_scorecard.md)
+- [quality/architecture_rules.md](../quality/architecture_rules.md)
+- [quality/api_governance_rules.md](../quality/api_governance_rules.md)


### PR DESCRIPTION
## Summary
- add report-only Quality Baseline workflow with optional quality tooling, import-linter contracts, and Spectral OpenAPI rules
- document measured gateway quality baseline, scorecard, architecture/API governance, operations, observability, security, and supported features
- update README and repo-authored wiki source to expose the quality baseline lane and root docs

## Validation
- make check
- make ci
- python -m pip install -e ".[quality]"
- lint-imports --config .importlinter: 5 contracts kept, 0 broken
- npx --yes @stoplight/spectral-cli lint openapi.json --ruleset .spectral.yaml: 186 warnings, 0 errors (report-only baseline)
- stranded-truth precheck: no remote branches unmerged into origin/main
- wiki check: expected branch drift for Architecture.md, Home.md, Operations-Runbook.md, Validation-and-CI.md; publish after merge

## Notes
- Quality Baseline is report-only and must not replace Feature Lane or PR Merge Gate.
- Follow-up should classify uploaded quality logs and promote only agreed no-new-regression checks.
