### PR TITLE
Refactor risk attribution response mapping

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -36,7 +36,7 @@ report-only baseline is reviewed.
 The largest current modularity risks are:
 
 1. `src/app/services/portfolio_service.py` at 3,016 lines,
-2. `src/app/services/risk_workspace_service.py` at 2,063 lines,
+2. `src/app/services/risk_workspace_service.py` at 2,162 lines,
 3. `src/app/services/advisor_brief_service.py` at 1,392 lines,
 4. `src/app/services/performance_workspace_service.py` at 1,152 lines,
 5. `src/app/services/dpm_command_center_service.py` at 966 lines.
@@ -48,8 +48,10 @@ helpers. The advisor-brief response builder has been split into source-context, 
 runtime supportability, and response assembly helpers. The risk drawdown mapper has been split into
 period mapping, supportability, state, metadata, and payload helpers. The risk rolling mapper has
 been split into period mapping, dependency context, supportability, state, metadata, Sharpe
-fallback, and payload helpers. The current longest function is `_build_normalized_capabilities` in
-`src/app/services/platform_capabilities_service.py` at 195 lines.
+fallback, and payload helpers. The risk attribution mapper has been split into period mapping,
+set/contributor parsing, state, metadata, and payload helpers. The current longest function is
+`_build_normalized_capabilities` in `src/app/services/platform_capabilities_service.py` at 195
+lines.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -8,9 +8,9 @@ Baseline phase: report-only
 
 This baseline covers the current gateway hardening state after the report-only quality governance
 lane, router-registry split, performance workspace response split, and advisor-brief response
-split, risk drawdown mapper split, and risk rolling mapper split. It is intended to make quality
-debt visible before introducing stricter CI gates. Findings are not yet enforced unless they are
-already covered by existing repo-native gates.
+split, risk drawdown mapper split, risk rolling mapper split, and risk attribution mapper split.
+It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
+yet enforced unless they are already covered by existing repo-native gates.
 
 ## Repository Size
 
@@ -28,7 +28,7 @@ already covered by existing repo-native gates.
 | ---: | ---: | --- |
 | 1 | 3,016 | `src/app/services/portfolio_service.py` |
 | 2 | 2,226 | `src/app/contracts/portfolio.py` |
-| 3 | 2,063 | `src/app/services/risk_workspace_service.py` |
+| 3 | 2,162 | `src/app/services/risk_workspace_service.py` |
 | 4 | 2,043 | `src/app/contracts/risk_workspace.py` |
 | 5 | 1,840 | `src/app/contracts/reporting.py` |
 | 6 | 1,606 | `src/app/contracts/performance_workspace.py` |
@@ -47,10 +47,10 @@ already covered by existing repo-native gates.
 | 4 | 153 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
 | 5 | 144 | `_build_advisor_brief_narrative_state` | `src/app/services/advisor_brief_service.py` |
 | 6 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
-| 7 | 141 | `_map_attribution_response` | `src/app/services/risk_workspace_service.py` |
-| 8 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
-| 9 | 134 | `_build_shell_bootstrap` | `src/app/services/platform_capabilities_service.py` |
-| 10 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
+| 7 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
+| 8 | 134 | `_build_shell_bootstrap` | `src/app/services/platform_capabilities_service.py` |
+| 9 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
+| 10 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
 
 ## Existing Blocking Gates
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -72,7 +72,7 @@ Most recent local evidence:
 1. `make check`: 934 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
 3. `make ci`: 1,141 coverage tests passed.
-4. Coverage: 92.65%.
+4. Coverage: 92.63%.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -6,9 +6,9 @@ Phase: baseline/report-only
 ## Current Direction
 
 Recent gateway hardening has reduced monolithic Workbench, router-registry, performance workspace,
-advisor-brief, risk drawdown, and risk rolling responsibilities by extracting focused service
-adapters while preserving public behavior and keeping CI green. The remaining work is still
-substantial: large portfolio, risk workspace, contract, and client modules remain.
+advisor-brief, risk drawdown, risk rolling, and risk attribution responsibilities by extracting
+focused service adapters while preserving public behavior and keeping CI green. The remaining work
+is still substantial: large portfolio, risk workspace, contract, and client modules remain.
 
 ## Health Signals
 
@@ -28,8 +28,8 @@ substantial: large portfolio, risk workspace, contract, and client modules remai
 
 1. Split `portfolio_service.py` into source-readiness, transaction/activity, income, workspace,
    and workflow-cue adapters.
