### PR TITLE
Refactor advisor brief narrative state

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -84,8 +84,12 @@ selection, row construction, period-block extraction, and date-resolution helper
 `parse_horizon_comparison_result` from 172 lines to 50 lines. The foundation core snapshot parser
 has been split into validation, section extraction, totals,
 enrichment indexing, position projection, allocation finalization, and portfolio identity helpers,
-reducing `_parse_core_snapshot` from 153 lines to 38 lines. The current longest function is
-`_build_advisor_brief_narrative_state` in `src/app/services/advisor_brief_service.py` at 144 lines.
+reducing `_parse_core_snapshot` from 153 lines to 38 lines. The advisor-brief narrative-state
+builder has been split into source fallback, AI result
+classification, completed-output projection, unavailable-risk construction, and route-resolution
+helpers, reducing `_build_advisor_brief_narrative_state` from 144 lines to 30 lines. The current
+longest function is `get_platform_capabilities` in
+`src/app/services/platform_capabilities_service.py` at 143 lines.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -12,7 +12,8 @@ split, risk drawdown mapper split, risk rolling mapper split, risk attribution m
 risk concentration mapper extraction, shared risk unavailable-envelope helper extraction, and
 risk drawdown, rolling, attribution, and summary response module extraction, and platform
 capability normalization, shell-bootstrap, portfolio workspace-control boundary extraction, and
-performance horizon parser extraction, and foundation core snapshot parser extraction.
+performance horizon parser extraction, foundation core snapshot parser extraction, and
+advisor-brief narrative-state extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -45,16 +46,16 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Rank | Lines | Function | File |
 | ---: | ---: | --- | --- |
-| 1 | 144 | `_build_advisor_brief_narrative_state` | `src/app/services/advisor_brief_service.py` |
-| 2 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
-| 3 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
-| 4 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
-| 5 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
-| 6 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
-| 7 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
-| 8 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
-| 9 | 112 | `_build_workspace_summary_views` | `src/app/services/performance_workspace_service.py` |
-| 10 | 111 | `get_portfolio_workspace` | `src/app/services/foundation_service.py` |
+| 1 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
+| 2 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
+| 3 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
+| 4 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
+| 5 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
+| 6 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
+| 7 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
+| 8 | 112 | `_build_workspace_summary_views` | `src/app/services/performance_workspace_service.py` |
+| 9 | 111 | `get_portfolio_workspace` | `src/app/services/foundation_service.py` |
+| 10 | 111 | `get_portfolio_transactions` | `src/app/routers/portfolio_transactions.py` |
 
 ## Existing Blocking Gates
 
@@ -93,7 +94,7 @@ large-file and long-function hotspots in service, contract, and client code.
 The first enforcement candidates should be:
 
 1. no new service file above the current largest-file baseline,
-2. no new function above the current longest-function baseline of 144 lines,
+2. no new function above the current longest-function baseline of 143 lines,
 3. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
 4. no new architecture import-linter violations after contracts are reviewed.
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -77,7 +77,7 @@ Most recent local evidence:
 1. `make check`: 958 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
 3. `make ci`: 1,165 coverage tests passed.
-4. Coverage: 92.79%.
+4. Coverage: 92.78%.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -50,7 +50,7 @@ Most recent local PR-grade evidence:
 1. `make check`: 958 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
 3. `make ci`: 1,165 coverage tests passed.
-4. Total coverage: 92.79%, above the 84% floor.
+4. Total coverage: 92.78%, above the 84% floor.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Next Tightening Candidates

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -7,7 +7,7 @@ Mode: baseline/report-only
 | --- | ---: | --- | --- |
 | Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
 | Coverage | 4/5 | 92.79% total coverage | Add targeted middleware/security/error tests |
-| Modularity | 2/5 | Foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
+| Modularity | 2/5 | Advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -6,7 +6,7 @@ Mode: baseline/report-only
 | Dimension | Score | Baseline status | Next action |
 | --- | ---: | --- | --- |
 | Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
-| Coverage | 4/5 | 92.79% total coverage | Add targeted middleware/security/error tests |
+| Coverage | 4/5 | 92.78% total coverage | Add targeted middleware/security/error tests |
 | Modularity | 2/5 | Advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -49,7 +49,7 @@ performance workspace, advisor-brief orchestration, contract, and client modules
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
 | Unit/contract coverage | Healthy | 958 tests passed in latest `make check` evidence |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
