### PR TITLE
Refactor performance horizon parser

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -79,8 +79,10 @@ contract assembly and workspace descriptor state mapping have been further extra
 capability construction has been extracted to
 `src/app/services/portfolio_workspace_controls.py`, reducing `portfolio_service.py` to 2,839 lines
 and moving historical-snapshot and reporting-currency support matrices behind focused tests. The
-current longest function is `parse_horizon_comparison_result` in
-`src/app/services/performance_workspace_horizon.py` at 172 lines.
+performance horizon comparison parser has been split into diagnostic propagation, row-list
+selection, row construction, period-block extraction, and date-resolution helpers, reducing
+`parse_horizon_comparison_result` from 172 lines to 50 lines. The current longest function is
+`_parse_core_snapshot` in `src/app/services/foundation_service.py` at 153 lines.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -11,7 +11,8 @@ lane, router-registry split, performance workspace response split, and advisor-b
 split, risk drawdown mapper split, risk rolling mapper split, risk attribution mapper split,
 risk concentration mapper extraction, shared risk unavailable-envelope helper extraction, and
 risk drawdown, rolling, attribution, and summary response module extraction, and platform
-capability normalization, shell-bootstrap, and portfolio workspace-control boundary extraction.
+capability normalization, shell-bootstrap, portfolio workspace-control boundary extraction, and
+performance horizon parser extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -44,16 +45,16 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Rank | Lines | Function | File |
 | ---: | ---: | --- | --- |
-| 1 | 172 | `parse_horizon_comparison_result` | `src/app/services/performance_workspace_horizon.py` |
-| 2 | 153 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
-| 3 | 144 | `_build_advisor_brief_narrative_state` | `src/app/services/advisor_brief_service.py` |
-| 4 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
-| 5 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
-| 6 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
-| 7 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
-| 8 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
-| 9 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
-| 10 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
+| 1 | 153 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
+| 2 | 144 | `_build_advisor_brief_narrative_state` | `src/app/services/advisor_brief_service.py` |
+| 3 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
+| 4 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
+| 5 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
+| 6 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
+| 7 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
+| 8 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
+| 9 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
+| 10 | 112 | `_build_workspace_summary_views` | `src/app/services/performance_workspace_service.py` |
 
 ## Existing Blocking Gates
 
@@ -72,9 +73,9 @@ Current repo-native gates already cover:
 
 Most recent local evidence:
 
-1. `make check`: 957 unit/contract tests passed.
+1. `make check`: 958 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
-3. `make ci`: 1,164 coverage tests passed.
+3. `make ci`: 1,165 coverage tests passed.
 4. Coverage: 92.75%.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
@@ -92,7 +93,7 @@ large-file and long-function hotspots in service, contract, and client code.
 The first enforcement candidates should be:
 
 1. no new service file above the current largest-file baseline,
-2. no new function above the current longest-function baseline of 172 lines,
+2. no new function above the current longest-function baseline of 153 lines,
 3. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
 4. no new architecture import-linter violations after contracts are reviewed.
 

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -47,9 +47,9 @@ Report-only quality checks should remain advisory until findings are classified:
 
 Most recent local PR-grade evidence:
 
-1. `make check`: 957 unit/contract tests passed.
+1. `make check`: 958 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
-3. `make ci`: 1,164 coverage tests passed.
+3. `make ci`: 1,165 coverage tests passed.
 4. Total coverage: 92.75%, above the 84% floor.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -7,7 +7,7 @@ Mode: baseline/report-only
 | --- | ---: | --- | --- |
 | Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
 | Coverage | 4/5 | 92.75% total coverage | Add targeted middleware/security/error tests |
-| Modularity | 2/5 | Portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
+| Modularity | 2/5 | Performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -29,19 +29,22 @@ descriptor state mapping have been extracted to `platform_capabilities_shell.py`
 `platform_capabilities_normalization.py` to 355 lines while keeping shell navigation evidence
 separately testable. Portfolio workspace-control capability construction has been extracted to
 `portfolio_workspace_controls.py`, reducing `portfolio_service.py` to 2,839 lines and lowering the
