### PR TITLE
Extract risk summary response module

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -64,8 +64,11 @@ The risk attribution response mapper, blocked/unavailable envelopes, period/set/
 parsing, methodology metadata, and metric conversion have been extracted to
 `src/app/services/risk_workspace_attribution.py`, reducing `risk_workspace_service.py` to 780
 lines while keeping attribution request orchestration and cache semantics in the workspace service.
-The current longest
-function is `_build_normalized_capabilities` in
+The risk summary response mapper, unavailable envelope, metric labelling, dependency
+supportability, source-calculation supportability, and empty-result envelope have been extracted to
+`src/app/services/risk_workspace_summary.py`, reducing `risk_workspace_service.py` to 540 lines
+while keeping summary request orchestration, caching, and correlation handling in the workspace
+service. The current longest function is `_build_normalized_capabilities` in
 `src/app/services/platform_capabilities_service.py` at 195 lines.
 
 ## Progressive Enforcement

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -10,7 +10,7 @@ This baseline covers the current gateway hardening state after the report-only q
 lane, router-registry split, performance workspace response split, and advisor-brief response
 split, risk drawdown mapper split, risk rolling mapper split, risk attribution mapper split,
 risk concentration mapper extraction, shared risk unavailable-envelope helper extraction, and
-risk drawdown, rolling, and attribution response module extraction.
+risk drawdown, rolling, attribution, and summary response module extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -18,9 +18,9 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 659 |
-| Python source files under `src/app` | 436 |
-| Python test files under `tests` | 152 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 661 |
+| Python source files under `src/app` | 437 |
+| Python test files under `tests` | 153 |
 | OpenAPI paths | 170 |
 | OpenAPI operations | 170 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -73,8 +73,8 @@ Most recent local evidence:
 
 1. `make check`: 946 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
-3. `make ci`: 1,149 coverage tests passed.
-4. Coverage: 92.72%.
+3. `make ci`: 1,153 coverage tests passed.
+4. Coverage: 92.75%.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -71,7 +71,7 @@ Current repo-native gates already cover:
 
 Most recent local evidence:
 
-1. `make check`: 942 unit/contract tests passed.
+1. `make check`: 946 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
 3. `make ci`: 1,149 coverage tests passed.
 4. Coverage: 92.72%.

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -47,7 +47,7 @@ Report-only quality checks should remain advisory until findings are classified:
 
 Most recent local PR-grade evidence:
 
-1. `make check`: 942 unit/contract tests passed.
+1. `make check`: 946 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
 3. `make ci`: 1,149 coverage tests passed.
 4. Total coverage: 92.72%, above the 84% floor.

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -49,8 +49,8 @@ Most recent local PR-grade evidence:
 
 1. `make check`: 946 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
-3. `make ci`: 1,149 coverage tests passed.
-4. Total coverage: 92.72%, above the 84% floor.
+3. `make ci`: 1,153 coverage tests passed.
+4. Total coverage: 92.75%, above the 84% floor.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Next Tightening Candidates

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -6,7 +6,7 @@ Mode: baseline/report-only
 | Dimension | Score | Baseline status | Next action |
 | --- | ---: | --- | --- |
 | Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
-| Coverage | 4/5 | 92.72% total coverage | Add targeted middleware/security/error tests |
+| Coverage | 4/5 | 92.75% total coverage | Add targeted middleware/security/error tests |
 | Modularity | 2/5 | Large services and contracts remain | Continue extraction slices |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -18,15 +18,18 @@ dedicated rolling module, reducing `risk_workspace_service.py` to 1,185 lines wh
 retry, request, and cache semantics in the workspace service. The risk attribution response
 mapper, blocked/unavailable envelopes, and focused attribution module tests have been extracted to
 a dedicated attribution module, reducing `risk_workspace_service.py` to 780 lines while preserving
