### PR TITLE
Extract shared risk unavailable envelope helpers

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -36,7 +36,7 @@ report-only baseline is reviewed.
 The largest current modularity risks are:
 
 1. `src/app/services/portfolio_service.py` at 3,016 lines,
-2. `src/app/services/risk_workspace_service.py` at 1,942 lines,
+2. `src/app/services/risk_workspace_service.py` at 1,928 lines,
 3. `src/app/services/advisor_brief_service.py` at 1,392 lines,
 4. `src/app/services/performance_workspace_service.py` at 1,152 lines,
 5. `src/app/services/dpm_command_center_service.py` at 1,032 lines.
@@ -51,8 +51,11 @@ been split into period mapping, dependency context, supportability, state, metad
 fallback, and payload helpers. The risk attribution mapper has been split into period mapping,
 set/contributor parsing, state, metadata, and payload helpers. The risk concentration mapper has
 been extracted to `src/app/services/risk_workspace_concentration.py`, reducing
-`risk_workspace_service.py` to 1,942 lines while preserving source-owned concentration fields and
-supportability semantics. The current longest function is `_build_normalized_capabilities` in
+`risk_workspace_service.py` below 2,000 lines while preserving source-owned concentration fields
+and supportability semantics. Risk unavailable-envelope primitives have been centralized in
+`src/app/services/risk_workspace_envelopes.py` so upstream failure detail mapping, product-safe
+unavailable supportability, and risk metadata construction are no longer duplicated across risk
+surfaces. The current longest function is `_build_normalized_capabilities` in
 `src/app/services/platform_capabilities_service.py` at 195 lines.
 
 ## Progressive Enforcement

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -70,10 +70,10 @@ Current repo-native gates already cover:
 
 Most recent local evidence:
 
-1. `make check`: 934 unit/contract tests passed.
+1. `make check`: 938 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
-3. `make ci`: 1,141 coverage tests passed.
-4. Coverage: 92.64%.
+3. `make ci`: 1,145 coverage tests passed.
+4. Coverage: 92.65%.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -8,8 +8,8 @@ Baseline phase: report-only
 
 This baseline covers the current gateway hardening state after the report-only quality governance
 lane, router-registry split, performance workspace response split, and advisor-brief response
-split, risk drawdown mapper split, risk rolling mapper split, risk attribution mapper split, and
-risk concentration mapper extraction.
+split, risk drawdown mapper split, risk rolling mapper split, risk attribution mapper split,
+risk concentration mapper extraction, and shared risk unavailable-envelope helper extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -18,8 +18,8 @@ yet enforced unless they are already covered by existing repo-native gates.
 | Measure | Current value |
 | --- | ---: |
 | Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 645 |
-| Python source files under `src/app` | 431 |
-| Python test files under `tests` | 150 |
+| Python source files under `src/app` | 433 |
+| Python test files under `tests` | 151 |
 | OpenAPI paths | 170 |
 | OpenAPI operations | 170 |
 
@@ -30,7 +30,7 @@ yet enforced unless they are already covered by existing repo-native gates.
 | 1 | 3,016 | `src/app/services/portfolio_service.py` |
 | 2 | 2,226 | `src/app/contracts/portfolio.py` |
 | 3 | 2,043 | `src/app/contracts/risk_workspace.py` |
-| 4 | 1,942 | `src/app/services/risk_workspace_service.py` |
+| 4 | 1,928 | `src/app/services/risk_workspace_service.py` |
 | 5 | 1,840 | `src/app/contracts/reporting.py` |
 | 6 | 1,606 | `src/app/contracts/performance_workspace.py` |
 | 7 | 1,392 | `src/app/services/advisor_brief_service.py` |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -8,8 +8,10 @@ Phase: baseline/report-only
 Recent gateway hardening has reduced monolithic Workbench, router-registry, performance workspace,
 advisor-brief, risk drawdown, risk rolling, and risk attribution responsibilities by extracting
 focused service adapters and has extracted risk concentration response mapping behind a dedicated
-service module while preserving public behavior and keeping CI green. The remaining work is still
-substantial: large portfolio, risk workspace, contract, and client modules remain.
+service module. Shared risk unavailable-envelope helpers now centralize risk upstream failure
+detail mapping, risk-service unavailable supportability, and risk metadata construction while
+preserving public behavior and keeping CI green. The remaining work is still substantial: large
+portfolio, risk workspace, contract, and client modules remain.
 
 ## Health Signals
 
