### PR TITLE
Refactor advisor brief response assembly

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -37,15 +37,16 @@ The largest current modularity risks are:
 
 1. `src/app/services/portfolio_service.py` at 3,016 lines,
 2. `src/app/services/risk_workspace_service.py` at 1,912 lines,
-3. `src/app/services/advisor_brief_service.py` at 1,244 lines,
+3. `src/app/services/advisor_brief_service.py` at 1,388 lines,
 4. `src/app/services/performance_workspace_service.py` at 1,152 lines,
 5. `src/app/services/dpm_command_center_service.py` at 966 lines.
 
 The prior longest function, `register_routers` in `src/app/router_registry.py`, has been split
 into explicit route-family groups and a short registration loop. The performance workspace
 response builder has also been split into request-context, summary/detail, evidence, and assembly
-helpers. The current longest function is `_build_performance_advisor_brief` in
-`src/app/services/advisor_brief_service.py` at 241 lines.
+helpers. The advisor-brief response builder has been split into source-context, AI narrative,
+runtime supportability, and response assembly helpers. The current longest function is
+`_map_drawdown_response` in `src/app/services/risk_workspace_service.py` at 196 lines.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -7,9 +7,9 @@ Baseline phase: report-only
 ## Scope
 
 This baseline covers the current gateway hardening state after the report-only quality governance
-lane, router-registry split, and performance workspace response split. It is intended to make
-quality debt visible before introducing stricter CI gates. Findings are not yet enforced unless
-they are already covered by existing repo-native gates.
+lane, router-registry split, performance workspace response split, and advisor-brief response
+split. It is intended to make quality debt visible before introducing stricter CI gates. Findings
+are not yet enforced unless they are already covered by existing repo-native gates.
 
 ## Repository Size
 
@@ -31,8 +31,8 @@ they are already covered by existing repo-native gates.
 | 4 | 1,912 | `src/app/services/risk_workspace_service.py` |
 | 5 | 1,840 | `src/app/contracts/reporting.py` |
 | 6 | 1,606 | `src/app/contracts/performance_workspace.py` |
-| 7 | 1,362 | `src/app/clients/dpm_client.py` |
-| 8 | 1,244 | `src/app/services/advisor_brief_service.py` |
+| 7 | 1,388 | `src/app/services/advisor_brief_service.py` |
+| 8 | 1,362 | `src/app/clients/dpm_client.py` |
 | 9 | 1,152 | `src/app/services/performance_workspace_service.py` |
 | 10 | 1,098 | `src/app/clients/advise_client.py` |
 
@@ -40,13 +40,13 @@ they are already covered by existing repo-native gates.
 
 | Rank | Lines | Function | File |
 | ---: | ---: | --- | --- |
-| 1 | 241 | `_build_performance_advisor_brief` | `src/app/services/advisor_brief_service.py` |
-| 2 | 196 | `_map_drawdown_response` | `src/app/services/risk_workspace_service.py` |
-| 3 | 195 | `_build_normalized_capabilities` | `src/app/services/platform_capabilities_service.py` |
-| 4 | 191 | `_build_workspace_control_capabilities` | `src/app/services/portfolio_service.py` |
-| 5 | 184 | `_map_rolling_response` | `src/app/services/risk_workspace_service.py` |
-| 6 | 172 | `parse_horizon_comparison_result` | `src/app/services/performance_workspace_horizon.py` |
-| 7 | 153 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
+| 1 | 196 | `_map_drawdown_response` | `src/app/services/risk_workspace_service.py` |
+| 2 | 195 | `_build_normalized_capabilities` | `src/app/services/platform_capabilities_service.py` |
+| 3 | 191 | `_build_workspace_control_capabilities` | `src/app/services/portfolio_service.py` |
+| 4 | 184 | `_map_rolling_response` | `src/app/services/risk_workspace_service.py` |
+| 5 | 172 | `parse_horizon_comparison_result` | `src/app/services/performance_workspace_horizon.py` |
+| 6 | 153 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
+| 7 | 144 | `_build_advisor_brief_narrative_state` | `src/app/services/advisor_brief_service.py` |
 | 8 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
 | 9 | 141 | `_map_attribution_response` | `src/app/services/risk_workspace_service.py` |
 | 10 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
