### PR TITLE
Extract risk attribution response module

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -37,9 +37,9 @@ The largest current modularity risks are:
 
 1. `src/app/services/portfolio_service.py` at 3,016 lines,
 2. `src/app/services/advisor_brief_service.py` at 1,392 lines,
-3. `src/app/services/risk_workspace_service.py` at 1,185 lines,
-4. `src/app/services/performance_workspace_service.py` at 1,152 lines,
-5. `src/app/services/dpm_command_center_service.py` at 1,032 lines.
+3. `src/app/services/performance_workspace_service.py` at 1,152 lines,
+4. `src/app/services/dpm_command_center_service.py` at 1,032 lines,
+5. `src/app/services/dpm_wave_service.py` at 981 lines.
 
 The prior longest function, `register_routers` in `src/app/router_registry.py`, has been split
 into explicit route-family groups and a short registration loop. The performance workspace
@@ -60,6 +60,10 @@ surfaces. The drawdown response mapper and unavailable envelope have been extrac
 while keeping request orchestration and caching in the workspace service. The rolling response
 mapper, Sharpe fallback policy, window parsing, and unavailable envelope have been extracted to
 `src/app/services/risk_workspace_rolling.py`, reducing `risk_workspace_service.py` to 1,185 lines.
+The risk attribution response mapper, blocked/unavailable envelopes, period/set/contributor
+parsing, methodology metadata, and metric conversion have been extracted to
+`src/app/services/risk_workspace_attribution.py`, reducing `risk_workspace_service.py` to 780
+lines while keeping attribution request orchestration and cache semantics in the workspace service.
 The current longest
 function is `_build_normalized_capabilities` in
 `src/app/services/platform_capabilities_service.py` at 195 lines.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -71,7 +71,7 @@ Current repo-native gates already cover:
 
 Most recent local evidence:
 
-1. `make check`: 938 unit/contract tests passed.
+1. `make check`: 942 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
 3. `make ci`: 1,145 coverage tests passed.
 4. Coverage: 92.65%.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -10,7 +10,7 @@ This baseline covers the current gateway hardening state after the report-only q
 lane, router-registry split, performance workspace response split, and advisor-brief response
 split, risk drawdown mapper split, risk rolling mapper split, risk attribution mapper split,
 risk concentration mapper extraction, shared risk unavailable-envelope helper extraction, and
-risk drawdown response module extraction, and risk rolling response module extraction.
+risk drawdown, rolling, and attribution response module extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -18,9 +18,9 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 647 |
-| Python source files under `src/app` | 435 |
-| Python test files under `tests` | 151 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 659 |
+| Python source files under `src/app` | 436 |
+| Python test files under `tests` | 152 |
 | OpenAPI paths | 170 |
 | OpenAPI operations | 170 |
 
@@ -35,9 +35,9 @@ yet enforced unless they are already covered by existing repo-native gates.
 | 5 | 1,606 | `src/app/contracts/performance_workspace.py` |
 | 6 | 1,392 | `src/app/services/advisor_brief_service.py` |
 | 7 | 1,362 | `src/app/clients/dpm_client.py` |
-| 8 | 1,185 | `src/app/services/risk_workspace_service.py` |
-| 9 | 1,152 | `src/app/services/performance_workspace_service.py` |
-| 10 | 1,098 | `src/app/clients/advise_client.py` |
+| 8 | 1,152 | `src/app/services/performance_workspace_service.py` |
+| 9 | 1,098 | `src/app/clients/advise_client.py` |
+| 10 | 1,032 | `src/app/services/dpm_command_center_service.py` |
 
 ## Largest Functions
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -73,8 +73,8 @@ Most recent local evidence:
 
 1. `make check`: 942 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
-3. `make ci`: 1,145 coverage tests passed.
-4. Coverage: 92.65%.
+3. `make ci`: 1,149 coverage tests passed.
+4. Coverage: 92.72%.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -1,0 +1,62 @@
+# CI Quality Gates
+
+Date: 2026-06-04  
+Mode: progressive enforcement
+
+This file records the governed CI measurement posture for the gateway hardening program. It is the
+operator-facing companion to `baseline_report.md`, `quality_scorecard.md`,
+`architecture_rules.md`, and `api_governance_rules.md`.
+
+## Current Blocking Gates
+
+The current local and PR-grade blocking gates are:
+
+1. `ruff` lint and format checks,
+2. monetary-float governance,
+3. `mypy` over `src`,
+4. Workbench OpenAPI contract smoke,
+5. migration contract smoke,
+6. unit and contract tests,
+7. integration tests,
+8. coverage with an 84% floor,
+9. `pip-audit` with the governed temporary `PYSEC-2026-161` exception,
+10. Docker build and local Docker parity in the PR Merge Gate.
+
+## Report-Only Gates
+
+Report-only quality checks should remain advisory until findings are classified:
+
+1. complexity and maintainability,
+2. high-confidence dead-code candidates,
+3. dependency hygiene,
+4. static security scanning beyond dependency vulnerabilities,
+5. OpenAPI Spectral warnings,
+6. import-linter architecture contracts,
+7. documentation and observability scorecard gaps.
+
+## Progressive Enforcement Plan
+
+1. Baseline/report-only: publish evidence without failing existing delivery lanes.
+2. No-new-regression: fail only new violations above the accepted baseline.
+3. Threshold enforcement: apply agreed limits for file size, function length, complexity,
+   OpenAPI completeness, import boundaries, and high-confidence security findings.
+4. Enterprise-readiness: require architecture, API, tests, security, observability, operations,
+   documentation, and scorecard evidence before release promotion.
+
+## Current Evidence
+
+Most recent local PR-grade evidence:
+
+1. `make check`: 942 unit/contract tests passed.
+2. `make ci`: 207 integration tests passed.
+3. `make ci`: 1,149 coverage tests passed.
+4. Total coverage: 92.72%, above the 84% floor.
+5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
+
+## Next Tightening Candidates
+
+1. Keep the quality baseline workflow report-only while findings are classified.
+2. Add no-new-regression checks for OpenAPI missing descriptions, tags, and standard errors.
+3. Promote import-linter contracts after false positives are classified.
+4. Add no-new-file/function-above-baseline checks for refactor slices.
+5. Add static no-sensitive-observability checks for logs, metrics labels, and diagnostics fields.

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -6,7 +6,7 @@ Mode: baseline/report-only
 | Dimension | Score | Baseline status | Next action |
 | --- | ---: | --- | --- |
 | Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
