### PR TITLE
Extract platform capability normalization boundary

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -68,8 +68,13 @@ The risk summary response mapper, unavailable envelope, metric labelling, depend
 supportability, source-calculation supportability, and empty-result envelope have been extracted to
 `src/app/services/risk_workspace_summary.py`, reducing `risk_workspace_service.py` to 540 lines
 while keeping summary request orchestration, caching, and correlation handling in the workspace
-service. The current longest function is `_build_normalized_capabilities` in
-`src/app/services/platform_capabilities_service.py` at 195 lines.
+service. Platform capability normalization, shell-bootstrap construction, workspace descriptors,
+module-health classification, policy diagnostics, workflow flags, and input-mode normalization have
+been extracted to `src/app/services/platform_capabilities_normalization.py`, reducing
+`platform_capabilities_service.py` to 330 lines while keeping upstream orchestration, timeout
+handling, correlation propagation, and partial-failure collection in the service. The current
+longest function is `_build_workspace_control_capabilities` in
+`src/app/services/portfolio_service.py` at 191 lines.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -72,9 +72,9 @@ Current repo-native gates already cover:
 
 Most recent local evidence:
 
-1. `make check`: 946 unit/contract tests passed.
+1. `make check`: 950 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
-3. `make ci`: 1,153 coverage tests passed.
+3. `make ci`: 1,157 coverage tests passed.
 4. Coverage: 92.75%.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -10,7 +10,8 @@ This baseline covers the current gateway hardening state after the report-only q
 lane, router-registry split, performance workspace response split, and advisor-brief response
 split, risk drawdown mapper split, risk rolling mapper split, risk attribution mapper split,
 risk concentration mapper extraction, shared risk unavailable-envelope helper extraction, and
-risk drawdown, rolling, attribution, and summary response module extraction.
+risk drawdown, rolling, attribution, and summary response module extraction, and platform
+capability normalization boundary extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -18,9 +19,9 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 661 |
-| Python source files under `src/app` | 437 |
-| Python test files under `tests` | 153 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 663 |
+| Python source files under `src/app` | 438 |
+| Python test files under `tests` | 154 |
 | OpenAPI paths | 170 |
 | OpenAPI operations | 170 |
 
@@ -43,16 +44,16 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Rank | Lines | Function | File |
 | ---: | ---: | --- | --- |
-| 1 | 195 | `_build_normalized_capabilities` | `src/app/services/platform_capabilities_service.py` |
-| 2 | 191 | `_build_workspace_control_capabilities` | `src/app/services/portfolio_service.py` |
-| 3 | 172 | `parse_horizon_comparison_result` | `src/app/services/performance_workspace_horizon.py` |
-| 4 | 153 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
-| 5 | 144 | `_build_advisor_brief_narrative_state` | `src/app/services/advisor_brief_service.py` |
-| 6 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
-| 7 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
-| 8 | 134 | `_build_shell_bootstrap` | `src/app/services/platform_capabilities_service.py` |
-| 9 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
-| 10 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
+| 1 | 191 | `_build_workspace_control_capabilities` | `src/app/services/portfolio_service.py` |
+| 2 | 172 | `parse_horizon_comparison_result` | `src/app/services/performance_workspace_horizon.py` |
+| 3 | 153 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
+| 4 | 144 | `_build_advisor_brief_narrative_state` | `src/app/services/advisor_brief_service.py` |
+| 5 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
+| 6 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
+| 7 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
+| 8 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
+| 9 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
+| 10 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
 
 ## Existing Blocking Gates
 
@@ -91,7 +92,7 @@ large-file and long-function hotspots in service, contract, and client code.
 The first enforcement candidates should be:
 
 1. no new service file above the current largest-file baseline,
-2. no new function above the current longest-function baseline of 195 lines,
+2. no new function above the current longest-function baseline of 191 lines,
 3. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
 4. no new architecture import-linter violations after contracts are reviewed.
 

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -47,9 +47,9 @@ Report-only quality checks should remain advisory until findings are classified:
 
 Most recent local PR-grade evidence:
 
-1. `make check`: 946 unit/contract tests passed.
+1. `make check`: 950 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
-3. `make ci`: 1,153 coverage tests passed.
+3. `make ci`: 1,157 coverage tests passed.
 4. Total coverage: 92.75%, above the 84% floor.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -7,7 +7,7 @@ Mode: baseline/report-only
 | --- | ---: | --- | --- |
 | Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
 | Coverage | 4/5 | 92.75% total coverage | Add targeted middleware/security/error tests |
-| Modularity | 2/5 | Large services and contracts remain | Continue extraction slices |
+| Modularity | 2/5 | Platform capability normalization extracted; large services and contracts remain | Continue extraction slices |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -21,8 +21,11 @@ a dedicated attribution module, reducing `risk_workspace_service.py` to 780 line
 request, cache, and correlation semantics in the workspace service. The risk summary response
 mapper and focused summary module tests have been extracted to a dedicated summary module,
 reducing `risk_workspace_service.py` to 540 lines while preserving request, cache, and correlation
-semantics in the workspace service. The remaining work is still substantial: large portfolio,
-performance workspace, contract, and client modules remain.
+semantics in the workspace service. Platform capability normalization has been extracted to
+`platform_capabilities_normalization.py`, reducing `platform_capabilities_service.py` to 330 lines
+while preserving upstream orchestration, timeout handling, correlation propagation, and
+partial-failure collection in the service. The remaining work is still substantial: large
+portfolio, performance workspace, contract, and client modules remain.
 
 ## Health Signals
 
@@ -33,7 +36,7 @@ performance workspace, contract, and client modules remain.
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.75%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
-| Modularity | Improving, incomplete | Several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Platform capability normalization extracted; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -44,7 +47,8 @@ performance workspace, contract, and client modules remain.
    and workflow-cue adapters.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
-3. Split `platform_capabilities_service.py` capability normalization into smaller adapters.
+3. Continue splitting platform capability normalization into smaller feature/workflow/bootstrap
+   helpers if future changes expand the extracted module.
 4. Continue extracting performance workspace evidence and attribution helpers behind stable
    response contracts.
 5. Split large contract modules only when contract ownership boundaries are clear and tests remain

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -32,7 +32,7 @@ portfolio, performance workspace, contract, and client modules remain.
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
-| Unit/contract coverage | Healthy | 946 tests passed in latest `make check` evidence |
+| Unit/contract coverage | Healthy | 950 tests passed in latest `make check` evidence |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.75%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |

--- a/src/app/services/platform_capabilities_normalization.py
+++ b/src/app/services/platform_capabilities_normalization.py
@@ -1,0 +1,613 @@
+from typing import Any
+
+from app.contracts.platform_capabilities import (
+    CapabilitySourceError,
+    PlatformBootstrapCaching,
+    PlatformBootstrapEvidence,
+    PlatformBootstrapFreshness,
+    PlatformBootstrapSupportability,
+    PlatformBootstrapVersioning,
+    PlatformCapabilitiesNormalized,
+    PlatformShellBootstrap,
+    PlatformShellWorkspaceDescriptor,
+)
+
+SHELL_BOOTSTRAP_CONTRACT_VERSION = "shell-bootstrap.v1"
+PRIMARY_CAPABILITY_SOURCES = (
+    "lotus_core",
+    "lotus_performance",
+    "lotus_advise",
+    "lotus_manage",
+    "lotus_report",
+)
+OPTIONAL_CAPABILITY_SOURCES = ("lotus_risk",)
+RISK_ANALYTICS_FEATURE_KEYS = (
+    "risk.analytics.risk_analytics",
+    "risk.analytics.drawdown",
+    "risk.analytics.concentration",
+    "risk.analytics.rolling_metrics",
+    "risk.analytics.historical_attribution",
+    "risk.analytics.metrics",
+)
+
+
+def build_normalized_capabilities(
+    *,
+    sources: dict[str, dict[str, Any]],
+    errors: list[CapabilitySourceError],
+    lotus_core_policy: dict[str, Any] | None,
+    evaluated_at: str,
+    contract_version: str,
+) -> PlatformCapabilitiesNormalized:
+    input_modes_by_source, input_modes_union, policy_versions_by_source = (
+        source_input_modes_and_policy_versions(sources)
+    )
+    feature_enabled = feature_enablement(sources)
+    health = module_health(sources=sources, errors=errors)
+    navigation = navigation_flags(feature_enabled)
+    workflows = workflow_flags(sources)
+    policy_diagnostics = lotus_core_policy_diagnostics(
+        lotus_core_policy=lotus_core_policy,
+        errors=errors,
+    )
+    shell_bootstrap = build_shell_bootstrap(
+        sources=sources,
+        navigation=navigation,
+        module_health_by_source=health,
+        policy_versions_by_source=policy_versions_by_source,
+        errors=errors,
+        evaluated_at=evaluated_at,
+        contract_version=contract_version,
+    )
+    return PlatformCapabilitiesNormalized(
+        navigation=navigation,
+        workflowFlags=workflows,
+        inputModesBySource=input_modes_by_source,
+        inputModesUnion=input_modes_union,
+        moduleHealth=health,
+        policyVersionsBySource=policy_versions_by_source,
+        lotusCorePolicyDiagnostics=policy_diagnostics,
+        shellBootstrap=shell_bootstrap,
+    )
+
+
+def source_input_modes_and_policy_versions(
+    sources: dict[str, dict[str, Any]],
+) -> tuple[dict[str, list[str]], list[str], dict[str, str]]:
+    input_modes_by_source: dict[str, list[str]] = {}
+    input_modes_union: list[str] = []
+    policy_versions_by_source: dict[str, str] = {}
+    for source_name, source_payload in sources.items():
+        source_modes = payload_value(
+            source_payload,
+            "supportedInputModes",
+            "supported_input_modes",
+            default=[],
+        )
+        normalized_modes = [str(mode) for mode in source_modes]
+        input_modes_by_source[source_name] = normalized_modes
+        policy_versions_by_source[source_name] = str(
+            payload_value(
+                source_payload,
+                "policyVersion",
+                "policy_version",
+                default="unknown",
+            )
+        )
+        for mode in normalized_modes:
+            if mode not in input_modes_union:
+                input_modes_union.append(mode)
+    for source_name in (*PRIMARY_CAPABILITY_SOURCES, *OPTIONAL_CAPABILITY_SOURCES):
+        policy_versions_by_source.setdefault(source_name, "unknown")
+    return input_modes_by_source, input_modes_union, policy_versions_by_source
+
+
+def feature_enablement(sources: dict[str, dict[str, Any]]) -> dict[str, bool]:
+    return {
+        "lotus_core_snapshot": feature_enabled(
+            sources=sources,
+            source_name="lotus_core",
+            feature_keys=(
+                "lotus_core.integration.core_snapshot",
+                "lotus_core.support.overview_api",
+                "lotus_core.ingestion.portfolio_bundle_adapter",
+                "pas.integration.core_snapshot",
+            ),
+        ),
+        "lotus_core_intake": feature_enabled(
+            sources=sources,
+            source_name="lotus_core",
+            feature_keys=(
+                "lotus_core.ingestion.bulk_upload",
+                "lotus_core.ingestion.bulk_upload_adapter",
+                "lotus_core.ingestion.portfolio_bundle_adapter",
+                "pas.ingestion.bulk_upload",
+            ),
+        ),
+        "lotus_performance_analytics": any(
+            feature_enabled(sources=sources, source_name="lotus_performance", feature_keys=(key,))
+            for key in (
+                "lotus_performance.analytics.twr",
+                "performance.analytics.twr",
+                "lotus_performance.analytics.mwr",
+                "performance.analytics.mwr",
+                "lotus_performance.analytics.contribution",
+                "performance.analytics.contribution",
+                "lotus_performance.analytics.attribution",
+                "performance.analytics.attribution",
+            )
+        ),
+        "lotus_advise_lifecycle": feature_enabled(
+            sources=sources,
+            source_name="lotus_advise",
+            feature_keys=(
+                "advisory.proposals.lifecycle",
+                "lotus_advise.proposals.lifecycle",
+                "advise.proposals.lifecycle",
+                "dpm.proposals.lifecycle",
+            ),
+        ),
+        "lotus_manage_support": feature_enabled(
+            sources=sources,
+            source_name="lotus_manage",
+            feature_keys=(
+                "lotus_manage.support.run_apis",
+                "dpm.support.run_apis",
+            ),
+        ),
+        "lotus_report_reporting": any(
+            feature_enabled(sources=sources, source_name="lotus_report", feature_keys=(key,))
+            for key in (
+                "lotus_report.reporting.portfolio_summary",
+                "ras.reporting.portfolio_summary",
+                "lotus_report.reporting.portfolio_review",
+                "ras.reporting.portfolio_review",
+                "lotus_report.aggregation.portfolio_snapshot",
+                "ras.aggregation.portfolio_snapshot",
+            )
+        ),
+        "lotus_risk_analytics": any(
+            feature_enabled(sources=sources, source_name="lotus_risk", feature_keys=(key,))
+            for key in RISK_ANALYTICS_FEATURE_KEYS
+        ),
+    }
+
+
+def navigation_flags(feature_enabled_by_key: dict[str, bool]) -> dict[str, bool]:
+    core_available = (
+        feature_enabled_by_key["lotus_core_intake"] or feature_enabled_by_key["lotus_core_snapshot"]
+    )
+    return {
+        "command_center": True,
+        "portfolio_intake": core_available,
+        "analytics_studio": feature_enabled_by_key["lotus_performance_analytics"],
+        "advisory_pipeline": feature_enabled_by_key["lotus_advise_lifecycle"],
+        "scenario_builder": feature_enabled_by_key["lotus_advise_lifecycle"],
+        "decision_console": (
+            feature_enabled_by_key["lotus_core_snapshot"]
+            and (
+                feature_enabled_by_key["lotus_advise_lifecycle"]
+                or feature_enabled_by_key["lotus_manage_support"]
+            )
+        ),
+        "reporting_hub": feature_enabled_by_key["lotus_report_reporting"],
+        "portfolio_workspace": core_available,
+        "performance_workspace": feature_enabled_by_key["lotus_performance_analytics"],
+        "risk_workspace": feature_enabled_by_key["lotus_risk_analytics"],
+        "proposal_workspace": feature_enabled_by_key["lotus_advise_lifecycle"],
+        "advisory_workspace": feature_enabled_by_key["lotus_advise_lifecycle"],
+    }
+
+
+def workflow_flags(sources: dict[str, dict[str, Any]]) -> dict[str, bool]:
+    return {
+        "proposal_lifecycle": any_workflow_enabled(
+            sources=sources,
+            source_name="lotus_advise",
+            workflow_keys=(
+                "advisory_proposal_lifecycle",
+                "proposal_lifecycle",
+            ),
+        ),
+        "proposal_approval_flow": any_workflow_enabled(
+            sources=sources,
+            source_name="lotus_advise",
+            workflow_keys=(
+                "advisory_proposal_approval_flow",
+                "proposal_approval_flow",
+            ),
+        ),
+        "portfolio_bulk_onboarding": workflow_enabled(
+            sources=sources,
+            source_name="lotus_core",
+            workflow_key="portfolio_bulk_onboarding",
+        ),
+        "performance_snapshot": workflow_enabled(
+            sources=sources,
+            source_name="lotus_performance",
+            workflow_key="performance_snapshot",
+        ),
+        "portfolio_reporting": workflow_enabled(
+            sources=sources,
+            source_name="lotus_report",
+            workflow_key="portfolio_reporting",
+        ),
+    }
+
+
+def build_shell_bootstrap(
+    *,
+    sources: dict[str, dict[str, Any]],
+    navigation: dict[str, bool],
+    module_health_by_source: dict[str, str],
+    policy_versions_by_source: dict[str, str],
+    errors: list[CapabilitySourceError],
+    evaluated_at: str,
+    contract_version: str,
+) -> PlatformShellBootstrap:
+    error_services = [error.service for error in errors]
+    shell_state = "partial" if errors else "ready"
+    shell_reasons = [f"{error.service}:{error.status_code}" for error in errors]
+
+    return PlatformShellBootstrap(
+        contractVersion=SHELL_BOOTSTRAP_CONTRACT_VERSION,
+        supportability=PlatformBootstrapSupportability(
+            state=shell_state,
+            reasons=shell_reasons,
+        ),
+        freshness=PlatformBootstrapFreshness(
+            state="current" if not errors else "partial",
+            freshnessClass="shell_navigation",
+            evaluatedAt=evaluated_at,
+            maxAgeSeconds=60,
+        ),
+        evidence=PlatformBootstrapEvidence(
+            state="partial" if errors else "source_backed",
+            lineageSources=list(policy_versions_by_source.keys()),
+            partialFailure=bool(errors),
+            sourceErrorServices=error_services,
+        ),
+        versioning=PlatformBootstrapVersioning(
+            shellContractVersion=SHELL_BOOTSTRAP_CONTRACT_VERSION,
+            capabilityContractVersion=contract_version,
+            sourcePolicyVersions=policy_versions_by_source,
+        ),
+        caching=PlatformBootstrapCaching(
+            cacheMode="request_scoped_composition",
+            invalidationOwner="upstream_service",
+            staleReadTolerance="bounded_navigation_refresh",
+            revalidateOnNavigation=True,
+            ttlSeconds=60,
+            correctnessCritical=False,
+        ),
+        workspaces=workspace_descriptors(
+            sources=sources,
+            navigation=navigation,
+            module_health_by_source=module_health_by_source,
+            policy_versions_by_source=policy_versions_by_source,
+            error_services=error_services,
+            evaluated_at=evaluated_at,
+            contract_version=contract_version,
+        ),
+    )
+
+
+def workspace_descriptors(
+    *,
+    sources: dict[str, dict[str, Any]],
+    navigation: dict[str, bool],
+    module_health_by_source: dict[str, str],
+    policy_versions_by_source: dict[str, str],
+    error_services: list[str],
+    evaluated_at: str,
+    contract_version: str,
+) -> list[PlatformShellWorkspaceDescriptor]:
+    return [
+        build_workspace_descriptor(
+            workspace_id="portfolio",
+            label="Portfolio",
+            href="/portfolio",
+            enabled=navigation["portfolio_workspace"],
+            dependency_source="lotus_core",
+            source_supportability=None,
+            module_health_by_source=module_health_by_source,
+            policy_versions_by_source=policy_versions_by_source,
+            error_services=error_services,
+            evaluated_at=evaluated_at,
+            contract_version=contract_version,
+            freshness_class="shell_navigation",
+            max_age_seconds=60,
+            cache_mode="request_scoped_composition",
+            stale_read_tolerance="bounded_navigation_refresh",
+        ),
+        build_workspace_descriptor(
+            workspace_id="performance",
+            label="Performance",
+            href="/performance",
+            enabled=navigation["performance_workspace"],
+            dependency_source="lotus_performance",
+            source_supportability=None,
+            module_health_by_source=module_health_by_source,
+            policy_versions_by_source=policy_versions_by_source,
+            error_services=error_services,
+            evaluated_at=evaluated_at,
+            contract_version=contract_version,
+            freshness_class="analytical_summary",
+            max_age_seconds=120,
+            cache_mode="short_lived_revalidation",
+            stale_read_tolerance="bounded_analytical_read",
+        ),
+        build_workspace_descriptor(
+            workspace_id="risk",
+            label="Risk",
+            href="/performance?mode=risk",
+            enabled=navigation["risk_workspace"],
+            dependency_source="lotus_risk",
+            source_supportability=None,
+            module_health_by_source=module_health_by_source,
+            policy_versions_by_source=policy_versions_by_source,
+            error_services=error_services,
+            evaluated_at=evaluated_at,
+            contract_version=contract_version,
+            freshness_class="analytical_summary",
+            max_age_seconds=120,
+            cache_mode="short_lived_revalidation",
+            stale_read_tolerance="bounded_analytical_read",
+        ),
+        build_workspace_descriptor(
+            workspace_id="proposal",
+            label="Proposal",
+            href="/proposals",
+            enabled=navigation["proposal_workspace"],
+            dependency_source="lotus_advise",
+            source_supportability=source_supportability(
+                sources=sources,
+                source_name="lotus_advise",
+            ),
+            module_health_by_source=module_health_by_source,
+            policy_versions_by_source=policy_versions_by_source,
+            error_services=error_services,
+            evaluated_at=evaluated_at,
+            contract_version=contract_version,
+            freshness_class="workflow_truth",
+            max_age_seconds=0,
+            cache_mode="authoritative_read",
+            stale_read_tolerance="none",
+        ),
+        build_workspace_descriptor(
+            workspace_id="advisory",
+            label="Advisory",
+            href="/recommendations",
+            enabled=navigation["advisory_workspace"],
+            dependency_source="lotus_advise",
+            source_supportability=source_supportability(
+                sources=sources,
+                source_name="lotus_advise",
+            ),
+            module_health_by_source=module_health_by_source,
+            policy_versions_by_source=policy_versions_by_source,
+            error_services=error_services,
+            evaluated_at=evaluated_at,
+            contract_version=contract_version,
+            freshness_class="workflow_truth",
+            max_age_seconds=0,
+            cache_mode="authoritative_read",
+            stale_read_tolerance="none",
+        ),
+    ]
+
+
+def build_workspace_descriptor(
+    *,
+    workspace_id: str,
+    label: str,
+    href: str,
+    enabled: bool,
+    dependency_source: str,
+    source_supportability: dict[str, Any] | None,
+    module_health_by_source: dict[str, str],
+    policy_versions_by_source: dict[str, str],
+    error_services: list[str],
+    evaluated_at: str,
+    contract_version: str,
+    freshness_class: str,
+    max_age_seconds: int,
+    cache_mode: str,
+    stale_read_tolerance: str,
+) -> PlatformShellWorkspaceDescriptor:
+    source_health = module_health_by_source.get(dependency_source, "unknown")
+    if enabled and source_health == "available":
+        supportability_state = "ready"
+        evidence_state = "source_backed"
+        freshness_state = "current"
+        reasons: list[str] = []
+    elif source_health == "unavailable":
+        supportability_state = "partial"
+        evidence_state = "partial"
+        freshness_state = "partial"
+        reasons = [f"{dependency_source}_unavailable"]
+    else:
+        supportability_state = "unavailable"
+        evidence_state = "unavailable"
+        freshness_state = "unavailable"
+        reasons = [f"{workspace_id}_disabled"] if not enabled else [f"{dependency_source}_unknown"]
+    if source_supportability is not None and source_health == "available":
+        supportability_state = str(source_supportability.get("state") or supportability_state)
+        source_reason = source_supportability.get("reason")
+        reasons = [str(source_reason)] if source_reason else reasons
+
+    return PlatformShellWorkspaceDescriptor(
+        id=workspace_id,
+        label=label,
+        href=href,
+        enabled=enabled,
+        supportability=PlatformBootstrapSupportability(
+            state=supportability_state,
+            reasons=reasons,
+        ),
+        freshness=PlatformBootstrapFreshness(
+            state=freshness_state,
+            freshnessClass=freshness_class,
+            evaluatedAt=evaluated_at,
+            maxAgeSeconds=max_age_seconds,
+        ),
+        evidence=PlatformBootstrapEvidence(
+            state=evidence_state,
+            lineageSources=[dependency_source],
+            partialFailure=dependency_source in error_services,
+            sourceErrorServices=(
+                [dependency_source] if dependency_source in error_services else []
+            ),
+        ),
+        versioning=PlatformBootstrapVersioning(
+            shellContractVersion=SHELL_BOOTSTRAP_CONTRACT_VERSION,
+            capabilityContractVersion=contract_version,
+            sourcePolicyVersion=policy_versions_by_source.get(dependency_source),
+        ),
+        caching=PlatformBootstrapCaching(
+            cacheMode=cache_mode,
+            invalidationOwner=dependency_source,
+            staleReadTolerance=stale_read_tolerance,
+            revalidateOnNavigation=True,
+            ttlSeconds=max_age_seconds,
+            correctnessCritical=freshness_class == "workflow_truth",
+        ),
+    )
+
+
+def feature_enabled(
+    *,
+    sources: dict[str, dict[str, Any]],
+    source_name: str,
+    feature_keys: tuple[str, ...],
+) -> bool:
+    source_payload = sources.get(source_name, {})
+    features = source_payload.get("features", [])
+    if not isinstance(features, list):
+        return False
+    for feature in features:
+        if not isinstance(feature, dict):
+            continue
+        if str(feature.get("key")) in feature_keys:
+            return bool(feature.get("enabled"))
+    return False
+
+
+def payload_value(
+    payload: dict[str, Any],
+    camel_key: str,
+    snake_key: str,
+    *,
+    default: Any,
+) -> Any:
+    value = payload.get(camel_key, payload.get(snake_key, default))
+    if isinstance(default, list) and not isinstance(value, list):
+        return []
+    return value
+
+
+def workflow_enabled(
+    *,
+    sources: dict[str, dict[str, Any]],
+    source_name: str,
+    workflow_key: str,
+) -> bool:
+    source_payload = sources.get(source_name, {})
+    workflows = source_payload.get("workflows", [])
+    if not isinstance(workflows, list):
+        return False
+    for workflow in workflows:
+        if not isinstance(workflow, dict):
+            continue
+        if str(workflow.get("workflow_key")) == workflow_key:
+            return bool(workflow.get("enabled"))
+    return False
+
+
+def any_workflow_enabled(
+    *,
+    sources: dict[str, dict[str, Any]],
+    source_name: str,
+    workflow_keys: tuple[str, ...],
+) -> bool:
+    return any(
+        workflow_enabled(
+            sources=sources,
+            source_name=source_name,
+            workflow_key=workflow_key,
+        )
+        for workflow_key in workflow_keys
+    )
+
+
+def source_supportability(
+    *,
+    sources: dict[str, dict[str, Any]],
+    source_name: str,
+) -> dict[str, Any] | None:
+    supportability = sources.get(source_name, {}).get("supportability")
+    if not isinstance(supportability, dict):
+        return None
+    return supportability
+
+
+def module_health(
+    *,
+    sources: dict[str, dict[str, Any]],
+    errors: list[CapabilitySourceError],
+) -> dict[str, str]:
+    errored_sources = {error.service for error in errors}
+    health: dict[str, str] = {}
+    for source_name in (*PRIMARY_CAPABILITY_SOURCES, *OPTIONAL_CAPABILITY_SOURCES):
+        if source_name in sources:
+            health[source_name] = "available"
+        elif source_name in errored_sources:
+            health[source_name] = "unavailable"
+        else:
+            health[source_name] = "unknown"
+    return health
+
+
+def lotus_core_policy_diagnostics(
+    *,
+    lotus_core_policy: dict[str, Any] | None,
+    errors: list[CapabilitySourceError],
+) -> dict[str, Any]:
+    diagnostics: dict[str, Any] = {
+        "available": False,
+        "allowedSections": [],
+        "warnings": [],
+        "policyProvenance": {
+            "policyVersion": "unknown",
+            "policySource": "unknown",
+            "matchedRuleId": "unknown",
+            "strictMode": False,
+        },
+    }
+
+    if lotus_core_policy is not None:
+        diagnostics["available"] = True
+        allowed_sections = lotus_core_policy.get("allowedSections", [])
+        warnings = lotus_core_policy.get("warnings", [])
+        provenance = lotus_core_policy.get("policyProvenance", {})
+        diagnostics["allowedSections"] = (
+            [str(section) for section in allowed_sections]
+            if isinstance(allowed_sections, list)
+            else []
+        )
+        diagnostics["warnings"] = (
+            [str(warning) for warning in warnings] if isinstance(warnings, list) else []
+        )
+        if isinstance(provenance, dict):
+            diagnostics["policyProvenance"] = {
+                "policyVersion": str(provenance.get("policyVersion", "unknown")),
+                "policySource": str(provenance.get("policySource", "unknown")),
+                "matchedRuleId": str(provenance.get("matchedRuleId", "unknown")),
+                "strictMode": bool(provenance.get("strictMode", False)),
+            }
+
+    if any(error.service == "lotus_core_policy" for error in errors):
+        diagnostics["warnings"] = list(diagnostics["warnings"]) + [
+            "LOTUS_CORE_POLICY_ENDPOINT_UNAVAILABLE"
+        ]
+    return diagnostics