-longest-function baseline to 172 lines. The remaining work is still substantial: large portfolio,
-performance workspace, contract, and client modules remain.
+longest-function baseline to 172 lines. The performance horizon comparison parser has now been
+split into diagnostic, row-selection, row-construction, period-block, and date-resolution helpers,
+reducing the parser itself from 172 lines to 50 lines and lowering the repository
+longest-function baseline to 153 lines. The remaining work is still substantial: large portfolio,
+performance workspace, foundation, contract, and client modules remain.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
-| Unit/contract coverage | Healthy | 957 tests passed in latest `make check` evidence |
+| Unit/contract coverage | Healthy | 958 tests passed in latest `make check` evidence |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.75%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
-| Modularity | Improving, incomplete | Portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -54,8 +57,8 @@ performance workspace, contract, and client modules remain.
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization into smaller feature/workflow helpers if
    future changes expand the extracted module.
-4. Continue extracting performance workspace evidence and attribution helpers behind stable
-   response contracts.
+4. Continue extracting performance workspace service orchestration helpers behind stable response
+   contracts; horizon parsing is now below the current function-size baseline.
 5. Split large contract modules only when contract ownership boundaries are clear and tests remain
    stable.
 6. Normalize route-specific upstream errors toward shared problem-details mapping.

--- a/src/app/services/performance_workspace_horizon.py
+++ b/src/app/services/performance_workspace_horizon.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import date
 from typing import Any, TypeAlias, cast
 
@@ -25,6 +26,17 @@ STANDARD_HORIZON_COMPARISON_PERIODS = ("MTD", "QTD", "YTD")
 UpstreamPayload: TypeAlias = dict[str, Any]
 UpstreamResult: TypeAlias = tuple[int, UpstreamPayload]
 GatheredResult: TypeAlias = UpstreamResult | BaseException
+
+
+@dataclass(frozen=True)
+class HorizonPeriodBlocks:
+    period_payload: dict[str, Any]
+    benchmark_block: dict[str, Any]
+    active_block: dict[str, Any]
+    net_block: dict[str, Any]
+    gross_block: dict[str, Any]
+    economics: dict[str, Any]
+    money_weighted_return: dict[str, Any]
 
 
 def build_horizon_comparison_frequencies(chart_frequency: str) -> list[str]:
@@ -236,9 +248,11 @@ def parse_horizon_comparison_result(
     partial_failures: list[WorkbenchPartialFailure],
 ) -> tuple[list[PerformanceHorizonComparisonRow], str | None]:
     if isinstance(result, BaseException):
