### PR TITLE
Extract portfolio workspace control capabilities

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -35,7 +35,7 @@ report-only baseline is reviewed.
 
 The largest current modularity risks are:
 
-1. `src/app/services/portfolio_service.py` at 3,016 lines,
+1. `src/app/services/portfolio_service.py` at 2,839 lines,
 2. `src/app/services/advisor_brief_service.py` at 1,392 lines,
 3. `src/app/services/performance_workspace_service.py` at 1,152 lines,
 4. `src/app/services/dpm_command_center_service.py` at 1,032 lines,
@@ -75,9 +75,12 @@ been extracted to `src/app/services/platform_capabilities_normalization.py`, red
 handling, correlation propagation, and partial-failure collection in the service. Shell-bootstrap
 contract assembly and workspace descriptor state mapping have been further extracted to
 `src/app/services/platform_capabilities_shell.py`, reducing the capability normalization module to
-355 lines and keeping shell navigation evidence separately testable. The current longest function
-is `_build_workspace_control_capabilities` in
-`src/app/services/portfolio_service.py` at 191 lines.
+355 lines and keeping shell navigation evidence separately testable. Portfolio workspace-control
+capability construction has been extracted to
+`src/app/services/portfolio_workspace_controls.py`, reducing `portfolio_service.py` to 2,839 lines
+and moving historical-snapshot and reporting-currency support matrices behind focused tests. The
+current longest function is `parse_horizon_comparison_result` in
+`src/app/services/performance_workspace_horizon.py` at 172 lines.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -11,7 +11,7 @@ lane, router-registry split, performance workspace response split, and advisor-b
 split, risk drawdown mapper split, risk rolling mapper split, risk attribution mapper split,
 risk concentration mapper extraction, shared risk unavailable-envelope helper extraction, and
 risk drawdown, rolling, attribution, and summary response module extraction, and platform
-capability normalization and shell-bootstrap boundary extraction.
+capability normalization, shell-bootstrap, and portfolio workspace-control boundary extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -19,9 +19,9 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 665 |
-| Python source files under `src/app` | 439 |
-| Python test files under `tests` | 155 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 667 |
+| Python source files under `src/app` | 440 |
+| Python test files under `tests` | 156 |
 | OpenAPI paths | 170 |
 | OpenAPI operations | 170 |
 
@@ -29,7 +29,7 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 3,016 | `src/app/services/portfolio_service.py` |
+| 1 | 2,839 | `src/app/services/portfolio_service.py` |
 | 2 | 2,226 | `src/app/contracts/portfolio.py` |
 | 3 | 2,043 | `src/app/contracts/risk_workspace.py` |
 | 4 | 1,840 | `src/app/contracts/reporting.py` |
@@ -44,16 +44,16 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Rank | Lines | Function | File |
 | ---: | ---: | --- | --- |
-| 1 | 191 | `_build_workspace_control_capabilities` | `src/app/services/portfolio_service.py` |
-| 2 | 172 | `parse_horizon_comparison_result` | `src/app/services/performance_workspace_horizon.py` |
-| 3 | 153 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
-| 4 | 144 | `_build_advisor_brief_narrative_state` | `src/app/services/advisor_brief_service.py` |
-| 5 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
-| 6 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
-| 7 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
-| 8 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
-| 9 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
-| 10 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
+| 1 | 172 | `parse_horizon_comparison_result` | `src/app/services/performance_workspace_horizon.py` |
+| 2 | 153 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
+| 3 | 144 | `_build_advisor_brief_narrative_state` | `src/app/services/advisor_brief_service.py` |
+| 4 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
+| 5 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
+| 6 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
+| 7 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
+| 8 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
+| 9 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
+| 10 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
 
 ## Existing Blocking Gates
 
@@ -92,7 +92,7 @@ large-file and long-function hotspots in service, contract, and client code.
 The first enforcement candidates should be:
 
 1. no new service file above the current largest-file baseline,
-2. no new function above the current longest-function baseline of 191 lines,
+2. no new function above the current longest-function baseline of 172 lines,
 3. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
 4. no new architecture import-linter violations after contracts are reviewed.
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -72,9 +72,9 @@ Current repo-native gates already cover:
 
 Most recent local evidence:
 