-request, cache, and correlation semantics in the workspace service. The remaining work is still
-substantial: large portfolio, performance workspace, contract, and client modules remain.
+request, cache, and correlation semantics in the workspace service. The risk summary response
+mapper and focused summary module tests have been extracted to a dedicated summary module,
+reducing `risk_workspace_service.py` to 540 lines while preserving request, cache, and correlation
+semantics in the workspace service. The remaining work is still substantial: large portfolio,
+performance workspace, contract, and client modules remain.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
-| Unit/contract coverage | Healthy | 942 tests passed in latest `make check` evidence |
+| Unit/contract coverage | Healthy | 942 tests passed in latest `make check` evidence before the summary module test addition |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.72%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
@@ -39,9 +42,8 @@ substantial: large portfolio, performance workspace, contract, and client module
 
 1. Split `portfolio_service.py` into source-readiness, transaction/activity, income, workspace,
    and workflow-cue adapters.
-2. Continue splitting `risk_workspace_service.py` by risk surface; the next risk workspace target
-   should be a bounded summary response module extraction after the shared unavailable-envelope,
-   drawdown, rolling, and attribution helpers.
+2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
+   behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Split `platform_capabilities_service.py` capability normalization into smaller adapters.
 4. Continue extracting performance workspace evidence and attribution helpers behind stable
    response contracts.

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -31,7 +31,7 @@ performance workspace, contract, and client modules remain.
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
 | Unit/contract coverage | Healthy | 946 tests passed in latest `make check` evidence |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
-| Total coverage | Healthy | 92.72%, above the 84% floor |
+| Total coverage | Healthy | 92.75%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
 | Modularity | Improving, incomplete | Several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -29,7 +29,7 @@ performance workspace, contract, and client modules remain.
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
-| Unit/contract coverage | Healthy | 942 tests passed in latest `make check` evidence before the summary module test addition |
+| Unit/contract coverage | Healthy | 946 tests passed in latest `make check` evidence |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.72%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |

--- a/src/app/services/risk_workspace_service.py
+++ b/src/app/services/risk_workspace_service.py
@@ -5,19 +5,12 @@ from fastapi import status
 
 from app.config import settings
 from app.contracts.risk_workspace import (
-    RiskModuleState,
     WorkbenchRiskAttributionResponse,
     WorkbenchRiskConcentrationResponse,
     WorkbenchRiskDrawdownResponse,
-    WorkbenchRiskMetadata,
-    WorkbenchRiskMetric,
-    WorkbenchRiskPeriodResult,
     WorkbenchRiskRollingResponse,
-    WorkbenchRiskSummaryPayload,
     WorkbenchRiskSummaryResponse,
-    WorkbenchRiskSupportabilityItem,
 )
