### PR TITLE
Refactor risk rolling response mapping

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -36,7 +36,7 @@ report-only baseline is reviewed.
 The largest current modularity risks are:
 
 1. `src/app/services/portfolio_service.py` at 3,016 lines,
-2. `src/app/services/risk_workspace_service.py` at 2,062 lines,
+2. `src/app/services/risk_workspace_service.py` at 2,063 lines,
 3. `src/app/services/advisor_brief_service.py` at 1,392 lines,
 4. `src/app/services/performance_workspace_service.py` at 1,152 lines,
 5. `src/app/services/dpm_command_center_service.py` at 966 lines.

--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -36,7 +36,7 @@ report-only baseline is reviewed.
 The largest current modularity risks are:
 
 1. `src/app/services/portfolio_service.py` at 3,016 lines,
-2. `src/app/services/risk_workspace_service.py` at 1,986 lines,
+2. `src/app/services/risk_workspace_service.py` at 2,062 lines,
 3. `src/app/services/advisor_brief_service.py` at 1,392 lines,
 4. `src/app/services/performance_workspace_service.py` at 1,152 lines,
 5. `src/app/services/dpm_command_center_service.py` at 966 lines.
@@ -46,9 +46,10 @@ into explicit route-family groups and a short registration loop. The performance
 response builder has also been split into request-context, summary/detail, evidence, and assembly
 helpers. The advisor-brief response builder has been split into source-context, AI narrative,
 runtime supportability, and response assembly helpers. The risk drawdown mapper has been split into
-period mapping, supportability, state, metadata, and payload helpers. The current longest function
-is `_build_normalized_capabilities` in `src/app/services/platform_capabilities_service.py` at 195
-lines.
+period mapping, supportability, state, metadata, and payload helpers. The risk rolling mapper has
+been split into period mapping, dependency context, supportability, state, metadata, Sharpe
+fallback, and payload helpers. The current longest function is `_build_normalized_capabilities` in
+`src/app/services/platform_capabilities_service.py` at 195 lines.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -28,7 +28,7 @@ already covered by existing repo-native gates.
 | ---: | ---: | --- |
 | 1 | 3,016 | `src/app/services/portfolio_service.py` |
 | 2 | 2,226 | `src/app/contracts/portfolio.py` |
-| 3 | 2,062 | `src/app/services/risk_workspace_service.py` |
+| 3 | 2,063 | `src/app/services/risk_workspace_service.py` |
 | 4 | 2,043 | `src/app/contracts/risk_workspace.py` |
 | 5 | 1,840 | `src/app/contracts/reporting.py` |
 | 6 | 1,606 | `src/app/contracts/performance_workspace.py` |
@@ -72,7 +72,7 @@ Most recent local evidence:
 1. `make check`: 934 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
 3. `make ci`: 1,141 coverage tests passed.
-4. Coverage: 92.60%.
+4. Coverage: 92.65%.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -8,9 +8,9 @@ Baseline phase: report-only
 
 This baseline covers the current gateway hardening state after the report-only quality governance
 lane, router-registry split, performance workspace response split, and advisor-brief response
-split, and risk drawdown mapper split. It is intended to make quality debt visible before
-introducing stricter CI gates. Findings are not yet enforced unless they are already covered by
-existing repo-native gates.
+split, risk drawdown mapper split, and risk rolling mapper split. It is intended to make quality
+debt visible before introducing stricter CI gates. Findings are not yet enforced unless they are
+already covered by existing repo-native gates.
 
 ## Repository Size
 
@@ -28,8 +28,8 @@ existing repo-native gates.
 | ---: | ---: | --- |
 | 1 | 3,016 | `src/app/services/portfolio_service.py` |
 | 2 | 2,226 | `src/app/contracts/portfolio.py` |
-| 3 | 2,043 | `src/app/contracts/risk_workspace.py` |
-| 4 | 1,986 | `src/app/services/risk_workspace_service.py` |
+| 3 | 2,062 | `src/app/services/risk_workspace_service.py` |
+| 4 | 2,043 | `src/app/contracts/risk_workspace.py` |
 | 5 | 1,840 | `src/app/contracts/reporting.py` |
 | 6 | 1,606 | `src/app/contracts/performance_workspace.py` |
 | 7 | 1,392 | `src/app/services/advisor_brief_service.py` |
