### PR TITLE
Extract risk drawdown response module

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -36,7 +36,7 @@ report-only baseline is reviewed.
 The largest current modularity risks are:
 
 1. `src/app/services/portfolio_service.py` at 3,016 lines,
-2. `src/app/services/risk_workspace_service.py` at 1,928 lines,
+2. `src/app/services/risk_workspace_service.py` at 1,594 lines,
 3. `src/app/services/advisor_brief_service.py` at 1,392 lines,
 4. `src/app/services/performance_workspace_service.py` at 1,152 lines,
 5. `src/app/services/dpm_command_center_service.py` at 1,032 lines.
@@ -55,7 +55,10 @@ been extracted to `src/app/services/risk_workspace_concentration.py`, reducing
 and supportability semantics. Risk unavailable-envelope primitives have been centralized in
 `src/app/services/risk_workspace_envelopes.py` so upstream failure detail mapping, product-safe
 unavailable supportability, and risk metadata construction are no longer duplicated across risk
-surfaces. The current longest function is `_build_normalized_capabilities` in
+surfaces. The drawdown response mapper and unavailable envelope have been extracted to
+`src/app/services/risk_workspace_drawdown.py`, reducing `risk_workspace_service.py` to 1,594 lines
+while keeping request orchestration and caching in the workspace service. The current longest
+function is `_build_normalized_capabilities` in
 `src/app/services/platform_capabilities_service.py` at 195 lines.
 
 ## Progressive Enforcement

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -9,7 +9,8 @@ Baseline phase: report-only
 This baseline covers the current gateway hardening state after the report-only quality governance
 lane, router-registry split, performance workspace response split, and advisor-brief response
 split, risk drawdown mapper split, risk rolling mapper split, risk attribution mapper split,
-risk concentration mapper extraction, and shared risk unavailable-envelope helper extraction.
+risk concentration mapper extraction, shared risk unavailable-envelope helper extraction, and
+risk drawdown response module extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -17,8 +18,8 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 645 |
-| Python source files under `src/app` | 433 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 646 |
+| Python source files under `src/app` | 434 |
 | Python test files under `tests` | 151 |
 | OpenAPI paths | 170 |
 | OpenAPI operations | 170 |
@@ -30,9 +31,9 @@ yet enforced unless they are already covered by existing repo-native gates.
 | 1 | 3,016 | `src/app/services/portfolio_service.py` |
 | 2 | 2,226 | `src/app/contracts/portfolio.py` |
 | 3 | 2,043 | `src/app/contracts/risk_workspace.py` |
-| 4 | 1,928 | `src/app/services/risk_workspace_service.py` |
-| 5 | 1,840 | `src/app/contracts/reporting.py` |
-| 6 | 1,606 | `src/app/contracts/performance_workspace.py` |
+| 4 | 1,840 | `src/app/contracts/reporting.py` |
+| 5 | 1,606 | `src/app/contracts/performance_workspace.py` |
+| 6 | 1,594 | `src/app/services/risk_workspace_service.py` |
 | 7 | 1,392 | `src/app/services/advisor_brief_service.py` |
 | 8 | 1,362 | `src/app/clients/dpm_client.py` |
 | 9 | 1,152 | `src/app/services/performance_workspace_service.py` |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -10,8 +10,10 @@ advisor-brief, risk drawdown, risk rolling, and risk attribution responsibilitie
 focused service adapters and has extracted risk concentration response mapping behind a dedicated
 service module. Shared risk unavailable-envelope helpers now centralize risk upstream failure
 detail mapping, risk-service unavailable supportability, and risk metadata construction while
-preserving public behavior and keeping CI green. The remaining work is still substantial: large
-portfolio, risk workspace, contract, and client modules remain.
+preserving public behavior and keeping CI green. The risk drawdown response mapper has now been
+extracted to a dedicated drawdown module, reducing `risk_workspace_service.py` to 1,594 lines while
+leaving request orchestration and cache semantics in the workspace service. The remaining work is
+still substantial: large portfolio, risk workspace, contract, and client modules remain.
 
 ## Health Signals
 
@@ -32,8 +34,8 @@ portfolio, risk workspace, contract, and client modules remain.
 1. Split `portfolio_service.py` into source-readiness, transaction/activity, income, workspace,
    and workflow-cue adapters.
 2. Continue splitting `risk_workspace_service.py` by risk surface; the next risk workspace target