@@ -88,7 +88,7 @@ large-file and long-function hotspots in service, contract, and client code.
 The first enforcement candidates should be:
 
 1. no new service file above the current largest-file baseline,
-2. no new function above the current longest-function baseline of 241 lines,
+2. no new function above the current longest-function baseline of 196 lines,
 3. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
 4. no new architecture import-linter violations after contracts are reviewed.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -5,10 +5,10 @@ Phase: baseline/report-only
 
 ## Current Direction
 
-Recent gateway hardening has reduced monolithic Workbench, router-registry, advisor-brief, and
-performance workspace responsibilities by extracting focused service adapters while preserving
-public behavior and keeping CI green. The remaining work is still substantial: large portfolio,
-risk workspace, contract, and client modules remain.
+Recent gateway hardening has reduced monolithic Workbench, router-registry, performance workspace,
+and advisor-brief responsibilities by extracting focused service adapters while preserving public
+behavior and keeping CI green. The remaining work is still substantial: large portfolio, risk
+workspace, contract, and client modules remain.
 
 ## Health Signals
 
@@ -29,7 +29,7 @@ risk workspace, contract, and client modules remain.
 1. Split `portfolio_service.py` into source-readiness, transaction/activity, income, workspace,
    and workflow-cue adapters.
 2. Split `risk_workspace_service.py` response mappers by risk surface.