-        warnings.append("PERFORMANCE_HORIZON_COMPARISON_UNAVAILABLE")
-        partial_failures.append(
-            build_performance_failure("lotus-performance", "UPSTREAM_EXCEPTION", str(result))
+        record_horizon_upstream_failure(
+            warnings=warnings,
+            partial_failures=partial_failures,
+            error_code="UPSTREAM_EXCEPTION",
+            detail=str(result),
         )
         return [], None
 
@@ -246,29 +260,18 @@ def parse_horizon_comparison_result(
     if not isinstance(payload, dict):
         warnings.append("PERFORMANCE_HORIZON_COMPARISON_INVALID")
         return [], None
-    gateway_warnings = payload.get("_gateway_warnings", [])
-    if isinstance(gateway_warnings, list):
-        warnings.extend(str(warning) for warning in gateway_warnings)
-    gateway_partial_failures = payload.get("_gateway_partial_failures", [])
-    if isinstance(gateway_partial_failures, list):
-        for failure in gateway_partial_failures:
-            if not isinstance(failure, Mapping):
-                continue
-            partial_failures.append(
-                build_performance_failure(
-                    str(failure.get("source_service", "lotus-performance")),
-                    str(failure.get("error_code", "UNKNOWN_ERROR")),
-                    str(failure.get("detail", "")),
-                )
-            )
+
+    propagate_gateway_horizon_diagnostics(
+        payload=payload,
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
     if status_code >= 400:
-        warnings.append("PERFORMANCE_HORIZON_COMPARISON_UNAVAILABLE")
-        partial_failures.append(
-            build_performance_failure(
-                "lotus-performance",
-                f"HTTP_{status_code}",
-                str(payload.get("detail", payload)),
-            )
+        record_horizon_upstream_failure(
+            warnings=warnings,
+            partial_failures=partial_failures,
+            error_code=f"HTTP_{status_code}",
+            detail=str(payload.get("detail", payload)),
         )
         return [], None
 
@@ -277,6 +280,60 @@ def parse_horizon_comparison_result(
         warnings.append("PERFORMANCE_HORIZON_COMPARISON_INVALID")
         return [], None
 
+    return build_horizon_comparison_rows(
+        results_by_period=results_by_period,
+        requested_period=requested_period,
+        requested_report_start_date=requested_report_start_date,
+        requested_report_end_date=requested_report_end_date,
+        detail_basis=detail_basis,
+    )
+
+
+def record_horizon_upstream_failure(
+    *,
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+    error_code: str,
+    detail: str,
+) -> None:
+    warnings.append("PERFORMANCE_HORIZON_COMPARISON_UNAVAILABLE")
+    partial_failures.append(build_performance_failure("lotus-performance", error_code, detail))
+
+
+def propagate_gateway_horizon_diagnostics(
+    *,
+    payload: Mapping[str, Any],
+    warnings: list[str],
+    partial_failures: list[WorkbenchPartialFailure],
+) -> None:
+    gateway_warnings = payload.get("_gateway_warnings", [])
+    if isinstance(gateway_warnings, list):
+        warnings.extend(str(warning) for warning in gateway_warnings)
+
+    gateway_partial_failures = payload.get("_gateway_partial_failures", [])
+    if not isinstance(gateway_partial_failures, list):
+        return
+
+    for failure in gateway_partial_failures:
+        if not isinstance(failure, Mapping):
+            continue
+        partial_failures.append(
+            build_performance_failure(
+                str(failure.get("source_service", "lotus-performance")),
+                str(failure.get("error_code", "UNKNOWN_ERROR")),
+                str(failure.get("detail", "")),
+            )
+        )
+
+
+def build_horizon_comparison_rows(
+    *,
+    results_by_period: dict[str, Any],
+    requested_period: str,
+    requested_report_start_date: str | None,
+    requested_report_end_date: str | None,
+    detail_basis: str,
+) -> tuple[list[PerformanceHorizonComparisonRow], str | None]:
     rows: list[PerformanceHorizonComparisonRow] = []
     resolved_benchmark_code: str | None = None
     periods_to_render = (
@@ -292,108 +349,154 @@ def parse_horizon_comparison_result(
         period_payload = results_by_period.get(period_key, {})
         if not isinstance(period_payload, dict):
             continue
-        benchmark_block = period_payload.get("benchmark", {})
-        active_block = period_payload.get("active", {})
-        net_block = extract_twr_workspace_block(period_payload, "net")
-        gross_block = extract_twr_workspace_block(period_payload, "gross")
-        net_summary_payload = net_block.get("summary", {}) if isinstance(net_block, dict) else {}
-        money_weighted_return = period_payload.get("money_weighted_return", {})
-        economics = (
-            net_summary_payload.get("economics", {})
-            if isinstance(net_summary_payload, dict)
-            else {}
+
+        row, benchmark_code = build_horizon_comparison_row(
+            period=period,
+            period_payload=period_payload,
+            detail_basis=detail_basis,
+            requested_report_start_date=requested_report_start_date,
+            requested_report_end_date=requested_report_end_date,
         )
-        comparative = build_workspace_comparative_summary(
-            metric_basis=detail_basis.upper(),
-            portfolio_block=net_block,
-            benchmark_block=benchmark_block if isinstance(benchmark_block, dict) else {},
-            active_basis_block=active_block.get("net") if isinstance(active_block, dict) else {},
-        )
-        if comparative.portfolio_return_pct is None and comparative.benchmark_return_pct is None:
+        if row is None:
             continue
-        rows.append(
-            PerformanceHorizonComparisonRow(
-                period=period,
-                period_start=(
-                    safe_str(money_weighted_return.get("start_date"))
-                    if isinstance(money_weighted_return, dict)
-                    else None
-                )
-                or safe_str(period_payload.get("_gateway_requested_period_start"))
-                or requested_report_start_date,
-                period_end=(
-                    safe_str(money_weighted_return.get("end_date"))
-                    if isinstance(money_weighted_return, dict)
-                    else None
-                )
-                or safe_str(period_payload.get("_gateway_requested_period_end"))
-                or requested_report_end_date,
-                begin_market_value=quantize_optional(economics.get("begin_market_value"))
-                if isinstance(economics, dict)
-                else None,
-                end_market_value=quantize_optional(economics.get("end_market_value"))
-                if isinstance(economics, dict)
-                else None,
-                beginning_cash_flow=quantize_optional(economics.get("beginning_cash_flow"))
-                if isinstance(economics, dict)
-                else None,
-                ending_cash_flow=quantize_optional(economics.get("ending_cash_flow"))
-                if isinstance(economics, dict)
-                else None,
-                flow_adjusted_end_market_value=quantize_optional(
-                    economics.get("flow_adjusted_end_market_value")
-                )
-                if isinstance(economics, dict)
-                else None,
-                net_cash_flow=quantize_optional(economics.get("net_cash_flow"))
-                if isinstance(economics, dict)
-                else None,
-                fees=quantize_optional(economics.get("fees"))
-                if isinstance(economics, dict)
-                else None,
-                net_return_pct=extract_return(net_block, "summary", "period_return", "base"),
-                gross_return_pct=extract_return(gross_block, "summary", "period_return", "base"),
-                portfolio_return_pct=comparative.portfolio_return_pct,
-                benchmark_return_pct=comparative.benchmark_return_pct,
-                active_return_pct=comparative.active_return_pct,
-                cumulative_net_return_pct=extract_return(
-                    net_block,
-                    "summary",
-                    "cumulative_return",
-                    "base",
-                ),
-                cumulative_gross_return_pct=extract_return(
-                    gross_block,
-                    "summary",
-                    "cumulative_return",
-                    "base",
-                ),
-                cumulative_benchmark_return_pct=extract_return(
-                    benchmark_block if isinstance(benchmark_block, dict) else {},
-                    "summary",
-                    "cumulative_return",
-                    "base",
-                ),
-                cumulative_active_return_pct=extract_return(
-                    active_block.get("net") if isinstance(active_block, dict) else {},
-                    "cumulative_return",
-                    "base",
-                ),
-                annualized_net_return_pct=extract_return(
-                    net_block,
-                    "summary",
-                    "annualized_return",
-                    "base",
-                ),
-                annualized_gross_return_pct=extract_return(
-                    gross_block,
-                    "summary",
-                    "annualized_return",
-                    "base",
-                ),
-                annualized_return_pct=comparative.annualized_return_pct,
-            )
-        )
+        rows.append(row)
         if resolved_benchmark_code is None:
-            resolved_benchmark_code = comparative.benchmark_id
+            resolved_benchmark_code = benchmark_code
     return rows, resolved_benchmark_code
+
+
+def build_horizon_comparison_row(
+    *,
+    period: str,
+    period_payload: dict[str, Any],
+    detail_basis: str,
+    requested_report_start_date: str | None,
+    requested_report_end_date: str | None,
+) -> tuple[PerformanceHorizonComparisonRow | None, str | None]:
+    blocks = extract_horizon_period_blocks(period_payload)
+    comparative = build_workspace_comparative_summary(
+        metric_basis=detail_basis.upper(),
+        portfolio_block=blocks.net_block,
+        benchmark_block=blocks.benchmark_block,
+        active_basis_block=blocks.active_block.get("net", {}),
+    )
+    if comparative.portfolio_return_pct is None and comparative.benchmark_return_pct is None:
+        return None, None
+
+    return (
+        PerformanceHorizonComparisonRow(
+            period=period,
+            period_start=resolve_horizon_period_start(
+                blocks=blocks,
+                requested_report_start_date=requested_report_start_date,
+            ),
+            period_end=resolve_horizon_period_end(
+                blocks=blocks,
+                requested_report_end_date=requested_report_end_date,
+            ),
+            begin_market_value=quantize_optional(blocks.economics.get("begin_market_value")),
+            end_market_value=quantize_optional(blocks.economics.get("end_market_value")),
+            beginning_cash_flow=quantize_optional(blocks.economics.get("beginning_cash_flow")),
+            ending_cash_flow=quantize_optional(blocks.economics.get("ending_cash_flow")),
+            flow_adjusted_end_market_value=quantize_optional(
+                blocks.economics.get("flow_adjusted_end_market_value")
+            ),
+            net_cash_flow=quantize_optional(blocks.economics.get("net_cash_flow")),
+            fees=quantize_optional(blocks.economics.get("fees")),
+            net_return_pct=extract_return(blocks.net_block, "summary", "period_return", "base"),
+            gross_return_pct=extract_return(
+                blocks.gross_block,
+                "summary",
+                "period_return",
+                "base",
+            ),
+            portfolio_return_pct=comparative.portfolio_return_pct,
+            benchmark_return_pct=comparative.benchmark_return_pct,
+            active_return_pct=comparative.active_return_pct,
+            cumulative_net_return_pct=extract_return(
+                blocks.net_block,
+                "summary",
+                "cumulative_return",
+                "base",
+            ),
+            cumulative_gross_return_pct=extract_return(
+                blocks.gross_block,
+                "summary",
+                "cumulative_return",
+                "base",
+            ),
+            cumulative_benchmark_return_pct=extract_return(
+                blocks.benchmark_block,
+                "summary",
+                "cumulative_return",
+                "base",
+            ),
+            cumulative_active_return_pct=extract_return(
+                blocks.active_block.get("net", {}),
+                "cumulative_return",
+                "base",
+            ),
+            annualized_net_return_pct=extract_return(
+                blocks.net_block,
+                "summary",
+                "annualized_return",
+                "base",
+            ),
+            annualized_gross_return_pct=extract_return(
+                blocks.gross_block,
+                "summary",
+                "annualized_return",
+                "base",
+            ),
+            annualized_return_pct=comparative.annualized_return_pct,
+        ),
+        comparative.benchmark_id,
+    )
+
+
+def extract_horizon_period_blocks(
+    period_payload: dict[str, Any],
+) -> HorizonPeriodBlocks:
+    benchmark_payload = period_payload.get("benchmark", {})
+    active_payload = period_payload.get("active", {})
+    net_block = extract_twr_workspace_block(period_payload, "net")
+    gross_block = extract_twr_workspace_block(period_payload, "gross")
+    net_summary_payload = net_block.get("summary", {})
+    money_weighted_payload = period_payload.get("money_weighted_return", {})
+    economics_payload = net_summary_payload.get("economics", {})
+
+    return HorizonPeriodBlocks(
+        period_payload=period_payload,
+        benchmark_block=benchmark_payload if isinstance(benchmark_payload, dict) else {},
+        active_block=active_payload if isinstance(active_payload, dict) else {},
+        net_block=net_block,
+        gross_block=gross_block,
+        economics=economics_payload if isinstance(economics_payload, dict) else {},
+        money_weighted_return=money_weighted_payload
+        if isinstance(money_weighted_payload, dict)
+        else {},
+    )
+
+
+def resolve_horizon_period_start(
+    *,
+    blocks: HorizonPeriodBlocks,
+    requested_report_start_date: str | None,
+) -> str | None:
+    return (
+        safe_str(blocks.money_weighted_return.get("start_date"))
+        or safe_str(blocks.period_payload.get("_gateway_requested_period_start"))
+        or requested_report_start_date
+    )
+
+
+def resolve_horizon_period_end(
+    *,
+    blocks: HorizonPeriodBlocks,
+    requested_report_end_date: str | None,
+) -> str | None:
+    return (
+        safe_str(blocks.money_weighted_return.get("end_date"))
+        or safe_str(blocks.period_payload.get("_gateway_requested_period_end"))
+        or requested_report_end_date
+    )

--- a/tests/unit/test_performance_workspace_horizon.py
+++ b/tests/unit/test_performance_workspace_horizon.py
@@ -254,6 +254,62 @@ def test_parse_horizon_comparison_result_returns_row_and_benchmark_code():
     assert partial_failures == []
 
 
+def test_parse_horizon_comparison_result_renders_standard_period_date_fallbacks():
+    warnings: list[str] = []
+    partial_failures = []
+
+    rows, benchmark_code = parse_horizon_comparison_result(
+        result=(
+            200,
+            {
+                "results_by_period": {
+                    "MTD": {
+                        "_gateway_requested_period_start": "2026-03-01",
+                        "_gateway_requested_period_end": "2026-03-27",
+                        "portfolio_twr": {
+                            "net": {"summary": {"period_return": {"base": 1.1}}},
+                        },
+                    },
+                    "QTD": {
+                        "_gateway_requested_period_start": "2026-01-01",
+                        "_gateway_requested_period_end": "2026-03-27",
+                        "portfolio_twr": {
+                            "net": {"summary": {"period_return": {"base": 2.2}}},
+                        },
+                    },
+                    "YTD": {
+                        "portfolio_twr": {
+                            "net": {"summary": {"period_return": {"base": 3.3}}},
+                        },
+                        "benchmark": {
+                            "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+                            "summary": {"period_return": {"base": 2.8}},
+                        },
+                    },
+                },
+            },
+        ),
+        requested_period="YTD",
+        requested_report_start_date=None,
+        requested_report_end_date="2026-03-27",
+        detail_basis="NET",
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert [row.period for row in rows] == ["MTD", "QTD", "YTD"]
+    assert [(row.period_start, row.period_end) for row in rows] == [
+        ("2026-03-01", "2026-03-27"),
+        ("2026-01-01", "2026-03-27"),
+        (None, "2026-03-27"),
+    ]
+    assert [row.portfolio_return_pct for row in rows] == [1.1, 2.2, 3.3]
+    assert rows[2].benchmark_return_pct == 2.8
+    assert benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert warnings == []
+    assert partial_failures == []
+
+
 def test_parse_horizon_comparison_result_propagates_gateway_failures():
     warnings: list[str] = []
     partial_failures = []


### PR DESCRIPTION
## Summary
- Split performance horizon comparison parsing into focused helpers for upstream diagnostics, row-list selection, row construction, period-block extraction, and period date resolution.
- Preserve the public `parse_horizon_comparison_result` API and existing service call sites.
- Add regression coverage for standard MTD/QTD/YTD row rendering and gateway-requested period date fallbacks.
- Refresh quality evidence for the new longest-function baseline.

## Measured Improvement
- `parse_horizon_comparison_result`: 172 -> 50 lines.
- Largest helper introduced in `performance_workspace_horizon.py`: 87 lines.
- Repository longest-function baseline: 172 -> 153 lines.
- New longest function: `_parse_core_snapshot` in `src/app/services/foundation_service.py` at 153 lines.
- `make check`: 958 unit/contract tests passed.
- `make ci`: 207 integration tests passed; 1,165 coverage tests passed; total coverage 92.75%.

## Validation
- `python -m ruff check src\app\services\performance_workspace_horizon.py tests\unit\test_performance_workspace_horizon.py`
- `python -m ruff format --check src\app\services\performance_workspace_horizon.py tests\unit\test_performance_workspace_horizon.py`
- `python -m mypy src\app\services\performance_workspace_horizon.py tests\unit\test_performance_workspace_horizon.py`
- `python -m pytest tests\unit\test_performance_workspace_horizon.py -q` -> 7 passed.
- `make check` -> green, 958 passed.
- `make ci` -> green, 207 integration passed; 1,165 coverage passed; 92.75%; `pip-audit` found no known vulnerabilities after the governed exception.
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` -> DiffCount 0.
- Stranded-truth preflight: `git branch -r --no-merged origin/main` returned no unmerged remote branches.