### PR TITLE
Refactor risk concentration response mapping

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -36,10 +36,10 @@ report-only baseline is reviewed.
 The largest current modularity risks are:
 
 1. `src/app/services/portfolio_service.py` at 3,016 lines,
-2. `src/app/services/risk_workspace_service.py` at 2,162 lines,
+2. `src/app/services/risk_workspace_service.py` at 1,942 lines,
 3. `src/app/services/advisor_brief_service.py` at 1,392 lines,
 4. `src/app/services/performance_workspace_service.py` at 1,152 lines,
-5. `src/app/services/dpm_command_center_service.py` at 966 lines.
+5. `src/app/services/dpm_command_center_service.py` at 1,032 lines.
 
 The prior longest function, `register_routers` in `src/app/router_registry.py`, has been split
 into explicit route-family groups and a short registration loop. The performance workspace
@@ -49,9 +49,11 @@ runtime supportability, and response assembly helpers. The risk drawdown mapper 
 period mapping, supportability, state, metadata, and payload helpers. The risk rolling mapper has
 been split into period mapping, dependency context, supportability, state, metadata, Sharpe
 fallback, and payload helpers. The risk attribution mapper has been split into period mapping,
-set/contributor parsing, state, metadata, and payload helpers. The current longest function is
-`_build_normalized_capabilities` in `src/app/services/platform_capabilities_service.py` at 195
-lines.
+set/contributor parsing, state, metadata, and payload helpers. The risk concentration mapper has
+been extracted to `src/app/services/risk_workspace_concentration.py`, reducing
+`risk_workspace_service.py` to 1,942 lines while preserving source-owned concentration fields and
+supportability semantics. The current longest function is `_build_normalized_capabilities` in
+`src/app/services/platform_capabilities_service.py` at 195 lines.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -8,7 +8,8 @@ Baseline phase: report-only
 
 This baseline covers the current gateway hardening state after the report-only quality governance
 lane, router-registry split, performance workspace response split, and advisor-brief response
-split, risk drawdown mapper split, risk rolling mapper split, and risk attribution mapper split.
+split, risk drawdown mapper split, risk rolling mapper split, risk attribution mapper split, and
+risk concentration mapper extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -28,8 +29,8 @@ yet enforced unless they are already covered by existing repo-native gates.
 | ---: | ---: | --- |
 | 1 | 3,016 | `src/app/services/portfolio_service.py` |
 | 2 | 2,226 | `src/app/contracts/portfolio.py` |
-| 3 | 2,162 | `src/app/services/risk_workspace_service.py` |
-| 4 | 2,043 | `src/app/contracts/risk_workspace.py` |
+| 3 | 2,043 | `src/app/contracts/risk_workspace.py` |
+| 4 | 1,942 | `src/app/services/risk_workspace_service.py` |
 | 5 | 1,840 | `src/app/contracts/reporting.py` |
 | 6 | 1,606 | `src/app/contracts/performance_workspace.py` |
 | 7 | 1,392 | `src/app/services/advisor_brief_service.py` |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -73,7 +73,7 @@ Most recent local evidence:
 1. `make check`: 934 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
 3. `make ci`: 1,141 coverage tests passed.
-4. Coverage: 92.63%.
+4. Coverage: 92.64%.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -7,8 +7,9 @@ Phase: baseline/report-only
 
 Recent gateway hardening has reduced monolithic Workbench, router-registry, performance workspace,
 advisor-brief, risk drawdown, risk rolling, and risk attribution responsibilities by extracting
-focused service adapters while preserving public behavior and keeping CI green. The remaining work
-is still substantial: large portfolio, risk workspace, contract, and client modules remain.
+focused service adapters and has extracted risk concentration response mapping behind a dedicated
+service module while preserving public behavior and keeping CI green. The remaining work is still
+substantial: large portfolio, risk workspace, contract, and client modules remain.
 
 ## Health Signals
 
@@ -28,8 +29,8 @@ is still substantial: large portfolio, risk workspace, contract, and client modu
 
 1. Split `portfolio_service.py` into source-readiness, transaction/activity, income, workspace,
    and workflow-cue adapters.
-2. Continue splitting `risk_workspace_service.py` by risk surface, with concentration and shared
-   unavailable-envelope helpers as the next risk workspace targets.
+2. Continue splitting `risk_workspace_service.py` by risk surface, with shared unavailable-envelope
+   helpers as the next risk workspace target.
 3. Split `platform_capabilities_service.py` capability normalization into smaller adapters.
 4. Continue extracting performance workspace evidence and attribution helpers behind stable
    response contracts.

