### PR TITLE
Extract risk rolling response module

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -36,8 +36,8 @@ report-only baseline is reviewed.
 The largest current modularity risks are:
 
 1. `src/app/services/portfolio_service.py` at 3,016 lines,
-2. `src/app/services/risk_workspace_service.py` at 1,594 lines,
-3. `src/app/services/advisor_brief_service.py` at 1,392 lines,
+2. `src/app/services/advisor_brief_service.py` at 1,392 lines,
+3. `src/app/services/risk_workspace_service.py` at 1,185 lines,
 4. `src/app/services/performance_workspace_service.py` at 1,152 lines,
 5. `src/app/services/dpm_command_center_service.py` at 1,032 lines.
 
@@ -57,7 +57,10 @@ and supportability semantics. Risk unavailable-envelope primitives have been cen
 unavailable supportability, and risk metadata construction are no longer duplicated across risk
 surfaces. The drawdown response mapper and unavailable envelope have been extracted to
 `src/app/services/risk_workspace_drawdown.py`, reducing `risk_workspace_service.py` to 1,594 lines
-while keeping request orchestration and caching in the workspace service. The current longest
+while keeping request orchestration and caching in the workspace service. The rolling response
+mapper, Sharpe fallback policy, window parsing, and unavailable envelope have been extracted to
+`src/app/services/risk_workspace_rolling.py`, reducing `risk_workspace_service.py` to 1,185 lines.
+The current longest
 function is `_build_normalized_capabilities` in
 `src/app/services/platform_capabilities_service.py` at 195 lines.
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -10,7 +10,7 @@ This baseline covers the current gateway hardening state after the report-only q
 lane, router-registry split, performance workspace response split, and advisor-brief response
 split, risk drawdown mapper split, risk rolling mapper split, risk attribution mapper split,
 risk concentration mapper extraction, shared risk unavailable-envelope helper extraction, and
-risk drawdown response module extraction.
+risk drawdown response module extraction, and risk rolling response module extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -18,8 +18,8 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 646 |
-| Python source files under `src/app` | 434 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 647 |
+| Python source files under `src/app` | 435 |
 | Python test files under `tests` | 151 |
 | OpenAPI paths | 170 |
 | OpenAPI operations | 170 |
@@ -33,9 +33,9 @@ yet enforced unless they are already covered by existing repo-native gates.
 | 3 | 2,043 | `src/app/contracts/risk_workspace.py` |
 | 4 | 1,840 | `src/app/contracts/reporting.py` |
 | 5 | 1,606 | `src/app/contracts/performance_workspace.py` |
-| 6 | 1,594 | `src/app/services/risk_workspace_service.py` |
-| 7 | 1,392 | `src/app/services/advisor_brief_service.py` |
-| 8 | 1,362 | `src/app/clients/dpm_client.py` |
+| 6 | 1,392 | `src/app/services/advisor_brief_service.py` |
+| 7 | 1,362 | `src/app/clients/dpm_client.py` |
+| 8 | 1,185 | `src/app/services/risk_workspace_service.py` |
 | 9 | 1,152 | `src/app/services/performance_workspace_service.py` |
 | 10 | 1,098 | `src/app/clients/advise_client.py` |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -12,7 +12,10 @@ service module. Shared risk unavailable-envelope helpers now centralize risk ups
 detail mapping, risk-service unavailable supportability, and risk metadata construction while
 preserving public behavior and keeping CI green. The risk drawdown response mapper has now been
 extracted to a dedicated drawdown module, reducing `risk_workspace_service.py` to 1,594 lines while
-leaving request orchestration and cache semantics in the workspace service. The remaining work is
+leaving request orchestration and cache semantics in the workspace service. The risk rolling
+response mapper, Sharpe fallback policy, and unavailable envelope have been extracted to a
+dedicated rolling module, reducing `risk_workspace_service.py` to 1,185 lines while preserving
+retry, request, and cache semantics in the workspace service. The remaining work is
 still substantial: large portfolio, risk workspace, contract, and client modules remain.
 
 ## Health Signals
@@ -34,8 +37,8 @@ still substantial: large portfolio, risk workspace, contract, and client modules
 1. Split `portfolio_service.py` into source-readiness, transaction/activity, income, workspace,
    and workflow-cue adapters.
 2. Continue splitting `risk_workspace_service.py` by risk surface; the next risk workspace target
-   should be a bounded rolling module extraction after the shared unavailable-envelope and
-   drawdown-module helpers.
+   should be a bounded attribution module extraction after the shared unavailable-envelope,
+   drawdown-module, and rolling-module helpers.
 3. Split `platform_capabilities_service.py` capability normalization into smaller adapters.
 4. Continue extracting performance workspace evidence and attribution helpers behind stable
    response contracts.