-| Total coverage | Healthy | 92.79%, above the 84% floor |
+| Total coverage | Healthy | 92.78%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
 | Modularity | Improving, incomplete | Advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -35,9 +35,12 @@ reducing the parser itself from 172 lines to 50 lines and lowering the repositor
 longest-function baseline to 153 lines. The foundation core snapshot parser has now been split
 into validation, section extraction, totals, enrichment indexing, position projection, allocation
 finalization, and portfolio identity helpers, reducing `_parse_core_snapshot` from 153 lines to
-38 lines and lowering the repository longest-function baseline to 144 lines. The remaining work is
-still substantial: large portfolio, performance workspace, advisor-brief, contract, and client
-modules remain.
+38 lines and lowering the repository longest-function baseline to 144 lines. The advisor-brief
+narrative-state builder has now been split into source fallback, AI result classification,
+completed-output projection, unavailable-risk construction, and route-resolution helpers, reducing
+`_build_advisor_brief_narrative_state` from 144 lines to 30 lines and lowering the repository
+longest-function baseline to 143 lines. The remaining work is still substantial: large portfolio,
+performance workspace, advisor-brief orchestration, contract, and client modules remain.
 
 ## Health Signals
 
@@ -48,7 +51,7 @@ modules remain.
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.79%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
-| Modularity | Improving, incomplete | Foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -63,8 +66,8 @@ modules remain.
    future changes expand the extracted module.
 4. Continue extracting performance workspace service orchestration helpers behind stable response
    contracts; horizon parsing is now below the current function-size baseline.
-5. Continue splitting advisor-brief narrative construction behind stable reviewed-narrative
-   contracts.
+5. Continue splitting advisor-brief service orchestration around stable reviewed-narrative
+   contracts if future changes expand the remaining runtime or review helpers.
 6. Split large contract modules only when contract ownership boundaries are clear and tests remain
    stable.
 7. Normalize route-specific upstream errors toward shared problem-details mapping.

--- a/src/app/services/advisor_brief_service.py
+++ b/src/app/services/advisor_brief_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Protocol
 
 from fastapi import HTTPException, status
@@ -233,143 +233,29 @@ class AdvisorBriefService:
         correlation_id: str,
         source_context: AdvisorBriefSourceContext,
     ) -> AdvisorBriefNarrativeState:
-        workspace = source_context.workspace
-        status = source_context.status
-        source_summary = source_context.summary
-        talking_points = source_context.talking_points
-        recommended_actions = source_context.recommended_actions
-        risks_and_exceptions = source_context.risks_and_exceptions
-        ai_audit: dict[str, Any] = _normalize_ai_audit({})
-        ai_evidence: dict[str, Any] = {"descriptors": []}
+        narrative_state = _build_source_advisor_brief_narrative_state(source_context=source_context)
+        if narrative_state.status is AdvisorBriefStatus.UNAVAILABLE:
+            return narrative_state
 