--- a/src/app/services/risk_workspace_concentration.py
+++ b/src/app/services/risk_workspace_concentration.py
@@ -1,0 +1,336 @@
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from app.contracts.risk_workspace import (
+    RiskModuleState,
+    RiskSupportabilityState,
+    WorkbenchIssuerConcentration,
+    WorkbenchPortfolioConcentration,
+    WorkbenchRiskConcentrationExecutionContext,
+    WorkbenchRiskConcentrationPayload,
+    WorkbenchRiskConcentrationResponse,
+    WorkbenchRiskConcentrationValuationContext,
+    WorkbenchRiskMetadata,
+    WorkbenchRiskSupportabilityItem,
+    WorkbenchSinglePositionConcentration,
+)
+from app.contracts.workbench import WorkbenchPartialFailure
+from app.services.source_supportability import (
+    extract_calculation_supportability,
+    source_supportability_reason,
+)
+
+
+@dataclass(frozen=True)
+class ConcentrationBlocks:
+    portfolio: dict[str, Any]
+    single_position: dict[str, Any]
+    issuer: dict[str, Any]
+
+
+def map_concentration_response(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    upstream_payload: dict[str, Any],
+) -> WorkbenchRiskConcentrationResponse:
+    concentration_blocks, missing_blocks = _extract_concentration_blocks(upstream_payload)
+    if missing_blocks:
+        return malformed_concentration(
+            correlation_id=correlation_id,
+            portfolio_id=portfolio_id,
+            period=period,
+            as_of_date=as_of_date,
+            benchmark_code=benchmark_code,
+            missing_blocks=missing_blocks,
+        )
+    assert concentration_blocks is not None
+    supportability = _build_concentration_supportability(
+        blocks=concentration_blocks,
+        upstream_payload=upstream_payload,
+    )
+    _append_source_calculation_supportability(
+        supportability=supportability,
+        upstream_payload=upstream_payload,
+    )
+    return WorkbenchRiskConcentrationResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state=_concentration_response_state(supportability),
+        payload=_build_concentration_payload(
+            blocks=concentration_blocks,
+            upstream_payload=upstream_payload,
+        ),
+        supportability=supportability,
+        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def unavailable_concentration(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> WorkbenchRiskConcentrationResponse:
+    return WorkbenchRiskConcentrationResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="unavailable",
+        payload=None,
+        supportability=[
+            WorkbenchRiskSupportabilityItem(
+                key="risk_service",
+                label="Risk service",
+                state="unavailable",
+                reason="lotus-risk concentration endpoint is unavailable.",
+                source_service="lotus-risk",
+            )
+        ],
+        warnings=["RISK_CONCENTRATION_UNAVAILABLE"],
+        partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
+        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def malformed_concentration(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    missing_blocks: list[str],
+) -> WorkbenchRiskConcentrationResponse:
+    detail = "lotus-risk concentration response omitted required blocks: " + ", ".join(
+        missing_blocks
+    )
+    return WorkbenchRiskConcentrationResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="unavailable",
+        payload=None,
+        supportability=[
+            WorkbenchRiskSupportabilityItem(
+                key="risk_service_contract",
+                label="Risk service contract",
+                state="unavailable",
+                reason=detail,
+                source_service="lotus-risk",
+            )
+        ],
+        warnings=["RISK_CONCENTRATION_CONTRACT_INVALID"],
+        partial_failures=[
+            WorkbenchPartialFailure(
+                source_service="risk",
+                error_code="MALFORMED_RISK_CONCENTRATION",
+                detail=detail,
+            )
+        ],
+        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def _extract_concentration_blocks(
+    upstream_payload: dict[str, Any],
+) -> tuple[ConcentrationBlocks | None, list[str]]:
+    block_payloads = {
+        "portfolio_concentration": upstream_payload.get("risk_proxy"),
+        "single_position_concentration": upstream_payload.get("single_position_concentration"),
+        "issuer_concentration": upstream_payload.get("issuer_concentration"),
+    }
+    missing_blocks = [key for key, value in block_payloads.items() if not isinstance(value, dict)]
+    if missing_blocks:
+        return None, missing_blocks
+    return (
+        ConcentrationBlocks(
+            portfolio=cast(dict[str, Any], block_payloads["portfolio_concentration"]),
+            single_position=cast(
+                dict[str, Any],
+                block_payloads["single_position_concentration"],
+            ),
+            issuer=cast(dict[str, Any], block_payloads["issuer_concentration"]),
+        ),
+        [],
+    )
+
+
+def _build_concentration_supportability(
+    *,
+    blocks: ConcentrationBlocks,
+    upstream_payload: dict[str, Any],
+) -> list[WorkbenchRiskSupportabilityItem]:
+    return [
+        WorkbenchRiskSupportabilityItem(
+            key="portfolio_positions",
+            label="Portfolio positions",
+            state="ready",
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="issuer_enrichment",
+            label="Issuer enrichment",
+            state=_issuer_supportability_state(blocks.issuer),
+            reason=_issuer_supportability_reason(blocks.issuer),
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="issuer_grouping",
+            label="Issuer grouping",
+            state="ready",
+            reason=_issuer_grouping_reason(upstream_payload.get("metadata")),
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="valuation_basis",
+            label="Valuation basis",
+            state="ready",
+            reason=_valuation_context_reason(upstream_payload.get("valuation_context")),
+            source_service="lotus-risk",
+        ),
+    ]
+
+
+def _build_concentration_payload(
+    *,
+    blocks: ConcentrationBlocks,
+    upstream_payload: dict[str, Any],
+) -> WorkbenchRiskConcentrationPayload:
+    valuation_context = upstream_payload.get("valuation_context")
+    execution_context = upstream_payload.get("metadata")
+    return WorkbenchRiskConcentrationPayload(
+        portfolio_concentration=WorkbenchPortfolioConcentration.model_validate(blocks.portfolio),
+        single_position_concentration=WorkbenchSinglePositionConcentration.model_validate(
+            blocks.single_position
+        ),
+        issuer_concentration=WorkbenchIssuerConcentration.model_validate(blocks.issuer),
+        valuation_context=WorkbenchRiskConcentrationValuationContext.model_validate(
+            valuation_context
+        )
+        if isinstance(valuation_context, dict)
+        else None,
+        execution_context=WorkbenchRiskConcentrationExecutionContext.model_validate(
+            execution_context
+        )
+        if isinstance(execution_context, dict)
+        else None,
+    )
+
+
+def _concentration_response_state(
+    supportability: list[WorkbenchRiskSupportabilityItem],
+) -> RiskModuleState:
+    return "ready" if all(item.state == "ready" for item in supportability) else "partial"
+
+
+def _issuer_supportability_state(payload: Any) -> RiskSupportabilityState:
+    if not isinstance(payload, dict):
+        return "unavailable"
+    status_value = str(payload.get("coverage_status", "")).lower()
+    if status_value == "complete":
+        return "ready"
+    if status_value == "partial":
+        return "partial"
+    return "unavailable"
+
+
+def _issuer_supportability_reason(payload: Any) -> str | None:
+    if not isinstance(payload, dict):
+        return "Issuer concentration block was not returned by lotus-risk."
+    note = payload.get("note")
+    if isinstance(note, str) and note.strip():
+        return note
+    if str(payload.get("coverage_status", "")).lower() != "complete":
+        return "Issuer coverage is not complete for the selected portfolio context."
+    return None
+
+
+def _issuer_grouping_reason(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return "Issuer grouping metadata was not returned by lotus-risk."
+    grouping = payload.get("issuer_grouping_level")
+    policy = payload.get("enrichment_policy")
+    grouping_label = str(grouping).replace("_", " ") if grouping else "unspecified grouping"
+    policy_label = str(policy).replace("_", " ") if policy else "unspecified policy"
+    return f"{grouping_label.title()} grouping with {policy_label} enrichment policy."
+
+
+def _valuation_context_reason(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return "Valuation context was not returned by lotus-risk."
+    reporting_currency = payload.get("reporting_currency")
+    portfolio_currency = payload.get("portfolio_currency")
+    weight_basis = payload.get("weight_basis")
+    basis_label = str(weight_basis).replace("_", " ") if weight_basis else "reported weights"
+    currency_context = " / ".join(
+        part
+        for part in [
+            str(reporting_currency) if reporting_currency else None,
+            str(portfolio_currency) if portfolio_currency else None,
+        ]
+        if part
+    )
+    if currency_context:
+        return f"{basis_label.title()} in {currency_context} context."
+    return f"{basis_label.title()} context."
+
+
+def _append_source_calculation_supportability(
+    *,
+    supportability: list[WorkbenchRiskSupportabilityItem],
+    upstream_payload: dict[str, Any],
+) -> None:
+    source_supportability = extract_calculation_supportability(upstream_payload)
+    if source_supportability is None:
+        return
+
+    supportability.append(
+        WorkbenchRiskSupportabilityItem(
+            key="source_calculation",
+            label="Source calculation",
+            state=cast(Any, source_supportability.risk_contract_state),
+            reason=source_supportability_reason(
+                source_supportability,
+                default_ready_reason="Source calculation supportability was confirmed upstream.",
+            ),
+            source_service=source_supportability.source_service or "lotus-risk",
+        )
+    )
+
+
+def _upstream_failure(upstream_status: int, upstream_payload: Any) -> WorkbenchPartialFailure:
+    detail = (
+        str(upstream_payload.get("detail", upstream_payload))
+        if isinstance(upstream_payload, dict)
+        else str(upstream_payload)
+    )
+    return WorkbenchPartialFailure(
+        source_service="risk",
+        error_code=f"HTTP_{upstream_status}",
+        detail=detail,
+    )
+
+
+def _metadata(*, input_mode: str, cache_status: str) -> WorkbenchRiskMetadata:
+    return WorkbenchRiskMetadata(
+        generated_at=datetime.now(tz=UTC).isoformat(),
+        input_mode=cast(Any, input_mode),
+        cache_status=cast(Any, cache_status),
+        methodology_version="lotus-risk",
+    )

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -130,6 +130,13 @@ class AttributionMappingResult:
     partial_failures: list[WorkbenchPartialFailure]
 
 
+@dataclass(frozen=True)
+class ConcentrationBlocks:
+    portfolio: dict[str, Any]
+    single_position: dict[str, Any]
+    issuer: dict[str, Any]
+
+
 class RiskWorkspaceService:
     def __init__(
         self,
@@ -752,12 +759,7 @@ def _map_concentration_response(
     benchmark_code: str | None,
     upstream_payload: dict[str, Any],
 ) -> WorkbenchRiskConcentrationResponse:
-    required_blocks = {
-        "portfolio_concentration": upstream_payload.get("risk_proxy"),
-        "single_position_concentration": upstream_payload.get("single_position_concentration"),
-        "issuer_concentration": upstream_payload.get("issuer_concentration"),
-    }
-    missing_blocks = [key for key, value in required_blocks.items() if not isinstance(value, dict)]
+    concentration_blocks, missing_blocks = _extract_concentration_blocks(upstream_payload)
     if missing_blocks:
         return _malformed_concentration(
             correlation_id=correlation_id,
@@ -767,9 +769,61 @@ def _map_concentration_response(
             benchmark_code=benchmark_code,
             missing_blocks=missing_blocks,
         )
-    issuer_payload = upstream_payload.get("issuer_concentration")
-    issuer_state = _issuer_supportability_state(issuer_payload)
-    supportability = [
+    assert concentration_blocks is not None
+    supportability = _build_concentration_supportability(
+        blocks=concentration_blocks,
+        upstream_payload=upstream_payload,
+    )
+    _append_source_calculation_supportability(
+        supportability=supportability,
+        upstream_payload=upstream_payload,
+    )
+    return WorkbenchRiskConcentrationResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state=_concentration_response_state(supportability),
+        payload=_build_concentration_payload(
+            blocks=concentration_blocks,
+            upstream_payload=upstream_payload,
+        ),
+        supportability=supportability,
+        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def _extract_concentration_blocks(
+    upstream_payload: dict[str, Any],
+) -> tuple[ConcentrationBlocks | None, list[str]]:
+    block_payloads = {
+        "portfolio_concentration": upstream_payload.get("risk_proxy"),
+        "single_position_concentration": upstream_payload.get("single_position_concentration"),
+        "issuer_concentration": upstream_payload.get("issuer_concentration"),
+    }
+    missing_blocks = [key for key, value in block_payloads.items() if not isinstance(value, dict)]
+    if missing_blocks:
+        return None, missing_blocks
+    return (
+        ConcentrationBlocks(
+            portfolio=cast(dict[str, Any], block_payloads["portfolio_concentration"]),
+            single_position=cast(
+                dict[str, Any],
+                block_payloads["single_position_concentration"],
+            ),
+            issuer=cast(dict[str, Any], block_payloads["issuer_concentration"]),
+        ),
+        [],
+    )
+
+
+def _build_concentration_supportability(
+    *,
+    blocks: ConcentrationBlocks,
+    upstream_payload: dict[str, Any],
+) -> list[WorkbenchRiskSupportabilityItem]:
+    return [
         WorkbenchRiskSupportabilityItem(
             key="portfolio_positions",
             label="Portfolio positions",
@@ -779,8 +833,8 @@ def _map_concentration_response(
         WorkbenchRiskSupportabilityItem(
             key="issuer_enrichment",
             label="Issuer enrichment",
-            state=issuer_state,
-            reason=_issuer_supportability_reason(issuer_payload),
+            state=_issuer_supportability_state(blocks.issuer),
+            reason=_issuer_supportability_reason(blocks.issuer),
             source_service="lotus-risk",
         ),
         WorkbenchRiskSupportabilityItem(
@@ -798,41 +852,38 @@ def _map_concentration_response(
             source_service="lotus-risk",
         ),
     ]
-    _append_source_calculation_supportability(
-        supportability=supportability,
-        upstream_payload=upstream_payload,
-    )
-    return WorkbenchRiskConcentrationResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state="ready" if all(item.state == "ready" for item in supportability) else "partial",
-        payload=WorkbenchRiskConcentrationPayload(
-            portfolio_concentration=WorkbenchPortfolioConcentration.model_validate(
-                required_blocks["portfolio_concentration"]
-            ),
-            single_position_concentration=WorkbenchSinglePositionConcentration.model_validate(
-                required_blocks["single_position_concentration"]
-            ),
-            issuer_concentration=WorkbenchIssuerConcentration.model_validate(
-                required_blocks["issuer_concentration"]
-            ),
-            valuation_context=WorkbenchRiskConcentrationValuationContext.model_validate(
-                upstream_payload.get("valuation_context")
-            )
-            if isinstance(upstream_payload.get("valuation_context"), dict)
-            else None,
-            execution_context=WorkbenchRiskConcentrationExecutionContext.model_validate(
-                upstream_payload.get("metadata")
-            )
-            if isinstance(upstream_payload.get("metadata"), dict)
-            else None,
+
+
+def _build_concentration_payload(
+    *,
+    blocks: ConcentrationBlocks,
+    upstream_payload: dict[str, Any],
+) -> WorkbenchRiskConcentrationPayload:
+    valuation_context = upstream_payload.get("valuation_context")
+    execution_context = upstream_payload.get("metadata")
+    return WorkbenchRiskConcentrationPayload(
+        portfolio_concentration=WorkbenchPortfolioConcentration.model_validate(blocks.portfolio),
+        single_position_concentration=WorkbenchSinglePositionConcentration.model_validate(
+            blocks.single_position
         ),
-        supportability=supportability,
-        metadata=_metadata(input_mode="stateful", cache_status="miss"),
+        issuer_concentration=WorkbenchIssuerConcentration.model_validate(blocks.issuer),
+        valuation_context=WorkbenchRiskConcentrationValuationContext.model_validate(
+            valuation_context
+        )
+        if isinstance(valuation_context, dict)
+        else None,
+        execution_context=WorkbenchRiskConcentrationExecutionContext.model_validate(
+            execution_context
+        )
+        if isinstance(execution_context, dict)
+        else None,
     )
+
+
+def _concentration_response_state(
+    supportability: list[WorkbenchRiskSupportabilityItem],
+) -> RiskModuleState:
+    return "ready" if all(item.state == "ready" for item in supportability) else "partial"
 
 
 def _map_drawdown_response(

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -9,8 +9,6 @@ from app.config import settings
 from app.contracts.risk_workspace import (
     RiskModuleState,
     RiskSupportabilityState,
-    WorkbenchIssuerConcentration,
-    WorkbenchPortfolioConcentration,
     WorkbenchRiskAttributionContributor,
     WorkbenchRiskAttributionControls,
     WorkbenchRiskAttributionMethodologyContext,
@@ -18,10 +16,7 @@ from app.contracts.risk_workspace import (
     WorkbenchRiskAttributionPeriodResult,
     WorkbenchRiskAttributionResponse,
     WorkbenchRiskAttributionSet,
-    WorkbenchRiskConcentrationExecutionContext,
-    WorkbenchRiskConcentrationPayload,
     WorkbenchRiskConcentrationResponse,
-    WorkbenchRiskConcentrationValuationContext,
     WorkbenchRiskDrawdownAnalysisContext,
     WorkbenchRiskDrawdownEpisode,
     WorkbenchRiskDrawdownPayload,
@@ -46,7 +41,6 @@ from app.contracts.risk_workspace import (
     WorkbenchRiskSummaryResponse,
     WorkbenchRiskSupportabilityItem,
     WorkbenchRiskUnderwaterPoint,
-    WorkbenchSinglePositionConcentration,
 )
 from app.contracts.workbench import WorkbenchPartialFailure
 from app.services.async_ttl_cache import AsyncTtlCache
@@ -63,6 +57,10 @@ from app.services.risk_workspace_attribution_controls import (
     resolve_active_risk_grouping_support,
     risk_attribution_grouping_label,
     total_risk_gated_grouping_reason,
+)
+from app.services.risk_workspace_concentration import (
+    map_concentration_response,
+    unavailable_concentration,
 )
 from app.services.risk_workspace_requests import (
     SUMMARY_METRICS as _SUMMARY_METRICS,
@@ -128,13 +126,6 @@ class AttributionMappingResult:
     periods: list[WorkbenchRiskAttributionPeriodResult]
     warnings: list[str]
     partial_failures: list[WorkbenchPartialFailure]
-
-
-@dataclass(frozen=True)
-class ConcentrationBlocks:
-    portfolio: dict[str, Any]
-    single_position: dict[str, Any]
-    issuer: dict[str, Any]
 
 
 class RiskWorkspaceService:
@@ -266,7 +257,7 @@ class RiskWorkspaceService:
             if upstream_status >= status.HTTP_400_BAD_REQUEST or not isinstance(
                 upstream_payload, dict
             ):
-                return _unavailable_concentration(
+                return unavailable_concentration(
                     correlation_id=correlation_id,
                     portfolio_id=portfolio_id,
                     period=period,
@@ -275,7 +266,7 @@ class RiskWorkspaceService:
                     upstream_status=upstream_status,
                     upstream_payload=upstream_payload,
                 )
-            return _map_concentration_response(
+            return map_concentration_response(
                 correlation_id=correlation_id,
                 portfolio_id=portfolio_id,
                 period=period,
@@ -748,142 +739,6 @@ def _metric_dependency_supportability(
             source_service="lotus-risk",
         ),
     ]
-
-
-def _map_concentration_response(
-    *,
-    correlation_id: str,
-    portfolio_id: str,
-    period: str,
-    as_of_date: str,
-    benchmark_code: str | None,
-    upstream_payload: dict[str, Any],
-) -> WorkbenchRiskConcentrationResponse:
-    concentration_blocks, missing_blocks = _extract_concentration_blocks(upstream_payload)
-    if missing_blocks:
-        return _malformed_concentration(
-            correlation_id=correlation_id,
-            portfolio_id=portfolio_id,
-            period=period,
-            as_of_date=as_of_date,
-            benchmark_code=benchmark_code,
-            missing_blocks=missing_blocks,
-        )
-    assert concentration_blocks is not None
-    supportability = _build_concentration_supportability(
-        blocks=concentration_blocks,
-        upstream_payload=upstream_payload,
-    )
-    _append_source_calculation_supportability(
-        supportability=supportability,
-        upstream_payload=upstream_payload,
-    )
-    return WorkbenchRiskConcentrationResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state=_concentration_response_state(supportability),
-        payload=_build_concentration_payload(
-            blocks=concentration_blocks,
-            upstream_payload=upstream_payload,
-        ),
-        supportability=supportability,
-        metadata=_metadata(input_mode="stateful", cache_status="miss"),
-    )
-
-
-def _extract_concentration_blocks(
-    upstream_payload: dict[str, Any],
-) -> tuple[ConcentrationBlocks | None, list[str]]:
-    block_payloads = {
-        "portfolio_concentration": upstream_payload.get("risk_proxy"),
-        "single_position_concentration": upstream_payload.get("single_position_concentration"),
-        "issuer_concentration": upstream_payload.get("issuer_concentration"),
-    }
-    missing_blocks = [key for key, value in block_payloads.items() if not isinstance(value, dict)]
-    if missing_blocks:
-        return None, missing_blocks
-    return (
-        ConcentrationBlocks(
-            portfolio=cast(dict[str, Any], block_payloads["portfolio_concentration"]),
-            single_position=cast(
-                dict[str, Any],
-                block_payloads["single_position_concentration"],
-            ),
-            issuer=cast(dict[str, Any], block_payloads["issuer_concentration"]),
-        ),
-        [],
-    )
-
-
-def _build_concentration_supportability(
-    *,
-    blocks: ConcentrationBlocks,
-    upstream_payload: dict[str, Any],
-) -> list[WorkbenchRiskSupportabilityItem]:
-    return [
-        WorkbenchRiskSupportabilityItem(
-            key="portfolio_positions",
-            label="Portfolio positions",
-            state="ready",
-            source_service="lotus-risk",
-        ),
-        WorkbenchRiskSupportabilityItem(
-            key="issuer_enrichment",
-            label="Issuer enrichment",
-            state=_issuer_supportability_state(blocks.issuer),
-            reason=_issuer_supportability_reason(blocks.issuer),
-            source_service="lotus-risk",
-        ),
-        WorkbenchRiskSupportabilityItem(
-            key="issuer_grouping",
-            label="Issuer grouping",
-            state="ready",
-            reason=_issuer_grouping_reason(upstream_payload.get("metadata")),
-            source_service="lotus-risk",
-        ),
-        WorkbenchRiskSupportabilityItem(
-            key="valuation_basis",
-            label="Valuation basis",
-            state="ready",
-            reason=_valuation_context_reason(upstream_payload.get("valuation_context")),
-            source_service="lotus-risk",
-        ),
-    ]
-
-
-def _build_concentration_payload(
-    *,
-    blocks: ConcentrationBlocks,
-    upstream_payload: dict[str, Any],
-) -> WorkbenchRiskConcentrationPayload:
-    valuation_context = upstream_payload.get("valuation_context")
-    execution_context = upstream_payload.get("metadata")
-    return WorkbenchRiskConcentrationPayload(
-        portfolio_concentration=WorkbenchPortfolioConcentration.model_validate(blocks.portfolio),
-        single_position_concentration=WorkbenchSinglePositionConcentration.model_validate(
-            blocks.single_position
-        ),
-        issuer_concentration=WorkbenchIssuerConcentration.model_validate(blocks.issuer),
-        valuation_context=WorkbenchRiskConcentrationValuationContext.model_validate(
-            valuation_context
-        )
-        if isinstance(valuation_context, dict)
-        else None,
-        execution_context=WorkbenchRiskConcentrationExecutionContext.model_validate(
-            execution_context
-        )
-        if isinstance(execution_context, dict)
-        else None,
-    )
-
-
-def _concentration_response_state(
-    supportability: list[WorkbenchRiskSupportabilityItem],
-) -> RiskModuleState:
-    return "ready" if all(item.state == "ready" for item in supportability) else "partial"
 
 
 def _map_drawdown_response(
@@ -1739,58 +1594,6 @@ def _safe_float(value: Any) -> float | None:
         return None
 
 
-def _issuer_supportability_state(payload: Any) -> RiskSupportabilityState:
-    if not isinstance(payload, dict):
-        return "unavailable"
-    status_value = str(payload.get("coverage_status", "")).lower()
-    if status_value == "complete":
-        return "ready"
-    if status_value == "partial":
-        return "partial"
-    return "unavailable"
-
-
-def _issuer_supportability_reason(payload: Any) -> str | None:
-    if not isinstance(payload, dict):
-        return "Issuer concentration block was not returned by lotus-risk."
-    note = payload.get("note")
-    if isinstance(note, str) and note.strip():
-        return note
-    if str(payload.get("coverage_status", "")).lower() != "complete":
-        return "Issuer coverage is not complete for the selected portfolio context."
-    return None
-
-
-def _issuer_grouping_reason(payload: Any) -> str:
-    if not isinstance(payload, dict):
-        return "Issuer grouping metadata was not returned by lotus-risk."
-    grouping = payload.get("issuer_grouping_level")
-    policy = payload.get("enrichment_policy")
-    grouping_label = str(grouping).replace("_", " ") if grouping else "unspecified grouping"
-    policy_label = str(policy).replace("_", " ") if policy else "unspecified policy"
-    return f"{grouping_label.title()} grouping with {policy_label} enrichment policy."
-
-
-def _valuation_context_reason(payload: Any) -> str:
-    if not isinstance(payload, dict):
-        return "Valuation context was not returned by lotus-risk."
-    reporting_currency = payload.get("reporting_currency")
-    portfolio_currency = payload.get("portfolio_currency")
-    weight_basis = payload.get("weight_basis")
-    basis_label = str(weight_basis).replace("_", " ") if weight_basis else "reported weights"
-    currency_context = " / ".join(
-        part
-        for part in [
-            str(reporting_currency) if reporting_currency else None,
-            str(portfolio_currency) if portfolio_currency else None,
-        ]
-        if part
-    )
-    if currency_context:
-        return f"{basis_label.title()} in {currency_context} context."
-    return f"{basis_label.title()} context."
-
-
 def _unavailable_summary(
     *,
     correlation_id: str,
@@ -1819,39 +1622,6 @@ def _unavailable_summary(
             )
         ],
         warnings=["RISK_SUMMARY_UNAVAILABLE"],
-        partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
-        metadata=_metadata(input_mode="stateful", cache_status="miss"),
-    )
-
-
-def _unavailable_concentration(
-    *,
-    correlation_id: str,
-    portfolio_id: str,
-    period: str,
-    as_of_date: str,
-    benchmark_code: str | None,
-    upstream_status: int,
-    upstream_payload: Any,
-) -> WorkbenchRiskConcentrationResponse:
-    return WorkbenchRiskConcentrationResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state="unavailable",
-        payload=None,
-        supportability=[
-            WorkbenchRiskSupportabilityItem(
-                key="risk_service",
-                label="Risk service",
-                state="unavailable",
-                reason="lotus-risk concentration endpoint is unavailable.",
-                source_service="lotus-risk",
-            )
-        ],
-        warnings=["RISK_CONCENTRATION_UNAVAILABLE"],
         partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
         metadata=_metadata(input_mode="stateful", cache_status="miss"),
     )
@@ -1969,47 +1739,6 @@ def _unavailable_attribution(
         ),
         warnings=["RISK_ATTRIBUTION_UNAVAILABLE"],
         partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
-        metadata=_metadata(input_mode="stateful", cache_status="miss"),
-    )
-
-
-def _malformed_concentration(
-    *,
-    correlation_id: str,
-    portfolio_id: str,
-    period: str,
-    as_of_date: str,
-    benchmark_code: str | None,
-    missing_blocks: list[str],
-) -> WorkbenchRiskConcentrationResponse:
-    detail = "lotus-risk concentration response omitted required blocks: " + ", ".join(
-        missing_blocks
-    )
-    return WorkbenchRiskConcentrationResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state="unavailable",
-        payload=None,
-        supportability=[
-            WorkbenchRiskSupportabilityItem(
-                key="risk_service_contract",
-                label="Risk service contract",
-                state="unavailable",
-                reason=detail,
-                source_service="lotus-risk",
-            )
-        ],
-        warnings=["RISK_CONCENTRATION_CONTRACT_INVALID"],
-        partial_failures=[
-            WorkbenchPartialFailure(
-                source_service="risk",
-                error_code="MALFORMED_RISK_CONCENTRATION",
-                detail=detail,
-            )
-        ],
         metadata=_metadata(input_mode="stateful", cache_status="miss"),
     )
 

--- a/tests/unit/test_risk_workspace_service.py
+++ b/tests/unit/test_risk_workspace_service.py
@@ -491,13 +491,23 @@ async def test_risk_concentration_uses_stateful_request_and_maps_issuer_supporta
     assert response.payload.issuer_concentration.coverage_ratio_current == 0.8
     assert response.payload.execution_context is not None
     assert response.payload.execution_context.issuer_grouping_level == "ultimate_parent"
-    assert {item.key: item.state for item in response.supportability} == {
+    supportability = {item.key: item for item in response.supportability}
+    assert {key: item.state for key, item in supportability.items()} == {
         "portfolio_positions": "ready",
         "issuer_enrichment": "partial",
         "issuer_grouping": "ready",
         "valuation_basis": "ready",
         "source_calculation": "ready",
     }
+    assert supportability["issuer_enrichment"].reason == (
+        "Two positions have no issuer enrichment."
+    )
+    assert supportability["issuer_grouping"].reason == (
+        "Ultimate Parent grouping with merge caller then core enrichment policy."
+    )
+    assert supportability["valuation_basis"].reason == (
+        "Total Market Value Base in USD / USD context."
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- refactor risk concentration response mapping into focused helper boundaries
- extract concentration mapping, malformed response, unavailable response, issuer supportability, valuation context, and source calculation supportability into risk_workspace_concentration.py
- refresh quality baseline evidence after reducing risk_workspace_service.py to 1,942 lines

## Validation
- python -m ruff format src\\app\\services\\risk_workspace_service.py src\\app\\services\\risk_workspace_concentration.py tests\\unit\\test_risk_workspace_service.py --check
- python -m ruff check src\\app\\services\\risk_workspace_service.py src\\app\\services\\risk_workspace_concentration.py tests\\unit\\test_risk_workspace_service.py
- python -m mypy src\\app\\services\\risk_workspace_service.py src\\app\\services\\risk_workspace_concentration.py
- python -m pytest tests\\unit\\test_risk_workspace_service.py -q (21 passed)
- make check (934 passed)
- make ci (207 integration passed; 1,141 coverage tests passed; coverage 92.64%; pip-audit no known vulnerabilities after governed PYSEC-2026-161 exception)
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway (DiffCount 0)

## Governance
- Experience API boundary preserved; lotus-risk remains concentration analytics authority.
- No OpenAPI route shape or public contract change.
- No wiki source change required; repo-local wiki is synchronized with published wiki.