--- a/src/app/services/risk_workspace_rolling.py
+++ b/src/app/services/risk_workspace_rolling.py
@@ -451,9 +451,9 @@ def _map_rolling_metric_series(
     return series
 
 
-def _safe_float(value: Any) -> float | None:
+def _safe_float(value: Any) -> float | None:  # monetary-float-allow
     if value is None:
         return None
     if isinstance(value, Real):
-        return float(value)
+        return float(value)  # monetary-float-allow
     return None

--- a/src/app/services/risk_workspace_rolling.py
+++ b/src/app/services/risk_workspace_rolling.py
@@ -1,0 +1,459 @@
+from dataclasses import dataclass
+from numbers import Real
+from typing import Any, cast
+
+from fastapi import status
+
+from app.contracts.risk_workspace import (
+    RiskModuleState,
+    WorkbenchRiskMetadata,
+    WorkbenchRiskRollingDependencyContext,
+    WorkbenchRiskRollingMetricSeriesContext,
+    WorkbenchRiskRollingMetricSeriesPoint,
+    WorkbenchRiskRollingMetricSummary,
+    WorkbenchRiskRollingPayload,
+    WorkbenchRiskRollingPeriodResult,
+    WorkbenchRiskRollingRequestContext,
+    WorkbenchRiskRollingResponse,
+    WorkbenchRiskRollingWindowResult,
+    WorkbenchRiskSupportabilityItem,
+)
+from app.contracts.workbench import WorkbenchPartialFailure
+from app.services.risk_workspace_envelopes import (
+    risk_metadata,
+    risk_upstream_failure,
+    unavailable_risk_service_supportability,
+)
+from app.services.source_supportability import (
+    extract_calculation_supportability,
+    source_supportability_reason,
+)
+
+
+@dataclass(frozen=True)
+class RollingMappingResult:
+    periods: list[WorkbenchRiskRollingPeriodResult]
+    warnings: list[str]
+    partial_failures: list[WorkbenchPartialFailure]
+
+
+def map_rolling_response(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    include_time_series: bool,
+    sharpe_fallback_reason: str | None,
+    upstream_payload: dict[str, Any],
+) -> WorkbenchRiskRollingResponse:
+    results = upstream_payload.get("results")
+    mapping = _map_rolling_period_results(results)
+    supportability = _build_rolling_supportability(
+        results=results,
+        benchmark_code=benchmark_code,
+        include_time_series=include_time_series,
+        sharpe_fallback_reason=sharpe_fallback_reason,
+    )
+    _append_source_calculation_supportability(
+        supportability=supportability,
+        upstream_payload=upstream_payload,
+    )
+    upstream_metadata = upstream_payload.get("metadata")
+    warnings = list(mapping.warnings)
+    partial_failures = list(mapping.partial_failures)
+    _append_rolling_sharpe_fallback(
+        warnings=warnings,
+        partial_failures=partial_failures,
+        sharpe_fallback_reason=sharpe_fallback_reason,
+    )
+    state, warnings, partial_failures = _resolve_rolling_state(
+        period_results=mapping.periods,
+        supportability=supportability,
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    return WorkbenchRiskRollingResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state=state,
+        payload=_build_rolling_payload(
+            period_results=mapping.periods,
+            upstream_metadata=upstream_metadata,
+        ),
+        supportability=supportability,
+        warnings=sorted(set(warnings)),
+        partial_failures=partial_failures,
+        metadata=_build_rolling_metadata(upstream_metadata=upstream_metadata),
+    )
+
+
+def unavailable_rolling(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    include_time_series: bool,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> WorkbenchRiskRollingResponse:
+    reason = (
+        "lotus-risk rolling endpoint is unavailable."
+        if not include_time_series
+        else "lotus-risk rolling detail endpoint is unavailable."
+    )
+    return WorkbenchRiskRollingResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="unavailable",
+        payload=None,
+        supportability=unavailable_risk_service_supportability(reason=reason),
+        warnings=["RISK_ROLLING_UNAVAILABLE"],
+        partial_failures=[
+            risk_upstream_failure(
+                upstream_status=upstream_status,
+                upstream_payload=upstream_payload,
+            )
+        ],
+        metadata=risk_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def should_retry_rolling_without_sharpe(
+    *,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> bool:
+    if upstream_status != status.HTTP_424_FAILED_DEPENDENCY:
+        return False
+    if isinstance(upstream_payload, dict):
+        detail = upstream_payload.get("detail")
+        if isinstance(detail, dict):
+            message = detail.get("message")
+            if isinstance(message, str) and "risk-free" in message.lower():
+                return True
+        text = str(upstream_payload.get("detail", "")).lower()
+        return "risk-free" in text
+    return "risk-free" in str(upstream_payload).lower()
+
+
+def rolling_sharpe_failure_reason(upstream_payload: Any) -> str:
+    if isinstance(upstream_payload, dict):
+        detail = upstream_payload.get("detail")
+        if isinstance(detail, dict):
+            message = detail.get("message")
+            if isinstance(message, str) and message.strip():
+                return message
+        text = upstream_payload.get("detail")
+        if isinstance(text, str) and text.strip():
+            return text
+    return "Rolling Sharpe is unavailable because the risk-free series could not be sourced."
+
+
+def _build_rolling_supportability(
+    *,
+    results: Any,
+    benchmark_code: str | None,
+    include_time_series: bool,
+    sharpe_fallback_reason: str | None,
+) -> list[WorkbenchRiskSupportabilityItem]:
+    return [
+        WorkbenchRiskSupportabilityItem(
+            key="portfolio_returns",
+            label="Portfolio returns",
+            state="ready" if isinstance(results, dict) and results else "unavailable",
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="benchmark_returns",
+            label="Benchmark returns",
+            state="ready" if benchmark_code else "partial",
+            reason=(
+                None
+                if benchmark_code
+                else "Benchmark-relative rolling metrics require benchmark context."
+            ),
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="risk_free_series",
+            label="Risk-free series",
+            state="partial" if sharpe_fallback_reason else "ready",
+            reason=sharpe_fallback_reason,
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="rolling_time_series",
+            label="Rolling time series",
+            state="ready" if include_time_series else "partial",
+            reason=(
+                None
+                if include_time_series
+                else "Rolling metric series is available on demand and excluded from first paint."
+            ),
+            source_service="lotus-risk",
+        ),
+    ]
+
+
+def _map_rolling_period_results(results: Any) -> RollingMappingResult:
+    warnings: list[str] = []
+    partial_failures: list[WorkbenchPartialFailure] = []
+    period_results: list[WorkbenchRiskRollingPeriodResult] = []
+
+    if not isinstance(results, dict):
+        return RollingMappingResult(
+            periods=period_results,
+            warnings=warnings,
+            partial_failures=partial_failures,
+        )
+
+    for key, value in results.items():
+        if not isinstance(value, dict):
+            continue
+        period = _map_rolling_period_result(key=key, value=value)
+        if period.quality_flags:
+            warnings.append("RISK_ROLLING_QUALITY_FLAGS")
+        if period.error:
+            partial_failures.append(
+                WorkbenchPartialFailure(
+                    source_service="risk",
+                    error_code="ROLLING_PERIOD_ERROR",
+                    detail=f"{key}: {period.error}",
+                )
+            )
+            warnings.append("RISK_ROLLING_PERIOD_PARTIAL")
+        period_results.append(period)
+
+    return RollingMappingResult(
+        periods=period_results,
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+
+def _map_rolling_period_result(
+    *,
+    key: Any,
+    value: dict[str, Any],
+) -> WorkbenchRiskRollingPeriodResult:
+    quality_flags = [
+        str(flag)
+        for flag in value.get("quality_flags", [])
+        if isinstance(flag, str) and flag.strip()
+    ]
+    error = value.get("error")
+    return WorkbenchRiskRollingPeriodResult(
+        key=str(key),
+        label=str(key),
+        start_date=str(value.get("start_date", "")),
+        end_date=str(value.get("end_date", "")),
+        series_count=int(value.get("series_count", 0)),
+        benchmark_series_count=int(value.get("benchmark_series_count", 0)),
+        aligned_benchmark_series_count=int(value.get("aligned_benchmark_series_count", 0)),
+        risk_free_series_count=int(value.get("risk_free_series_count", 0)),
+        aligned_risk_free_series_count=int(value.get("aligned_risk_free_series_count", 0)),
+        window_lengths_requested=_rolling_window_lengths(value.get("window_lengths_requested")),
+        window_count_requested=int(value.get("window_count_requested", 0)),
+        window_lengths_emitted=_rolling_window_lengths(value.get("window_lengths_emitted")),
+        window_count_emitted=int(value.get("window_count_emitted", 0)),
+        benchmark_context=_rolling_dependency_context(value.get("benchmark_context")),
+        risk_free_context=_rolling_dependency_context(value.get("risk_free_context")),
+        window_results=_map_rolling_window_results(value.get("window_results")),
+        quality_flags=quality_flags,
+        error=str(error) if isinstance(error, str) and error.strip() else None,
+    )
+
+
+def _rolling_window_lengths(value: Any) -> list[int]:
+    if not isinstance(value, list):
+        return []
+    return [int(cast(Any, window)) for window in value if isinstance(window, Real)]
+
+
+def _rolling_dependency_context(value: Any) -> WorkbenchRiskRollingDependencyContext | None:
+    return (
+        WorkbenchRiskRollingDependencyContext.model_validate(value)
+        if isinstance(value, dict)
+        else None
+    )
+
+
+def _append_rolling_sharpe_fallback(
+    *,
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+    sharpe_fallback_reason: str | None,
+) -> None:
+    if not sharpe_fallback_reason:
+        return
+
+    partial_failures.append(
+        WorkbenchPartialFailure(
+            source_service="risk",
+            error_code="ROLLING_SHARPE_UNAVAILABLE",
+            detail=sharpe_fallback_reason,
+        )
+    )
+    warnings.append("RISK_ROLLING_SHARPE_PARTIAL")
+
+
+def _resolve_rolling_state(
+    *,
+    period_results: list[WorkbenchRiskRollingPeriodResult],
+    supportability: list[WorkbenchRiskSupportabilityItem],
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+) -> tuple[RiskModuleState, list[str], list[WorkbenchPartialFailure]]:
+    resolved_warnings = list(warnings)
+    resolved_partial_failures = list(partial_failures)
+    state: RiskModuleState = (
+        "partial" if any(item.state != "ready" for item in supportability) else "ready"
+    )
+    if not period_results:
+        state = "unavailable"
+        resolved_warnings.append("RISK_ROLLING_EMPTY")
+        resolved_partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="risk",
+                error_code="EMPTY_RISK_ROLLING",
+                detail="lotus-risk returned no rolling periods.",
+            )
+        )
+    elif all(not period.window_results for period in period_results):
+        state = "unavailable"
+    return state, resolved_warnings, resolved_partial_failures
+
+
+def _build_rolling_metadata(*, upstream_metadata: Any) -> WorkbenchRiskMetadata:
+    metadata = risk_metadata(input_mode="stateful", cache_status="miss")
+    if isinstance(upstream_metadata, dict):
+        methodology_version = upstream_metadata.get("methodology_version")
+        if isinstance(methodology_version, str) and methodology_version.strip():
+            return metadata.model_copy(update={"methodology_version": methodology_version})
+    return metadata
+
+
+def _build_rolling_payload(
+    *,
+    period_results: list[WorkbenchRiskRollingPeriodResult],
+    upstream_metadata: Any,
+) -> WorkbenchRiskRollingPayload | None:
+    if not period_results:
+        return None
+    return WorkbenchRiskRollingPayload(
+        periods=period_results,
+        request_context=(
+            WorkbenchRiskRollingRequestContext.model_validate(upstream_metadata)
+            if isinstance(upstream_metadata, dict)
+            else None
+        ),
+    )
+
+
+def _append_source_calculation_supportability(
+    *,
+    supportability: list[WorkbenchRiskSupportabilityItem],
+    upstream_payload: dict[str, Any],
+) -> None:
+    source_supportability = extract_calculation_supportability(upstream_payload)
+    if source_supportability is None:
+        return
+
+    supportability.append(
+        WorkbenchRiskSupportabilityItem(
+            key="source_calculation",
+            label="Source calculation",
+            state=cast(Any, source_supportability.risk_contract_state),
+            reason=source_supportability_reason(
+                source_supportability,
+                default_ready_reason="Source calculation supportability was confirmed upstream.",
+            ),
+            source_service=source_supportability.source_service or "lotus-risk",
+        )
+    )
+
+
+def _map_rolling_window_results(window_payload: Any) -> list[WorkbenchRiskRollingWindowResult]:
+    if not isinstance(window_payload, list):
+        return []
+    results: list[WorkbenchRiskRollingWindowResult] = []
+    for entry in window_payload:
+        if not isinstance(entry, dict):
+            continue
+        metric_summaries_payload = entry.get("metric_summaries")
+        metric_series_payload = entry.get("metric_series")
+        metric_summaries = (
+            {
+                str(key): WorkbenchRiskRollingMetricSummary.model_validate(value)
+                for key, value in metric_summaries_payload.items()
+                if isinstance(key, str) and isinstance(value, dict)
+            }
+            if isinstance(metric_summaries_payload, dict)
+            else {}
+        )
+        metric_series = (
+            _map_rolling_metric_series(metric_series_payload)
+            if isinstance(metric_series_payload, list)
+            else None
+        )
+        results.append(
+            WorkbenchRiskRollingWindowResult(
+                window_length=int(entry.get("window_length", 0)),
+                metric_summaries=metric_summaries,
+                metric_series=metric_series,
+                metric_series_context=(
+                    WorkbenchRiskRollingMetricSeriesContext.model_validate(
+                        entry.get("metric_series_context")
+                    )
+                    if isinstance(entry.get("metric_series_context"), dict)
+                    else None
+                ),
+            )
+        )
+    results.sort(key=lambda item: item.window_length)
+    return results
+
+
+def _map_rolling_metric_series(
+    series_payload: list[Any],
+) -> list[WorkbenchRiskRollingMetricSeriesPoint]:
+    series: list[WorkbenchRiskRollingMetricSeriesPoint] = []
+    for entry in series_payload:
+        if not isinstance(entry, dict):
+            continue
+        metric_values_payload = entry.get("metric_values")
+        metric_values = (
+            {
+                str(key): _safe_float(value)
+                for key, value in metric_values_payload.items()
+                if isinstance(key, str)
+            }
+            if isinstance(metric_values_payload, dict)
+            else {}
+        )
+        series.append(
+            WorkbenchRiskRollingMetricSeriesPoint(
+                date=str(entry.get("date", "")),
+                metric_values=metric_values,
+            )
+        )
+    return series
+
+
+def _safe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, Real):
+        return float(value)
+    return None

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from datetime import date, timedelta
-from numbers import Real
 from typing import Any, cast
 
 from fastapi import status
@@ -20,15 +19,7 @@ from app.contracts.risk_workspace import (
     WorkbenchRiskMetadata,
     WorkbenchRiskMetric,
     WorkbenchRiskPeriodResult,
-    WorkbenchRiskRollingDependencyContext,
-    WorkbenchRiskRollingMetricSeriesContext,
-    WorkbenchRiskRollingMetricSeriesPoint,
-    WorkbenchRiskRollingMetricSummary,
-    WorkbenchRiskRollingPayload,
-    WorkbenchRiskRollingPeriodResult,
-    WorkbenchRiskRollingRequestContext,
     WorkbenchRiskRollingResponse,
-    WorkbenchRiskRollingWindowResult,
     WorkbenchRiskSummaryPayload,
     WorkbenchRiskSummaryResponse,
     WorkbenchRiskSupportabilityItem,
@@ -75,6 +66,12 @@ from app.services.risk_workspace_requests import (
     normalize_period,
     resolve_reporting_currency,
 )
+from app.services.risk_workspace_rolling import (
+    map_rolling_response,
+    rolling_sharpe_failure_reason,
+    should_retry_rolling_without_sharpe,
+    unavailable_rolling,
+)
 from app.services.source_supportability import (
     extract_calculation_supportability,
     source_supportability_reason,
@@ -82,14 +79,6 @@ from app.services.source_supportability import (
 
 _BENCHMARK_DEPENDENT_METRICS = {"BETA", "TRACKING_ERROR", "INFORMATION_RATIO"}
 _RISK_FREE_DEPENDENT_METRICS = {"SHARPE"}
-_ROLLING_METRIC_LABELS = {
-    "ROLLING_VOLATILITY": "Rolling Volatility",
-    "ROLLING_SHARPE": "Rolling Sharpe",
-    "ROLLING_BETA": "Rolling Beta",
-    "ROLLING_TRACKING_ERROR": "Rolling Tracking Error",
-    "ROLLING_INFORMATION_RATIO": "Rolling Information Ratio",
-    "ROLLING_MAX_DRAWDOWN": "Rolling Max Drawdown",
-}
 _METRIC_LABELS = {
     "VOLATILITY": "Volatility",
     "DRAWDOWN": "Drawdown",
@@ -100,13 +89,6 @@ _METRIC_LABELS = {
     "INFORMATION_RATIO": "Information Ratio",
     "VAR": "Value at Risk",
 }
-
-
-@dataclass(frozen=True)
-class RollingMappingResult:
-    periods: list[WorkbenchRiskRollingPeriodResult]
-    warnings: list[str]
-    partial_failures: list[WorkbenchPartialFailure]
 
 
 @dataclass(frozen=True)
@@ -400,11 +382,11 @@ class RiskWorkspaceService:
                 correlation_id=correlation_id,
             )
             sharpe_fallback_reason: str | None = None
-            if _should_retry_rolling_without_sharpe(
+            if should_retry_rolling_without_sharpe(
                 upstream_status=upstream_status,
                 upstream_payload=upstream_payload,
             ):
-                sharpe_fallback_reason = _rolling_sharpe_failure_reason(upstream_payload)
+                sharpe_fallback_reason = rolling_sharpe_failure_reason(upstream_payload)
                 fallback_payload = build_rolling_request(
                     portfolio_id=portfolio_id,
                     period=period,
@@ -428,7 +410,7 @@ class RiskWorkspaceService:
             if upstream_status >= status.HTTP_400_BAD_REQUEST or not isinstance(
                 upstream_payload, dict
             ):
-                return _unavailable_rolling(
+                return unavailable_rolling(
                     correlation_id=correlation_id,
                     portfolio_id=portfolio_id,
                     period=period,
@@ -439,7 +421,7 @@ class RiskWorkspaceService:
                     upstream_payload=upstream_payload,
                 )
 
-            return _map_rolling_response(
+            return map_rolling_response(
                 correlation_id=correlation_id,
                 portfolio_id=portfolio_id,
                 period=period,
@@ -727,263 +709,6 @@ def _metric_dependency_supportability(
             source_service="lotus-risk",
         ),
     ]
-
-
-def _map_rolling_response(
-    *,
-    correlation_id: str,
-    portfolio_id: str,
-    period: str,
-    as_of_date: str,
-    benchmark_code: str | None,
-    include_time_series: bool,
-    sharpe_fallback_reason: str | None,
-    upstream_payload: dict[str, Any],
-) -> WorkbenchRiskRollingResponse:
-    results = upstream_payload.get("results")
-    mapping = _map_rolling_period_results(results)
-    supportability = _build_rolling_supportability(
-        results=results,
-        benchmark_code=benchmark_code,
-        include_time_series=include_time_series,
-        sharpe_fallback_reason=sharpe_fallback_reason,
-    )
-    _append_source_calculation_supportability(
-        supportability=supportability,
-        upstream_payload=upstream_payload,
-    )
-    upstream_metadata = upstream_payload.get("metadata")
-    warnings = list(mapping.warnings)
-    partial_failures = list(mapping.partial_failures)
-    _append_rolling_sharpe_fallback(
-        warnings=warnings,
-        partial_failures=partial_failures,
-        sharpe_fallback_reason=sharpe_fallback_reason,
-    )
-    state, warnings, partial_failures = _resolve_rolling_state(
-        period_results=mapping.periods,
-        supportability=supportability,
-        warnings=warnings,
-        partial_failures=partial_failures,
-    )
-
-    return WorkbenchRiskRollingResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state=state,
-        payload=_build_rolling_payload(
-            period_results=mapping.periods,
-            upstream_metadata=upstream_metadata,
-        ),
-        supportability=supportability,
-        warnings=sorted(set(warnings)),
-        partial_failures=partial_failures,
-        metadata=_build_rolling_metadata(upstream_metadata=upstream_metadata),
-    )
-
-
-def _build_rolling_supportability(
-    *,
-    results: Any,
-    benchmark_code: str | None,
-    include_time_series: bool,
-    sharpe_fallback_reason: str | None,
-) -> list[WorkbenchRiskSupportabilityItem]:
-    return [
-        WorkbenchRiskSupportabilityItem(
-            key="portfolio_returns",
-            label="Portfolio returns",
-            state="ready" if isinstance(results, dict) and results else "unavailable",
-            source_service="lotus-risk",
-        ),
-        WorkbenchRiskSupportabilityItem(
-            key="benchmark_returns",
-            label="Benchmark returns",
-            state="ready" if benchmark_code else "partial",
-            reason=(
-                None
-                if benchmark_code
-                else "Benchmark-relative rolling metrics require benchmark context."
-            ),
-            source_service="lotus-risk",
-        ),
-        WorkbenchRiskSupportabilityItem(
-            key="risk_free_series",
-            label="Risk-free series",
-            state="partial" if sharpe_fallback_reason else "ready",
-            reason=sharpe_fallback_reason,
-            source_service="lotus-risk",
-        ),
-        WorkbenchRiskSupportabilityItem(
-            key="rolling_time_series",
-            label="Rolling time series",
-            state="ready" if include_time_series else "partial",
-            reason=(
-                None
-                if include_time_series
-                else "Rolling metric series is available on demand and excluded from first paint."
-            ),
-            source_service="lotus-risk",
-        ),
-    ]
-
-
-def _map_rolling_period_results(results: Any) -> RollingMappingResult:
-    warnings: list[str] = []
-    partial_failures: list[WorkbenchPartialFailure] = []
-    period_results: list[WorkbenchRiskRollingPeriodResult] = []
-
-    if not isinstance(results, dict):
-        return RollingMappingResult(
-            periods=period_results,
-            warnings=warnings,
-            partial_failures=partial_failures,
-        )
-
-    for key, value in results.items():
-        if not isinstance(value, dict):
-            continue
-        period = _map_rolling_period_result(key=key, value=value)
-        if period.quality_flags:
-            warnings.append("RISK_ROLLING_QUALITY_FLAGS")
-        if period.error:
-            partial_failures.append(
-                WorkbenchPartialFailure(
-                    source_service="risk",
-                    error_code="ROLLING_PERIOD_ERROR",
-                    detail=f"{key}: {period.error}",
-                )
-            )
-            warnings.append("RISK_ROLLING_PERIOD_PARTIAL")
-        period_results.append(period)
-
-    return RollingMappingResult(
-        periods=period_results,
-        warnings=warnings,
-        partial_failures=partial_failures,
-    )
-
-
-def _map_rolling_period_result(
-    *,
-    key: Any,
-    value: dict[str, Any],
-) -> WorkbenchRiskRollingPeriodResult:
-    quality_flags = [
-        str(flag)
-        for flag in value.get("quality_flags", [])
-        if isinstance(flag, str) and flag.strip()
-    ]
-    error = value.get("error")
-    return WorkbenchRiskRollingPeriodResult(
-        key=str(key),
-        label=str(key),
-        start_date=str(value.get("start_date", "")),
-        end_date=str(value.get("end_date", "")),
-        series_count=int(value.get("series_count", 0)),
-        benchmark_series_count=int(value.get("benchmark_series_count", 0)),
-        aligned_benchmark_series_count=int(value.get("aligned_benchmark_series_count", 0)),
-        risk_free_series_count=int(value.get("risk_free_series_count", 0)),
-        aligned_risk_free_series_count=int(value.get("aligned_risk_free_series_count", 0)),
-        window_lengths_requested=_rolling_window_lengths(value.get("window_lengths_requested")),
-        window_count_requested=int(value.get("window_count_requested", 0)),
-        window_lengths_emitted=_rolling_window_lengths(value.get("window_lengths_emitted")),
-        window_count_emitted=int(value.get("window_count_emitted", 0)),
-        benchmark_context=_rolling_dependency_context(value.get("benchmark_context")),
-        risk_free_context=_rolling_dependency_context(value.get("risk_free_context")),
-        window_results=_map_rolling_window_results(value.get("window_results")),
-        quality_flags=quality_flags,
-        error=str(error) if isinstance(error, str) and error.strip() else None,
-    )
-
-
-def _rolling_window_lengths(value: Any) -> list[int]:
-    if not isinstance(value, list):
-        return []
-    return [int(cast(Any, window)) for window in value if isinstance(window, Real)]
-
-
-def _rolling_dependency_context(value: Any) -> WorkbenchRiskRollingDependencyContext | None:
-    return (
-        WorkbenchRiskRollingDependencyContext.model_validate(value)
-        if isinstance(value, dict)
-        else None
-    )
-
-
-def _append_rolling_sharpe_fallback(
-    *,
-    warnings: list[str],
-    partial_failures: list[WorkbenchPartialFailure],
-    sharpe_fallback_reason: str | None,
-) -> None:
-    if not sharpe_fallback_reason:
-        return
-
-    partial_failures.append(
-        WorkbenchPartialFailure(
-            source_service="risk",
-            error_code="ROLLING_SHARPE_UNAVAILABLE",
-            detail=sharpe_fallback_reason,
-        )
-    )
-    warnings.append("RISK_ROLLING_SHARPE_PARTIAL")
-
-
-def _resolve_rolling_state(
-    *,
-    period_results: list[WorkbenchRiskRollingPeriodResult],
-    supportability: list[WorkbenchRiskSupportabilityItem],
-    warnings: list[str],
-    partial_failures: list[WorkbenchPartialFailure],
-) -> tuple[RiskModuleState, list[str], list[WorkbenchPartialFailure]]:
-    resolved_warnings = list(warnings)
-    resolved_partial_failures = list(partial_failures)
-    state: RiskModuleState = (
-        "partial" if any(item.state != "ready" for item in supportability) else "ready"
-    )
-    if not period_results:
-        state = "unavailable"
-        resolved_warnings.append("RISK_ROLLING_EMPTY")
-        resolved_partial_failures.append(
-            WorkbenchPartialFailure(
-                source_service="risk",
-                error_code="EMPTY_RISK_ROLLING",
-                detail="lotus-risk returned no rolling periods.",
-            )
-        )
-    elif all(not period.window_results for period in period_results):
-        state = "unavailable"
-    return state, resolved_warnings, resolved_partial_failures
-
-
-def _build_rolling_metadata(*, upstream_metadata: Any) -> WorkbenchRiskMetadata:
-    metadata = _metadata(input_mode="stateful", cache_status="miss")
-    if isinstance(upstream_metadata, dict):
-        methodology_version = upstream_metadata.get("methodology_version")
-        if isinstance(methodology_version, str) and methodology_version.strip():
-            return metadata.model_copy(update={"methodology_version": methodology_version})
-    return metadata
-
-
-def _build_rolling_payload(
-    *,
-    period_results: list[WorkbenchRiskRollingPeriodResult],
-    upstream_metadata: Any,
-) -> WorkbenchRiskRollingPayload | None:
-    if not period_results:
-        return None
-    return WorkbenchRiskRollingPayload(
-        periods=period_results,
-        request_context=(
-            WorkbenchRiskRollingRequestContext.model_validate(upstream_metadata)
-            if isinstance(upstream_metadata, dict)
-            else None
-        ),
-    )
 
 
 def _map_attribution_response(
@@ -1356,42 +1081,6 @@ def _unavailable_summary(
     )
 
 
-def _unavailable_rolling(
-    *,
-    correlation_id: str,
-    portfolio_id: str,
-    period: str,
-    as_of_date: str,
-    benchmark_code: str | None,
-    include_time_series: bool,
-    upstream_status: int,
-    upstream_payload: Any,
-) -> WorkbenchRiskRollingResponse:
-    reason = (
-        "lotus-risk rolling endpoint is unavailable."
-        if not include_time_series
-        else "lotus-risk rolling detail endpoint is unavailable."
-    )
-    return WorkbenchRiskRollingResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state="unavailable",
-        payload=None,
-        supportability=unavailable_risk_service_supportability(reason=reason),
-        warnings=["RISK_ROLLING_UNAVAILABLE"],
-        partial_failures=[
-            risk_upstream_failure(
-                upstream_status=upstream_status,
-                upstream_payload=upstream_payload,
-            )
-        ],
-        metadata=_metadata(input_mode="stateful", cache_status="miss"),
-    )
-
-
 def _unavailable_attribution(
     *,
     correlation_id: str,
@@ -1467,104 +1156,6 @@ def _build_risk_periods(
         report_start_date=report_start_date,
         report_end_date=report_end_date,
     )
-
-
-def _map_rolling_window_results(window_payload: Any) -> list[WorkbenchRiskRollingWindowResult]:
-    if not isinstance(window_payload, list):
-        return []
-    results: list[WorkbenchRiskRollingWindowResult] = []
-    for entry in window_payload:
-        if not isinstance(entry, dict):
-            continue
-        metric_summaries_payload = entry.get("metric_summaries")
-        metric_series_payload = entry.get("metric_series")
-        metric_summaries = (
-            {
-                str(key): WorkbenchRiskRollingMetricSummary.model_validate(value)
-                for key, value in metric_summaries_payload.items()
-                if isinstance(key, str) and isinstance(value, dict)
-            }
-            if isinstance(metric_summaries_payload, dict)
-            else {}
-        )
-        metric_series = (
-            _map_rolling_metric_series(metric_series_payload)
-            if isinstance(metric_series_payload, list)
-            else None
-        )
-        results.append(
-            WorkbenchRiskRollingWindowResult(
-                window_length=int(entry.get("window_length", 0)),
-                metric_summaries=metric_summaries,
-                metric_series=metric_series,
-                metric_series_context=(
-                    WorkbenchRiskRollingMetricSeriesContext.model_validate(
-                        entry.get("metric_series_context")
-                    )
-                    if isinstance(entry.get("metric_series_context"), dict)
-                    else None
-                ),
-            )
-        )
-    results.sort(key=lambda item: item.window_length)
-    return results
-
-
-def _map_rolling_metric_series(
-    series_payload: list[Any],
-) -> list[WorkbenchRiskRollingMetricSeriesPoint]:
-    series: list[WorkbenchRiskRollingMetricSeriesPoint] = []
-    for entry in series_payload:
-        if not isinstance(entry, dict):
-            continue
-        metric_values_payload = entry.get("metric_values")
-        metric_values = (
-            {
-                str(key): _safe_float(value)
-                for key, value in metric_values_payload.items()
-                if isinstance(key, str)
-            }
-            if isinstance(metric_values_payload, dict)
-            else {}
-        )
-        series.append(
-            WorkbenchRiskRollingMetricSeriesPoint(
-                date=str(entry.get("date", "")),
-                metric_values=metric_values,
-            )
-        )
-    return series
-
-
-def _should_retry_rolling_without_sharpe(
-    *,
-    upstream_status: int,
-    upstream_payload: Any,
-) -> bool:
-    if upstream_status != status.HTTP_424_FAILED_DEPENDENCY:
-        return False
-    if isinstance(upstream_payload, dict):
-        detail = upstream_payload.get("detail")
-        if isinstance(detail, dict):
-            message = detail.get("message")
-            if isinstance(message, str) and "risk-free" in message.lower():
-                return True
-        text = str(upstream_payload.get("detail", "")).lower()
-        return "risk-free" in text
-    return "risk-free" in str(upstream_payload).lower()
-
-
-def _rolling_sharpe_failure_reason(upstream_payload: Any) -> str:
-    if isinstance(upstream_payload, dict):
-        detail = upstream_payload.get("detail")
-        if isinstance(detail, dict):
-            message = detail.get("message")
-            if isinstance(message, str) and message.strip():
-                return message
-        text = upstream_payload.get("detail")
-        if isinstance(text, str) and text.strip():
-            return text
-    return "Rolling Sharpe is unavailable because the risk-free series could not be sourced."
 
 
 def _risk_attribution_grouping_label(grouping_key: str) -> str:


### PR DESCRIPTION
## Summary
- Extract risk rolling response mapping, supportability, Sharpe fallback policy, window/series parsing, metadata, and unavailable envelope into `risk_workspace_rolling.py`.
- Keep `RiskWorkspaceService.get_rolling` responsible for request construction, upstream retry orchestration, caching, and correlation refresh.
- Refresh quality baseline and architecture ledger to record `risk_workspace_service.py` reduced to 1,185 lines and the next risk workspace target as attribution extraction.

## Validation
- `python -m ruff format src\app\services\risk_workspace_service.py src\app\services\risk_workspace_rolling.py --check`
- `python -m ruff check src\app\services\risk_workspace_service.py src\app\services\risk_workspace_rolling.py`
- `python -m mypy src\app\services\risk_workspace_service.py src\app\services\risk_workspace_rolling.py`
- `python -m pytest tests\unit\test_risk_workspace_service.py tests\unit\test_risk_workspace_envelopes.py -q` (25 passed)
- `make check` (938 unit/contract tests passed)
- `make ci` (integration, coverage, migration smoke, audit passed)
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` (`DiffCount 0`)

## Governance
- Experience API boundary preserved: rolling risk calculation truth remains source-owned by `lotus-risk`.
- No wiki source changes required; wiki publication check is clean.
- Stranded-truth check reported no unmerged remote branches.