-from app.contracts.workbench import WorkbenchPartialFailure
 from app.services.async_ttl_cache import AsyncTtlCache
 from app.services.domain_client_protocols import RiskWorkspaceClient
 from app.services.risk_workspace_attribution import (
@@ -35,14 +28,6 @@ from app.services.risk_workspace_drawdown import (
     map_drawdown_response,
     unavailable_drawdown,
 )
-from app.services.risk_workspace_envelopes import (
-    risk_metadata,
-    risk_upstream_failure,
-    unavailable_risk_service_supportability,
-)
-from app.services.risk_workspace_requests import (
-    SUMMARY_METRICS as _SUMMARY_METRICS,
-)
 from app.services.risk_workspace_requests import (
     build_attribution_request,
     build_concentration_request,
@@ -59,23 +44,10 @@ from app.services.risk_workspace_rolling import (
     should_retry_rolling_without_sharpe,
     unavailable_rolling,
 )
-from app.services.source_supportability import (
-    extract_calculation_supportability,
-    source_supportability_reason,
+from app.services.risk_workspace_summary import (
+    map_summary_response,
+    unavailable_summary,
 )
-
-_BENCHMARK_DEPENDENT_METRICS = {"BETA", "TRACKING_ERROR", "INFORMATION_RATIO"}
-_RISK_FREE_DEPENDENT_METRICS = {"SHARPE"}
-_METRIC_LABELS = {
-    "VOLATILITY": "Volatility",
-    "DRAWDOWN": "Drawdown",
-    "SHARPE": "Sharpe",
-    "SORTINO": "Sortino",
-    "BETA": "Beta",
-    "TRACKING_ERROR": "Tracking Error",
-    "INFORMATION_RATIO": "Information Ratio",
-    "VAR": "Value at Risk",
-}
 
 
 class RiskWorkspaceService:
@@ -140,7 +112,7 @@ class RiskWorkspaceService:
             if upstream_status >= status.HTTP_400_BAD_REQUEST or not isinstance(
                 upstream_payload, dict
             ):
-                return _unavailable_summary(
+                return unavailable_summary(
                     correlation_id=correlation_id,
                     portfolio_id=portfolio_id,
                     period=period,
@@ -149,7 +121,7 @@ class RiskWorkspaceService:
                     upstream_status=upstream_status,
                     upstream_payload=upstream_payload,
                 )
-            return _map_summary_response(
+            return map_summary_response(
                 correlation_id=correlation_id,
                 portfolio_id=portfolio_id,
                 period=period,
@@ -536,218 +508,6 @@ def _normalize_risk_attribution_type(value: str) -> str:
 
 def _normalize_risk_attribution_grouping(value: str) -> str:
     return normalize_risk_attribution_grouping(value)
-
-
-def _map_summary_response(
-    *,
-    correlation_id: str,
-    portfolio_id: str,
-    period: str,
-    as_of_date: str,
-    benchmark_code: str | None,
-    upstream_payload: dict[str, Any],
-) -> WorkbenchRiskSummaryResponse:
-    results = upstream_payload.get("results")
-    warnings: list[str] = []
-    partial_failures: list[WorkbenchPartialFailure] = []
-    period_results: list[WorkbenchRiskPeriodResult] = []
-    supportability = [
-        WorkbenchRiskSupportabilityItem(
-            key="portfolio_returns",
-            label="Portfolio returns",
-            state="ready" if isinstance(results, dict) and results else "unavailable",
-            source_service="lotus-risk",
-        )
-    ]
-    metric_states: dict[str, str] = {}
-    if isinstance(results, dict):
-        for key, value in results.items():
-            if not isinstance(value, dict):
-                continue
-            metrics_payload = value.get("metrics")
-            metrics = _map_metrics(metrics_payload if isinstance(metrics_payload, dict) else {})
-            for metric in metrics:
-                metric_states[metric.key] = metric.state
-            period_results.append(
-                WorkbenchRiskPeriodResult(
-                    key=str(key),
-                    label=str(key),
-                    start_date=str(value.get("start_date", "")),
-                    end_date=str(value.get("end_date", "")),
-                    portfolio_observation_count=int(value.get("portfolio_observation_count", 0)),
-                    benchmark_observation_count=int(value.get("benchmark_observation_count", 0)),
-                    aligned_benchmark_observation_count=int(
-                        value.get("aligned_benchmark_observation_count", 0)
-                    ),
-                    benchmark_context=(
-                        cast(dict[str, Any], value.get("benchmark_context"))
-                        if isinstance(value.get("benchmark_context"), dict)
-                        else None
-                    ),
-                    metrics=metrics,
-                )
-            )
-    supportability.extend(_metric_dependency_supportability(metric_states, benchmark_code))
-    _append_source_calculation_supportability(
-        supportability=supportability,
-        upstream_payload=upstream_payload,
-    )
-    state: RiskModuleState = (
-        "partial" if any(item.state != "ready" for item in supportability) else "ready"
-    )
-    if not period_results:
-        state = "unavailable"
-        warnings.append("RISK_SUMMARY_EMPTY")
-        partial_failures.append(
-            WorkbenchPartialFailure(
-                source_service="risk",
-                error_code="EMPTY_RISK_SUMMARY",
-                detail="lotus-risk returned no risk summary periods.",
-            )
-        )
-    return WorkbenchRiskSummaryResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state=state,
-        payload=WorkbenchRiskSummaryPayload(periods=period_results) if period_results else None,
-        supportability=supportability,
-        warnings=warnings,
-        partial_failures=partial_failures,
-        metadata=_metadata(input_mode="stateful", cache_status="miss"),
-    )
-
-
-def _map_metrics(metrics_payload: dict[str, Any]) -> list[WorkbenchRiskMetric]:
-    metrics: list[WorkbenchRiskMetric] = []
-    for key in _SUMMARY_METRICS:
-        raw_value = metrics_payload.get(key)
-        if not isinstance(raw_value, dict):
-            metrics.append(
-                WorkbenchRiskMetric(
-                    key=key,
-                    label=_METRIC_LABELS.get(key, key),
-                    value=None,
-                    state="unavailable",
-                    reason="Metric was not returned by lotus-risk.",
-                )
-            )
-            continue
-        value = raw_value.get("value")
-        details = raw_value.get("details") if isinstance(raw_value.get("details"), dict) else None
-        error = details.get("error") if isinstance(details, dict) else None
-        metrics.append(
-            WorkbenchRiskMetric(
-                key=key,
-                label=_METRIC_LABELS.get(key, key),
-                value=float(value) if isinstance(value, int | float) else None,
-                state="partial" if error else "ready",
-                reason=str(error) if error else None,
-                details=details,
-            )
-        )
-    return metrics
-
-
-def _metric_dependency_supportability(
-    metric_states: dict[str, str], benchmark_code: str | None
-) -> list[WorkbenchRiskSupportabilityItem]:
-    benchmark_metric_states = [
-        metric_states.get(metric, "unavailable") for metric in _BENCHMARK_DEPENDENT_METRICS
-    ]
-    risk_free_metric_states = [
-        metric_states.get(metric, "unavailable") for metric in _RISK_FREE_DEPENDENT_METRICS
-    ]
-    benchmark_ready = (
-        bool(benchmark_code)
-        and benchmark_metric_states
-        and all(state == "ready" for state in benchmark_metric_states)
-    )
-    risk_free_ready = bool(risk_free_metric_states) and all(
-        state == "ready" for state in risk_free_metric_states
-    )
-    return [
-        WorkbenchRiskSupportabilityItem(
-            key="benchmark_returns",
-            label="Benchmark returns",
-            state="ready" if benchmark_ready else "partial",
-            reason=None
-            if benchmark_code
-            else "Benchmark-relative metrics require benchmark context.",
-            source_service="lotus-risk",
-        ),
-        WorkbenchRiskSupportabilityItem(
-            key="risk_free_series",
-            label="Risk-free series",
-            state="ready" if risk_free_ready else "partial",
-            reason=(
-                "Sharpe is partial or unavailable when lotus-risk cannot source "
-                "the required risk-free series."
-            ),
-            source_service="lotus-risk",
-        ),
-    ]
-
-
-def _append_source_calculation_supportability(
-    *,
-    supportability: list[WorkbenchRiskSupportabilityItem],
-    upstream_payload: dict[str, Any],
-) -> None:
-    source_supportability = extract_calculation_supportability(upstream_payload)
-    if source_supportability is None:
-        return
-
-    supportability.append(
-        WorkbenchRiskSupportabilityItem(
-            key="source_calculation",
-            label="Source calculation",
-            state=cast(Any, source_supportability.risk_contract_state),
-            reason=source_supportability_reason(
-                source_supportability,
-                default_ready_reason="Source calculation supportability was confirmed upstream.",
-            ),
-            source_service=source_supportability.source_service or "lotus-risk",
-        )
-    )
-
-
-def _unavailable_summary(
-    *,
-    correlation_id: str,
-    portfolio_id: str,
-    period: str,
-    as_of_date: str,
-    benchmark_code: str | None,
-    upstream_status: int,
-    upstream_payload: Any,
-) -> WorkbenchRiskSummaryResponse:
-    return WorkbenchRiskSummaryResponse(
-        correlation_id=correlation_id,
-        portfolio_id=portfolio_id,
-        period=period,
-        as_of_date=as_of_date,
-        benchmark_code=benchmark_code,
-        state="unavailable",
-        payload=None,
-        supportability=unavailable_risk_service_supportability(
-            reason="lotus-risk summary endpoint is unavailable."
-        ),
-        warnings=["RISK_SUMMARY_UNAVAILABLE"],
-        partial_failures=[
-            risk_upstream_failure(
-                upstream_status=upstream_status,
-                upstream_payload=upstream_payload,
-            )
-        ],
-        metadata=_metadata(input_mode="stateful", cache_status="miss"),
-    )
-
-
-def _metadata(*, input_mode: str, cache_status: str) -> WorkbenchRiskMetadata:
-    return risk_metadata(input_mode=input_mode, cache_status=cache_status)
 
 
 def _latest_business_day(today: date | None = None) -> date:

--- a/src/app/services/risk_workspace_summary.py
+++ b/src/app/services/risk_workspace_summary.py
@@ -1,0 +1,269 @@
+from typing import Any, cast
+
+from app.contracts.risk_workspace import (
+    RiskModuleState,
+    WorkbenchRiskMetric,
+    WorkbenchRiskPeriodResult,
+    WorkbenchRiskSummaryPayload,
+    WorkbenchRiskSummaryResponse,
+    WorkbenchRiskSupportabilityItem,
+)
+from app.contracts.workbench import WorkbenchPartialFailure
+from app.services.risk_workspace_envelopes import (
+    risk_metadata,
+    risk_upstream_failure,
+    unavailable_risk_service_supportability,
+)
+from app.services.risk_workspace_requests import SUMMARY_METRICS
+from app.services.source_supportability import (
+    extract_calculation_supportability,
+    source_supportability_reason,
+)
+
+_BENCHMARK_DEPENDENT_METRICS = {"BETA", "TRACKING_ERROR", "INFORMATION_RATIO"}
+_RISK_FREE_DEPENDENT_METRICS = {"SHARPE"}
+_METRIC_LABELS = {
+    "VOLATILITY": "Volatility",
+    "DRAWDOWN": "Drawdown",
+    "SHARPE": "Sharpe",
+    "SORTINO": "Sortino",
+    "BETA": "Beta",
+    "TRACKING_ERROR": "Tracking Error",
+    "INFORMATION_RATIO": "Information Ratio",
+    "VAR": "Value at Risk",
+}
+
+
+def map_summary_response(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    upstream_payload: dict[str, Any],
+) -> WorkbenchRiskSummaryResponse:
+    results = upstream_payload.get("results")
+    warnings: list[str] = []
+    partial_failures: list[WorkbenchPartialFailure] = []
+    period_results: list[WorkbenchRiskPeriodResult] = []
+    supportability = [
+        WorkbenchRiskSupportabilityItem(
+            key="portfolio_returns",
+            label="Portfolio returns",
+            state="ready" if isinstance(results, dict) and results else "unavailable",
+            source_service="lotus-risk",
+        )
+    ]
+    metric_states: dict[str, str] = {}
+    if isinstance(results, dict):
+        for key, value in results.items():
+            if not isinstance(value, dict):
+                continue
+            mapped_period = _map_summary_period(key=key, value=value)
+            for metric in mapped_period.metrics:
+                metric_states[metric.key] = metric.state
+            period_results.append(mapped_period)
+
+    supportability.extend(_metric_dependency_supportability(metric_states, benchmark_code))
+    _append_source_calculation_supportability(
+        supportability=supportability,
+        upstream_payload=upstream_payload,
+    )
+    state = _summary_response_state(
+        period_results=period_results,
+        supportability=supportability,
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    return WorkbenchRiskSummaryResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state=state,
+        payload=WorkbenchRiskSummaryPayload(periods=period_results) if period_results else None,
+        supportability=supportability,
+        warnings=warnings,
+        partial_failures=partial_failures,
+        metadata=risk_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def unavailable_summary(
+    *,
+    correlation_id: str,
+    portfolio_id: str,
+    period: str,
+    as_of_date: str,
+    benchmark_code: str | None,
+    upstream_status: int,
+    upstream_payload: Any,
+) -> WorkbenchRiskSummaryResponse:
+    return WorkbenchRiskSummaryResponse(
+        correlation_id=correlation_id,
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=as_of_date,
+        benchmark_code=benchmark_code,
+        state="unavailable",
+        payload=None,
+        supportability=unavailable_risk_service_supportability(
+            reason="lotus-risk summary endpoint is unavailable."
+        ),
+        warnings=["RISK_SUMMARY_UNAVAILABLE"],
+        partial_failures=[
+            risk_upstream_failure(
+                upstream_status=upstream_status,
+                upstream_payload=upstream_payload,
+            )
+        ],
+        metadata=risk_metadata(input_mode="stateful", cache_status="miss"),
+    )
+
+
+def _map_summary_period(*, key: Any, value: dict[str, Any]) -> WorkbenchRiskPeriodResult:
+    metrics_payload = value.get("metrics")
+    return WorkbenchRiskPeriodResult(
+        key=str(key),
+        label=str(key),
+        start_date=str(value.get("start_date", "")),
+        end_date=str(value.get("end_date", "")),
+        portfolio_observation_count=int(value.get("portfolio_observation_count", 0)),
+        benchmark_observation_count=int(value.get("benchmark_observation_count", 0)),
+        aligned_benchmark_observation_count=int(
+            value.get("aligned_benchmark_observation_count", 0)
+        ),
+        benchmark_context=(
+            cast(dict[str, Any], value.get("benchmark_context"))
+            if isinstance(value.get("benchmark_context"), dict)
+            else None
+        ),
+        metrics=_map_metrics(metrics_payload if isinstance(metrics_payload, dict) else {}),
+    )
+
+
+def _map_metrics(metrics_payload: dict[str, Any]) -> list[WorkbenchRiskMetric]:
+    metrics: list[WorkbenchRiskMetric] = []
+    for key in SUMMARY_METRICS:
+        raw_value = metrics_payload.get(key)
+        if not isinstance(raw_value, dict):
+            metrics.append(
+                WorkbenchRiskMetric(
+                    key=key,
+                    label=_METRIC_LABELS.get(key, key),
+                    value=None,
+                    state="unavailable",
+                    reason="Metric was not returned by lotus-risk.",
+                )
+            )
+            continue
+        value = raw_value.get("value")
+        details = raw_value.get("details") if isinstance(raw_value.get("details"), dict) else None
+        error = details.get("error") if isinstance(details, dict) else None
+        metrics.append(
+            WorkbenchRiskMetric(
+                key=key,
+                label=_METRIC_LABELS.get(key, key),
+                value=_safe_float(value),
+                state="partial" if error else "ready",
+                reason=str(error) if error else None,
+                details=details,
+            )
+        )
+    return metrics
+
+
+def _metric_dependency_supportability(
+    metric_states: dict[str, str], benchmark_code: str | None
+) -> list[WorkbenchRiskSupportabilityItem]:
+    benchmark_metric_states = [
+        metric_states.get(metric, "unavailable") for metric in _BENCHMARK_DEPENDENT_METRICS
+    ]
+    risk_free_metric_states = [
+        metric_states.get(metric, "unavailable") for metric in _RISK_FREE_DEPENDENT_METRICS
+    ]
+    benchmark_ready = (
+        bool(benchmark_code)
+        and benchmark_metric_states
+        and all(state == "ready" for state in benchmark_metric_states)
+    )
+    risk_free_ready = bool(risk_free_metric_states) and all(
+        state == "ready" for state in risk_free_metric_states
+    )
+    return [
+        WorkbenchRiskSupportabilityItem(
+            key="benchmark_returns",
+            label="Benchmark returns",
+            state="ready" if benchmark_ready else "partial",
+            reason=None
+            if benchmark_code
+            else "Benchmark-relative metrics require benchmark context.",
+            source_service="lotus-risk",
+        ),
+        WorkbenchRiskSupportabilityItem(
+            key="risk_free_series",
+            label="Risk-free series",
+            state="ready" if risk_free_ready else "partial",
+            reason=(
+                "Sharpe is partial or unavailable when lotus-risk cannot source "
+                "the required risk-free series."
+            ),
+            source_service="lotus-risk",
+        ),
+    ]
+
+
+def _append_source_calculation_supportability(
+    *,
+    supportability: list[WorkbenchRiskSupportabilityItem],
+    upstream_payload: dict[str, Any],
+) -> None:
+    source_supportability = extract_calculation_supportability(upstream_payload)
+    if source_supportability is None:
+        return
+
+    supportability.append(
+        WorkbenchRiskSupportabilityItem(
+            key="source_calculation",
+            label="Source calculation",
+            state=cast(Any, source_supportability.risk_contract_state),
+            reason=source_supportability_reason(
+                source_supportability,
+                default_ready_reason="Source calculation supportability was confirmed upstream.",
+            ),
+            source_service=source_supportability.source_service or "lotus-risk",
+        )
+    )
+
+
+def _summary_response_state(
+    *,
+    period_results: list[WorkbenchRiskPeriodResult],
+    supportability: list[WorkbenchRiskSupportabilityItem],
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+) -> RiskModuleState:
+    state: RiskModuleState = (
+        "partial" if any(item.state != "ready" for item in supportability) else "ready"
+    )
+    if period_results:
+        return state
+
+    warnings.append("RISK_SUMMARY_EMPTY")
+    partial_failures.append(
+        WorkbenchPartialFailure(
+            source_service="risk",
+            error_code="EMPTY_RISK_SUMMARY",
+            detail="lotus-risk returned no risk summary periods.",
+        )
+    )
+    return "unavailable"
+
+
+def _safe_float(value: Any) -> float | None:  # monetary-float-allow
+    if isinstance(value, int | float):
+        return float(value)  # monetary-float-allow
+    return None

--- a/src/app/services/risk_workspace_summary.py
+++ b/src/app/services/risk_workspace_summary.py
@@ -264,6 +264,6 @@ def _summary_response_state(
 
 
 def _safe_float(value: Any) -> float | None:  # monetary-float-allow
-    if isinstance(value, int | float):
+    if isinstance(value, int | float):  # monetary-float-allow
         return float(value)  # monetary-float-allow
     return None

--- a/tests/unit/test_risk_workspace_summary.py
+++ b/tests/unit/test_risk_workspace_summary.py
@@ -1,0 +1,126 @@
+from app.services.risk_workspace_summary import map_summary_response, unavailable_summary
+
+
+def test_map_summary_response_maps_metrics_and_source_supportability() -> None:
+    response = map_summary_response(
+        correlation_id="corr-summary",
+        portfolio_id="PF_1",
+        period="YTD",
+        as_of_date="2026-04-04",
+        benchmark_code="BMK_1",
+        upstream_payload=_summary_payload(),
+    )
+
+    assert response.state == "ready"
+    assert response.payload is not None
+    period = response.payload.periods[0]
+    assert period.key == "YTD"
+    assert period.metrics[0].label == "Volatility"
+    assert period.metrics[0].value == 0.12
+    assert {item.key: item.state for item in response.supportability} == {
+        "portfolio_returns": "ready",
+        "benchmark_returns": "ready",
+        "risk_free_series": "ready",
+        "source_calculation": "ready",
+    }
+    source_support = {item.key: item for item in response.supportability}["source_calculation"]
+    assert source_support.reason == "Source calculation supportability was confirmed upstream."
+
+
+def test_map_summary_response_reports_partial_metric_dependencies() -> None:
+    payload = _summary_payload()
+    payload["results"]["YTD"]["metrics"]["TRACKING_ERROR"] = {
+        "value": None,
+        "details": {"error": "benchmark returns unavailable"},
+    }
+
+    response = map_summary_response(
+        correlation_id="corr-summary",
+        portfolio_id="PF_1",
+        period="YTD",
+        as_of_date="2026-04-04",
+        benchmark_code="BMK_1",
+        upstream_payload=payload,
+    )
+
+    assert response.state == "partial"
+    assert response.payload is not None
+    tracking_error = [
+        metric for metric in response.payload.periods[0].metrics if metric.key == "TRACKING_ERROR"
+    ][0]
+    assert tracking_error.state == "partial"
+    assert tracking_error.reason == "benchmark returns unavailable"
+    benchmark_support = {item.key: item for item in response.supportability}["benchmark_returns"]
+    assert benchmark_support.state == "partial"
+
+
+def test_map_summary_response_returns_empty_envelope_for_missing_periods() -> None:
+    response = map_summary_response(
+        correlation_id="corr-summary",
+        portfolio_id="PF_1",
+        period="YTD",
+        as_of_date="2026-04-04",
+        benchmark_code="BMK_1",
+        upstream_payload={"results": {}},
+    )
+
+    assert response.state == "unavailable"
+    assert response.payload is None
+    assert response.warnings == ["RISK_SUMMARY_EMPTY"]
+    assert response.partial_failures[0].error_code == "EMPTY_RISK_SUMMARY"
+    assert {item.key: item.state for item in response.supportability} == {
+        "portfolio_returns": "unavailable",
+        "benchmark_returns": "partial",
+        "risk_free_series": "partial",
+    }
+
+
+def test_unavailable_summary_preserves_product_safe_failure_detail() -> None:
+    response = unavailable_summary(
+        correlation_id="corr-summary",
+        portfolio_id="PF_1",
+        period="YTD",
+        as_of_date="2026-04-04",
+        benchmark_code="BMK_1",
+        upstream_status=503,
+        upstream_payload={"detail": "risk unavailable"},
+    )
+
+    assert response.state == "unavailable"
+    assert response.payload is None
+    assert response.warnings == ["RISK_SUMMARY_UNAVAILABLE"]
+    assert response.supportability[0].key == "risk_service"
+    assert response.partial_failures[0].error_code == "HTTP_503"
+    assert response.partial_failures[0].detail == "risk unavailable"
+
+
+def _summary_payload() -> dict:
+    return {
+        "results": {
+            "YTD": {
+                "start_date": "2026-01-01",
+                "end_date": "2026-04-04",
+                "portfolio_observation_count": 66,
+                "benchmark_observation_count": 66,
+                "aligned_benchmark_observation_count": 64,
+                "benchmark_context": {"reason": "APPLIED"},
+                "metrics": {
+                    "VOLATILITY": {"value": 0.12},
+                    "SHARPE": {"value": 1.4},
+                    "SORTINO": {"value": 1.7},
+                    "BETA": {"value": 0.92},
+                    "TRACKING_ERROR": {"value": 0.04},
+                    "INFORMATION_RATIO": {"value": 0.3},
+                    "VAR": {"value": -0.02, "details": {"expected_shortfall": -0.03}},
+                },
+            }
+        },
+        "metadata": {
+            "calculation_supportability": {
+                "state": "ready",
+                "reason": "Source calculation supportability was confirmed upstream.",
+                "freshness_bucket": "fresh",
+                "source_service": "lotus-risk",
+            }
+        },
+    }


### PR DESCRIPTION
## Summary
- Extract the risk workspace summary response mapper, unavailable envelope, metric mapping, dependency supportability, and source-calculation supportability into `risk_workspace_summary.py`.
- Keep `RiskWorkspaceService` focused on request orchestration, cache semantics, and correlation handling.
- Add focused unit coverage for summary metric mapping, dependency partials, empty result envelopes, and upstream failure normalization.
- Refresh quality baseline and scorecard evidence for the 540-line service boundary and latest local gates.

## Validation
- Targeted: `python -m ruff check src\app\services\risk_workspace_service.py src\app\services\risk_workspace_summary.py tests\unit\test_risk_workspace_summary.py`
- Targeted: `python -m ruff format --check src\app\services\risk_workspace_service.py src\app\services\risk_workspace_summary.py tests\unit\test_risk_workspace_summary.py`
- Targeted: `python -m mypy src\app\services\risk_workspace_service.py src\app\services\risk_workspace_summary.py tests\unit\test_risk_workspace_summary.py`
- Targeted: `python -m pytest tests\unit\test_risk_workspace_summary.py tests\unit\test_risk_workspace_service.py -q` (25 passed)
- Feature Lane local: `make check` (946 unit/contract tests passed)
- PR Merge Gate local: `make ci` (207 integration tests, 1,153 coverage tests, 92.75% total coverage, pip-audit clean after governed `PYSEC-2026-161` exception)

## Governance
- Stranded truth: `git fetch origin --prune` and `git branch -r --no-merged origin/main` reported no unmerged remote branches.
- Open PR scan: `gh pr list --state open --limit 100` reported none before this PR.
- Wiki source check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reported `DiffCount 0`.
- Wiki decision: no wiki source change needed; this is an internal service-boundary and quality-evidence slice.