-1. `make check`: 953 unit/contract tests passed.
+1. `make check`: 957 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
-3. `make ci`: 1,160 coverage tests passed.
+3. `make ci`: 1,164 coverage tests passed.
 4. Coverage: 92.75%.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -47,9 +47,9 @@ Report-only quality checks should remain advisory until findings are classified:
 
 Most recent local PR-grade evidence:
 
-1. `make check`: 953 unit/contract tests passed.
+1. `make check`: 957 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
-3. `make ci`: 1,160 coverage tests passed.
+3. `make ci`: 1,164 coverage tests passed.
 4. Total coverage: 92.75%, above the 84% floor.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -7,7 +7,7 @@ Mode: baseline/report-only
 | --- | ---: | --- | --- |
 | Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
 | Coverage | 4/5 | 92.75% total coverage | Add targeted middleware/security/error tests |
-| Modularity | 2/5 | Platform capability normalization and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
+| Modularity | 2/5 | Portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -27,8 +27,10 @@ while preserving upstream orchestration, timeout handling, correlation propagati
 partial-failure collection in the service. Shell-bootstrap contract assembly and workspace
 descriptor state mapping have been extracted to `platform_capabilities_shell.py`, reducing
 `platform_capabilities_normalization.py` to 355 lines while keeping shell navigation evidence
-separately testable. The remaining work is still substantial: large portfolio, performance
-workspace, contract, and client modules remain.
+separately testable. Portfolio workspace-control capability construction has been extracted to
+`portfolio_workspace_controls.py`, reducing `portfolio_service.py` to 2,839 lines and lowering the
+longest-function baseline to 172 lines. The remaining work is still substantial: large portfolio,
+performance workspace, contract, and client modules remain.
 
 ## Health Signals
 
@@ -39,15 +41,15 @@ workspace, contract, and client modules remain.
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.75%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
-| Modularity | Improving, incomplete | Platform capability normalization and shell bootstrap extracted; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
 
 ## Primary Refactor Backlog
 