-| Coverage | 4/5 | 92.60% total coverage | Add targeted middleware/security/error tests |
+| Coverage | 4/5 | 92.72% total coverage | Add targeted middleware/security/error tests |
 | Modularity | 2/5 | Large services and contracts remain | Continue extraction slices |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -15,8 +15,11 @@ extracted to a dedicated drawdown module, reducing `risk_workspace_service.py` t
 leaving request orchestration and cache semantics in the workspace service. The risk rolling
 response mapper, Sharpe fallback policy, and unavailable envelope have been extracted to a
 dedicated rolling module, reducing `risk_workspace_service.py` to 1,185 lines while preserving
-retry, request, and cache semantics in the workspace service. The remaining work is
-still substantial: large portfolio, risk workspace, contract, and client modules remain.
+retry, request, and cache semantics in the workspace service. The risk attribution response
+mapper, blocked/unavailable envelopes, and focused attribution module tests have been extracted to
+a dedicated attribution module, reducing `risk_workspace_service.py` to 780 lines while preserving
+request, cache, and correlation semantics in the workspace service. The remaining work is still
+substantial: large portfolio, performance workspace, contract, and client modules remain.
 
 ## Health Signals
 
@@ -27,7 +30,7 @@ still substantial: large portfolio, risk workspace, contract, and client modules
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.65%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
-| Modularity | Improving, incomplete | Multiple service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -37,8 +40,8 @@ still substantial: large portfolio, risk workspace, contract, and client modules
 1. Split `portfolio_service.py` into source-readiness, transaction/activity, income, workspace,
    and workflow-cue adapters.
 2. Continue splitting `risk_workspace_service.py` by risk surface; the next risk workspace target
-   should be a bounded attribution module extraction after the shared unavailable-envelope,
-   drawdown-module, and rolling-module helpers.
+   should be a bounded summary response module extraction after the shared unavailable-envelope,
+   drawdown, rolling, and attribution helpers.
 3. Split `platform_capabilities_service.py` capability normalization into smaller adapters.
 4. Continue extracting performance workspace evidence and attribution helpers behind stable
    response contracts.

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -28,7 +28,7 @@ substantial: large portfolio, performance workspace, contract, and client module
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
 | Unit/contract coverage | Healthy | 942 tests passed in latest `make check` evidence |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
-| Total coverage | Healthy | 92.65%, above the 84% floor |
+| Total coverage | Healthy | 92.72%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
 | Modularity | Improving, incomplete | Several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -26,7 +26,7 @@ substantial: large portfolio, performance workspace, contract, and client module
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
-| Unit/contract coverage | Healthy | 938 tests passed in latest `make check` evidence |
+| Unit/contract coverage | Healthy | 942 tests passed in latest `make check` evidence |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.65%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |

--- a/src/app/services/risk_workspace_attribution.py
+++ b/src/app/services/risk_workspace_attribution.py
@@ -1,0 +1,400 @@
+from dataclasses import dataclass
+from typing import Any, cast
+
+from app.contracts.risk_workspace import (
+    RiskModuleState,
+    WorkbenchRiskAttributionContributor,
+    WorkbenchRiskAttributionMethodologyContext,
+    WorkbenchRiskAttributionPayload,
+    WorkbenchRiskAttributionPeriodResult,
+    WorkbenchRiskAttributionResponse,
+    WorkbenchRiskAttributionSet,
+    WorkbenchRiskMetadata,
+    WorkbenchRiskSupportabilityItem,
+)
+from app.contracts.workbench import WorkbenchPartialFailure
+from app.services.risk_workspace_attribution_controls import (
+    RISK_ATTRIBUTION_ACTIVE_RISK_GATED_GROUPINGS,
+    build_attribution_controls,
+    build_attribution_supportability,
+)
+from app.services.risk_workspace_attribution_controls import (
+    normalize_risk_attribution_grouping as _normalize_risk_attribution_grouping,
+)
+from app.services.risk_workspace_attribution_controls import (
+    normalize_risk_attribution_type as _normalize_risk_attribution_type,
+)
+from app.services.risk_workspace_envelopes import (
+    risk_metadata,
+    risk_upstream_failure,
+)
+from app.services.source_supportability import (
+    extract_calculation_supportability,
+    source_supportability_reason,
+)
+
+
+@dataclass(frozen=True)
+class AttributionMappingResult:
+    periods: list[WorkbenchRiskAttributionPeriodResult]
+    warnings: list[str]
+    partial_failures: list[WorkbenchPartialFailure]
+
+
+def normalize_risk_attribution_type(value: str) -> str:
+    return _normalize_risk_attribution_type(value)
+
+
+def normalize_risk_attribution_grouping(value: str) -> str:
+    return _normalize_risk_attribution_grouping(value)
+
+
+def map_attribution_response(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    attribution_type: str,
+    grouping_dimension: str,
+    upstream_payload: dict[str, Any],
+) -> WorkbenchRiskAttributionResponse:
+    results = upstream_payload.get("results")
+    upstream_metadata = upstream_payload.get("metadata")
+    mapping = _map_attribution_period_results(
+        results=results,
+        attribution_type=attribution_type,
+        grouping_dimension=grouping_dimension,
+    )
+    supportability = build_attribution_supportability(
+        benchmark_code=benchmark_code,
+        attribution_type=attribution_type,
+        grouping_dimension=grouping_dimension,
+    )
+    _append_source_calculation_supportability(
+        supportability=supportability,
+        upstream_payload=upstream_payload,
+    )
+    state, warnings, partial_failures = _resolve_attribution_state(
+        period_results=mapping.periods,
+        supportability=supportability,
+        warnings=mapping.warnings,
+        partial_failures=mapping.partial_failures,
+    )
+
+    return WorkbenchRiskAttributionResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state=state,
+        payload=_build_attribution_payload(
+            period_results=mapping.periods,
+            benchmark_code=benchmark_code,
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+            upstream_metadata=upstream_metadata,
+        ),
+        supportability=supportability,
+        warnings=sorted(set(warnings)),
+        partial_failures=partial_failures,
+        metadata=_build_attribution_metadata(upstream_metadata=upstream_metadata),
+    )
+
+
+def blocked_attribution_response(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    attribution_type: str,
+    grouping_dimension: str,
+) -> WorkbenchRiskAttributionResponse | None:
+    is_active_risk_without_benchmark = attribution_type == "ACTIVE_RISK" and not benchmark_code
+    is_active_risk_gated_grouping = (
+        attribution_type == "ACTIVE_RISK"
+        and grouping_dimension in RISK_ATTRIBUTION_ACTIVE_RISK_GATED_GROUPINGS
+    )
+    if not is_active_risk_without_benchmark and not is_active_risk_gated_grouping:
+        return None
+    controls = build_attribution_controls(
+        benchmark_code=benchmark_code,
+        attribution_type=attribution_type,
+        grouping_dimension=grouping_dimension,
+    )
+    return WorkbenchRiskAttributionResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="blocked",
+        payload=WorkbenchRiskAttributionPayload(controls=controls, periods=[]),
+        supportability=build_attribution_supportability(
+            benchmark_code=benchmark_code,
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+        ),
+        warnings=["RISK_ATTRIBUTION_BLOCKED"],
+        partial_failures=[],
+        metadata=risk_metadata(input_mode="stateful", cache_status="bypass"),
+    )
+
+
+def unavailable_attribution(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    attribution_type: str,
+    grouping_dimension: str,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> WorkbenchRiskAttributionResponse:
+    return WorkbenchRiskAttributionResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="unavailable",
+        payload=WorkbenchRiskAttributionPayload(
+            controls=build_attribution_controls(
+                benchmark_code=benchmark_code,
+                attribution_type=attribution_type,
+                grouping_dimension=grouping_dimension,
+            ),
+            periods=[],
+        ),
+        supportability=build_attribution_supportability(
+            benchmark_code=benchmark_code,
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+        ),
+        warnings=["RISK_ATTRIBUTION_UNAVAILABLE"],
+        partial_failures=[
+            risk_upstream_failure(
+                upstream_status=upstream_status,
+                upstream_payload=upstream_payload,
+            )
+        ],
+        metadata=risk_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def _map_attribution_period_results(
+    *,
+    results: Any,
+    attribution_type: str,
+    grouping_dimension: str,
+) -> AttributionMappingResult:
+    warnings: list[str] = []
+    partial_failures: list[WorkbenchPartialFailure] = []
+    period_results: list[WorkbenchRiskAttributionPeriodResult] = []
+
+    if not isinstance(results, dict):
+        return AttributionMappingResult(
+            periods=period_results,
+            warnings=warnings,
+            partial_failures=partial_failures,
+        )
+
+    for key, value in results.items():
+        if not isinstance(value, dict):
+            continue
+        period = _map_attribution_period_result(
+            key=key,
+            value=value,
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+        )
+        if period.error:
+            partial_failures.append(
+                WorkbenchPartialFailure(
+                    source_service="risk",
+                    error_code="RISK_ATTRIBUTION_PERIOD_ERROR",
+                    detail=f"{key}: {period.error}",
+                )
+            )
+            warnings.append("RISK_ATTRIBUTION_PERIOD_PARTIAL")
+        period_results.append(period)
+
+    return AttributionMappingResult(
+        periods=period_results,
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+
+def _map_attribution_period_result(
+    *,
+    key: Any,
+    value: dict[str, Any],
+    attribution_type: str,
+    grouping_dimension: str,
+) -> WorkbenchRiskAttributionPeriodResult:
+    error = value.get("error")
+    return WorkbenchRiskAttributionPeriodResult(
+        key=str(key),
+        label=str(key),
+        start_date=str(value.get("start_date", "")),
+        end_date=str(value.get("end_date", "")),
+        attribution_sets=_map_attribution_sets(
+            value.get("attribution_sets"),
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+        ),
+        error=str(error) if isinstance(error, str) and error.strip() else None,
+    )
+
+
+def _map_attribution_sets(
+    value: Any,
+    *,
+    attribution_type: str,
+    grouping_dimension: str,
+) -> list[WorkbenchRiskAttributionSet]:
+    if not isinstance(value, list):
+        return []
+    return [
+        _map_attribution_set(
+            entry,
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+        )
+        for entry in value
+        if isinstance(entry, dict)
+    ]
+
+
+def _map_attribution_set(
+    entry: dict[str, Any],
+    *,
+    attribution_type: str,
+    grouping_dimension: str,
+) -> WorkbenchRiskAttributionSet:
+    return WorkbenchRiskAttributionSet(
+        attribution_type=str(entry.get("attribution_type", attribution_type)),
+        metric=str(entry.get("metric", "")),
+        grouping_dimension=str(entry.get("grouping_dimension", grouping_dimension)),
+        total_value=_safe_float(entry.get("total_value")),
+        reconciled_sum=_safe_float(entry.get("reconciled_sum")),
+        residual=_safe_float(entry.get("residual")),
+        contributors=_map_attribution_contributors(entry.get("contributors")),
+        quality_flags=[
+            str(flag)
+            for flag in entry.get("quality_flags", [])
+            if isinstance(flag, str) and flag.strip()
+        ],
+    )
+
+
+def _map_attribution_contributors(value: Any) -> list[WorkbenchRiskAttributionContributor]:
+    if not isinstance(value, list):
+        return []
+    return [
+        WorkbenchRiskAttributionContributor.model_validate(contributor)
+        for contributor in value
+        if isinstance(contributor, dict)
+    ]
+
+
+def _resolve_attribution_state(
+    *,
+    period_results: list[WorkbenchRiskAttributionPeriodResult],
+    supportability: list[WorkbenchRiskSupportabilityItem],
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+) -> tuple[RiskModuleState, list[str], list[WorkbenchPartialFailure]]:
+    resolved_warnings = list(warnings)
+    resolved_partial_failures = list(partial_failures)
+    state: RiskModuleState = (
+        "partial" if any(item.state != "ready" for item in supportability) else "ready"
+    )
+    if not period_results:
+        state = "unavailable"
+        resolved_warnings.append("RISK_ATTRIBUTION_EMPTY")
+        resolved_partial_failures.append(
+            WorkbenchPartialFailure(
+                source_service="risk",
+                error_code="EMPTY_RISK_ATTRIBUTION",
+                detail="lotus-risk returned no attribution periods.",
+            )
+        )
+    elif all(not period.attribution_sets for period in period_results):
+        state = "unavailable"
+    return state, resolved_warnings, resolved_partial_failures
+
+
+def _build_attribution_metadata(*, upstream_metadata: Any) -> WorkbenchRiskMetadata:
+    metadata = risk_metadata(input_mode="stateful", cache_status="miss")
+    if isinstance(upstream_metadata, dict):
+        methodology_version = upstream_metadata.get("methodology_version")
+        if isinstance(methodology_version, str) and methodology_version.strip():
+            return metadata.model_copy(update={"methodology_version": methodology_version})
+    return metadata
+
+
+def _build_attribution_payload(
+    *,
+    period_results: list[WorkbenchRiskAttributionPeriodResult],
+    benchmark_code: str | None,
+    attribution_type: str,
+    grouping_dimension: str,
+    upstream_metadata: Any,
+) -> WorkbenchRiskAttributionPayload | None:
+    if not period_results:
+        return None
+    metadata = upstream_metadata if isinstance(upstream_metadata, dict) else None
+    return WorkbenchRiskAttributionPayload(
+        controls=build_attribution_controls(
+            benchmark_code=benchmark_code,
+            attribution_type=attribution_type,
+            grouping_dimension=grouping_dimension,
+            upstream_metadata=metadata,
+        ),
+        periods=period_results,
+        methodology_context=(
+            WorkbenchRiskAttributionMethodologyContext.model_validate(upstream_metadata)
+            if isinstance(upstream_metadata, dict)
+            else None
+        ),
+    )
+
+
+def _append_source_calculation_supportability(
+    *,
+    supportability: list[WorkbenchRiskSupportabilityItem],
+    upstream_payload: dict[str, Any],
+) -> None:
+    source_supportability = extract_calculation_supportability(upstream_payload)
+    if source_supportability is None:
+        return
+
+    supportability.append(
+        WorkbenchRiskSupportabilityItem(
+            key="source_calculation",
+            label="Source calculation",
+            state=cast(Any, source_supportability.risk_contract_state),
+            reason=source_supportability_reason(
+                source_supportability,
+                default_ready_reason="Source calculation supportability was confirmed upstream.",
+            ),
+            source_service=source_supportability.source_service or "lotus-risk",
+        )
+    )
+
+
+def _safe_float(value: Any) -> float | None:  # monetary-float-allow
+    if value is None:
+        return None
+    try:
+        return float(value)  # monetary-float-allow
+    except (TypeError, ValueError):
+        return None

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Any, cast
 
@@ -7,13 +6,7 @@ from fastapi import status
 from app.config import settings
 from app.contracts.risk_workspace import (
     RiskModuleState,
-    WorkbenchRiskAttributionContributor,
-    WorkbenchRiskAttributionControls,
-    WorkbenchRiskAttributionMethodologyContext,
-    WorkbenchRiskAttributionPayload,
-    WorkbenchRiskAttributionPeriodResult,
     WorkbenchRiskAttributionResponse,
-    WorkbenchRiskAttributionSet,
     WorkbenchRiskConcentrationResponse,
     WorkbenchRiskDrawdownResponse,
     WorkbenchRiskMetadata,
@@ -27,18 +20,12 @@ from app.contracts.risk_workspace import (
 from app.contracts.workbench import WorkbenchPartialFailure
 from app.services.async_ttl_cache import AsyncTtlCache
 from app.services.domain_client_protocols import RiskWorkspaceClient
-from app.services.risk_workspace_attribution_controls import (
-    RISK_ATTRIBUTION_ACTIVE_RISK_GATED_GROUPINGS as _RISK_ATTRIBUTION_ACTIVE_RISK_GATED_GROUPINGS,
-)
-from app.services.risk_workspace_attribution_controls import (
-    build_attribution_controls,
-    build_attribution_supportability,
-    metadata_grouping_dimension_set,
+from app.services.risk_workspace_attribution import (
+    blocked_attribution_response,
+    map_attribution_response,
     normalize_risk_attribution_grouping,
     normalize_risk_attribution_type,
-    resolve_active_risk_grouping_support,
-    risk_attribution_grouping_label,
-    total_risk_gated_grouping_reason,
+    unavailable_attribution,
 )
 from app.services.risk_workspace_concentration import (
     map_concentration_response,
@@ -89,13 +76,6 @@ _METRIC_LABELS = {
     "INFORMATION_RATIO": "Information Ratio",
     "VAR": "Value at Risk",
 }
-
-
-@dataclass(frozen=True)
-class AttributionMappingResult:
-    periods: list[WorkbenchRiskAttributionPeriodResult]
-    warnings: list[str]
-    partial_failures: list[WorkbenchPartialFailure]
 
 
 class RiskWorkspaceService:
@@ -462,7 +442,7 @@ class RiskWorkspaceService:
         resolved_as_of_date = _resolve_as_of_date(as_of_date)
         normalized_type = _normalize_risk_attribution_type(attribution_type)
         normalized_grouping = _normalize_risk_attribution_grouping(grouping_dimension)
-        blocked_response = _blocked_attribution_response(
+        blocked_response = blocked_attribution_response(
             correlation_id=correlation_id,
             portfolio_id=portfolio_id,
             period=period,
@@ -511,7 +491,7 @@ class RiskWorkspaceService:
             if upstream_status >= status.HTTP_400_BAD_REQUEST or not isinstance(
                 upstream_payload, dict
             ):
-                return _unavailable_attribution(
+                return unavailable_attribution(
                     correlation_id=correlation_id,
                     portfolio_id=portfolio_id,
                     period=period,
@@ -522,7 +502,7 @@ class RiskWorkspaceService:
                     upstream_status=upstream_status,
                     upstream_payload=upstream_payload,
                 )
-            return _map_attribution_response(
+            return map_attribution_response(
                 correlation_id=correlation_id,
                 portfolio_id=portfolio_id,
                 period=period,
@@ -711,241 +691,6 @@ def _metric_dependency_supportability(
     ]
 
 
-def _map_attribution_response(
-    *,
-    correlation_id: str,
-    portfolio_id: str,
-    period: str,
-    as_of_date: str,
-    benchmark_code: str | None,
-    attribution_type: str,
-    grouping_dimension: str,
-    upstream_payload: dict[str, Any],
-) -> WorkbenchRiskAttributionResponse:
-    results = upstream_payload.get("results")
-    mapping = _map_attribution_period_results(
-        results=results,
-        attribution_type=attribution_type,
-        grouping_dimension=grouping_dimension,
-    )
-    supportability = _build_attribution_supportability(
-        benchmark_code=benchmark_code,
-        attribution_type=attribution_type,
-        grouping_dimension=grouping_dimension,
-    )
-    _append_source_calculation_supportability(
-        supportability=supportability,
-        upstream_payload=upstream_payload,
-    )
-    upstream_metadata = upstream_payload.get("metadata")
-    state, warnings, partial_failures = _resolve_attribution_state(
-        period_results=mapping.periods,
-        supportability=supportability,
-        warnings=mapping.warnings,
-        partial_failures=mapping.partial_failures,
-    )
-
-    return WorkbenchRiskAttributionResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state=state,
-        payload=_build_attribution_payload(
-            period_results=mapping.periods,
-            benchmark_code=benchmark_code,
-            attribution_type=attribution_type,
-            grouping_dimension=grouping_dimension,
-            upstream_metadata=upstream_metadata,
-        ),
-        supportability=supportability,
-        warnings=sorted(set(warnings)),
-        partial_failures=partial_failures,
-        metadata=_build_attribution_metadata(upstream_metadata=upstream_metadata),
-    )
-
-
-def _map_attribution_period_results(
-    *,
-    results: Any,
-    attribution_type: str,
-    grouping_dimension: str,
-) -> AttributionMappingResult:
-    warnings: list[str] = []
-    partial_failures: list[WorkbenchPartialFailure] = []
-    period_results: list[WorkbenchRiskAttributionPeriodResult] = []
-
-    if not isinstance(results, dict):
-        return AttributionMappingResult(
-            periods=period_results,
-            warnings=warnings,
-            partial_failures=partial_failures,
-        )
-
-    for key, value in results.items():
-        if not isinstance(value, dict):
-            continue
-        period = _map_attribution_period_result(
-            key=key,
-            value=value,
-            attribution_type=attribution_type,
-            grouping_dimension=grouping_dimension,
-        )
-        if period.error:
-            partial_failures.append(
-                WorkbenchPartialFailure(
-                    source_service="risk",
-                    error_code="RISK_ATTRIBUTION_PERIOD_ERROR",
-                    detail=f"{key}: {period.error}",
-                )
-            )
-            warnings.append("RISK_ATTRIBUTION_PERIOD_PARTIAL")
-        period_results.append(period)
-
-    return AttributionMappingResult(
-        periods=period_results,
-        warnings=warnings,
-        partial_failures=partial_failures,
-    )
-
-
-def _map_attribution_period_result(
-    *,
-    key: Any,
-    value: dict[str, Any],
-    attribution_type: str,
-    grouping_dimension: str,
-) -> WorkbenchRiskAttributionPeriodResult:
-    error = value.get("error")
-    return WorkbenchRiskAttributionPeriodResult(
-        key=str(key),
-        label=str(key),
-        start_date=str(value.get("start_date", "")),
-        end_date=str(value.get("end_date", "")),
-        attribution_sets=_map_attribution_sets(
-            value.get("attribution_sets"),
-            attribution_type=attribution_type,
-            grouping_dimension=grouping_dimension,
-        ),
-        error=str(error) if isinstance(error, str) and error.strip() else None,
-    )
-
-
-def _map_attribution_sets(
-    value: Any,
-    *,
-    attribution_type: str,
-    grouping_dimension: str,
-) -> list[WorkbenchRiskAttributionSet]:
-    if not isinstance(value, list):
-        return []
-    return [
-        _map_attribution_set(
-            entry,
-            attribution_type=attribution_type,
-            grouping_dimension=grouping_dimension,
-        )
-        for entry in value
-        if isinstance(entry, dict)
-    ]
-
-
-def _map_attribution_set(
-    entry: dict[str, Any],
-    *,
-    attribution_type: str,
-    grouping_dimension: str,
-) -> WorkbenchRiskAttributionSet:
-    return WorkbenchRiskAttributionSet(
-        attribution_type=str(entry.get("attribution_type", attribution_type)),
-        metric=str(entry.get("metric", "")),
-        grouping_dimension=str(entry.get("grouping_dimension", grouping_dimension)),
-        total_value=_safe_float(entry.get("total_value")),
-        reconciled_sum=_safe_float(entry.get("reconciled_sum")),
-        residual=_safe_float(entry.get("residual")),
-        contributors=_map_attribution_contributors(entry.get("contributors")),
-        quality_flags=[
-            str(flag)
-            for flag in entry.get("quality_flags", [])
-            if isinstance(flag, str) and flag.strip()
-        ],
-    )
-
-
-def _map_attribution_contributors(value: Any) -> list[WorkbenchRiskAttributionContributor]:
-    if not isinstance(value, list):
-        return []
-    return [
-        WorkbenchRiskAttributionContributor.model_validate(contributor)
-        for contributor in value
-        if isinstance(contributor, dict)
-    ]
-
-
-def _resolve_attribution_state(
-    *,
-    period_results: list[WorkbenchRiskAttributionPeriodResult],
-    supportability: list[WorkbenchRiskSupportabilityItem],
-    warnings: list[str],
-    partial_failures: list[WorkbenchPartialFailure],
-) -> tuple[RiskModuleState, list[str], list[WorkbenchPartialFailure]]:
-    resolved_warnings = list(warnings)
-    resolved_partial_failures = list(partial_failures)
-    state: RiskModuleState = (
-        "partial" if any(item.state != "ready" for item in supportability) else "ready"
-    )
-    if not period_results:
-        state = "unavailable"
-        resolved_warnings.append("RISK_ATTRIBUTION_EMPTY")
-        resolved_partial_failures.append(
-            WorkbenchPartialFailure(
-                source_service="risk",
-                error_code="EMPTY_RISK_ATTRIBUTION",
-                detail="lotus-risk returned no attribution periods.",
-            )
-        )
-    elif all(not period.attribution_sets for period in period_results):
-        state = "unavailable"
-    return state, resolved_warnings, resolved_partial_failures
-
-
-def _build_attribution_metadata(*, upstream_metadata: Any) -> WorkbenchRiskMetadata:
-    metadata = _metadata(input_mode="stateful", cache_status="miss")
-    if isinstance(upstream_metadata, dict):
-        methodology_version = upstream_metadata.get("methodology_version")
-        if isinstance(methodology_version, str) and methodology_version.strip():
-            return metadata.model_copy(update={"methodology_version": methodology_version})
-    return metadata
-
-
-def _build_attribution_payload(
-    *,
-    period_results: list[WorkbenchRiskAttributionPeriodResult],
-    benchmark_code: str | None,
-    attribution_type: str,
-    grouping_dimension: str,
-    upstream_metadata: Any,
-) -> WorkbenchRiskAttributionPayload | None:
-    if not period_results:
-        return None
-    metadata = upstream_metadata if isinstance(upstream_metadata, dict) else None
-    return WorkbenchRiskAttributionPayload(
-        controls=_build_attribution_controls(
-            benchmark_code=benchmark_code,
-            attribution_type=attribution_type,
-            grouping_dimension=grouping_dimension,
-            upstream_metadata=metadata,
-        ),
-        periods=period_results,
-        methodology_context=(
-            WorkbenchRiskAttributionMethodologyContext.model_validate(upstream_metadata)
-            if isinstance(upstream_metadata, dict)
-            else None
-        ),
-    )
-
-
 def _append_source_calculation_supportability(
     *,
     supportability: list[WorkbenchRiskSupportabilityItem],
@@ -967,86 +712,6 @@ def _append_source_calculation_supportability(
             source_service=source_supportability.source_service or "lotus-risk",
         )
     )
-
-
-def _build_attribution_controls(
-    *,
-    benchmark_code: str | None,
-    attribution_type: str,
-    grouping_dimension: str,
-    upstream_metadata: dict[str, Any] | None = None,
-) -> WorkbenchRiskAttributionControls:
-    return build_attribution_controls(
-        benchmark_code=benchmark_code,
-        attribution_type=attribution_type,
-        grouping_dimension=grouping_dimension,
-        upstream_metadata=upstream_metadata,
-    )
-
-
-def _build_attribution_supportability(
-    *,
-    benchmark_code: str | None,
-    attribution_type: str,
-    grouping_dimension: str,
-    upstream_metadata: dict[str, Any] | None = None,
-) -> list[WorkbenchRiskSupportabilityItem]:
-    return build_attribution_supportability(
-        benchmark_code=benchmark_code,
-        attribution_type=attribution_type,
-        grouping_dimension=grouping_dimension,
-        upstream_metadata=upstream_metadata,
-    )
-
-
-def _blocked_attribution_response(
-    *,
-    correlation_id: str,
-    portfolio_id: str,
-    period: str,
-    as_of_date: str,
-    benchmark_code: str | None,
-    attribution_type: str,
-    grouping_dimension: str,
-) -> WorkbenchRiskAttributionResponse | None:
-    is_active_risk_without_benchmark = attribution_type == "ACTIVE_RISK" and not benchmark_code
-    is_active_risk_gated_grouping = (
-        attribution_type == "ACTIVE_RISK"
-        and grouping_dimension in _RISK_ATTRIBUTION_ACTIVE_RISK_GATED_GROUPINGS
-    )
-    if not is_active_risk_without_benchmark and not is_active_risk_gated_grouping:
-        return None
-    controls = _build_attribution_controls(
-        benchmark_code=benchmark_code,
-        attribution_type=attribution_type,
-        grouping_dimension=grouping_dimension,
-    )
-    return WorkbenchRiskAttributionResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state="blocked",
-        payload=WorkbenchRiskAttributionPayload(controls=controls, periods=[]),
-        supportability=_build_attribution_supportability(
-            benchmark_code=benchmark_code,
-            attribution_type=attribution_type,
-            grouping_dimension=grouping_dimension,
-        ),
-        warnings=["RISK_ATTRIBUTION_BLOCKED"],
-        partial_failures=[],
-        metadata=_metadata(input_mode="stateful", cache_status="bypass"),
-    )
-
-
-def _safe_float(value: Any) -> float | None:
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
 
 
 def _unavailable_summary(
@@ -1071,49 +736,6 @@ def _unavailable_summary(
             reason="lotus-risk summary endpoint is unavailable."
         ),
         warnings=["RISK_SUMMARY_UNAVAILABLE"],
-        partial_failures=[
-            risk_upstream_failure(
-                upstream_status=upstream_status,
-                upstream_payload=upstream_payload,
-            )
-        ],
-        metadata=_metadata(input_mode="stateful", cache_status="miss"),
-    )
-
-
-def _unavailable_attribution(
-    *,
-    correlation_id: str,
-    portfolio_id: str,
-    period: str,
-    as_of_date: str,
-    benchmark_code: str | None,
-    attribution_type: str,
-    grouping_dimension: str,
-    upstream_status: int,
-    upstream_payload: Any,
-) -> WorkbenchRiskAttributionResponse:
-    return WorkbenchRiskAttributionResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state="unavailable",
-        payload=WorkbenchRiskAttributionPayload(
-            controls=_build_attribution_controls(
-                benchmark_code=benchmark_code,
-                attribution_type=attribution_type,
-                grouping_dimension=grouping_dimension,
-            ),
-            periods=[],
-        ),
-        supportability=_build_attribution_supportability(
-            benchmark_code=benchmark_code,
-            attribution_type=attribution_type,
-            grouping_dimension=grouping_dimension,
-        ),
-        warnings=["RISK_ATTRIBUTION_UNAVAILABLE"],
         partial_failures=[
             risk_upstream_failure(
                 upstream_status=upstream_status,
@@ -1155,31 +777,4 @@ def _build_risk_periods(
         period=period,
         report_start_date=report_start_date,
         report_end_date=report_end_date,
-    )
-
-
-def _risk_attribution_grouping_label(grouping_key: str) -> str:
-    return risk_attribution_grouping_label(grouping_key)
-
-
-def _resolve_active_risk_grouping_support(
-    metadata: dict[str, Any] | None,
-) -> tuple[set[str], set[str], str]:
-    return resolve_active_risk_grouping_support(metadata)
-
-
-def _total_risk_gated_grouping_reason(active_risk_gate_reason: str | None) -> str:
-    return total_risk_gated_grouping_reason(active_risk_gate_reason)
-
-
-def _metadata_grouping_dimension_set(
-    *,
-    metadata: dict[str, Any],
-    field_name: str,
-    default: tuple[str, ...],
-) -> set[str]:
-    return metadata_grouping_dimension_set(
-        metadata=metadata,
-        field_name=field_name,
-        default=default,
     )

--- a/tests/unit/test_risk_workspace_attribution.py
+++ b/tests/unit/test_risk_workspace_attribution.py
@@ -1,0 +1,109 @@
+from app.services.risk_workspace_attribution import (
+    blocked_attribution_response,
+    map_attribution_response,
+    unavailable_attribution,
+)
+
+
+def test_map_attribution_response_preserves_upstream_methodology_and_period_errors() -> None:
+    response = map_attribution_response(
+        correlation_id="corr-1",
+        portfolio_id="PF_1",
+        period="YTD",
+        as_of_date="2026-04-04",
+        benchmark_code="BMK_1",
+        attribution_type="TOTAL_RISK",
+        grouping_dimension="SECTOR",
+        upstream_payload={
+            "results": {
+                "YTD": {
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-04-04",
+                    "attribution_sets": [
+                        {
+                            "metric": "VOLATILITY",
+                            "total_value": "0.12",
+                            "reconciled_sum": 0.119,
+                            "residual": "not-a-number",
+                            "contributors": [
+                                {
+                                    "group_key": "SECTOR_TECH",
+                                    "group_label": "Technology",
+                                    "weight_average": 0.42,
+                                    "marginal_contribution": 0.05,
+                                    "component_contribution": 0.044,
+                                    "percent_contribution": 0.36,
+                                }
+                            ],
+                        }
+                    ],
+                    "error": "issuer enrichment partial",
+                }
+            },
+            "metadata": {"methodology_version": "historical_attribution.v1"},
+        },
+    )
+
+    assert response.state == "ready"
+    assert response.metadata.methodology_version == "historical_attribution.v1"
+    assert response.payload is not None
+    attribution_set = response.payload.periods[0].attribution_sets[0]
+    assert attribution_set.total_value == 0.12
+    assert attribution_set.reconciled_sum == 0.119
+    assert attribution_set.residual is None
+    assert response.partial_failures[0].error_code == "RISK_ATTRIBUTION_PERIOD_ERROR"
+    assert response.warnings == ["RISK_ATTRIBUTION_PERIOD_PARTIAL"]
+
+
+def test_map_attribution_response_returns_unavailable_when_periods_are_missing() -> None:
+    response = map_attribution_response(
+        correlation_id="corr-1",
+        portfolio_id="PF_1",
+        period="YTD",
+        as_of_date="2026-04-04",
+        benchmark_code="BMK_1",
+        attribution_type="TOTAL_RISK",
+        grouping_dimension="SECTOR",
+        upstream_payload={"results": {}, "metadata": {}},
+    )
+
+    assert response.state == "unavailable"
+    assert response.payload is None
+    assert response.partial_failures[0].error_code == "EMPTY_RISK_ATTRIBUTION"
+    assert response.warnings == ["RISK_ATTRIBUTION_EMPTY"]
+
+
+def test_blocked_attribution_response_bypasses_active_risk_without_benchmark() -> None:
+    response = blocked_attribution_response(
+        correlation_id="corr-1",
+        portfolio_id="PF_1",
+        period="YTD",
+        as_of_date="2026-04-04",
+        benchmark_code=None,
+        attribution_type="ACTIVE_RISK",
+        grouping_dimension="SECTOR",
+    )
+
+    assert response is not None
+    assert response.state == "blocked"
+    assert response.metadata.cache_status == "bypass"
+    assert response.warnings == ["RISK_ATTRIBUTION_BLOCKED"]
+
+
+def test_unavailable_attribution_preserves_product_safe_upstream_failure() -> None:
+    response = unavailable_attribution(
+        correlation_id="corr-1",
+        portfolio_id="PF_1",
+        period="YTD",
+        as_of_date="2026-04-04",
+        benchmark_code="BMK_1",
+        attribution_type="TOTAL_RISK",
+        grouping_dimension="SECTOR",
+        upstream_status=503,
+        upstream_payload={"detail": "risk attribution unavailable", "debug": "hidden"},
+    )
+
+    assert response.state == "unavailable"
+    assert response.payload is not None
+    assert response.partial_failures[0].error_code == "HTTP_503"
+    assert response.partial_failures[0].detail == "risk attribution unavailable"


### PR DESCRIPTION
## Summary
- Extract risk attribution response mapping, blocked/unavailable envelopes, period/set/contributor parsing, methodology metadata, and metric conversion into `risk_workspace_attribution.py`.
- Keep `RiskWorkspaceService.get_attribution` focused on request construction, upstream orchestration, caching, and correlation refresh.
- Add direct attribution module tests for mapping, empty results, blocked active-risk requests, and product-safe upstream failures.
- Add `quality/ci_quality_gates.md` and refresh baseline/scorecard evidence per `enterprise_backend_refactoring_instructions.md`.

## Before / After Scorecard
| Measure | Before | After |
| --- | ---: | ---: |
| `risk_workspace_service.py` lines | 1,185 | 780 |
| Dedicated risk attribution module | no | yes, 400 lines |
| Python source files under `src/app` | 435 | 436 |
| Python test files under `tests` | 151 | 152 |
| Unit/contract tests in `make check` | 938 previous baseline | 942 passed |
| Coverage tests in `make ci` | 1,145 previous baseline | 1,149 passed |
| Total coverage | 92.65% previous evidence | 92.72% |
| CI quality gate documentation | missing `quality/ci_quality_gates.md` | added progressive gate roadmap |

## Architecture / API / Operations
- Experience API boundary preserved: attribution calculation truth remains source-owned by `lotus-risk`.
- Gateway attribution orchestration still uses the existing risk client protocol and cache path.
- No public API shape change intended; Workbench attribution behavior is preserved by service tests.
- OpenAPI surface unchanged in this slice.
- Operational evidence updated in `quality/` rather than duplicating wiki truth; wiki check is clean.

## Validation
- `python -m ruff check src\app\services\risk_workspace_service.py src\app\services\risk_workspace_attribution.py tests\unit\test_risk_workspace_attribution.py`
- `python -m ruff format src\app\services\risk_workspace_service.py src\app\services\risk_workspace_attribution.py tests\unit\test_risk_workspace_attribution.py --check`
- `python -m mypy src\app\services\risk_workspace_service.py src\app\services\risk_workspace_attribution.py tests\unit\test_risk_workspace_attribution.py`
- `python -m pytest tests\unit\test_risk_workspace_attribution.py tests\unit\test_risk_workspace_service.py tests\unit\test_risk_workspace_attribution_controls.py tests\unit\test_risk_workspace_envelopes.py -q` (36 passed)
- `make check` (942 unit/contract tests passed)
- `make ci` (207 integration tests, 1,149 coverage tests, 92.72% coverage, dependency audit passed)
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` (`DiffCount 0`)

## Security / Observability / Documentation
- Security posture preserved: `pip-audit` reports no known vulnerabilities after the governed `PYSEC-2026-161` exception.
- Product-safe upstream failure detail mapping remains centralized through risk workspace envelope helpers.
- Quality documentation now includes the CI gate roadmap requested by the enterprise backend refactoring instructions.

## Known Limitations / Follow-up Backlog
- Full enterprise refactor remains incomplete; this is one incremental slice.
- Remaining large hotspots include `portfolio_service.py`, `advisor_brief_service.py`, `performance_workspace_service.py`, and DPM service modules.
- Next risk workspace slice should extract summary response mapping after attribution, drawdown, rolling, concentration, and envelope helpers.
- OpenAPI quality, architecture-boundary enforcement, security scanning beyond dependency audit, and observability static gates remain progressive hardening work.

## Governance
- Read `C:\Users\Sandeep\Downloads\enterprise_backend_refactoring_instructions.md` before PR creation and reconciled this slice against its baseline/reporting and incremental-refactor expectations.
- Stranded-truth check reported no unmerged remote branches.
- No wiki source changes required; repo-authored wiki remains synchronized.