-        if status is not AdvisorBriefStatus.UNAVAILABLE:
-            task_request = _build_advisor_brief_ai_task_request(
+        task_request = _build_advisor_brief_ai_task_request(
+            correlation_id=correlation_id,
+            source_context=source_context,
+        )
+        async with server_timing_span("perf-advisor-brief-ai"):
+            ai_status, ai_payload = await self._lotus_ai_client.execute_workflow_pack(
+                pack_id="advisor_brief.pack",
+                version="v1",
+                environment="DEVELOPMENT",
+                caller_identity_class="BANKER_PRODUCT",
+                workflow_surface="advisor-brief-workspace",
+                task_request=task_request,
                 correlation_id=correlation_id,
-                source_context=source_context,
             )
-            async with server_timing_span("perf-advisor-brief-ai"):
-                ai_status, ai_payload = await self._lotus_ai_client.execute_workflow_pack(
-                    pack_id="advisor_brief.pack",
-                    version="v1",
-                    environment="DEVELOPMENT",
-                    caller_identity_class="BANKER_PRODUCT",
-                    workflow_surface="advisor-brief-workspace",
-                    task_request=task_request,
-                    correlation_id=correlation_id,
-                )
-            execution_payload = _safe_dict(ai_payload.get("execution")) if ai_status == 200 else {}
-            if ai_status == 200:
-                ai_audit = _normalize_ai_audit(_safe_dict(execution_payload.get("audit")))
-                ai_evidence = _safe_dict(execution_payload.get("evidence")) or {"descriptors": []}
-            if ai_status == 200 and execution_payload.get("status") == "COMPLETED":
-                result = _safe_dict(execution_payload.get("result"))
-                structured_output = _safe_dict(result.get("structured_output"))
-                source_summary = (
-                    _extract_ai_summary(
-                        ai_payload=execution_payload,
-                        structured_output=structured_output,
-                    )
-                    or source_summary
-                )
-                talking_points = (
-                    _extract_ai_talking_points(
-                        structured_output=structured_output,
-                        route=_route_query(
-                            portfolio_id=workspace.portfolio_id,
-                            period=workspace.period,
-                            basis=workspace.detail_basis,
-                            benchmark_code=workspace.benchmark_code,
-                        ),
-                    )
-                    or talking_points
-                )
-                recommended_actions = (
-                    _extract_ai_recommended_actions(
-                        structured_output=structured_output,
-                        route=_route_query(
-                            portfolio_id=workspace.portfolio_id,
-                            period=workspace.period,
-                            basis=workspace.detail_basis,
-                            benchmark_code=workspace.benchmark_code,
-                        ),
-                    )
-                    or recommended_actions
-                )
-                risks_and_exceptions = (
-                    _extract_ai_risks(
-                        structured_output=structured_output,
-                        route=_route_query(
-                            portfolio_id=workspace.portfolio_id,
-                            period=workspace.period,
-                            basis=workspace.detail_basis,
-                            benchmark_code=workspace.benchmark_code,
-                        ),
-                    )
-                    or risks_and_exceptions
-                )
-            elif ai_status == 200:
-                status = AdvisorBriefStatus.PARTIAL
-                risks_and_exceptions.append(
-                    AdvisorBriefNarrativeItem(
-                        headline="AI narrative generation is unavailable.",
-                        detail=(
-                            _safe_execution_detail(execution_payload)
-                            or (
-                                "Source-backed metrics remain available for manual review and "
-                                "client prep."
-                            )
-                        ),
-                        tone=AdvisorBriefTone.WARNING,
-                        evidence_refs=[
-                            _summary_evidence_ref(
-                                label="Advisor Brief",
-                                value="Unavailable",
-                                portfolio_id=workspace.portfolio_id,
-                                period=workspace.period,
-                                basis=workspace.detail_basis,
-                                benchmark_code=workspace.benchmark_code,
-                            )
-                        ],
-                    )
-                )
-            else:
-                status = AdvisorBriefStatus.PARTIAL
-                ai_audit = _normalize_ai_audit(
-                    {
-                        "task_id": _TASK_ID,
-                        "output_label": _EXPECTED_OUTPUT_LABEL,
-                        "provider_mode": "unavailable",
-                        "detail": _safe_error_detail(ai_payload),
-                    }
-                )
-                risks_and_exceptions.append(
-                    AdvisorBriefNarrativeItem(
-                        headline="AI narrative generation is unavailable.",
-                        detail=(
-                            "Source-backed metrics remain available for manual review and "
-                            "client prep."
-                        ),
-                        tone=AdvisorBriefTone.WARNING,
-                        evidence_refs=[
-                            _summary_evidence_ref(
-                                label="Advisor Brief",
-                                value="Unavailable",
-                                portfolio_id=workspace.portfolio_id,
-                                period=workspace.period,
-                                basis=workspace.detail_basis,
-                                benchmark_code=workspace.benchmark_code,
-                            )
-                        ],
-                    )
-                )
-        return AdvisorBriefNarrativeState(
-            status=status,
-            summary=source_summary,
-            talking_points=talking_points,
-            recommended_actions=recommended_actions,
-            risks_and_exceptions=risks_and_exceptions,
-            ai_audit=ai_audit,
-            ai_evidence=ai_evidence,
+        return _build_ai_advisor_brief_narrative_state(
+            source_context=source_context,
+            narrative_state=narrative_state,
+            ai_status=ai_status,
+            ai_payload=ai_payload,
         )
 
     async def _load_advisor_brief_runtime_context(
@@ -596,6 +482,191 @@ def _build_advisor_brief_ai_task_request(
         },
         "expected_output_label": _EXPECTED_OUTPUT_LABEL,
     }
+
+
+def _build_source_advisor_brief_narrative_state(
+    *,
+    source_context: AdvisorBriefSourceContext,
+) -> AdvisorBriefNarrativeState:
+    return AdvisorBriefNarrativeState(
+        status=source_context.status,
+        summary=source_context.summary,
+        talking_points=source_context.talking_points,
+        recommended_actions=source_context.recommended_actions,
+        risks_and_exceptions=source_context.risks_and_exceptions,
+        ai_audit=_normalize_ai_audit({}),
+        ai_evidence={"descriptors": []},
+    )
+
+
+def _build_ai_advisor_brief_narrative_state(
+    *,
+    source_context: AdvisorBriefSourceContext,
+    narrative_state: AdvisorBriefNarrativeState,
+    ai_status: int,
+    ai_payload: dict[str, Any],
+) -> AdvisorBriefNarrativeState:
+    if ai_status != 200:
+        return _build_ai_http_unavailable_narrative_state(
+            source_context=source_context,
+            narrative_state=narrative_state,
+            ai_payload=ai_payload,
+        )
+
+    execution_payload = _safe_dict(ai_payload.get("execution"))
+    ai_audit = _normalize_ai_audit(_safe_dict(execution_payload.get("audit")))
+    ai_evidence = _safe_dict(execution_payload.get("evidence")) or {"descriptors": []}
+    if execution_payload.get("status") == "COMPLETED":
+        return _build_completed_ai_advisor_brief_narrative_state(
+            source_context=source_context,
+            narrative_state=narrative_state,
+            execution_payload=execution_payload,
+            ai_audit=ai_audit,
+            ai_evidence=ai_evidence,
+        )
+
+    return _build_ai_execution_unavailable_narrative_state(
+        source_context=source_context,
+        narrative_state=narrative_state,
+        execution_payload=execution_payload,
+        ai_audit=ai_audit,
+        ai_evidence=ai_evidence,
+    )
+
+
+def _build_completed_ai_advisor_brief_narrative_state(
+    *,
+    source_context: AdvisorBriefSourceContext,
+    narrative_state: AdvisorBriefNarrativeState,
+    execution_payload: dict[str, Any],
+    ai_audit: dict[str, Any],
+    ai_evidence: dict[str, Any],
+) -> AdvisorBriefNarrativeState:
+    structured_output = _safe_dict(
+        _safe_dict(execution_payload.get("result")).get("structured_output")
+    )
+    route = _advisor_brief_workspace_route(source_context=source_context)
+    return replace(
+        narrative_state,
+        summary=_extract_ai_summary(
+            ai_payload=execution_payload,
+            structured_output=structured_output,
+        )
+        or narrative_state.summary,
+        talking_points=_extract_ai_talking_points(
+            structured_output=structured_output,
+            route=route,
+        )
+        or narrative_state.talking_points,
+        recommended_actions=_extract_ai_recommended_actions(
+            structured_output=structured_output,
+            route=route,
+        )
+        or narrative_state.recommended_actions,
+        risks_and_exceptions=_extract_ai_risks(
+            structured_output=structured_output,
+            route=route,
+        )
+        or narrative_state.risks_and_exceptions,
+        ai_audit=ai_audit,
+        ai_evidence=ai_evidence,
+    )
+
+
+def _build_ai_execution_unavailable_narrative_state(
+    *,
+    source_context: AdvisorBriefSourceContext,
+    narrative_state: AdvisorBriefNarrativeState,
+    execution_payload: dict[str, Any],
+    ai_audit: dict[str, Any],
+    ai_evidence: dict[str, Any],
+) -> AdvisorBriefNarrativeState:
+    detail = _safe_execution_detail(execution_payload) or (
+        "Source-backed metrics remain available for manual review and client prep."
+    )
+    return _with_ai_unavailable_risk(
+        source_context=source_context,
+        narrative_state=narrative_state,
+        detail=detail,
+        ai_audit=ai_audit,
+        ai_evidence=ai_evidence,
+    )
+
+
+def _build_ai_http_unavailable_narrative_state(
+    *,
+    source_context: AdvisorBriefSourceContext,
+    narrative_state: AdvisorBriefNarrativeState,
+    ai_payload: dict[str, Any],
+) -> AdvisorBriefNarrativeState:
+    ai_audit = _normalize_ai_audit(
+        {
+            "task_id": _TASK_ID,
+            "output_label": _EXPECTED_OUTPUT_LABEL,
+            "provider_mode": "unavailable",
+            "detail": _safe_error_detail(ai_payload),
+        }
+    )
+    return _with_ai_unavailable_risk(
+        source_context=source_context,
+        narrative_state=narrative_state,
+        detail="Source-backed metrics remain available for manual review and client prep.",
+        ai_audit=ai_audit,
+        ai_evidence={"descriptors": []},
+    )
+
+
+def _with_ai_unavailable_risk(
+    *,
+    source_context: AdvisorBriefSourceContext,
+    narrative_state: AdvisorBriefNarrativeState,
+    detail: str,
+    ai_audit: dict[str, Any],
+    ai_evidence: dict[str, Any],
+) -> AdvisorBriefNarrativeState:
+    return replace(
+        narrative_state,
+        status=AdvisorBriefStatus.PARTIAL,
+        risks_and_exceptions=[
+            *narrative_state.risks_and_exceptions,
+            _build_ai_unavailable_risk(source_context=source_context, detail=detail),
+        ],
+        ai_audit=ai_audit,
+        ai_evidence=ai_evidence,
+    )
+
+
+def _build_ai_unavailable_risk(
+    *,
+    source_context: AdvisorBriefSourceContext,
+    detail: str,
+) -> AdvisorBriefNarrativeItem:
+    workspace = source_context.workspace
+    return AdvisorBriefNarrativeItem(
+        headline="AI narrative generation is unavailable.",
+        detail=detail,
+        tone=AdvisorBriefTone.WARNING,
+        evidence_refs=[
+            _summary_evidence_ref(
+                label="Advisor Brief",
+                value="Unavailable",
+                portfolio_id=workspace.portfolio_id,
+                period=workspace.period,
+                basis=workspace.detail_basis,
+                benchmark_code=workspace.benchmark_code,
+            )
+        ],
+    )
+
+
+def _advisor_brief_workspace_route(*, source_context: AdvisorBriefSourceContext) -> str:
+    workspace = source_context.workspace
+    return _route_query(
+        portfolio_id=workspace.portfolio_id,
+        period=workspace.period,
+        basis=workspace.detail_basis,
+        benchmark_code=workspace.benchmark_code,
+    )
 
 
 def _normalize_ai_audit(audit: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Refactors the advisor-brief narrative-state builder into focused helpers while preserving the existing source fallback, lotus-ai workflow-pack execution, partial-result, non-200, and unavailable-source behavior.

## Measured improvement

- `_build_advisor_brief_narrative_state`: 144 lines -> 30 lines.
- Largest new advisor-brief narrative helper: 37 lines.
- Repository longest-function baseline: 144 lines -> 143 lines.
- Current longest function: `get_platform_capabilities` in `src/app/services/platform_capabilities_service.py` at 143 lines.
- Quality reports and scorecard updated to reflect the new modularity baseline and current coverage evidence.

## Validation

- `python -m ruff check src\app\services\advisor_brief_service.py tests\unit\test_advisor_brief_service.py`
- `python -m ruff format --check src\app\services\advisor_brief_service.py tests\unit\test_advisor_brief_service.py`
- `python -m mypy src\app\services\advisor_brief_service.py tests\unit\test_advisor_brief_service.py`
- `python -m pytest tests\unit\test_advisor_brief_service.py -q` -> 17 passed
- `make check` -> 958 unit/contract tests passed; ruff, format, monetary-float guard, mypy, and Workbench contract smoke passed
- `make ci` -> 207 integration tests passed; 1,165 coverage tests passed; total coverage 92.78%; pip-audit found no known vulnerabilities after governed `PYSEC-2026-161` exception
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` -> DiffCount 0
- `git fetch origin --prune; git branch -r --no-merged origin/main` -> no unmerged remote branches reported before PR

## Wiki

No wiki source change was needed for this behavior-preserving internal refactor; wiki check-only remains clean with DiffCount 0.