-1. Split `portfolio_service.py` into source-readiness, transaction/activity, income, workspace,
-   and workflow-cue adapters.
+1. Continue splitting `portfolio_service.py` into source-readiness, transaction/activity, income,
+   workspace, and workflow-cue adapters.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization into smaller feature/workflow helpers if

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -37,7 +37,7 @@ performance workspace, contract, and client modules remain.
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
-| Unit/contract coverage | Healthy | 953 tests passed in latest `make check` evidence |
+| Unit/contract coverage | Healthy | 957 tests passed in latest `make check` evidence |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.75%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -49,9 +49,6 @@ from app.contracts.portfolio import (
     PortfolioWorkflowLaunchCue,
     PortfolioWorkflowResponse,
     PortfolioWorkspaceControlCapabilities,
-    PortfolioWorkspaceHistoricalSnapshotCapability,
-    PortfolioWorkspaceModuleCapability,
-    PortfolioWorkspaceReportingCurrencyCapability,
     PortfolioWorkspaceResponse,
 )
 from app.precision_policy import (
@@ -61,6 +58,7 @@ from app.precision_policy import (
     quantize_quantity,
 )
 from app.services.async_ttl_cache import AsyncTtlCache
+from app.services.portfolio_workspace_controls import build_workspace_control_capabilities
 from app.services.workspace_client_protocols import (
     PortfolioCoreClient,
     PortfolioManageClient,
@@ -2784,187 +2782,12 @@ class PortfolioService:
         effective_as_of_date: str,
         requested_reporting_currency: str | None,
     ) -> PortfolioWorkspaceControlCapabilities:
-        effective_reporting_currency = requested_reporting_currency or portfolio.base_currency
-        supported_currencies: list[str] = []
-        for currency in (portfolio.base_currency, effective_reporting_currency):
-            if currency not in supported_currencies:
-                supported_currencies.append(currency)
-
-        return PortfolioWorkspaceControlCapabilities(
-            historical_snapshots=PortfolioWorkspaceHistoricalSnapshotCapability(
-                state="partial",
-                reason=(
-                    "Most portfolio modules honor as_of_date, but rebalance and performance "
-                    "snapshot still follow separate control semantics."
-                ),
-                requested_as_of_date=requested_as_of_date,
-                effective_as_of_date=effective_as_of_date,
-                earliest_available_as_of_date=profile.open_date,
-                latest_available_as_of_date=effective_as_of_date,
-                module_capabilities=[
-                    PortfolioWorkspaceModuleCapability(
-                        module="workspace",
-                        state="supported",
-                        reason=(
-                            "Workspace shell summary, cashflow, and readiness resolve the "
-                            "selected as_of_date."
-                        ),
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="book",
-                        state="supported",
-                        reason="Book accepts and honors as_of_date directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="liquidity",
-                        state="supported",
-                        reason="Liquidity accepts and honors as_of_date directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="allocations",
-                        state="supported",
-                        reason="Allocations accept and honor as_of_date directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="positions",
-                        state="supported",
-                        reason="Positions accept and honor as_of_date directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="transactions",
-                        state="supported",
-                        reason="Transactions accept and honor as_of_date directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="income_summary",
-                        state="supported",
-                        reason="Income summary accepts and honors as_of_date directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="activity_summary",
-                        state="supported",
-                        reason="Activity summary accepts and honors as_of_date directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="readiness",
-                        state="supported",
-                        reason="Readiness accepts and honors as_of_date directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="workflow",
-                        state="supported",
-                        reason="Workflow accepts and honors as_of_date directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="insights",
-                        state="supported",
-                        reason="Insights accept and honor as_of_date directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="performance_snapshot",
-                        state="partial",
-                        reason=(
-                            "Performance snapshot aligns through explicit report window controls "
-                            "rather than a first-class as_of_date parameter."
-                        ),
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="rebalance",
-                        state="unsupported",
-                        reason=(
-                            "Rebalance shell summary is always sourced from the latest "
-                            "available run."
-                        ),
-                    ),
-                ],
-            ),
-            reporting_currency_restatement=PortfolioWorkspaceReportingCurrencyCapability(
-                state="partial",
-                reason=(
-                    "Book-style holdings and transaction modules honor reporting_currency, but "
-                    "workflow, readiness, and performance snapshot do not yet share that control."
-                ),
-                requested_reporting_currency=requested_reporting_currency,
-                effective_reporting_currency=effective_reporting_currency,
-                supported_currencies=supported_currencies,
-                module_capabilities=[
-                    PortfolioWorkspaceModuleCapability(
-                        module="workspace",
-                        state="partial",
-                        reason=(
-                            "Workspace shell summary honors reporting_currency for holdings and "
-                            "cash, but not for every shell section."
-                        ),
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="book",
-                        state="supported",
-                        reason="Book accepts and honors reporting_currency directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="liquidity",
-                        state="supported",
-                        reason="Liquidity accepts and honors reporting_currency directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="allocations",
-                        state="supported",
-                        reason="Allocations accept and honor reporting_currency directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="positions",
-                        state="supported",
-                        reason="Positions accept and honor reporting_currency directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="transactions",
-                        state="supported",
-                        reason="Transactions accept and honor reporting_currency directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="income_summary",
-                        state="supported",
-                        reason="Income summary accepts and honors reporting_currency directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="activity_summary",
-                        state="supported",
-                        reason="Activity summary accepts and honors reporting_currency directly.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="readiness",
-                        state="unsupported",
-                        reason="Readiness does not expose reporting_currency-aware semantics.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="workflow",
-                        state="unsupported",
-                        reason=(
-                            "Workflow priorities do not expose reporting_currency-aware semantics."
-                        ),
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="insights",
-                        state="unsupported",
-                        reason=(
-                            "Insights do not currently expose reporting_currency-aware semantics."
-                        ),
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="performance_snapshot",
-                        state="unsupported",
-                        reason="Performance snapshot does not expose reporting_currency.",
-                    ),
-                    PortfolioWorkspaceModuleCapability(
-                        module="rebalance",
-                        state="unsupported",
-                        reason=(
-                            "Rebalance shell summary does not expose reporting_currency-aware "
-                            "state."
-                        ),
-                    ),
-                ],
-            ),
+        return build_workspace_control_capabilities(
+            portfolio=portfolio,
+            profile=profile,
+            requested_as_of_date=requested_as_of_date,
+            effective_as_of_date=effective_as_of_date,
+            requested_reporting_currency=requested_reporting_currency,
         )
 
     def _optional_str(self, value: Any) -> str | None:

--- a/src/app/services/portfolio_workspace_controls.py
+++ b/src/app/services/portfolio_workspace_controls.py
@@ -1,0 +1,207 @@
+from app.contracts.portfolio import (
+    PortfolioIdentity,
+    PortfolioProfile,
+    PortfolioWorkspaceControlCapabilities,
+    PortfolioWorkspaceHistoricalSnapshotCapability,
+    PortfolioWorkspaceModuleCapability,
+    PortfolioWorkspaceReportingCurrencyCapability,
+)
+
+
+def build_workspace_control_capabilities(
+    *,
+    portfolio: PortfolioIdentity,
+    profile: PortfolioProfile,
+    requested_as_of_date: str,
+    effective_as_of_date: str,
+    requested_reporting_currency: str | None,
+) -> PortfolioWorkspaceControlCapabilities:
+    effective_reporting_currency = requested_reporting_currency or portfolio.base_currency
+    return PortfolioWorkspaceControlCapabilities(
+        historical_snapshots=PortfolioWorkspaceHistoricalSnapshotCapability(
+            state="partial",
+            reason=(
+                "Most portfolio modules honor as_of_date, but rebalance and performance "
+                "snapshot still follow separate control semantics."
+            ),
+            requested_as_of_date=requested_as_of_date,
+            effective_as_of_date=effective_as_of_date,
+            earliest_available_as_of_date=profile.open_date,
+            latest_available_as_of_date=effective_as_of_date,
+            module_capabilities=historical_snapshot_module_capabilities(),
+        ),
+        reporting_currency_restatement=PortfolioWorkspaceReportingCurrencyCapability(
+            state="partial",
+            reason=(
+                "Book-style holdings and transaction modules honor reporting_currency, but "
+                "workflow, readiness, and performance snapshot do not yet share that control."
+            ),
+            requested_reporting_currency=requested_reporting_currency,
+            effective_reporting_currency=effective_reporting_currency,
+            supported_currencies=supported_reporting_currencies(
+                base_currency=portfolio.base_currency,
+                effective_reporting_currency=effective_reporting_currency,
+            ),
+            module_capabilities=reporting_currency_module_capabilities(),
+        ),
+    )
+
+
+def supported_reporting_currencies(
+    *,
+    base_currency: str,
+    effective_reporting_currency: str,
+) -> list[str]:
+    supported_currencies: list[str] = []
+    for currency in (base_currency, effective_reporting_currency):
+        if currency not in supported_currencies:
+            supported_currencies.append(currency)
+    return supported_currencies
+
+
+def historical_snapshot_module_capabilities() -> list[PortfolioWorkspaceModuleCapability]:
+    return [
+        PortfolioWorkspaceModuleCapability(
+            module="workspace",
+            state="supported",
+            reason=(
+                "Workspace shell summary, cashflow, and readiness resolve the selected as_of_date."
+            ),
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="book",
+            state="supported",
+            reason="Book accepts and honors as_of_date directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="liquidity",
+            state="supported",
+            reason="Liquidity accepts and honors as_of_date directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="allocations",
+            state="supported",
+            reason="Allocations accept and honor as_of_date directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="positions",
+            state="supported",
+            reason="Positions accept and honor as_of_date directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="transactions",
+            state="supported",
+            reason="Transactions accept and honor as_of_date directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="income_summary",
+            state="supported",
+            reason="Income summary accepts and honors as_of_date directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="activity_summary",
+            state="supported",
+            reason="Activity summary accepts and honors as_of_date directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="readiness",
+            state="supported",
+            reason="Readiness accepts and honors as_of_date directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="workflow",
+            state="supported",
+            reason="Workflow accepts and honors as_of_date directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="insights",
+            state="supported",
+            reason="Insights accept and honor as_of_date directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="performance_snapshot",
+            state="partial",
+            reason=(
+                "Performance snapshot aligns through explicit report window controls rather than "
+                "a first-class as_of_date parameter."
+            ),
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="rebalance",
+            state="unsupported",
+            reason="Rebalance shell summary is always sourced from the latest available run.",
+        ),
+    ]
+
+
+def reporting_currency_module_capabilities() -> list[PortfolioWorkspaceModuleCapability]:
+    return [
+        PortfolioWorkspaceModuleCapability(
+            module="workspace",
+            state="partial",
+            reason=(
+                "Workspace shell summary honors reporting_currency for holdings and cash, but "
+                "not for every shell section."
+            ),
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="book",
+            state="supported",
+            reason="Book accepts and honors reporting_currency directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="liquidity",
+            state="supported",
+            reason="Liquidity accepts and honors reporting_currency directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="allocations",
+            state="supported",
+            reason="Allocations accept and honor reporting_currency directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="positions",
+            state="supported",
+            reason="Positions accept and honor reporting_currency directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="transactions",
+            state="supported",
+            reason="Transactions accept and honor reporting_currency directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="income_summary",
+            state="supported",
+            reason="Income summary accepts and honors reporting_currency directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="activity_summary",
+            state="supported",
+            reason="Activity summary accepts and honors reporting_currency directly.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="readiness",
+            state="unsupported",
+            reason="Readiness does not expose reporting_currency-aware semantics.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="workflow",
+            state="unsupported",
+            reason="Workflow priorities do not expose reporting_currency-aware semantics.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="insights",
+            state="unsupported",
+            reason="Insights do not currently expose reporting_currency-aware semantics.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="performance_snapshot",
+            state="unsupported",
+            reason="Performance snapshot does not expose reporting_currency.",
+        ),
+        PortfolioWorkspaceModuleCapability(
+            module="rebalance",
+            state="unsupported",
+            reason="Rebalance shell summary does not expose reporting_currency-aware state.",
+        ),
+    ]

--- a/tests/unit/test_portfolio_workspace_controls.py
+++ b/tests/unit/test_portfolio_workspace_controls.py
@@ -1,0 +1,96 @@
+from app.contracts.portfolio import PortfolioIdentity, PortfolioProfile
+from app.services.portfolio_workspace_controls import (
+    build_workspace_control_capabilities,
+    historical_snapshot_module_capabilities,
+    reporting_currency_module_capabilities,
+    supported_reporting_currencies,
+)
+
+
+def _portfolio_identity(base_currency: str = "USD") -> PortfolioIdentity:
+    return PortfolioIdentity(
+        portfolio_id="PF_1001",
+        display_name="Alpha Growth",
+        client_id="CIF_1",
+        base_currency=base_currency,
+        booking_center_code="SGPB",
+    )
+
+
+def _portfolio_profile() -> PortfolioProfile:
+    return PortfolioProfile(
+        status="ACTIVE",
+        portfolio_type="ADVISORY",
+        risk_exposure="Moderate Growth",
+        investment_time_horizon="Long Term",
+        objective="Long-term capital appreciation.",
+        is_leverage_allowed=False,
+        advisor_id="ADV_1001",
+        open_date="2024-01-15",
+        close_date=None,
+    )
+
+
+def test_build_workspace_control_capabilities_preserves_requested_context() -> None:
+    capabilities = build_workspace_control_capabilities(
+        portfolio=_portfolio_identity(),
+        profile=_portfolio_profile(),
+        requested_as_of_date="2026-03-20",
+        effective_as_of_date="2026-03-27",
+        requested_reporting_currency="SGD",
+    )
+
+    assert capabilities.historical_snapshots.state == "partial"
+    assert capabilities.historical_snapshots.requested_as_of_date == "2026-03-20"
+    assert capabilities.historical_snapshots.effective_as_of_date == "2026-03-27"
+    assert capabilities.historical_snapshots.earliest_available_as_of_date == "2024-01-15"
+    assert capabilities.historical_snapshots.latest_available_as_of_date == "2026-03-27"
+
+    assert capabilities.reporting_currency_restatement.state == "partial"
+    assert capabilities.reporting_currency_restatement.requested_reporting_currency == "SGD"
+    assert capabilities.reporting_currency_restatement.effective_reporting_currency == "SGD"
+    assert capabilities.reporting_currency_restatement.supported_currencies == ["USD", "SGD"]
+
+
+def test_build_workspace_control_capabilities_defaults_reporting_currency_to_base() -> None:
+    capabilities = build_workspace_control_capabilities(
+        portfolio=_portfolio_identity(base_currency="CHF"),
+        profile=_portfolio_profile(),
+        requested_as_of_date="2026-03-27",
+        effective_as_of_date="2026-03-27",
+        requested_reporting_currency=None,
+    )
+
+    assert capabilities.reporting_currency_restatement.requested_reporting_currency is None
+    assert capabilities.reporting_currency_restatement.effective_reporting_currency == "CHF"
+    assert capabilities.reporting_currency_restatement.supported_currencies == ["CHF"]
+
+
+def test_supported_reporting_currencies_deduplicates_base_and_effective_currency() -> None:
+    assert supported_reporting_currencies(
+        base_currency="USD",
+        effective_reporting_currency="USD",
+    ) == ["USD"]
+    assert supported_reporting_currencies(
+        base_currency="USD",
+        effective_reporting_currency="SGD",
+    ) == ["USD", "SGD"]
+
+
+def test_workspace_control_module_capabilities_publish_expected_boundaries() -> None:
+    historical_modules = historical_snapshot_module_capabilities()
+    reporting_modules = reporting_currency_module_capabilities()
+
+    assert [(item.module, item.state) for item in historical_modules[-2:]] == [
+        ("performance_snapshot", "partial"),
+        ("rebalance", "unsupported"),
+    ]
+    assert [(item.module, item.state) for item in reporting_modules[-5:]] == [
+        ("readiness", "unsupported"),
+        ("workflow", "unsupported"),
+        ("insights", "unsupported"),
+        ("performance_snapshot", "unsupported"),
+        ("rebalance", "unsupported"),
+    ]
+    assert any(item.module == "book" and item.state == "supported" for item in historical_modules)
+    assert any(item.module == "book" and item.state == "supported" for item in reporting_modules)


### PR DESCRIPTION
## Summary
- Extract portfolio workspace-control capability construction from `portfolio_service.py` into `portfolio_workspace_controls.py`.
- Keep `portfolio_service.py` as the orchestration boundary with a small compatibility wrapper.
- Add direct unit coverage for historical snapshot and reporting-currency capability boundaries.
- Refresh the quality scorecard, baseline, refactor health report, architecture rules, and CI evidence for the new boundary.

## Measured Improvement
- `src/app/services/portfolio_service.py`: 3,016 -> 2,839 lines.
- Longest-function baseline: 191 -> 172 lines.
- Current counted files: 667.
- Python source files: 440.
- Python test files: 156.
- `make check`: 957 passed.
- `make ci`: 207 integration tests, 1,164 coverage tests, 92.75% total coverage.

## Validation
- `python -m ruff check src\app\services\portfolio_service.py src\app\services\portfolio_workspace_controls.py tests\unit\test_portfolio_service.py tests\unit\test_portfolio_workspace_controls.py`
- `python -m ruff format --check src\app\services\portfolio_service.py src\app\services\portfolio_workspace_controls.py tests\unit\test_portfolio_service.py tests\unit\test_portfolio_workspace_controls.py`
- `python -m mypy src\app\services\portfolio_service.py src\app\services\portfolio_workspace_controls.py tests\unit\test_portfolio_service.py tests\unit\test_portfolio_workspace_controls.py`
- `python -m pytest tests\unit\test_portfolio_service.py tests\unit\test_portfolio_workspace_controls.py -q` -> 47 passed.
- `make check` -> green, 957 passed.
- `make ci` -> green, 207 integration passed; 1,164 coverage passed; 92.75%; `pip-audit` found no known vulnerabilities after the governed exception.
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` -> DiffCount 0.
- Stranded-truth preflight: `git branch -r --no-merged origin/main` returned no unmerged remote branches.