-3. Split `advisor_brief_service.py` orchestration into smaller response-shaping adapters.
+3. Split `platform_capabilities_service.py` capability normalization into smaller adapters.
 4. Continue extracting performance workspace evidence and attribution helpers behind stable
    response contracts.
 5. Split large contract modules only when contract ownership boundaries are clear and tests remain

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Protocol
 
 from fastapi import HTTPException, status
 
 from app.contracts.advisor_brief import (
     AdvisorBriefActionItem,
+    AdvisorBriefAdvisorySupportability,
+    AdvisorBriefAiSurfaceSupportability,
     AdvisorBriefEvidenceRef,
     AdvisorBriefNarrativeItem,
     AdvisorBriefResponse,
@@ -13,7 +16,9 @@ from app.contracts.advisor_brief import (
     AdvisorBriefStatus,
     AdvisorBriefSupportabilityItem,
     AdvisorBriefTone,
+    AdvisorBriefWorkflowPackRun,
     AdvisorBriefWorkflowPackRunReviewActionRequest,
+    AdvisorBriefWorkflowPackTaskFlow,
 )
 from app.contracts.performance_workspace import (
     AttributionSummaryView,
@@ -39,6 +44,38 @@ from app.services.async_ttl_cache import AsyncTtlCache
 
 _TASK_ID = "explain.v1"
 _EXPECTED_OUTPUT_LABEL = "EXPLANATION_ONLY"
+
+
+@dataclass(frozen=True)
+class AdvisorBriefSourceContext:
+    workspace: PerformanceWorkspaceResponse
+    selected_performance: PerformanceComparativeSummary
+    source_refs: list[str]
+    supportability: list[AdvisorBriefSupportabilityItem]
+    status: AdvisorBriefStatus
+    summary: str
+    talking_points: list[AdvisorBriefNarrativeItem]
+    recommended_actions: list[AdvisorBriefActionItem]
+    risks_and_exceptions: list[AdvisorBriefNarrativeItem]
+
+
+@dataclass(frozen=True)
+class AdvisorBriefNarrativeState:
+    status: AdvisorBriefStatus
+    summary: str
+    talking_points: list[AdvisorBriefNarrativeItem]
+    recommended_actions: list[AdvisorBriefActionItem]
+    risks_and_exceptions: list[AdvisorBriefNarrativeItem]
+    ai_audit: dict[str, Any]
+    ai_evidence: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AdvisorBriefRuntimeContext:
+    workflow_pack_run: AdvisorBriefWorkflowPackRun | None
+    workflow_pack_task_flow: AdvisorBriefWorkflowPackTaskFlow | None
+    ai_surface_supportability: AdvisorBriefAiSurfaceSupportability | None
+    advisory_supportability: AdvisorBriefAdvisorySupportability | None
 
 
 class AdvisorBriefPerformanceWorkspaceService(Protocol):
@@ -131,8 +168,53 @@ class AdvisorBriefService:
         explicit_start_date: str | None = None,
         explicit_end_date: str | None = None,
     ) -> AdvisorBriefResponse:
+        workspace = await self._load_performance_workspace(
+            portfolio_id=portfolio_id,
+            correlation_id=correlation_id,
+            period=period,
+            chart_frequency=chart_frequency,
+            contribution_dimension=contribution_dimension,
+            attribution_dimension=attribution_dimension,
+            detail_basis=detail_basis,
+            benchmark_code=benchmark_code,
+            explicit_start_date=explicit_start_date,
+            explicit_end_date=explicit_end_date,
+        )
+        source_context = _build_advisor_brief_source_context(
+            workspace=workspace,
+            detail_basis=detail_basis,
+        )
+        narrative_state = await self._build_advisor_brief_narrative_state(
+            correlation_id=correlation_id,
+            source_context=source_context,
+        )
+        runtime_context = await self._load_advisor_brief_runtime_context(
+            correlation_id=correlation_id,
+            ai_audit=narrative_state.ai_audit,
+        )
+        return self._assemble_advisor_brief_response(
+            correlation_id=correlation_id,
+            source_context=source_context,
+            narrative_state=narrative_state,
+            runtime_context=runtime_context,
+        )
+
+    async def _load_performance_workspace(
+        self,
+        *,
+        portfolio_id: str,
+        correlation_id: str,
+        period: str,
+        chart_frequency: str,
+        contribution_dimension: str,
+        attribution_dimension: str,
+        detail_basis: str,
+        benchmark_code: str | None,
+        explicit_start_date: str | None,
+        explicit_end_date: str | None,
+    ) -> PerformanceWorkspaceResponse:
         async with server_timing_span("perf-advisor-brief-source"):
-            workspace = await self._performance_workspace_service.get_performance_workspace(
+            return await self._performance_workspace_service.get_performance_workspace(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 period=period,
@@ -145,52 +227,26 @@ class AdvisorBriefService:
                 explicit_end_date=explicit_end_date,
             )
 
-        selected_performance = (
-            workspace.net_performance
-            if detail_basis.upper() == "NET"
-            else workspace.gross_performance
-        )
-        source_refs = _build_source_refs(workspace=workspace)
-        supportability = _build_supportability(workspace=workspace)
-        status = _resolve_status(workspace=workspace, supportability=supportability)
-
-        source_summary = _build_source_summary(
-            workspace=workspace,
-            selected_performance=selected_performance,
-        )
-        talking_points = _build_source_talking_points(
-            workspace=workspace,
-            selected_performance=selected_performance,
-        )
-        recommended_actions = _build_recommended_actions(workspace=workspace)
-        risks_and_exceptions = _build_risks_and_exceptions(
-            workspace=workspace,
-            supportability=supportability,
-        )
+    async def _build_advisor_brief_narrative_state(
+        self,
+        *,
+        correlation_id: str,
+        source_context: AdvisorBriefSourceContext,
+    ) -> AdvisorBriefNarrativeState:
+        workspace = source_context.workspace
+        status = source_context.status
+        source_summary = source_context.summary
+        talking_points = source_context.talking_points
+        recommended_actions = source_context.recommended_actions
+        risks_and_exceptions = source_context.risks_and_exceptions
         ai_audit: dict[str, Any] = _normalize_ai_audit({})
         ai_evidence: dict[str, Any] = {"descriptors": []}
 
         if status is not AdvisorBriefStatus.UNAVAILABLE:
-            task_request = {
-                "task_id": _TASK_ID,
-                "input_mode": "STRUCTURED_CONTEXT",
-                "caller": {
-                    "caller_app": "lotus-gateway",
-                    "correlation_id": correlation_id,
-                },
-                "context": {
-                    "summary": (
-                        f"Advisor brief context for portfolio {workspace.portfolio_id}, "
-                        f"{workspace.period} period, basis {workspace.detail_basis}."
-                    ),
-                    "payload": _build_ai_fact_bundle(
-                        workspace=workspace,
-                        selected_performance=selected_performance,
-                    ),
-                    "source_refs": source_refs,
-                },
-                "expected_output_label": _EXPECTED_OUTPUT_LABEL,
-            }
+            task_request = _build_advisor_brief_ai_task_request(
+                correlation_id=correlation_id,
+                source_context=source_context,
+            )
             async with server_timing_span("perf-advisor-brief-ai"):
                 ai_status, ai_payload = await self._lotus_ai_client.execute_workflow_pack(
                     pack_id="advisor_brief.pack",
@@ -306,6 +362,22 @@ class AdvisorBriefService:
                         ],
                     )
                 )