@@ -43,14 +43,14 @@ existing repo-native gates.
 | ---: | ---: | --- | --- |
 | 1 | 195 | `_build_normalized_capabilities` | `src/app/services/platform_capabilities_service.py` |
 | 2 | 191 | `_build_workspace_control_capabilities` | `src/app/services/portfolio_service.py` |
-| 3 | 184 | `_map_rolling_response` | `src/app/services/risk_workspace_service.py` |
-| 4 | 172 | `parse_horizon_comparison_result` | `src/app/services/performance_workspace_horizon.py` |
-| 5 | 153 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
-| 6 | 144 | `_build_advisor_brief_narrative_state` | `src/app/services/advisor_brief_service.py` |
-| 7 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
-| 8 | 141 | `_map_attribution_response` | `src/app/services/risk_workspace_service.py` |
-| 9 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
-| 10 | 134 | `_build_shell_bootstrap` | `src/app/services/platform_capabilities_service.py` |
+| 3 | 172 | `parse_horizon_comparison_result` | `src/app/services/performance_workspace_horizon.py` |
+| 4 | 153 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
+| 5 | 144 | `_build_advisor_brief_narrative_state` | `src/app/services/advisor_brief_service.py` |
+| 6 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
+| 7 | 141 | `_map_attribution_response` | `src/app/services/risk_workspace_service.py` |
+| 8 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
+| 9 | 134 | `_build_shell_bootstrap` | `src/app/services/platform_capabilities_service.py` |
+| 10 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
 
 ## Existing Blocking Gates
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -6,9 +6,9 @@ Phase: baseline/report-only
 ## Current Direction
 
 Recent gateway hardening has reduced monolithic Workbench, router-registry, performance workspace,
-advisor-brief, and risk drawdown responsibilities by extracting focused service adapters while
-preserving public behavior and keeping CI green. The remaining work is still substantial: large
-portfolio, risk workspace, contract, and client modules remain.
+advisor-brief, risk drawdown, and risk rolling responsibilities by extracting focused service
+adapters while preserving public behavior and keeping CI green. The remaining work is still
+substantial: large portfolio, risk workspace, contract, and client modules remain.
 
 ## Health Signals
 
@@ -28,8 +28,8 @@ portfolio, risk workspace, contract, and client modules remain.
 
 1. Split `portfolio_service.py` into source-readiness, transaction/activity, income, workspace,
    and workflow-cue adapters.
-2. Continue splitting `risk_workspace_service.py` response mappers by risk surface, starting with
-   rolling and attribution helpers.
+2. Continue splitting `risk_workspace_service.py` response mappers by risk surface, with
+   attribution mapping now the next risk mapper target.
 3. Split `platform_capabilities_service.py` capability normalization into smaller adapters.
 4. Continue extracting performance workspace evidence and attribution helpers behind stable
    response contracts.

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -17,7 +17,7 @@ substantial: large portfolio, risk workspace, contract, and client modules remai
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
 | Unit/contract coverage | Healthy | 934 tests passed in `make check` for the router-registry split |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
-| Total coverage | Healthy | 92.60%, above the 84% floor |
+| Total coverage | Healthy | 92.65%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
 | Modularity | Improving, incomplete | Multiple service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -115,6 +115,13 @@ class DrawdownMappingResult:
     underwater_supportability_reason: str | None
 
 