@@ -29,8 +31,9 @@ substantial: large portfolio, risk workspace, contract, and client modules remai
 
 1. Split `portfolio_service.py` into source-readiness, transaction/activity, income, workspace,
    and workflow-cue adapters.
-2. Continue splitting `risk_workspace_service.py` by risk surface, with shared unavailable-envelope
-   helpers as the next risk workspace target.
+2. Continue splitting `risk_workspace_service.py` by risk surface; the next risk workspace target
+   should be a bounded drawdown or rolling module extraction after the shared unavailable-envelope
+   helpers.
 3. Split `platform_capabilities_service.py` capability normalization into smaller adapters.
 4. Continue extracting performance workspace evidence and attribution helpers behind stable
    response contracts.

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -18,9 +18,9 @@ portfolio, risk workspace, contract, and client modules remain.
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
-| Unit/contract coverage | Healthy | 934 tests passed in `make check` for the router-registry split |
+| Unit/contract coverage | Healthy | 938 tests passed in latest `make check` evidence |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
-| Total coverage | Healthy | 92.63%, above the 84% floor |
+| Total coverage | Healthy | 92.65%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
 | Modularity | Improving, incomplete | Multiple service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |

--- a/src/app/services/risk_workspace_concentration.py
+++ b/src/app/services/risk_workspace_concentration.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from typing import Any, cast
 
 from app.contracts.risk_workspace import (
@@ -16,6 +15,11 @@ from app.contracts.risk_workspace import (
     WorkbenchSinglePositionConcentration,
 )
 from app.contracts.workbench import WorkbenchPartialFailure
+from app.services.risk_workspace_envelopes import (
+    risk_metadata,
+    risk_upstream_failure,
+    unavailable_risk_service_supportability,
+)
 from app.services.source_supportability import (
     extract_calculation_supportability,
     source_supportability_reason,
@@ -91,17 +95,16 @@ def unavailable_concentration(
         benchmark_code=benchmark_code,
         state="unavailable",
         payload=None,
-        supportability=[
-            WorkbenchRiskSupportabilityItem(
-                key="risk_service",
-                label="Risk service",
-                state="unavailable",
-                reason="lotus-risk concentration endpoint is unavailable.",
-                source_service="lotus-risk",
+        supportability=unavailable_risk_service_supportability(
+            reason="lotus-risk concentration endpoint is unavailable."
+        ),
+        warnings=["RISK_CONCENTRATION_UNAVAILABLE"],
+        partial_failures=[
+            risk_upstream_failure(
+                upstream_status=upstream_status,
+                upstream_payload=upstream_payload,
             )
         ],
-        warnings=["RISK_CONCENTRATION_UNAVAILABLE"],
-        partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
         metadata=_metadata(input_mode="stateful", cache_status="miss"),
     )
 
@@ -314,23 +317,9 @@ def _append_source_calculation_supportability(
     )
 
 
-def _upstream_failure(upstream_status: int, upstream_payload: Any) -> WorkbenchPartialFailure:
-    detail = (
-        str(upstream_payload.get("detail", upstream_payload))
-        if isinstance(upstream_payload, dict)
-        else str(upstream_payload)
-    )
-    return WorkbenchPartialFailure(
-        source_service="risk",
-        error_code=f"HTTP_{upstream_status}",
-        detail=detail,
-    )
-
-
 def _metadata(*, input_mode: str, cache_status: str) -> WorkbenchRiskMetadata:
-    return WorkbenchRiskMetadata(
-        generated_at=datetime.now(tz=UTC).isoformat(),
-        input_mode=cast(Any, input_mode),
-        cache_status=cast(Any, cache_status),
+    return risk_metadata(
+        input_mode=input_mode,
+        cache_status=cache_status,
         methodology_version="lotus-risk",
     )

--- a/src/app/services/risk_workspace_envelopes.py
+++ b/src/app/services/risk_workspace_envelopes.py
@@ -1,0 +1,54 @@
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from app.contracts.risk_workspace import (
+    WorkbenchRiskMetadata,
+    WorkbenchRiskSupportabilityItem,
+)
+from app.contracts.workbench import WorkbenchPartialFailure
+
+
+def risk_upstream_failure(
+    *,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> WorkbenchPartialFailure:
+    detail = (
+        str(upstream_payload.get("detail", upstream_payload))
+        if isinstance(upstream_payload, dict)
+        else str(upstream_payload)
+    )
+    return WorkbenchPartialFailure(
+        source_service="risk",
+        error_code=f"HTTP_{upstream_status}",
+        detail=detail,
+    )
+
+
+def unavailable_risk_service_supportability(
+    *,
+    reason: str,
+) -> list[WorkbenchRiskSupportabilityItem]:
+    return [
+        WorkbenchRiskSupportabilityItem(
+            key="risk_service",
+            label="Risk service",
+            state="unavailable",
+            reason=reason,
+            source_service="lotus-risk",
+        )
+    ]
+
+
+def risk_metadata(
+    *,
+    input_mode: str,
+    cache_status: str,
+    methodology_version: str | None = None,
+) -> WorkbenchRiskMetadata:
+    return WorkbenchRiskMetadata(
+        generated_at=datetime.now(tz=UTC).isoformat(),
+        input_mode=cast(Any, input_mode),
+        cache_status=cast(Any, cache_status),
+        methodology_version=methodology_version,
+    )

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, timedelta
 from numbers import Real
 from typing import Any, cast
 
@@ -61,6 +61,11 @@ from app.services.risk_workspace_attribution_controls import (
 from app.services.risk_workspace_concentration import (
     map_concentration_response,
     unavailable_concentration,
+)
+from app.services.risk_workspace_envelopes import (
+    risk_metadata,
+    risk_upstream_failure,
+    unavailable_risk_service_supportability,
 )
 from app.services.risk_workspace_requests import (
     SUMMARY_METRICS as _SUMMARY_METRICS,
@@ -1612,17 +1617,16 @@ def _unavailable_summary(
         benchmark_code=benchmark_code,
         state="unavailable",
         payload=None,
-        supportability=[
-            WorkbenchRiskSupportabilityItem(
-                key="risk_service",
-                label="Risk service",
-                state="unavailable",
-                reason="lotus-risk summary endpoint is unavailable.",
-                source_service="lotus-risk",
+        supportability=unavailable_risk_service_supportability(
+            reason="lotus-risk summary endpoint is unavailable."
+        ),
+        warnings=["RISK_SUMMARY_UNAVAILABLE"],
+        partial_failures=[
+            risk_upstream_failure(
+                upstream_status=upstream_status,
+                upstream_payload=upstream_payload,
             )
         ],
-        warnings=["RISK_SUMMARY_UNAVAILABLE"],
-        partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
         metadata=_metadata(input_mode="stateful", cache_status="miss"),
     )
 
@@ -1651,17 +1655,14 @@ def _unavailable_drawdown(
         benchmark_code=benchmark_code,
         state="unavailable",
         payload=None,
-        supportability=[
-            WorkbenchRiskSupportabilityItem(
-                key="risk_service",
-                label="Risk service",
-                state="unavailable",
-                reason=reason,
-                source_service="lotus-risk",
+        supportability=unavailable_risk_service_supportability(reason=reason),
+        warnings=["RISK_DRAWDOWN_UNAVAILABLE"],
+        partial_failures=[
+            risk_upstream_failure(
+                upstream_status=upstream_status,
+                upstream_payload=upstream_payload,
             )
         ],
-        warnings=["RISK_DRAWDOWN_UNAVAILABLE"],
-        partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
         metadata=_metadata(input_mode="stateful", cache_status="miss"),
     )
 
@@ -1690,17 +1691,14 @@ def _unavailable_rolling(
         benchmark_code=benchmark_code,
         state="unavailable",
         payload=None,
-        supportability=[
-            WorkbenchRiskSupportabilityItem(
-                key="risk_service",
-                label="Risk service",
-                state="unavailable",
-                reason=reason,
-                source_service="lotus-risk",
+        supportability=unavailable_risk_service_supportability(reason=reason),
+        warnings=["RISK_ROLLING_UNAVAILABLE"],
+        partial_failures=[
+            risk_upstream_failure(
+                upstream_status=upstream_status,
+                upstream_payload=upstream_payload,
             )
         ],
-        warnings=["RISK_ROLLING_UNAVAILABLE"],
-        partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
         metadata=_metadata(input_mode="stateful", cache_status="miss"),
     )
 
@@ -1738,30 +1736,18 @@ def _unavailable_attribution(
             grouping_dimension=grouping_dimension,
         ),
         warnings=["RISK_ATTRIBUTION_UNAVAILABLE"],
-        partial_failures=[_upstream_failure(upstream_status, upstream_payload)],
+        partial_failures=[
+            risk_upstream_failure(
+                upstream_status=upstream_status,
+                upstream_payload=upstream_payload,
+            )
+        ],
         metadata=_metadata(input_mode="stateful", cache_status="miss"),
     )
 
 
-def _upstream_failure(upstream_status: int, upstream_payload: Any) -> WorkbenchPartialFailure:
-    detail = (
-        str(upstream_payload.get("detail", upstream_payload))
-        if isinstance(upstream_payload, dict)
-        else str(upstream_payload)
-    )
-    return WorkbenchPartialFailure(
-        source_service="risk",
-        error_code=f"HTTP_{upstream_status}",
-        detail=detail,
-    )
-
-
 def _metadata(*, input_mode: str, cache_status: str) -> WorkbenchRiskMetadata:
-    return WorkbenchRiskMetadata(
-        generated_at=datetime.now(tz=UTC).isoformat(),
-        input_mode=cast(Any, input_mode),
-        cache_status=cast(Any, cache_status),
-    )
+    return risk_metadata(input_mode=input_mode, cache_status=cache_status)
 
 
 def _latest_business_day(today: date | None = None) -> date:

--- a/tests/unit/test_risk_workspace_envelopes.py
+++ b/tests/unit/test_risk_workspace_envelopes.py
@@ -1,0 +1,53 @@
+from app.services.risk_workspace_envelopes import (
+    risk_metadata,
+    risk_upstream_failure,
+    unavailable_risk_service_supportability,
+)
+
+
+def test_risk_upstream_failure_preserves_dict_detail() -> None:
+    failure = risk_upstream_failure(
+        upstream_status=503,
+        upstream_payload={"detail": "risk service unavailable", "debug": "not exposed"},
+    )
+
+    assert failure.source_service == "risk"
+    assert failure.error_code == "HTTP_503"
+    assert failure.detail == "risk service unavailable"
+
+
+def test_risk_upstream_failure_handles_non_dict_payload() -> None:
+    failure = risk_upstream_failure(
+        upstream_status=502,
+        upstream_payload="bad gateway",
+    )
+
+    assert failure.source_service == "risk"
+    assert failure.error_code == "HTTP_502"
+    assert failure.detail == "bad gateway"
+
+
+def test_unavailable_risk_service_supportability_is_product_safe() -> None:
+    supportability = unavailable_risk_service_supportability(
+        reason="lotus-risk rolling endpoint is unavailable."
+    )
+
+    assert len(supportability) == 1
+    assert supportability[0].key == "risk_service"
+    assert supportability[0].label == "Risk service"
+    assert supportability[0].state == "unavailable"
+    assert supportability[0].source_service == "lotus-risk"
+    assert supportability[0].reason == "lotus-risk rolling endpoint is unavailable."
+
+
+def test_risk_metadata_preserves_methodology_when_supplied() -> None:
+    metadata = risk_metadata(
+        input_mode="stateful",
+        cache_status="miss",
+        methodology_version="lotus-risk",
+    )
+
+    assert metadata.input_mode == "stateful"
+    assert metadata.cache_status == "miss"
+    assert metadata.methodology_version == "lotus-risk"
+    assert metadata.generated_at


### PR DESCRIPTION
## Summary
- centralize risk upstream failure detail mapping, product-safe unavailable supportability, and risk metadata construction in risk_workspace_envelopes.py
- wire summary, drawdown, rolling, attribution, and concentration unavailable paths through shared helpers while preserving public response shapes
- add direct unit coverage for the shared risk envelope helpers
- refresh quality baseline evidence after reducing risk_workspace_service.py to 1,928 lines

## Validation
- python -m ruff format src\\app\\services\\risk_workspace_service.py src\\app\\services\\risk_workspace_concentration.py src\\app\\services\\risk_workspace_envelopes.py tests\\unit\\test_risk_workspace_service.py --check
- python -m ruff check src\\app\\services\\risk_workspace_service.py src\\app\\services\\risk_workspace_concentration.py src\\app\\services\\risk_workspace_envelopes.py tests\\unit\\test_risk_workspace_service.py
- python -m mypy src\\app\\services\\risk_workspace_service.py src\\app\\services\\risk_workspace_concentration.py src\\app\\services\\risk_workspace_envelopes.py
- python -m pytest tests\\unit\\test_risk_workspace_envelopes.py tests\\unit\\test_risk_workspace_service.py -q (25 passed)
- make check (938 passed)
- make ci (207 integration passed; 1,145 coverage tests passed; coverage 92.65%; pip-audit no known vulnerabilities after governed PYSEC-2026-161 exception)
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway (DiffCount 0)

## Governance
- Experience API behavior is preserved; lotus-risk remains the risk analytics authority.
- No OpenAPI route shape or public contract change.
- No wiki source change required; repo-local wiki is synchronized with published wiki.