+        return AdvisorBriefNarrativeState(
+            status=status,
+            summary=source_summary,
+            talking_points=talking_points,
+            recommended_actions=recommended_actions,
+            risks_and_exceptions=risks_and_exceptions,
+            ai_audit=ai_audit,
+            ai_evidence=ai_evidence,
+        )
+
+    async def _load_advisor_brief_runtime_context(
+        self,
+        *,
+        correlation_id: str,
+        ai_audit: dict[str, Any],
+    ) -> AdvisorBriefRuntimeContext:
         workflow_pack_run = await load_advisor_brief_workflow_pack_run(
             lotus_ai_client=self._lotus_ai_client,
             ai_audit=ai_audit,
@@ -324,7 +396,22 @@ class AdvisorBriefService:
             advise_client=self._advise_client,
             correlation_id=correlation_id,
         )
+        return AdvisorBriefRuntimeContext(
+            workflow_pack_run=workflow_pack_run,
+            workflow_pack_task_flow=workflow_pack_task_flow,
+            ai_surface_supportability=ai_surface_supportability,
+            advisory_supportability=advisory_supportability,
+        )
 
+    def _assemble_advisor_brief_response(
+        self,
+        *,
+        correlation_id: str,
+        source_context: AdvisorBriefSourceContext,
+        narrative_state: AdvisorBriefNarrativeState,
+        runtime_context: AdvisorBriefRuntimeContext,
+    ) -> AdvisorBriefResponse:
+        workspace = source_context.workspace
         return AdvisorBriefResponse(
             correlation_id=correlation_id,
             contract_version=workspace.contract_version,
@@ -339,22 +426,22 @@ class AdvisorBriefService:
             contribution_dimension=workspace.contribution_dimension,
             attribution_dimension=workspace.attribution_dimension,
             benchmark_code=workspace.benchmark_code,
-            status=status,
-            summary=source_summary,
-            talking_points=talking_points,
-            recommended_actions=recommended_actions,
-            risks_and_exceptions=risks_and_exceptions,
+            status=narrative_state.status,
+            summary=narrative_state.summary,
+            talking_points=narrative_state.talking_points,
+            recommended_actions=narrative_state.recommended_actions,
+            risks_and_exceptions=narrative_state.risks_and_exceptions,
             source_metrics=_build_source_metrics(
                 workspace=workspace,
-                selected_performance=selected_performance,
+                selected_performance=source_context.selected_performance,
             ),
-            supportability=supportability,
-            ai_surface_supportability=ai_surface_supportability,
-            advisory_supportability=advisory_supportability,
-            ai_audit=ai_audit,
-            ai_evidence=ai_evidence,
-            workflow_pack_run=workflow_pack_run,
-            workflow_pack_task_flow=workflow_pack_task_flow,
+            supportability=source_context.supportability,
+            ai_surface_supportability=runtime_context.ai_surface_supportability,
+            advisory_supportability=runtime_context.advisory_supportability,
+            ai_audit=narrative_state.ai_audit,
+            ai_evidence=narrative_state.ai_evidence,
+            workflow_pack_run=runtime_context.workflow_pack_run,
+            workflow_pack_task_flow=runtime_context.workflow_pack_task_flow,
             warnings=workspace.warnings,
             partial_failures=workspace.partial_failures,
         )