+@dataclass(frozen=True)
+class RollingMappingResult:
+    periods: list[WorkbenchRiskRollingPeriodResult]
+    warnings: list[str]
+    partial_failures: list[WorkbenchPartialFailure]
+
+
 class RiskWorkspaceService:
     def __init__(
         self,
@@ -1090,10 +1097,58 @@ def _map_rolling_response(
     upstream_payload: dict[str, Any],
 ) -> WorkbenchRiskRollingResponse:
     results = upstream_payload.get("results")
-    warnings: list[str] = []
-    partial_failures: list[WorkbenchPartialFailure] = []
-    period_results: list[WorkbenchRiskRollingPeriodResult] = []
-    supportability = [
+    mapping = _map_rolling_period_results(results)
+    supportability = _build_rolling_supportability(
+        results=results,
+        benchmark_code=benchmark_code,
+        include_time_series=include_time_series,
+        sharpe_fallback_reason=sharpe_fallback_reason,
+    )
+    _append_source_calculation_supportability(
+        supportability=supportability,
+        upstream_payload=upstream_payload,
+    )
+    upstream_metadata = upstream_payload.get("metadata")
+    warnings = list(mapping.warnings)
+    partial_failures = list(mapping.partial_failures)
+    _append_rolling_sharpe_fallback(
+        warnings=warnings,
+        partial_failures=partial_failures,
+        sharpe_fallback_reason=sharpe_fallback_reason,
+    )
+    state, warnings, partial_failures = _resolve_rolling_state(
+        period_results=mapping.periods,
+        supportability=supportability,
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    return WorkbenchRiskRollingResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state=state,
+        payload=_build_rolling_payload(
+            period_results=mapping.periods,
+            upstream_metadata=upstream_metadata,
+        ),
+        supportability=supportability,
+        warnings=sorted(set(warnings)),
+        partial_failures=partial_failures,
+        metadata=_build_rolling_metadata(upstream_metadata=upstream_metadata),
+    )
+
+
+def _build_rolling_supportability(
+    *,
+    results: Any,
+    benchmark_code: str | None,
+    include_time_series: bool,
+    sharpe_fallback_reason: str | None,
+) -> list[WorkbenchRiskSupportabilityItem]:
+    return [
         WorkbenchRiskSupportabilityItem(
             key="portfolio_returns",
             label="Portfolio returns",
@@ -1130,86 +1185,126 @@ def _map_rolling_response(
             source_service="lotus-risk",
         ),
     ]
-    _append_source_calculation_supportability(
-        supportability=supportability,
-        upstream_payload=upstream_payload,
-    )
 
-    if isinstance(results, dict):
-        for key, value in results.items():
-            if not isinstance(value, dict):
-                continue
-            quality_flags = [
-                str(flag)
-                for flag in value.get("quality_flags", [])
-                if isinstance(flag, str) and flag.strip()
-            ]
-            error = value.get("error")
-            if quality_flags:
-                warnings.append("RISK_ROLLING_QUALITY_FLAGS")
-            if isinstance(error, str) and error.strip():
-                partial_failures.append(
-                    WorkbenchPartialFailure(
-                        source_service="risk",
-                        error_code="ROLLING_PERIOD_ERROR",
-                        detail=f"{key}: {error}",
-                    )
-                )
-                warnings.append("RISK_ROLLING_PERIOD_PARTIAL")
-            period_results.append(
-                WorkbenchRiskRollingPeriodResult(
-                    key=str(key),
-                    label=str(key),
-                    start_date=str(value.get("start_date", "")),
-                    end_date=str(value.get("end_date", "")),
-                    series_count=int(value.get("series_count", 0)),
-                    benchmark_series_count=int(value.get("benchmark_series_count", 0)),
-                    aligned_benchmark_series_count=int(
-                        value.get("aligned_benchmark_series_count", 0)
-                    ),
-                    risk_free_series_count=int(value.get("risk_free_series_count", 0)),
-                    aligned_risk_free_series_count=int(
-                        value.get("aligned_risk_free_series_count", 0)
-                    ),
-                    window_lengths_requested=[
-                        int(window)
-                        for window in value.get("window_lengths_requested", [])
-                        if isinstance(window, int | float)
-                    ],
-                    window_count_requested=int(value.get("window_count_requested", 0)),
-                    window_lengths_emitted=[
-                        int(window)
-                        for window in value.get("window_lengths_emitted", [])
-                        if isinstance(window, int | float)
-                    ],
-                    window_count_emitted=int(value.get("window_count_emitted", 0)),
-                    benchmark_context=(
-                        WorkbenchRiskRollingDependencyContext.model_validate(
-                            value.get("benchmark_context")
-                        )
-                        if isinstance(value.get("benchmark_context"), dict)
-                        else None
-                    ),
-                    risk_free_context=(
-                        WorkbenchRiskRollingDependencyContext.model_validate(
-                            value.get("risk_free_context")
-                        )
-                        if isinstance(value.get("risk_free_context"), dict)
-                        else None
-                    ),
-                    window_results=_map_rolling_window_results(value.get("window_results")),
-                    quality_flags=quality_flags,
-                    error=str(error) if isinstance(error, str) and error.strip() else None,
+
+def _map_rolling_period_results(results: Any) -> RollingMappingResult:
+    warnings: list[str] = []
+    partial_failures: list[WorkbenchPartialFailure] = []
+    period_results: list[WorkbenchRiskRollingPeriodResult] = []
+
+    if not isinstance(results, dict):
+        return RollingMappingResult(
+            periods=period_results,
+            warnings=warnings,
+            partial_failures=partial_failures,
+        )
+
+    for key, value in results.items():
+        if not isinstance(value, dict):
+            continue
+        period = _map_rolling_period_result(key=key, value=value)
+        if period.quality_flags:
+            warnings.append("RISK_ROLLING_QUALITY_FLAGS")
+        if period.error:
+            partial_failures.append(
+                WorkbenchPartialFailure(
+                    source_service="risk",
+                    error_code="ROLLING_PERIOD_ERROR",
+                    detail=f"{key}: {period.error}",
                 )
             )
+            warnings.append("RISK_ROLLING_PERIOD_PARTIAL")
+        period_results.append(period)
 
+    return RollingMappingResult(
+        periods=period_results,
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+
+def _map_rolling_period_result(
+    *,
+    key: Any,
+    value: dict[str, Any],
+) -> WorkbenchRiskRollingPeriodResult:
+    quality_flags = [
+        str(flag)
+        for flag in value.get("quality_flags", [])
+        if isinstance(flag, str) and flag.strip()
+    ]
+    error = value.get("error")
+    return WorkbenchRiskRollingPeriodResult(
+        key=str(key),
+        label=str(key),
+        start_date=str(value.get("start_date", "")),
+        end_date=str(value.get("end_date", "")),
+        series_count=int(value.get("series_count", 0)),
+        benchmark_series_count=int(value.get("benchmark_series_count", 0)),
+        aligned_benchmark_series_count=int(value.get("aligned_benchmark_series_count", 0)),
+        risk_free_series_count=int(value.get("risk_free_series_count", 0)),
+        aligned_risk_free_series_count=int(value.get("aligned_risk_free_series_count", 0)),
+        window_lengths_requested=_rolling_window_lengths(value.get("window_lengths_requested")),
+        window_count_requested=int(value.get("window_count_requested", 0)),
+        window_lengths_emitted=_rolling_window_lengths(value.get("window_lengths_emitted")),
+        window_count_emitted=int(value.get("window_count_emitted", 0)),
+        benchmark_context=_rolling_dependency_context(value.get("benchmark_context")),
+        risk_free_context=_rolling_dependency_context(value.get("risk_free_context")),
+        window_results=_map_rolling_window_results(value.get("window_results")),
+        quality_flags=quality_flags,
+        error=str(error) if isinstance(error, str) and error.strip() else None,
+    )
+
+
+def _rolling_window_lengths(value: Any) -> list[int]:
+    if not isinstance(value, list):
+        return []
+    return [int(window) for window in value if isinstance(window, int | float)]
+
+
+def _rolling_dependency_context(value: Any) -> WorkbenchRiskRollingDependencyContext | None:
+    return (
+        WorkbenchRiskRollingDependencyContext.model_validate(value)
+        if isinstance(value, dict)
+        else None
+    )
+
+
+def _append_rolling_sharpe_fallback(
+    *,
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+    sharpe_fallback_reason: str | None,
+) -> None:
+    if not sharpe_fallback_reason:
+        return
+
+    partial_failures.append(
+        WorkbenchPartialFailure(
+            source_service="risk",
+            error_code="ROLLING_SHARPE_UNAVAILABLE",
+            detail=sharpe_fallback_reason,
+        )
+    )
+    warnings.append("RISK_ROLLING_SHARPE_PARTIAL")
+
+
+def _resolve_rolling_state(
+    *,
+    period_results: list[WorkbenchRiskRollingPeriodResult],
+    supportability: list[WorkbenchRiskSupportabilityItem],
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+) -> tuple[RiskModuleState, list[str], list[WorkbenchPartialFailure]]:
+    resolved_warnings = list(warnings)
+    resolved_partial_failures = list(partial_failures)
     state: RiskModuleState = (
         "partial" if any(item.state != "ready" for item in supportability) else "ready"
     )
     if not period_results:
         state = "unavailable"
-        warnings.append("RISK_ROLLING_EMPTY")
-        partial_failures.append(
+        resolved_warnings.append("RISK_ROLLING_EMPTY")
+        resolved_partial_failures.append(
             WorkbenchPartialFailure(
                 source_service="risk",
                 error_code="EMPTY_RISK_ROLLING",
@@ -1218,49 +1313,32 @@ def _map_rolling_response(
         )
     elif all(not period.window_results for period in period_results):
         state = "unavailable"
+    return state, resolved_warnings, resolved_partial_failures
 
+
+def _build_rolling_metadata(*, upstream_metadata: Any) -> WorkbenchRiskMetadata:
     metadata = _metadata(input_mode="stateful", cache_status="miss")
-    upstream_metadata = upstream_payload.get("metadata")
     if isinstance(upstream_metadata, dict):
         methodology_version = upstream_metadata.get("methodology_version")
         if isinstance(methodology_version, str) and methodology_version.strip():
-            metadata = metadata.model_copy(update={"methodology_version": methodology_version})
+            return metadata.model_copy(update={"methodology_version": methodology_version})
+    return metadata
 
-    if sharpe_fallback_reason:
-        partial_failures.append(
-            WorkbenchPartialFailure(
-                source_service="risk",
-                error_code="ROLLING_SHARPE_UNAVAILABLE",
-                detail=sharpe_fallback_reason,
-            )
-        )
-        warnings.append("RISK_ROLLING_SHARPE_PARTIAL")
 
-    rolling_payload = (
-        WorkbenchRiskRollingPayload(
-            periods=period_results,
-            request_context=(
-                WorkbenchRiskRollingRequestContext.model_validate(upstream_metadata)
-                if isinstance(upstream_metadata, dict)
-                else None
-            ),
-        )
-        if period_results
-        else None
-    )
-
-    return WorkbenchRiskRollingResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state=state,
-        payload=rolling_payload,
-        supportability=supportability,
-        warnings=sorted(set(warnings)),
-        partial_failures=partial_failures,
-        metadata=metadata,
+def _build_rolling_payload(
+    *,
+    period_results: list[WorkbenchRiskRollingPeriodResult],
+    upstream_metadata: Any,
+) -> WorkbenchRiskRollingPayload | None:
+    if not period_results:
+        return None
+    return WorkbenchRiskRollingPayload(
+        periods=period_results,
+        request_context=(
+            WorkbenchRiskRollingRequestContext.model_validate(upstream_metadata)
+            if isinstance(upstream_metadata, dict)
+            else None
+        ),
     )
 
 

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
+from numbers import Real
 from typing import Any, cast
 
 from fastapi import status
@@ -1259,7 +1260,7 @@ def _map_rolling_period_result(
 def _rolling_window_lengths(value: Any) -> list[int]:
     if not isinstance(value, list):
         return []
-    return [int(window) for window in value if isinstance(window, int | float)]
+    return [int(cast(Any, window)) for window in value if isinstance(window, Real)]
 
 
 def _rolling_dependency_context(value: Any) -> WorkbenchRiskRollingDependencyContext | None:


### PR DESCRIPTION
## Summary
- Split risk rolling response mapping into focused supportability, period parsing, dependency context, state, metadata, Sharpe fallback, and payload helpers.
- Preserve upstream rolling risk truth, quality flag warnings, partial-period failures, source calculation supportability, and request-context behavior.
- Refresh the quality baseline to record that `_map_rolling_response` dropped out of the largest-function list and that attribution is now the next risk mapper target.

## Validation
- python -m ruff check src\app\services\risk_workspace_service.py
- python -m ruff format --check src\app\services\risk_workspace_service.py
- python -m mypy src\app\services\risk_workspace_service.py
- python -m pytest tests\unit\test_risk_workspace_service.py tests\unit\test_risk_workspace_requests.py tests\unit\test_risk_workspace_attribution_controls.py -q (35 passed)
- make check (934 unit/contract tests passed)
- make ci (207 integration tests passed; 1,141 coverage tests passed; coverage 92.65%; no known vulnerabilities)
- git branch -r --no-merged origin/main (no stranded remote branches)
- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway (DiffCount 0)

## Notes
- Public API shape is unchanged.
- No wiki source update was required because this is an internal modularity and quality-baseline slice.