-2. Continue splitting `risk_workspace_service.py` response mappers by risk surface, with
-   attribution mapping now the next risk mapper target.
+2. Continue splitting `risk_workspace_service.py` by risk surface, with concentration and shared
+   unavailable-envelope helpers as the next risk workspace targets.
 3. Split `platform_capabilities_service.py` capability normalization into smaller adapters.
 4. Continue extracting performance workspace evidence and attribution helpers behind stable
    response contracts.

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -17,7 +17,7 @@ is still substantial: large portfolio, risk workspace, contract, and client modu
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
 | Unit/contract coverage | Healthy | 934 tests passed in `make check` for the router-registry split |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
-| Total coverage | Healthy | 92.65%, above the 84% floor |
+| Total coverage | Healthy | 92.63%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
 | Modularity | Improving, incomplete | Multiple service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -123,6 +123,13 @@ class RollingMappingResult:
     partial_failures: list[WorkbenchPartialFailure]
 
 
+@dataclass(frozen=True)
+class AttributionMappingResult:
+    periods: list[WorkbenchRiskAttributionPeriodResult]
+    warnings: list[str]
+    partial_failures: list[WorkbenchPartialFailure]
+
+
 class RiskWorkspaceService:
     def __init__(
         self,
@@ -1355,9 +1362,11 @@ def _map_attribution_response(
     upstream_payload: dict[str, Any],
 ) -> WorkbenchRiskAttributionResponse:
     results = upstream_payload.get("results")
-    warnings: list[str] = []
-    partial_failures: list[WorkbenchPartialFailure] = []
-    period_results: list[WorkbenchRiskAttributionPeriodResult] = []
+    mapping = _map_attribution_period_results(
+        results=results,
+        attribution_type=attribution_type,
+        grouping_dimension=grouping_dimension,
+    )
     supportability = _build_attribution_supportability(
         benchmark_code=benchmark_code,
         attribution_type=attribution_type,
@@ -1367,108 +1376,12 @@ def _map_attribution_response(
         supportability=supportability,
         upstream_payload=upstream_payload,
     )
-
-    if isinstance(results, dict):
-        for key, value in results.items():
-            if not isinstance(value, dict):
-                continue
-            error = value.get("error")
-            attribution_sets_payload = value.get("attribution_sets")
-            attribution_sets: list[WorkbenchRiskAttributionSet] = []
-            if isinstance(attribution_sets_payload, list):
-                for entry in attribution_sets_payload:
-                    if not isinstance(entry, dict):
-                        continue
-                    contributors_payload = entry.get("contributors")
-                    contributors = (
-                        [
-                            WorkbenchRiskAttributionContributor.model_validate(contributor)
-                            for contributor in contributors_payload
-                            if isinstance(contributor, dict)
-                        ]
-                        if isinstance(contributors_payload, list)
-                        else []
-                    )
-                    attribution_sets.append(
-                        WorkbenchRiskAttributionSet(
-                            attribution_type=str(entry.get("attribution_type", attribution_type)),
-                            metric=str(entry.get("metric", "")),
-                            grouping_dimension=str(
-                                entry.get("grouping_dimension", grouping_dimension)
-                            ),
-                            total_value=_safe_float(entry.get("total_value")),
-                            reconciled_sum=_safe_float(entry.get("reconciled_sum")),
-                            residual=_safe_float(entry.get("residual")),
-                            contributors=contributors,
-                            quality_flags=[
-                                str(flag)
-                                for flag in entry.get("quality_flags", [])
-                                if isinstance(flag, str) and flag.strip()
-                            ],
-                        )
-                    )
-            if isinstance(error, str) and error.strip():
-                partial_failures.append(
-                    WorkbenchPartialFailure(
-                        source_service="risk",
-                        error_code="RISK_ATTRIBUTION_PERIOD_ERROR",
-                        detail=f"{key}: {error}",
-                    )
-                )
-                warnings.append("RISK_ATTRIBUTION_PERIOD_PARTIAL")
-            period_results.append(
-                WorkbenchRiskAttributionPeriodResult(
-                    key=str(key),
-                    label=str(key),
-                    start_date=str(value.get("start_date", "")),
-                    end_date=str(value.get("end_date", "")),
-                    attribution_sets=attribution_sets,
-                    error=str(error) if isinstance(error, str) and error.strip() else None,
-                )
-            )
-
-    state: RiskModuleState = (
-        "partial" if any(item.state != "ready" for item in supportability) else "ready"
-    )
-    if not period_results:
-        state = "unavailable"
-        warnings.append("RISK_ATTRIBUTION_EMPTY")
-        partial_failures.append(
-            WorkbenchPartialFailure(
-                source_service="risk",
-                error_code="EMPTY_RISK_ATTRIBUTION",
-                detail="lotus-risk returned no attribution periods.",
-            )
-        )
-    elif all(not period.attribution_sets for period in period_results):
-        state = "unavailable"
-
-    metadata = _metadata(input_mode="stateful", cache_status="miss")
     upstream_metadata = upstream_payload.get("metadata")
-    if isinstance(upstream_metadata, dict):
-        methodology_version = upstream_metadata.get("methodology_version")
-        if isinstance(methodology_version, str) and methodology_version.strip():
-            metadata = metadata.model_copy(update={"methodology_version": methodology_version})
-
-    attribution_payload = (
-        WorkbenchRiskAttributionPayload(
-            controls=_build_attribution_controls(
-                benchmark_code=benchmark_code,
-                attribution_type=attribution_type,
-                grouping_dimension=grouping_dimension,
-                upstream_metadata=(
-                    upstream_metadata if isinstance(upstream_metadata, dict) else None
-                ),
-            ),
-            periods=period_results,
-            methodology_context=(
-                WorkbenchRiskAttributionMethodologyContext.model_validate(upstream_metadata)
-                if isinstance(upstream_metadata, dict)
-                else None
-            ),
-        )
-        if period_results
-        else None
+    state, warnings, partial_failures = _resolve_attribution_state(
+        period_results=mapping.periods,
+        supportability=supportability,
+        warnings=mapping.warnings,
+        partial_failures=mapping.partial_failures,
     )
 
     return WorkbenchRiskAttributionResponse(
@@ -1478,11 +1391,197 @@ def _map_attribution_response(
         as_of_date=as_of_date,
         benchmark_code=benchmark_code,
         state=state,
-        payload=attribution_payload,
+        payload=_build_attribution_payload(
+            period_results=mapping.periods,
+            benchmark_code=benchmark_code,
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+            upstream_metadata=upstream_metadata,
+        ),
         supportability=supportability,
         warnings=sorted(set(warnings)),
         partial_failures=partial_failures,
-        metadata=metadata,
+        metadata=_build_attribution_metadata(upstream_metadata=upstream_metadata),
+    )
+
+
+def _map_attribution_period_results(
+    *,
+    results: Any,
+    attribution_type: str,
+    grouping_dimension: str,
+) -> AttributionMappingResult:
+    warnings: list[str] = []
+    partial_failures: list[WorkbenchPartialFailure] = []
+    period_results: list[WorkbenchRiskAttributionPeriodResult] = []
+
+    if not isinstance(results, dict):
+        return AttributionMappingResult(
+            periods=period_results,
+            warnings=warnings,
+            partial_failures=partial_failures,
+        )
+
+    for key, value in results.items():
+        if not isinstance(value, dict):
+            continue
+        period = _map_attribution_period_result(
+            key=key,
+            value=value,
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+        )
+        if period.error:
+            partial_failures.append(
+                WorkbenchPartialFailure(
+                    source_service="risk",
+                    error_code="RISK_ATTRIBUTION_PERIOD_ERROR",
+                    detail=f"{key}: {period.error}",
+                )
+            )
+            warnings.append("RISK_ATTRIBUTION_PERIOD_PARTIAL")
+        period_results.append(period)
+
+    return AttributionMappingResult(
+        periods=period_results,
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+
+def _map_attribution_period_result(
+    *,
+    key: Any,
+    value: dict[str, Any],
+    attribution_type: str,
+    grouping_dimension: str,
+) -> WorkbenchRiskAttributionPeriodResult:
+    error = value.get("error")
+    return WorkbenchRiskAttributionPeriodResult(
+        key=str(key),
+        label=str(key),
+        start_date=str(value.get("start_date", "")),
+        end_date=str(value.get("end_date", "")),
+        attribution_sets=_map_attribution_sets(
+            value.get("attribution_sets"),
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+        ),
+        error=str(error) if isinstance(error, str) and error.strip() else None,
+    )
+
+
+def _map_attribution_sets(
+    value: Any,
+    *,
+    attribution_type: str,
+    grouping_dimension: str,
+) -> list[WorkbenchRiskAttributionSet]:
+    if not isinstance(value, list):
+        return []
+    return [
+        _map_attribution_set(
+            entry,
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+        )
+        for entry in value
+        if isinstance(entry, dict)
+    ]
+
+
+def _map_attribution_set(
+    entry: dict[str, Any],
+    *,
+    attribution_type: str,
+    grouping_dimension: str,
+) -> WorkbenchRiskAttributionSet:
+    return WorkbenchRiskAttributionSet(
+        attribution_type=str(entry.get("attribution_type", attribution_type)),
+        metric=str(entry.get("metric", "")),
+        grouping_dimension=str(entry.get("grouping_dimension", grouping_dimension)),
+        total_value=_safe_float(entry.get("total_value")),
+        reconciled_sum=_safe_float(entry.get("reconciled_sum")),
+        residual=_safe_float(entry.get("residual")),
+        contributors=_map_attribution_contributors(entry.get("contributors")),
+        quality_flags=[
+            str(flag)
+            for flag in entry.get("quality_flags", [])
+            if isinstance(flag, str) and flag.strip()
+        ],
+    )
+
+
+def _map_attribution_contributors(value: Any) -> list[WorkbenchRiskAttributionContributor]:
+    if not isinstance(value, list):
+        return []
+    return [
+        WorkbenchRiskAttributionContributor.model_validate(contributor)
+        for contributor in value
+        if isinstance(contributor, dict)
+    ]
+
+
+def _resolve_attribution_state(
+    *,
+    period_results: list[WorkbenchRiskAttributionPeriodResult],
+    supportability: list[WorkbenchRiskSupportabilityItem],
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+) -> tuple[RiskModuleState, list[str], list[WorkbenchPartialFailure]]:
+    resolved_warnings = list(warnings)
+    resolved_partial_failures = list(partial_failures)
+    state: RiskModuleState = (
+        "partial" if any(item.state != "ready" for item in supportability) else "ready"
+    )
+    if not period_results:
+        state = "unavailable"
+        resolved_warnings.append("RISK_ATTRIBUTION_EMPTY")
+        resolved_partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="risk",
+                error_code="EMPTY_RISK_ATTRIBUTION",
+                detail="lotus-risk returned no attribution periods.",
+            )
+        )
+    elif all(not period.attribution_sets for period in period_results):
+        state = "unavailable"
+    return state, resolved_warnings, resolved_partial_failures
+
+
+def _build_attribution_metadata(*, upstream_metadata: Any) -> WorkbenchRiskMetadata:
+    metadata = _metadata(input_mode="stateful", cache_status="miss")
+    if isinstance(upstream_metadata, dict):
+        methodology_version = upstream_metadata.get("methodology_version")
+        if isinstance(methodology_version, str) and methodology_version.strip():
+            return metadata.model_copy(update={"methodology_version": methodology_version})
+    return metadata
+
+
+def _build_attribution_payload(
+    *,
+    period_results: list[WorkbenchRiskAttributionPeriodResult],
+    benchmark_code: str | None,
+    attribution_type: str,
+    grouping_dimension: str,
+    upstream_metadata: Any,
+) -> WorkbenchRiskAttributionPayload | None:
+    if not period_results:
+        return None
+    metadata = upstream_metadata if isinstance(upstream_metadata, dict) else None
+    return WorkbenchRiskAttributionPayload(
+        controls=_build_attribution_controls(
+            benchmark_code=benchmark_code,
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+            upstream_metadata=metadata,
+        ),
+        periods=period_results,
+        methodology_context=(
+            WorkbenchRiskAttributionMethodologyContext.model_validate(upstream_metadata)
+            if isinstance(upstream_metadata, dict)
+            else None
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- Split risk attribution response mapping into focused period, attribution-set, contributor, state, metadata, and payload helpers.
- Preserve upstream `lotus-risk` attribution truth, source calculation supportability, blocked controls, period partial failures, and public response shape.
- Refresh quality reports so `_map_attribution_response` drops out of the largest-function list and the next risk workspace backlog moves to concentration/shared unavailable helpers.

## Validation
- python -m ruff check src\app\services\risk_workspace_service.py
- python -m ruff format --check src\app\services\risk_workspace_service.py
- python -m mypy src\app\services\risk_workspace_service.py
- python -m pytest tests\unit\test_risk_workspace_service.py tests\unit\test_risk_workspace_requests.py tests\unit\test_risk_workspace_attribution_controls.py -q (35 passed)
- make check (934 unit/contract tests passed)
- make ci (207 integration tests passed; 1,141 coverage tests passed; coverage 92.63%; no known vulnerabilities)
- git branch -r --no-merged origin/main (no stranded remote branches)
- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway (DiffCount 0)

## Notes
- Public API shape is unchanged.
- No wiki source update was required because this is an internal modularity and quality-baseline slice.