--- a/src/app/services/platform_capabilities_service.py
+++ b/src/app/services/platform_capabilities_service.py
@@ -4,16 +4,25 @@ from typing import Any, cast
 
 from app.contracts.platform_capabilities import (
     CapabilitySourceError,
-    PlatformBootstrapCaching,
-    PlatformBootstrapEvidence,
-    PlatformBootstrapFreshness,
-    PlatformBootstrapSupportability,
-    PlatformBootstrapVersioning,
     PlatformCapabilitiesData,
     PlatformCapabilitiesNormalized,
     PlatformCapabilitiesResponse,
-    PlatformShellBootstrap,
-    PlatformShellWorkspaceDescriptor,
+)
+from app.services.platform_capabilities_normalization import (
+    PRIMARY_CAPABILITY_SOURCES,
+    build_normalized_capabilities,
+)
+from app.services.platform_capabilities_normalization import (
+    feature_enabled as _normalized_feature_enabled,
+)
+from app.services.platform_capabilities_normalization import (
+    module_health as _normalized_module_health,
+)
+from app.services.platform_capabilities_normalization import (
+    payload_value as _normalized_payload_value,
+)
+from app.services.platform_capabilities_normalization import (
+    workflow_enabled as _normalized_workflow_enabled,
 )
 from app.services.workspace_client_protocols import (
     PlatformCapabilitiesCoreClient,
@@ -23,24 +32,6 @@ from app.services.workspace_client_protocols import (
 
 
 class PlatformCapabilitiesService:
-    _SHELL_BOOTSTRAP_CONTRACT_VERSION = "shell-bootstrap.v1"
-    _PRIMARY_CAPABILITY_SOURCES = (
-        "lotus_core",
-        "lotus_performance",
-        "lotus_advise",
-        "lotus_manage",
-        "lotus_report",
-    )
-    _OPTIONAL_CAPABILITY_SOURCES = ("lotus_risk",)
-    _RISK_ANALYTICS_FEATURE_KEYS = (
-        "risk.analytics.risk_analytics",
-        "risk.analytics.drawdown",
-        "risk.analytics.concentration",
-        "risk.analytics.rolling_metrics",
-        "risk.analytics.historical_attribution",
-        "risk.analytics.metrics",
-    )
-
     def __init__(
         self,
         lotus_core_query_client: PlatformCapabilitiesCoreClient,
@@ -136,7 +127,7 @@ class PlatformCapabilitiesService:
 
         sources: dict[str, dict[str, Any]] = {}
         errors: list[CapabilitySourceError] = []
-        for service_name, result in zip(self._PRIMARY_CAPABILITY_SOURCES, results[:5], strict=True):
+        for service_name, result in zip(PRIMARY_CAPABILITY_SOURCES, results[:5], strict=True):
             if isinstance(result, BaseException):
                 errors.append(
                     CapabilitySourceError(
@@ -225,406 +216,12 @@ class PlatformCapabilitiesService:
         lotus_core_policy: dict[str, Any] | None,
         evaluated_at: str,
     ) -> PlatformCapabilitiesNormalized:
-        input_modes_by_source: dict[str, list[str]] = {}
-        input_modes_union: list[str] = []
-        policy_versions_by_source: dict[str, str] = {}
-        for source_name, source_payload in sources.items():
-            source_modes = self._payload_value(
-                source_payload,
-                "supportedInputModes",
-                "supported_input_modes",
-                default=[],
-            )
-            normalized_modes = [str(mode) for mode in source_modes]
-            input_modes_by_source[source_name] = normalized_modes
-            policy_versions_by_source[source_name] = str(
-                self._payload_value(
-                    source_payload,
-                    "policyVersion",
-                    "policy_version",
-                    default="unknown",
-                )
-            )
-            for mode in normalized_modes:
-                if mode not in input_modes_union:
-                    input_modes_union.append(mode)
-        for source_name in (*self._PRIMARY_CAPABILITY_SOURCES, *self._OPTIONAL_CAPABILITY_SOURCES):
-            policy_versions_by_source.setdefault(source_name, "unknown")
-
-        feature_enabled = {
-            "lotus_core_snapshot": self._feature_enabled(
-                sources=sources,
-                source_name="lotus_core",
-                feature_keys=(
-                    "lotus_core.integration.core_snapshot",
-                    "lotus_core.support.overview_api",
-                    "lotus_core.ingestion.portfolio_bundle_adapter",
-                    "pas.integration.core_snapshot",
-                ),
-            ),
-            "lotus_core_intake": self._feature_enabled(
-                sources=sources,
-                source_name="lotus_core",
-                feature_keys=(
-                    "lotus_core.ingestion.bulk_upload",
-                    "lotus_core.ingestion.bulk_upload_adapter",
-                    "lotus_core.ingestion.portfolio_bundle_adapter",
-                    "pas.ingestion.bulk_upload",
-                ),
-            ),
-            "lotus_performance_analytics": any(
-                self._feature_enabled(
-                    sources=sources,
-                    source_name="lotus_performance",
-                    feature_keys=(key,),
-                )
-                for key in (
-                    "lotus_performance.analytics.twr",
-                    "performance.analytics.twr",
-                    "lotus_performance.analytics.mwr",
-                    "performance.analytics.mwr",
-                    "lotus_performance.analytics.contribution",
-                    "performance.analytics.contribution",
-                    "lotus_performance.analytics.attribution",
-                    "performance.analytics.attribution",
-                )
-            ),
-            "lotus_advise_lifecycle": self._feature_enabled(
-                sources=sources,
-                source_name="lotus_advise",
-                feature_keys=(
-                    "advisory.proposals.lifecycle",
-                    "lotus_advise.proposals.lifecycle",
-                    "advise.proposals.lifecycle",
-                    "dpm.proposals.lifecycle",
-                ),
-            ),
-            "lotus_manage_support": self._feature_enabled(
-                sources=sources,
-                source_name="lotus_manage",
-                feature_keys=(
-                    "lotus_manage.support.run_apis",
-                    "dpm.support.run_apis",
-                ),
-            ),
-            "lotus_report_reporting": any(
-                self._feature_enabled(
-                    sources=sources,
-                    source_name="lotus_report",
-                    feature_keys=(key,),
-                )
-                for key in (
-                    "lotus_report.reporting.portfolio_summary",
-                    "ras.reporting.portfolio_summary",
-                    "lotus_report.reporting.portfolio_review",
-                    "ras.reporting.portfolio_review",
-                    "lotus_report.aggregation.portfolio_snapshot",
-                    "ras.aggregation.portfolio_snapshot",
-                )
-            ),
-            "lotus_risk_analytics": any(
-                self._feature_enabled(
-                    sources=sources,
-                    source_name="lotus_risk",
-                    feature_keys=(key,),
-                )
-                for key in self._RISK_ANALYTICS_FEATURE_KEYS
-            ),
-        }
-
-        module_health = self._module_health(sources=sources, errors=errors)
-        navigation = {
-            "command_center": True,
-            "portfolio_intake": (
-                feature_enabled["lotus_core_intake"] or feature_enabled["lotus_core_snapshot"]
-            ),
-            "analytics_studio": feature_enabled["lotus_performance_analytics"],
-            "advisory_pipeline": feature_enabled["lotus_advise_lifecycle"],
-            "scenario_builder": feature_enabled["lotus_advise_lifecycle"],
-            "decision_console": (
-                feature_enabled["lotus_core_snapshot"]
-                and (
-                    feature_enabled["lotus_advise_lifecycle"]
-                    or feature_enabled["lotus_manage_support"]
-                )
-            ),
-            "reporting_hub": feature_enabled["lotus_report_reporting"],
-            "portfolio_workspace": (
-                feature_enabled["lotus_core_intake"] or feature_enabled["lotus_core_snapshot"]
-            ),
-            "performance_workspace": feature_enabled["lotus_performance_analytics"],
-            "risk_workspace": feature_enabled["lotus_risk_analytics"],
-            "proposal_workspace": feature_enabled["lotus_advise_lifecycle"],
-            "advisory_workspace": feature_enabled["lotus_advise_lifecycle"],
-        }
-        workflow_flags = {
-            "proposal_lifecycle": self._any_workflow_enabled(
-                sources=sources,
-                source_name="lotus_advise",
-                workflow_keys=(
-                    "advisory_proposal_lifecycle",
-                    "proposal_lifecycle",
-                ),
-            ),
-            "proposal_approval_flow": self._any_workflow_enabled(
-                sources=sources,
-                source_name="lotus_advise",
-                workflow_keys=(
-                    "advisory_proposal_approval_flow",
-                    "proposal_approval_flow",
-                ),
-            ),
-            "portfolio_bulk_onboarding": self._workflow_enabled(
-                sources=sources,
-                source_name="lotus_core",
-                workflow_key="portfolio_bulk_onboarding",
-            ),
-            "performance_snapshot": self._workflow_enabled(
-                sources=sources,
-                source_name="lotus_performance",
-                workflow_key="performance_snapshot",
-            ),
-            "portfolio_reporting": self._workflow_enabled(
-                sources=sources,
-                source_name="lotus_report",
-                workflow_key="portfolio_reporting",
-            ),
-        }
-        lotus_core_policy_diagnostics = self._lotus_core_policy_diagnostics(
-            lotus_core_policy=lotus_core_policy,
-            errors=errors,
-        )
-        shell_bootstrap = self._build_shell_bootstrap(
+        return build_normalized_capabilities(
             sources=sources,
-            navigation=navigation,
-            module_health=module_health,
-            policy_versions_by_source=policy_versions_by_source,
             errors=errors,
+            lotus_core_policy=lotus_core_policy,
             evaluated_at=evaluated_at,
-        )
-        return PlatformCapabilitiesNormalized(
-            navigation=navigation,
-            workflowFlags=workflow_flags,
-            inputModesBySource=input_modes_by_source,
-            inputModesUnion=input_modes_union,
-            moduleHealth=module_health,
-            policyVersionsBySource=policy_versions_by_source,
-            lotusCorePolicyDiagnostics=lotus_core_policy_diagnostics,
-            shellBootstrap=shell_bootstrap,
-        )
-
-    def _build_shell_bootstrap(
-        self,
-        *,
-        sources: dict[str, dict[str, Any]],
-        navigation: dict[str, bool],
-        module_health: dict[str, str],
-        policy_versions_by_source: dict[str, str],
-        errors: list[CapabilitySourceError],
-        evaluated_at: str,
-    ) -> PlatformShellBootstrap:
-        error_services = [error.service for error in errors]
-        shell_state = "partial" if errors else "ready"
-        shell_reasons = [f"{error.service}:{error.status_code}" for error in errors]
-
-        return PlatformShellBootstrap(
-            contractVersion=self._SHELL_BOOTSTRAP_CONTRACT_VERSION,
-            supportability=PlatformBootstrapSupportability(
-                state=shell_state,
-                reasons=shell_reasons,
-            ),
-            freshness=PlatformBootstrapFreshness(
-                state="current" if not errors else "partial",
-                freshnessClass="shell_navigation",
-                evaluatedAt=evaluated_at,
-                maxAgeSeconds=60,
-            ),
-            evidence=PlatformBootstrapEvidence(
-                state="partial" if errors else "source_backed",
-                lineageSources=list(policy_versions_by_source.keys()),
-                partialFailure=bool(errors),
-                sourceErrorServices=error_services,
-            ),
-            versioning=PlatformBootstrapVersioning(
-                shellContractVersion=self._SHELL_BOOTSTRAP_CONTRACT_VERSION,
-                capabilityContractVersion=self._contract_version,
-                sourcePolicyVersions=policy_versions_by_source,
-            ),
-            caching=PlatformBootstrapCaching(
-                cacheMode="request_scoped_composition",
-                invalidationOwner="upstream_service",
-                staleReadTolerance="bounded_navigation_refresh",
-                revalidateOnNavigation=True,
-                ttlSeconds=60,
-                correctnessCritical=False,
-            ),
-            workspaces=[
-                self._build_workspace_descriptor(
-                    workspace_id="portfolio",
-                    label="Portfolio",
-                    href="/portfolio",
-                    enabled=navigation["portfolio_workspace"],
-                    dependency_source="lotus_core",
-                    source_supportability=None,
-                    module_health=module_health,
-                    policy_versions_by_source=policy_versions_by_source,
-                    error_services=error_services,
-                    evaluated_at=evaluated_at,
-                    freshness_class="shell_navigation",
-                    max_age_seconds=60,
-                    cache_mode="request_scoped_composition",
-                    stale_read_tolerance="bounded_navigation_refresh",
-                ),
-                self._build_workspace_descriptor(
-                    workspace_id="performance",
-                    label="Performance",
-                    href="/performance",
-                    enabled=navigation["performance_workspace"],
-                    dependency_source="lotus_performance",
-                    source_supportability=None,
-                    module_health=module_health,
-                    policy_versions_by_source=policy_versions_by_source,
-                    error_services=error_services,
-                    evaluated_at=evaluated_at,
-                    freshness_class="analytical_summary",
-                    max_age_seconds=120,
-                    cache_mode="short_lived_revalidation",
-                    stale_read_tolerance="bounded_analytical_read",
-                ),
-                self._build_workspace_descriptor(
-                    workspace_id="risk",
-                    label="Risk",
-                    href="/performance?mode=risk",
-                    enabled=navigation["risk_workspace"],
-                    dependency_source="lotus_risk",
-                    source_supportability=None,
-                    module_health=module_health,
-                    policy_versions_by_source=policy_versions_by_source,
-                    error_services=error_services,
-                    evaluated_at=evaluated_at,
-                    freshness_class="analytical_summary",
-                    max_age_seconds=120,
-                    cache_mode="short_lived_revalidation",
-                    stale_read_tolerance="bounded_analytical_read",
-                ),
-                self._build_workspace_descriptor(
-                    workspace_id="proposal",
-                    label="Proposal",
-                    href="/proposals",
-                    enabled=navigation["proposal_workspace"],
-                    dependency_source="lotus_advise",
-                    source_supportability=self._source_supportability(
-                        sources=sources,
-                        source_name="lotus_advise",
-                    ),
-                    module_health=module_health,
-                    policy_versions_by_source=policy_versions_by_source,
-                    error_services=error_services,
-                    evaluated_at=evaluated_at,
-                    freshness_class="workflow_truth",
-                    max_age_seconds=0,
-                    cache_mode="authoritative_read",
-                    stale_read_tolerance="none",
-                ),
-                self._build_workspace_descriptor(
-                    workspace_id="advisory",
-                    label="Advisory",
-                    href="/recommendations",
-                    enabled=navigation["advisory_workspace"],
-                    dependency_source="lotus_advise",
-                    source_supportability=self._source_supportability(
-                        sources=sources,
-                        source_name="lotus_advise",
-                    ),
-                    module_health=module_health,
-                    policy_versions_by_source=policy_versions_by_source,
-                    error_services=error_services,
-                    evaluated_at=evaluated_at,
-                    freshness_class="workflow_truth",
-                    max_age_seconds=0,
-                    cache_mode="authoritative_read",
-                    stale_read_tolerance="none",
-                ),
-            ],
-        )
-
-    def _build_workspace_descriptor(
-        self,
-        *,
-        workspace_id: str,
-        label: str,
-        href: str,
-        enabled: bool,
-        dependency_source: str,
-        source_supportability: dict[str, Any] | None,
-        module_health: dict[str, str],
-        policy_versions_by_source: dict[str, str],
-        error_services: list[str],
-        evaluated_at: str,
-        freshness_class: str,
-        max_age_seconds: int,
-        cache_mode: str,
-        stale_read_tolerance: str,
-    ) -> PlatformShellWorkspaceDescriptor:
-        source_health = module_health.get(dependency_source, "unknown")
-        if enabled and source_health == "available":
-            supportability_state = "ready"
-            evidence_state = "source_backed"
-            freshness_state = "current"
-            reasons: list[str] = []
-        elif source_health == "unavailable":
-            supportability_state = "partial"
-            evidence_state = "partial"
-            freshness_state = "partial"
-            reasons = [f"{dependency_source}_unavailable"]
-        else:
-            supportability_state = "unavailable"
-            evidence_state = "unavailable"
-            freshness_state = "unavailable"
-            reasons = (
-                [f"{workspace_id}_disabled"] if not enabled else [f"{dependency_source}_unknown"]
-            )
-        if source_supportability is not None and source_health == "available":
-            supportability_state = str(source_supportability.get("state") or supportability_state)
-            source_reason = source_supportability.get("reason")
-            reasons = [str(source_reason)] if source_reason else reasons
-
-        return PlatformShellWorkspaceDescriptor(
-            id=workspace_id,
-            label=label,
-            href=href,
-            enabled=enabled,
-            supportability=PlatformBootstrapSupportability(
-                state=supportability_state,
-                reasons=reasons,
-            ),
-            freshness=PlatformBootstrapFreshness(
-                state=freshness_state,
-                freshnessClass=freshness_class,
-                evaluatedAt=evaluated_at,
-                maxAgeSeconds=max_age_seconds,
-            ),
-            evidence=PlatformBootstrapEvidence(
-                state=evidence_state,
-                lineageSources=[dependency_source],
-                partialFailure=dependency_source in error_services,
-                sourceErrorServices=(
-                    [dependency_source] if dependency_source in error_services else []
-                ),
-            ),
-            versioning=PlatformBootstrapVersioning(
-                shellContractVersion=self._SHELL_BOOTSTRAP_CONTRACT_VERSION,
-                capabilityContractVersion=self._contract_version,
-                sourcePolicyVersion=policy_versions_by_source.get(dependency_source),
-            ),
-            caching=PlatformBootstrapCaching(
-                cacheMode=cache_mode,
-                invalidationOwner=dependency_source,
-                staleReadTolerance=stale_read_tolerance,
-                revalidateOnNavigation=True,
-                ttlSeconds=max_age_seconds,
-                correctnessCritical=freshness_class == "workflow_truth",
-            ),
+            contract_version=self._contract_version,
         )
 
     def _feature_enabled(
@@ -634,16 +231,11 @@ class PlatformCapabilitiesService:
         source_name: str,
         feature_keys: tuple[str, ...],
     ) -> bool:
-        source_payload = sources.get(source_name, {})
-        features = source_payload.get("features", [])
-        if not isinstance(features, list):
-            return False
-        for feature in features:
-            if not isinstance(feature, dict):
-                continue
-            if str(feature.get("key")) in feature_keys:
-                return bool(feature.get("enabled"))
-        return False
+        return _normalized_feature_enabled(
+            sources=sources,
+            source_name=source_name,
+            feature_keys=feature_keys,
+        )
 
     def _payload_value(
         self,
@@ -653,10 +245,12 @@ class PlatformCapabilitiesService:
         *,
         default: Any,
     ) -> Any:
-        value = payload.get(camel_key, payload.get(snake_key, default))
-        if isinstance(default, list) and not isinstance(value, list):
-            return []
-        return value
+        return _normalized_payload_value(
+            payload,
+            camel_key,
+            snake_key,
+            default=default,
+        )
 
     def _workflow_enabled(
         self,
@@ -665,16 +259,11 @@ class PlatformCapabilitiesService:
         source_name: str,
         workflow_key: str,
     ) -> bool:
-        source_payload = sources.get(source_name, {})
-        workflows = source_payload.get("workflows", [])
-        if not isinstance(workflows, list):
-            return False
-        for workflow in workflows:
-            if not isinstance(workflow, dict):
-                continue
-            if str(workflow.get("workflow_key")) == workflow_key:
-                return bool(workflow.get("enabled"))
-        return False
+        return _normalized_workflow_enabled(
+            sources=sources,
+            source_name=source_name,
+            workflow_key=workflow_key,
+        )
 
     def _any_workflow_enabled(
         self,
@@ -684,7 +273,7 @@ class PlatformCapabilitiesService:
         workflow_keys: tuple[str, ...],
     ) -> bool:
         return any(
-            self._workflow_enabled(
+            _normalized_workflow_enabled(
                 sources=sources,
                 source_name=source_name,
                 workflow_key=workflow_key,
@@ -692,78 +281,13 @@ class PlatformCapabilitiesService:
             for workflow_key in workflow_keys
         )
 
-    def _source_supportability(
-        self,
-        *,
-        sources: dict[str, dict[str, Any]],
-        source_name: str,
-    ) -> dict[str, Any] | None:
-        supportability = sources.get(source_name, {}).get("supportability")
-        if not isinstance(supportability, dict):
-            return None
-        return supportability
-
     def _module_health(
         self,
         *,
         sources: dict[str, dict[str, Any]],
         errors: list[CapabilitySourceError],
     ) -> dict[str, str]:
-        errored_sources = {error.service for error in errors}
-        health: dict[str, str] = {}
-        for source_name in (*self._PRIMARY_CAPABILITY_SOURCES, *self._OPTIONAL_CAPABILITY_SOURCES):
-            if source_name in sources:
-                health[source_name] = "available"
-            elif source_name in errored_sources:
-                health[source_name] = "unavailable"
-            else:
-                health[source_name] = "unknown"
-        return health
-
-    def _lotus_core_policy_diagnostics(
-        self,
-        *,
-        lotus_core_policy: dict[str, Any] | None,
-        errors: list[CapabilitySourceError],
-    ) -> dict[str, Any]:
-        diagnostics: dict[str, Any] = {
-            "available": False,
-            "allowedSections": [],
-            "warnings": [],
-            "policyProvenance": {
-                "policyVersion": "unknown",
-                "policySource": "unknown",
-                "matchedRuleId": "unknown",
-                "strictMode": False,
-            },
-        }
-
-        if lotus_core_policy is not None:
-            diagnostics["available"] = True
-            allowed_sections = lotus_core_policy.get("allowedSections", [])
-            warnings = lotus_core_policy.get("warnings", [])
-            provenance = lotus_core_policy.get("policyProvenance", {})
-            diagnostics["allowedSections"] = (
-                [str(section) for section in allowed_sections]
-                if isinstance(allowed_sections, list)
-                else []
-            )
-            diagnostics["warnings"] = (
-                [str(warning) for warning in warnings] if isinstance(warnings, list) else []
-            )
-            if isinstance(provenance, dict):
-                diagnostics["policyProvenance"] = {
-                    "policyVersion": str(provenance.get("policyVersion", "unknown")),
-                    "policySource": str(provenance.get("policySource", "unknown")),
-                    "matchedRuleId": str(provenance.get("matchedRuleId", "unknown")),
-                    "strictMode": bool(provenance.get("strictMode", False)),
-                }
-
-        if any(error.service == "lotus_core_policy" for error in errors):
-            diagnostics["warnings"] = list(diagnostics["warnings"]) + [
-                "LOTUS_CORE_POLICY_ENDPOINT_UNAVAILABLE"
-            ]
-        return diagnostics
+        return _normalized_module_health(sources=sources, errors=errors)
 
     def _merge_optional_source(
         self,

--- a/tests/unit/test_platform_capabilities_normalization.py
+++ b/tests/unit/test_platform_capabilities_normalization.py
@@ -1,0 +1,236 @@
+from typing import Any
+
+from app.contracts.platform_capabilities import CapabilitySourceError
+from app.services.platform_capabilities_normalization import (
+    build_normalized_capabilities,
+    feature_enabled,
+    module_health,
+    workflow_enabled,
+)
+
+
+def test_build_normalized_capabilities_emits_source_backed_shell_bootstrap() -> None:
+    normalized = build_normalized_capabilities(
+        sources={
+            "lotus_core": {
+                "policyVersion": "core.policy.v1",
+                "supportedInputModes": ["pas_ref"],
+                "features": [
+                    {"key": "lotus_core.support.overview_api", "enabled": True},
+                    {"key": "lotus_core.ingestion.bulk_upload_adapter", "enabled": True},
+                ],
+                "workflows": [
+                    {"workflow_key": "portfolio_bulk_onboarding", "enabled": True},
+                ],
+            },
+            "lotus_performance": {
+                "policyVersion": "performance.policy.v1",
+                "supportedInputModes": ["stateful"],
+                "features": [{"key": "lotus_performance.analytics.twr", "enabled": True}],
+                "workflows": [{"workflow_key": "performance_snapshot", "enabled": True}],
+            },
+            "lotus_advise": {
+                "policyVersion": "advise.policy.v1",
+                "supportedInputModes": ["portfolio_id"],
+                "features": [{"key": "advisory.proposals.lifecycle", "enabled": True}],
+                "workflows": [{"workflow_key": "proposal_lifecycle", "enabled": True}],
+                "supportability": {"state": "ready", "reason": "advisory_ready"},
+            },
+            "lotus_manage": {
+                "policyVersion": "manage.policy.v1",
+                "supportedInputModes": ["portfolio_id"],
+                "features": [{"key": "dpm.support.run_apis", "enabled": True}],
+                "workflows": [],
+            },
+            "lotus_report": {
+                "policyVersion": "report.policy.v1",
+                "supportedInputModes": ["portfolio_id"],
+                "features": [
+                    {"key": "lotus_report.reporting.portfolio_summary", "enabled": True},
+                ],
+                "workflows": [{"workflow_key": "portfolio_reporting", "enabled": True}],
+            },
+            "lotus_risk": {
+                "policyVersion": "risk.policy.v1",
+                "supportedInputModes": ["simulation"],
+                "features": [{"key": "risk.analytics.metrics", "enabled": True}],
+                "workflows": [],
+            },
+        },
+        errors=[],
+        lotus_core_policy={
+            "policyProvenance": {
+                "policyVersion": "core.policy.v1",
+                "policySource": "tenant",
+                "matchedRuleId": "tenant.default",
+                "strictMode": True,
+            },
+            "allowedSections": ["OVERVIEW", "HOLDINGS"],
+            "warnings": ["TENANT_POLICY_WARNING"],
+        },
+        evaluated_at="2026-06-04T00:00:00Z",
+        contract_version="platform-capabilities.v1",
+    )
+
+    assert normalized.navigation["portfolio_workspace"] is True
+    assert normalized.navigation["performance_workspace"] is True
+    assert normalized.navigation["risk_workspace"] is True
+    assert normalized.workflow_flags["portfolio_bulk_onboarding"] is True
+    assert normalized.workflow_flags["proposal_lifecycle"] is True
+    assert normalized.input_modes_union == ["pas_ref", "stateful", "portfolio_id", "simulation"]
+    assert normalized.lotus_core_policy_diagnostics == {
+        "available": True,
+        "allowedSections": ["OVERVIEW", "HOLDINGS"],
+        "warnings": ["TENANT_POLICY_WARNING"],
+        "policyProvenance": {
+            "policyVersion": "core.policy.v1",
+            "policySource": "tenant",
+            "matchedRuleId": "tenant.default",
+            "strictMode": True,
+        },
+    }
+
+    shell_bootstrap = normalized.shell_bootstrap
+    assert shell_bootstrap.contract_version == "shell-bootstrap.v1"
+    assert shell_bootstrap.supportability.state == "ready"
+    assert shell_bootstrap.evidence.state == "source_backed"
+    assert shell_bootstrap.evidence.partial_failure is False
+    assert shell_bootstrap.versioning.capability_contract_version == "platform-capabilities.v1"
+
+    proposal_workspace = next(
+        workspace for workspace in shell_bootstrap.workspaces if workspace.id == "proposal"
+    )
+    assert proposal_workspace.enabled is True
+    assert proposal_workspace.supportability.state == "ready"
+    assert proposal_workspace.supportability.reasons == ["advisory_ready"]
+    assert proposal_workspace.caching.correctness_critical is True
+
+
+def test_build_normalized_capabilities_marks_degraded_policy_and_missing_sources() -> None:
+    normalized = build_normalized_capabilities(
+        sources={
+            "lotus_core": {
+                "policy_version": "core.policy.v2",
+                "supported_input_modes": ["pas_ref"],
+                "features": [{"key": "lotus_core.support.overview_api", "enabled": True}],
+                "workflows": [],
+            },
+        },
+        errors=[
+            CapabilitySourceError(
+                service="lotus_performance",
+                status_code=503,
+                detail="service unavailable",
+            ),
+            CapabilitySourceError(
+                service="lotus_core_policy",
+                status_code=504,
+                detail="policy timeout",
+            ),
+        ],
+        lotus_core_policy=None,
+        evaluated_at="2026-06-04T00:00:00Z",
+        contract_version="platform-capabilities.v1",
+    )
+
+    assert normalized.module_health["lotus_core"] == "available"
+    assert normalized.module_health["lotus_performance"] == "unavailable"
+    assert normalized.module_health["lotus_advise"] == "unknown"
+    assert normalized.policy_versions_by_source["lotus_risk"] == "unknown"
+    assert normalized.lotus_core_policy_diagnostics["warnings"] == [
+        "LOTUS_CORE_POLICY_ENDPOINT_UNAVAILABLE"
+    ]
+
+    shell_bootstrap = normalized.shell_bootstrap
+    assert shell_bootstrap.supportability.state == "partial"
+    assert shell_bootstrap.supportability.reasons == [
+        "lotus_performance:503",
+        "lotus_core_policy:504",
+    ]
+    assert shell_bootstrap.evidence.partial_failure is True
+    assert shell_bootstrap.evidence.source_error_services == [
+        "lotus_performance",
+        "lotus_core_policy",
+    ]
+
+    performance_workspace = next(
+        workspace for workspace in shell_bootstrap.workspaces if workspace.id == "performance"
+    )
+    assert performance_workspace.enabled is False
+    assert performance_workspace.supportability.state == "partial"
+    assert performance_workspace.supportability.reasons == ["lotus_performance_unavailable"]
+    assert performance_workspace.evidence.partial_failure is True
+
+
+def test_normalization_helpers_ignore_malformed_upstream_shapes() -> None:
+    sources: dict[str, dict[str, Any]] = {
+        "lotus_core": {
+            "features": "not-a-feature-list",
+            "workflows": {"workflow_key": "portfolio_bulk_onboarding", "enabled": True},
+        },
+        "lotus_advise": {
+            "features": [
+                "malformed",
+                {"key": "advisory.proposals.lifecycle", "enabled": True},
+            ],
+            "workflows": [
+                None,
+                {"workflow_key": "proposal_lifecycle", "enabled": True},
+            ],
+        },
+    }
+
+    assert (
+        feature_enabled(
+            sources=sources,
+            source_name="lotus_core",
+            feature_keys=("lotus_core.support.overview_api",),
+        )
+        is False
+    )
+    assert (
+        workflow_enabled(
+            sources=sources,
+            source_name="lotus_core",
+            workflow_key="portfolio_bulk_onboarding",
+        )
+        is False
+    )
+    assert (
+        feature_enabled(
+            sources=sources,
+            source_name="lotus_advise",
+            feature_keys=("advisory.proposals.lifecycle",),
+        )
+        is True
+    )
+    assert (
+        workflow_enabled(
+            sources=sources,
+            source_name="lotus_advise",
+            workflow_key="proposal_lifecycle",
+        )
+        is True
+    )
+
+
+def test_module_health_classifies_available_unavailable_and_unknown_sources() -> None:
+    health = module_health(
+        sources={"lotus_core": {}, "lotus_advise": {}},
+        errors=[
+            CapabilitySourceError(
+                service="lotus_report",
+                status_code=500,
+                detail="upstream exception",
+            )
+        ],
+    )
+
+    assert health == {
+        "lotus_core": "available",
+        "lotus_performance": "unknown",
+        "lotus_advise": "available",
+        "lotus_manage": "unknown",
+        "lotus_report": "unavailable",
+        "lotus_risk": "unknown",
+    }


### PR DESCRIPTION
## Summary
- Extract platform capability normalization, shell-bootstrap construction, workspace descriptors, module health, policy diagnostics, workflow flags, and input-mode normalization into `platform_capabilities_normalization.py`.
- Keep `PlatformCapabilitiesService` focused on upstream orchestration, timeout handling, correlation propagation, optional source merging, and partial-failure collection.
- Add direct unit coverage for the new normalization boundary and refresh quality scorecard evidence.

## Measured Improvement
- `platform_capabilities_service.py` reduced from 774 lines at branch base to 309 measured lines in this branch.
- Longest-function baseline reduced from `_build_normalized_capabilities` at 195 lines to `_build_workspace_control_capabilities` at 191 lines.
- Tracked Python source files: 438.
- Tracked Python test files: 154.
- `make check` unit/contract count increased from 946 to 950 with focused normalization boundary tests.
- Coverage suite count increased from 1,153 to 1,157; total coverage remains 92.75%.

## Validation
- `python -m ruff check src\app\services\platform_capabilities_service.py src\app\services\platform_capabilities_normalization.py tests\unit\test_platform_capabilities_service.py tests\unit\test_platform_capabilities_normalization.py`
- `python -m ruff format --check src\app\services\platform_capabilities_service.py src\app\services\platform_capabilities_normalization.py tests\unit\test_platform_capabilities_service.py tests\unit\test_platform_capabilities_normalization.py`
- `python -m mypy src\app\services\platform_capabilities_service.py src\app\services\platform_capabilities_normalization.py tests\unit\test_platform_capabilities_service.py tests\unit\test_platform_capabilities_normalization.py`
- `python -m pytest tests\unit\test_platform_capabilities_service.py tests\unit\test_platform_capabilities_normalization.py -q` - 16 passed
- `make check` - 950 passed
- `make ci` - 207 integration passed, 1,157 coverage tests passed, total coverage 92.75%, `pip-audit` passed with governed `PYSEC-2026-161` exception
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` - DiffCount 0

## Governance
- Stranded-truth check: `git fetch origin --prune; git branch -r --no-merged origin/main` returned no unmerged remote branches.
- Wiki source unchanged; no wiki publication needed before merge.