-   should be a bounded drawdown or rolling module extraction after the shared unavailable-envelope
-   helpers.
+   should be a bounded rolling module extraction after the shared unavailable-envelope and
+   drawdown-module helpers.
 3. Split `platform_capabilities_service.py` capability normalization into smaller adapters.
 4. Continue extracting performance workspace evidence and attribution helpers behind stable
    response contracts.

--- a/src/app/services/risk_workspace_drawdown.py
+++ b/src/app/services/risk_workspace_drawdown.py
@@ -1,0 +1,381 @@
+from dataclasses import dataclass
+from typing import Any, cast
+
+from app.contracts.risk_workspace import (
+    RiskModuleState,
+    RiskSupportabilityState,
+    WorkbenchRiskDrawdownAnalysisContext,
+    WorkbenchRiskDrawdownEpisode,
+    WorkbenchRiskDrawdownPayload,
+    WorkbenchRiskDrawdownPeriodResult,
+    WorkbenchRiskDrawdownResponse,
+    WorkbenchRiskDrawdownSummary,
+    WorkbenchRiskMetadata,
+    WorkbenchRiskRelativeDrawdownContext,
+    WorkbenchRiskRelativeDrawdownSummary,
+    WorkbenchRiskSupportabilityItem,
+    WorkbenchRiskUnderwaterPoint,
+)
+from app.contracts.workbench import WorkbenchPartialFailure
+from app.services.risk_workspace_envelopes import (
+    risk_metadata,
+    risk_upstream_failure,
+    unavailable_risk_service_supportability,
+)
+from app.services.source_supportability import (
+    extract_calculation_supportability,
+    source_supportability_reason,
+)
+
+_DRAWDOWN_SUPPORTABILITY_KEY_BENCHMARK = "benchmark_relative_drawdown"
+
+
+@dataclass(frozen=True)
+class DrawdownMappingResult:
+    periods: list[WorkbenchRiskDrawdownPeriodResult]
+    warnings: list[str]
+    partial_failures: list[WorkbenchPartialFailure]
+    benchmark_supportability_state: RiskSupportabilityState
+    benchmark_supportability_reason: str | None
+    underwater_supportability_state: RiskSupportabilityState
+    underwater_supportability_reason: str | None
+
+
+def map_drawdown_response(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    include_underwater_series: bool,
+    upstream_payload: dict[str, Any],
+) -> WorkbenchRiskDrawdownResponse:
+    results = upstream_payload.get("results")
+    mapping = _map_drawdown_period_results(
+        results=results,
+        benchmark_code=benchmark_code,
+        include_underwater_series=include_underwater_series,
+    )
+    supportability = _build_drawdown_supportability(
+        results=results,
+        mapping=mapping,
+    )
+    _append_source_calculation_supportability(
+        supportability=supportability,
+        upstream_payload=upstream_payload,
+    )
+
+    upstream_metadata = upstream_payload.get("metadata")
+    state, warnings, partial_failures = _resolve_drawdown_state(
+        period_results=mapping.periods,
+        supportability=supportability,
+        warnings=mapping.warnings,
+        partial_failures=mapping.partial_failures,
+    )
+
+    return WorkbenchRiskDrawdownResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state=state,
+        payload=_build_drawdown_payload(
+            period_results=mapping.periods,
+            upstream_metadata=upstream_metadata,
+        ),
+        supportability=supportability,
+        warnings=sorted(set(warnings)),
+        partial_failures=partial_failures,
+        metadata=_build_drawdown_metadata(upstream_metadata=upstream_metadata),
+    )
+
+
+def unavailable_drawdown(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    include_underwater_series: bool,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> WorkbenchRiskDrawdownResponse:
+    reason = (
+        "lotus-risk drawdown endpoint is unavailable."
+        if not include_underwater_series
+        else "lotus-risk drawdown detail endpoint is unavailable."
+    )
+    return WorkbenchRiskDrawdownResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="unavailable",
+        payload=None,
+        supportability=unavailable_risk_service_supportability(reason=reason),
+        warnings=["RISK_DRAWDOWN_UNAVAILABLE"],
+        partial_failures=[
+            risk_upstream_failure(
+                upstream_status=upstream_status,
+                upstream_payload=upstream_payload,
+            )
+        ],
+        metadata=risk_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def _map_drawdown_period_results(
+    *,
+    results: Any,
+    benchmark_code: str | None,
+    include_underwater_series: bool,
+) -> DrawdownMappingResult:
+    warnings: list[str] = []
+    partial_failures: list[WorkbenchPartialFailure] = []
+    period_results: list[WorkbenchRiskDrawdownPeriodResult] = []
+    benchmark_state: RiskSupportabilityState = "unavailable"
+    benchmark_reason: str | None = None
+    underwater_state: RiskSupportabilityState = (
+        "partial" if not include_underwater_series else "unavailable"
+    )
+    underwater_reason = (
+        "Underwater series is available on demand and is not included in first paint."
+        if not include_underwater_series
+        else None
+    )
+
+    if isinstance(results, dict):
+        for key, value in results.items():
+            if not isinstance(value, dict):
+                continue
+            period = _map_drawdown_period_result(key=key, value=value)
+            benchmark_state, benchmark_reason = _resolve_drawdown_benchmark_supportability(
+                benchmark_code=benchmark_code,
+                relative_to_benchmark=period.relative_to_benchmark,
+                error=value.get("error"),
+            )
+            if include_underwater_series:
+                underwater_state, underwater_reason = _resolve_underwater_supportability(
+                    underwater_series=period.underwater_series,
+                )
+            if period.error:
+                partial_failures.append(
+                    WorkbenchPartialFailure(
+                        source_service="risk",
+                        error_code="DRAWDOWN_PERIOD_ERROR",
+                        detail=f"{key}: {period.error}",
+                    )
+                )
+                warnings.append("RISK_DRAWDOWN_PERIOD_PARTIAL")
+            period_results.append(period)
+
+    return DrawdownMappingResult(
+        periods=period_results,
+        warnings=warnings,
+        partial_failures=partial_failures,
+        benchmark_supportability_state=benchmark_state,
+        benchmark_supportability_reason=benchmark_reason,
+        underwater_supportability_state=underwater_state,
+        underwater_supportability_reason=underwater_reason,
+    )
+
+
+def _map_drawdown_period_result(
+    *,
+    key: Any,
+    value: dict[str, Any],
+) -> WorkbenchRiskDrawdownPeriodResult:
+    summary_payload = value.get("summary")
+    episodes_payload = value.get("episodes")
+    relative_payload = value.get("relative_to_benchmark")
+    underwater_payload = value.get("underwater_series")
+    error = value.get("error")
+
+    return WorkbenchRiskDrawdownPeriodResult(
+        key=str(key),
+        label=str(key),
+        start_date=str(value.get("start_date", "")),
+        end_date=str(value.get("end_date", "")),
+        portfolio_observation_count=int(value.get("portfolio_observation_count", 0)),
+        benchmark_observation_count=int(value.get("benchmark_observation_count", 0)),
+        summary=(
+            _map_drawdown_summary(summary_payload) if isinstance(summary_payload, dict) else None
+        ),
+        episodes=(
+            _map_drawdown_episodes(episodes_payload) if isinstance(episodes_payload, list) else []
+        ),
+        relative_to_benchmark=(
+            WorkbenchRiskRelativeDrawdownSummary.model_validate(relative_payload)
+            if isinstance(relative_payload, dict)
+            else None
+        ),
+        relative_to_benchmark_context=(
+            WorkbenchRiskRelativeDrawdownContext.model_validate(
+                value.get("relative_to_benchmark_context")
+            )
+            if isinstance(value.get("relative_to_benchmark_context"), dict)
+            else None
+        ),
+        underwater_series=(
+            _map_underwater_series(underwater_payload)
+            if isinstance(underwater_payload, list)
+            else None
+        ),
+        error=str(error) if isinstance(error, str) and error.strip() else None,
+    )
+
+
+def _resolve_drawdown_benchmark_supportability(
+    *,
+    benchmark_code: str | None,
+    relative_to_benchmark: WorkbenchRiskRelativeDrawdownSummary | None,
+    error: Any,
+) -> tuple[RiskSupportabilityState, str | None]:
+    if not benchmark_code:
+        return "partial", "Benchmark-relative drawdown requires benchmark context."
+    if relative_to_benchmark is not None:
+        return "ready", None
+    if isinstance(error, str) and error.strip():
+        return "partial", error
+    return "partial", "Benchmark-relative drawdown was not returned by lotus-risk."
+
+
+def _resolve_underwater_supportability(
+    *,
+    underwater_series: list[WorkbenchRiskUnderwaterPoint] | None,
+) -> tuple[RiskSupportabilityState, str | None]:
+    if underwater_series is not None:
+        return "ready", None
+    return "partial", "Underwater series detail was requested but not returned by lotus-risk."
+
+
+def _build_drawdown_supportability(
+    *,
+    results: Any,
+    mapping: DrawdownMappingResult,
+) -> list[WorkbenchRiskSupportabilityItem]:
+    return [
+        WorkbenchRiskSupportabilityItem(
+            key="portfolio_returns",
+            label="Portfolio returns",
+            state="ready" if isinstance(results, dict) and results else "unavailable",
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key=_DRAWDOWN_SUPPORTABILITY_KEY_BENCHMARK,
+            label="Benchmark-relative drawdown",
+            state=mapping.benchmark_supportability_state,
+            reason=mapping.benchmark_supportability_reason,
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="underwater_series",
+            label="Underwater series",
+            state=mapping.underwater_supportability_state,
+            reason=mapping.underwater_supportability_reason,
+            source_service="lotus-risk",
+        ),
+    ]
+
+
+def _resolve_drawdown_state(
+    *,
+    period_results: list[WorkbenchRiskDrawdownPeriodResult],
+    supportability: list[WorkbenchRiskSupportabilityItem],
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+) -> tuple[RiskModuleState, list[str], list[WorkbenchPartialFailure]]:
+    resolved_warnings = list(warnings)
+    resolved_partial_failures = list(partial_failures)
+    state: RiskModuleState = (
+        "partial" if any(item.state != "ready" for item in supportability) else "ready"
+    )
+    if not period_results:
+        state = "unavailable"
+        resolved_warnings.append("RISK_DRAWDOWN_EMPTY")
+        resolved_partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="risk",
+                error_code="EMPTY_RISK_DRAWDOWN",
+                detail="lotus-risk returned no drawdown periods.",
+            )
+        )
+    elif all(period.summary is None for period in period_results):
+        state = "unavailable"
+    return state, resolved_warnings, resolved_partial_failures
+
+
+def _build_drawdown_metadata(*, upstream_metadata: Any) -> WorkbenchRiskMetadata:
+    metadata = risk_metadata(input_mode="stateful", cache_status="miss")
+    if isinstance(upstream_metadata, dict):
+        methodology_version = upstream_metadata.get("methodology_version")
+        if isinstance(methodology_version, str) and methodology_version.strip():
+            return metadata.model_copy(update={"methodology_version": methodology_version})
+    return metadata
+
+
+def _build_drawdown_payload(
+    *,
+    period_results: list[WorkbenchRiskDrawdownPeriodResult],
+    upstream_metadata: Any,
+) -> WorkbenchRiskDrawdownPayload | None:
+    if not period_results:
+        return None
+    return WorkbenchRiskDrawdownPayload(
+        periods=period_results,
+        analysis_context=(
+            WorkbenchRiskDrawdownAnalysisContext.model_validate(upstream_metadata)
+            if isinstance(upstream_metadata, dict)
+            else None
+        ),
+    )
+
+
+def _append_source_calculation_supportability(
+    *,
+    supportability: list[WorkbenchRiskSupportabilityItem],
+    upstream_payload: dict[str, Any],
+) -> None:
+    source_supportability = extract_calculation_supportability(upstream_payload)
+    if source_supportability is None:
+        return
+
+    supportability.append(
+        WorkbenchRiskSupportabilityItem(
+            key="source_calculation",
+            label="Source calculation",
+            state=cast(Any, source_supportability.risk_contract_state),
+            reason=source_supportability_reason(
+                source_supportability,
+                default_ready_reason="Source calculation supportability was confirmed upstream.",
+            ),
+            source_service=source_supportability.source_service or "lotus-risk",
+        )
+    )
+
+
+def _map_drawdown_summary(summary_payload: dict[str, Any]) -> WorkbenchRiskDrawdownSummary:
+    return WorkbenchRiskDrawdownSummary.model_validate(summary_payload)
+
+
+def _map_drawdown_episodes(episodes_payload: list[Any]) -> list[WorkbenchRiskDrawdownEpisode]:
+    episodes: list[WorkbenchRiskDrawdownEpisode] = []
+    for payload in episodes_payload:
+        if not isinstance(payload, dict):
+            continue
+        episodes.append(WorkbenchRiskDrawdownEpisode.model_validate(payload))
+    episodes.sort(key=lambda episode: episode.depth)
+    return episodes
+
+
+def _map_underwater_series(series_payload: list[Any]) -> list[WorkbenchRiskUnderwaterPoint]:
+    points: list[WorkbenchRiskUnderwaterPoint] = []
+    for payload in series_payload:
+        if not isinstance(payload, dict):
+            continue
+        points.append(WorkbenchRiskUnderwaterPoint.model_validate(payload))
+    return points

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -8,7 +8,6 @@ from fastapi import status
 from app.config import settings
 from app.contracts.risk_workspace import (
     RiskModuleState,
-    RiskSupportabilityState,
     WorkbenchRiskAttributionContributor,
     WorkbenchRiskAttributionControls,
     WorkbenchRiskAttributionMethodologyContext,
@@ -17,17 +16,10 @@ from app.contracts.risk_workspace import (
     WorkbenchRiskAttributionResponse,
     WorkbenchRiskAttributionSet,
     WorkbenchRiskConcentrationResponse,
-    WorkbenchRiskDrawdownAnalysisContext,
-    WorkbenchRiskDrawdownEpisode,
-    WorkbenchRiskDrawdownPayload,
-    WorkbenchRiskDrawdownPeriodResult,
     WorkbenchRiskDrawdownResponse,
-    WorkbenchRiskDrawdownSummary,
     WorkbenchRiskMetadata,
     WorkbenchRiskMetric,
     WorkbenchRiskPeriodResult,
-    WorkbenchRiskRelativeDrawdownContext,
-    WorkbenchRiskRelativeDrawdownSummary,
     WorkbenchRiskRollingDependencyContext,
     WorkbenchRiskRollingMetricSeriesContext,
     WorkbenchRiskRollingMetricSeriesPoint,
@@ -40,7 +32,6 @@ from app.contracts.risk_workspace import (
     WorkbenchRiskSummaryPayload,
     WorkbenchRiskSummaryResponse,
     WorkbenchRiskSupportabilityItem,
-    WorkbenchRiskUnderwaterPoint,
 )
 from app.contracts.workbench import WorkbenchPartialFailure
 from app.services.async_ttl_cache import AsyncTtlCache
@@ -61,6 +52,10 @@ from app.services.risk_workspace_attribution_controls import (
 from app.services.risk_workspace_concentration import (
     map_concentration_response,
     unavailable_concentration,
+)
+from app.services.risk_workspace_drawdown import (
+    map_drawdown_response,
+    unavailable_drawdown,
 )
 from app.services.risk_workspace_envelopes import (
     risk_metadata,
@@ -87,7 +82,6 @@ from app.services.source_supportability import (
 
 _BENCHMARK_DEPENDENT_METRICS = {"BETA", "TRACKING_ERROR", "INFORMATION_RATIO"}
 _RISK_FREE_DEPENDENT_METRICS = {"SHARPE"}
-_DRAWDOWN_SUPPORTABILITY_KEY_BENCHMARK = "benchmark_relative_drawdown"
 _ROLLING_METRIC_LABELS = {
     "ROLLING_VOLATILITY": "Rolling Volatility",
     "ROLLING_SHARPE": "Rolling Sharpe",
@@ -106,17 +100,6 @@ _METRIC_LABELS = {
     "INFORMATION_RATIO": "Information Ratio",
     "VAR": "Value at Risk",
 }
-
-
-@dataclass(frozen=True)
-class DrawdownMappingResult:
-    periods: list[WorkbenchRiskDrawdownPeriodResult]
-    warnings: list[str]
-    partial_failures: list[WorkbenchPartialFailure]
-    benchmark_supportability_state: RiskSupportabilityState
-    benchmark_supportability_reason: str | None
-    underwater_supportability_state: RiskSupportabilityState
-    underwater_supportability_reason: str | None
 
 
 @dataclass(frozen=True)
@@ -339,7 +322,7 @@ class RiskWorkspaceService:
             if upstream_status >= status.HTTP_400_BAD_REQUEST or not isinstance(
                 upstream_payload, dict
             ):
-                return _unavailable_drawdown(
+                return unavailable_drawdown(
                     correlation_id=correlation_id,
                     portfolio_id=portfolio_id,
                     period=period,
@@ -349,7 +332,7 @@ class RiskWorkspaceService:
                     upstream_status=upstream_status,
                     upstream_payload=upstream_payload,
                 )
-            return _map_drawdown_response(
+            return map_drawdown_response(
                 correlation_id=correlation_id,
                 portfolio_id=portfolio_id,
                 period=period,
@@ -744,264 +727,6 @@ def _metric_dependency_supportability(
             source_service="lotus-risk",
         ),
     ]
-
-
-def _map_drawdown_response(
-    *,
-    correlation_id: str,
-    portfolio_id: str,
-    period: str,
-    as_of_date: str,
-    benchmark_code: str | None,
-    include_underwater_series: bool,
-    upstream_payload: dict[str, Any],
-) -> WorkbenchRiskDrawdownResponse:
-    results = upstream_payload.get("results")
-    mapping = _map_drawdown_period_results(
-        results=results,
-        benchmark_code=benchmark_code,
-        include_underwater_series=include_underwater_series,
-    )
-    supportability = _build_drawdown_supportability(
-        results=results,
-        mapping=mapping,
-    )
-    _append_source_calculation_supportability(
-        supportability=supportability,
-        upstream_payload=upstream_payload,
-    )
-
-    upstream_metadata = upstream_payload.get("metadata")
-    state, warnings, partial_failures = _resolve_drawdown_state(
-        period_results=mapping.periods,
-        supportability=supportability,
-        warnings=mapping.warnings,
-        partial_failures=mapping.partial_failures,
-    )
-
-    return WorkbenchRiskDrawdownResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state=state,
-        payload=_build_drawdown_payload(
-            period_results=mapping.periods,
-            upstream_metadata=upstream_metadata,
-        ),
-        supportability=supportability,
-        warnings=sorted(set(warnings)),
-        partial_failures=partial_failures,
-        metadata=_build_drawdown_metadata(upstream_metadata=upstream_metadata),
-    )
-
-
-def _map_drawdown_period_results(
-    *,
-    results: Any,
-    benchmark_code: str | None,
-    include_underwater_series: bool,
-) -> DrawdownMappingResult:
-    warnings: list[str] = []
-    partial_failures: list[WorkbenchPartialFailure] = []
-    period_results: list[WorkbenchRiskDrawdownPeriodResult] = []
-    benchmark_state: RiskSupportabilityState = "unavailable"
-    benchmark_reason: str | None = None
-    underwater_state: RiskSupportabilityState = (
-        "partial" if not include_underwater_series else "unavailable"
-    )
-    underwater_reason = (
-        "Underwater series is available on demand and is not included in first paint."
-        if not include_underwater_series
-        else None
-    )
-
-    if isinstance(results, dict):
-        for key, value in results.items():
-            if not isinstance(value, dict):
-                continue
-            period = _map_drawdown_period_result(key=key, value=value)
-            benchmark_state, benchmark_reason = _resolve_drawdown_benchmark_supportability(
-                benchmark_code=benchmark_code,
-                relative_to_benchmark=period.relative_to_benchmark,
-                error=value.get("error"),
-            )
-            if include_underwater_series:
-                underwater_state, underwater_reason = _resolve_underwater_supportability(
-                    underwater_series=period.underwater_series,
-                )
-            if period.error:
-                partial_failures.append(
-                    WorkbenchPartialFailure(
-                        source_service="risk",
-                        error_code="DRAWDOWN_PERIOD_ERROR",
-                        detail=f"{key}: {period.error}",
-                    )
-                )
-                warnings.append("RISK_DRAWDOWN_PERIOD_PARTIAL")
-            period_results.append(period)
-
-    return DrawdownMappingResult(
-        periods=period_results,
-        warnings=warnings,
-        partial_failures=partial_failures,
-        benchmark_supportability_state=benchmark_state,
-        benchmark_supportability_reason=benchmark_reason,
-        underwater_supportability_state=underwater_state,
-        underwater_supportability_reason=underwater_reason,
-    )
-
-
-def _map_drawdown_period_result(
-    *,
-    key: Any,
-    value: dict[str, Any],
-) -> WorkbenchRiskDrawdownPeriodResult:
-    summary_payload = value.get("summary")
-    episodes_payload = value.get("episodes")
-    relative_payload = value.get("relative_to_benchmark")
-    underwater_payload = value.get("underwater_series")
-    error = value.get("error")
-
-    return WorkbenchRiskDrawdownPeriodResult(
-        key=str(key),
-        label=str(key),
-        start_date=str(value.get("start_date", "")),
-        end_date=str(value.get("end_date", "")),
-        portfolio_observation_count=int(value.get("portfolio_observation_count", 0)),
-        benchmark_observation_count=int(value.get("benchmark_observation_count", 0)),
-        summary=(
-            _map_drawdown_summary(summary_payload) if isinstance(summary_payload, dict) else None
-        ),
-        episodes=(
-            _map_drawdown_episodes(episodes_payload) if isinstance(episodes_payload, list) else []
-        ),
-        relative_to_benchmark=(
-            WorkbenchRiskRelativeDrawdownSummary.model_validate(relative_payload)
-            if isinstance(relative_payload, dict)
-            else None
-        ),
-        relative_to_benchmark_context=(
-            WorkbenchRiskRelativeDrawdownContext.model_validate(
-                value.get("relative_to_benchmark_context")
-            )
-            if isinstance(value.get("relative_to_benchmark_context"), dict)
-            else None
-        ),
-        underwater_series=(
-            _map_underwater_series(underwater_payload)
-            if isinstance(underwater_payload, list)
-            else None
-        ),
-        error=str(error) if isinstance(error, str) and error.strip() else None,
-    )
-
-
-def _resolve_drawdown_benchmark_supportability(
-    *,
-    benchmark_code: str | None,
-    relative_to_benchmark: WorkbenchRiskRelativeDrawdownSummary | None,
-    error: Any,
-) -> tuple[RiskSupportabilityState, str | None]:
-    if not benchmark_code:
-        return "partial", "Benchmark-relative drawdown requires benchmark context."
-    if relative_to_benchmark is not None:
-        return "ready", None
-    if isinstance(error, str) and error.strip():
-        return "partial", error
-    return "partial", "Benchmark-relative drawdown was not returned by lotus-risk."
-
-
-def _resolve_underwater_supportability(
-    *,
-    underwater_series: list[WorkbenchRiskUnderwaterPoint] | None,
-) -> tuple[RiskSupportabilityState, str | None]:
-    if underwater_series is not None:
-        return "ready", None
-    return "partial", "Underwater series detail was requested but not returned by lotus-risk."
-
-
-def _build_drawdown_supportability(
-    *,
-    results: Any,
-    mapping: DrawdownMappingResult,
-) -> list[WorkbenchRiskSupportabilityItem]:
-    return [
-        WorkbenchRiskSupportabilityItem(
-            key="portfolio_returns",
-            label="Portfolio returns",
-            state="ready" if isinstance(results, dict) and results else "unavailable",
-            source_service="lotus-risk",
-        ),
-        WorkbenchRiskSupportabilityItem(
-            key=_DRAWDOWN_SUPPORTABILITY_KEY_BENCHMARK,
-            label="Benchmark-relative drawdown",
-            state=mapping.benchmark_supportability_state,
-            reason=mapping.benchmark_supportability_reason,
-            source_service="lotus-risk",
-        ),
-        WorkbenchRiskSupportabilityItem(
-            key="underwater_series",
-            label="Underwater series",
-            state=mapping.underwater_supportability_state,
-            reason=mapping.underwater_supportability_reason,
-            source_service="lotus-risk",
-        ),
-    ]
-
-
-def _resolve_drawdown_state(
-    *,
-    period_results: list[WorkbenchRiskDrawdownPeriodResult],
-    supportability: list[WorkbenchRiskSupportabilityItem],
-    warnings: list[str],
-    partial_failures: list[WorkbenchPartialFailure],
-) -> tuple[RiskModuleState, list[str], list[WorkbenchPartialFailure]]:
-    resolved_warnings = list(warnings)
-    resolved_partial_failures = list(partial_failures)
-    state: RiskModuleState = (
-        "partial" if any(item.state != "ready" for item in supportability) else "ready"
-    )
-    if not period_results:
-        state = "unavailable"
-        resolved_warnings.append("RISK_DRAWDOWN_EMPTY")
-        resolved_partial_failures.append(
-            WorkbenchPartialFailure(
-                source_service="risk",
-                error_code="EMPTY_RISK_DRAWDOWN",
-                detail="lotus-risk returned no drawdown periods.",
-            )
-        )
-    elif all(period.summary is None for period in period_results):
-        state = "unavailable"
-    return state, resolved_warnings, resolved_partial_failures
-
-
-def _build_drawdown_metadata(*, upstream_metadata: Any) -> WorkbenchRiskMetadata:
-    metadata = _metadata(input_mode="stateful", cache_status="miss")
-    if isinstance(upstream_metadata, dict):
-        methodology_version = upstream_metadata.get("methodology_version")
-        if isinstance(methodology_version, str) and methodology_version.strip():
-            return metadata.model_copy(update={"methodology_version": methodology_version})
-    return metadata
-
-
-def _build_drawdown_payload(
-    *,
-    period_results: list[WorkbenchRiskDrawdownPeriodResult],
-    upstream_metadata: Any,
-) -> WorkbenchRiskDrawdownPayload | None:
-    if not period_results:
-        return None
-    return WorkbenchRiskDrawdownPayload(
-        periods=period_results,
-        analysis_context=(
-            WorkbenchRiskDrawdownAnalysisContext.model_validate(upstream_metadata)
-            if isinstance(upstream_metadata, dict)
-            else None
-        ),
-    )
 
 
 def _map_rolling_response(
@@ -1631,42 +1356,6 @@ def _unavailable_summary(
     )
 
 
-def _unavailable_drawdown(
-    *,
-    correlation_id: str,
-    portfolio_id: str,
-    period: str,
-    as_of_date: str,
-    benchmark_code: str | None,
-    include_underwater_series: bool,
-    upstream_status: int,
-    upstream_payload: Any,
-) -> WorkbenchRiskDrawdownResponse:
-    reason = (
-        "lotus-risk drawdown endpoint is unavailable."
-        if not include_underwater_series
-        else "lotus-risk drawdown detail endpoint is unavailable."
-    )
-    return WorkbenchRiskDrawdownResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state="unavailable",
-        payload=None,
-        supportability=unavailable_risk_service_supportability(reason=reason),
-        warnings=["RISK_DRAWDOWN_UNAVAILABLE"],
-        partial_failures=[
-            risk_upstream_failure(
-                upstream_status=upstream_status,
-                upstream_payload=upstream_payload,
-            )
-        ],
-        metadata=_metadata(input_mode="stateful", cache_status="miss"),
-    )
-
-
 def _unavailable_rolling(
     *,
     correlation_id: str,
@@ -1778,29 +1467,6 @@ def _build_risk_periods(
         report_start_date=report_start_date,
         report_end_date=report_end_date,
     )
-
-
-def _map_drawdown_summary(summary_payload: dict[str, Any]) -> WorkbenchRiskDrawdownSummary:
-    return WorkbenchRiskDrawdownSummary.model_validate(summary_payload)
-
-
-def _map_drawdown_episodes(episodes_payload: list[Any]) -> list[WorkbenchRiskDrawdownEpisode]:
-    episodes: list[WorkbenchRiskDrawdownEpisode] = []
-    for payload in episodes_payload:
-        if not isinstance(payload, dict):
-            continue
-        episodes.append(WorkbenchRiskDrawdownEpisode.model_validate(payload))
-    episodes.sort(key=lambda episode: episode.depth)
-    return episodes
-
-
-def _map_underwater_series(series_payload: list[Any]) -> list[WorkbenchRiskUnderwaterPoint]:
-    points: list[WorkbenchRiskUnderwaterPoint] = []
-    for payload in series_payload:
-        if not isinstance(payload, dict):
-            continue
-        points.append(WorkbenchRiskUnderwaterPoint.model_validate(payload))
-    return points
 
 
 def _map_rolling_window_results(window_payload: Any) -> list[WorkbenchRiskRollingWindowResult]:


### PR DESCRIPTION
## Summary
- Extract risk drawdown response mapping, supportability, metadata, and unavailable-envelope handling into `risk_workspace_drawdown.py`.
- Keep `RiskWorkspaceService.get_drawdown` responsible for request construction, upstream orchestration, caching, and correlation refresh.
- Refresh quality baseline and architecture ledger to record `risk_workspace_service.py` reduced to 1,594 lines and the next risk workspace target as rolling extraction.

## Validation
- `python -m ruff format src\app\services\risk_workspace_service.py src\app\services\risk_workspace_drawdown.py --check`
- `python -m ruff check src\app\services\risk_workspace_service.py src\app\services\risk_workspace_drawdown.py`
- `python -m mypy src\app\services\risk_workspace_service.py src\app\services\risk_workspace_drawdown.py`
- `python -m pytest tests\unit\test_risk_workspace_service.py tests\unit\test_risk_workspace_envelopes.py -q` (25 passed)
- `make check` (938 unit/contract tests passed)
- `make ci` (207 integration tests passed; 1,145 coverage tests passed; coverage 92.65%; `pip-audit` no known vulnerabilities with governed `PYSEC-2026-161` exception)
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` (`DiffCount 0`)

## Governance
- Experience API boundary preserved: drawdown calculation truth remains source-owned by `lotus-risk`.
- No wiki source changes required; wiki publication check is clean.
- Stranded-truth check reported no unmerged remote branches.