@@ -448,6 +535,67 @@ class AdvisorBriefService:
                 "advisory_supportability": advisory_supportability,
             }
         )
+
+
+def _build_advisor_brief_source_context(
+    *,
+    workspace: PerformanceWorkspaceResponse,
+    detail_basis: str,
+) -> AdvisorBriefSourceContext:
+    selected_performance = (
+        workspace.net_performance if detail_basis.upper() == "NET" else workspace.gross_performance
+    )
+    source_refs = _build_source_refs(workspace=workspace)
+    supportability = _build_supportability(workspace=workspace)
+    status = _resolve_status(workspace=workspace, supportability=supportability)
+    return AdvisorBriefSourceContext(
+        workspace=workspace,
+        selected_performance=selected_performance,
+        source_refs=source_refs,
+        supportability=supportability,
+        status=status,
+        summary=_build_source_summary(
+            workspace=workspace,
+            selected_performance=selected_performance,
+        ),
+        talking_points=_build_source_talking_points(
+            workspace=workspace,
+            selected_performance=selected_performance,
+        ),
+        recommended_actions=_build_recommended_actions(workspace=workspace),
+        risks_and_exceptions=_build_risks_and_exceptions(
+            workspace=workspace,
+            supportability=supportability,
+        ),
+    )
+
+
+def _build_advisor_brief_ai_task_request(
+    *,
+    correlation_id: str,
+    source_context: AdvisorBriefSourceContext,
+) -> dict[str, Any]:
+    workspace = source_context.workspace
+    return {
+        "task_id": _TASK_ID,
+        "input_mode": "STRUCTURED_CONTEXT",
+        "caller": {
+            "caller_app": "lotus-gateway",
+            "correlation_id": correlation_id,
+        },
+        "context": {
+            "summary": (
+                f"Advisor brief context for portfolio {workspace.portfolio_id}, "
+                f"{workspace.period} period, basis {workspace.detail_basis}."
+            ),
+            "payload": _build_ai_fact_bundle(
+                workspace=workspace,
+                selected_performance=source_context.selected_performance,
+            ),
+            "source_refs": source_context.source_refs,
+        },
+        "expected_output_label": _EXPECTED_OUTPUT_LABEL,
+    }
 
 
 def _normalize_ai_audit(audit: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- split the advisor brief response builder into source-context, AI narrative, runtime supportability, and response assembly helpers
- preserve the existing advisor brief request payloads, AI workflow-pack execution behavior, supportability loading, and response contract
- refresh quality evidence to show the new longest-function baseline after the split

## Validation
- `python -m ruff check src\app\services\advisor_brief_service.py`
- `python -m ruff format --check src\app\services\advisor_brief_service.py`
- `python -m mypy src\app\services\advisor_brief_service.py`
- `python -m pytest tests\unit\test_advisor_brief_service.py tests\unit\test_advisor_brief_supportability.py tests\unit\test_advisor_brief_workflow_pack.py -q` (27 passed)
- `make check` (934 passed)
- `make ci` (207 integration passed; 1,141 coverage tests passed; 92.65%; no known vulnerabilities after governed PYSEC-2026-161 exception)

## Governance
- Stranded truth: `git fetch origin --prune; git branch -r --no-merged origin/main` returned no unmerged remote branches
- Wiki: `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` returned DiffCount 0
- Public API shape unchanged