### PR TITLE
Refactor platform capabilities orchestration

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -88,8 +88,11 @@ reducing `_parse_core_snapshot` from 153 lines to 38 lines. The advisor-brief na
 builder has been split into source fallback, AI result
 classification, completed-output projection, unavailable-risk construction, and route-resolution
 helpers, reducing `_build_advisor_brief_narrative_state` from 144 lines to 30 lines. The current
-longest function is `get_platform_capabilities` in
-`src/app/services/platform_capabilities_service.py` at 143 lines.
+platform-capabilities orchestration has been split into task assembly, primary-source
+classification, policy-result extraction, optional-source merging, shared source-result mapping,
+and response construction helpers, reducing `get_platform_capabilities` from 143 lines to 32
+lines. The current longest function is `get_performance_attribution_trend` in
+`src/app/services/performance_workspace_service.py` at 135 lines.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -12,8 +12,8 @@ split, risk drawdown mapper split, risk rolling mapper split, risk attribution m
 risk concentration mapper extraction, shared risk unavailable-envelope helper extraction, and
 risk drawdown, rolling, attribution, and summary response module extraction, and platform
 capability normalization, shell-bootstrap, portfolio workspace-control boundary extraction, and
-performance horizon parser extraction, foundation core snapshot parser extraction, and
-advisor-brief narrative-state extraction.
+performance horizon parser extraction, foundation core snapshot parser extraction,
+advisor-brief narrative-state extraction, and platform-capabilities orchestration extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -46,16 +46,16 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Rank | Lines | Function | File |
 | ---: | ---: | --- | --- |
-| 1 | 143 | `get_platform_capabilities` | `src/app/services/platform_capabilities_service.py` |
-| 2 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
-| 3 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
-| 4 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
-| 5 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
-| 6 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
-| 7 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
-| 8 | 112 | `_build_workspace_summary_views` | `src/app/services/performance_workspace_service.py` |
-| 9 | 111 | `get_portfolio_workspace` | `src/app/services/foundation_service.py` |
-| 10 | 111 | `get_portfolio_transactions` | `src/app/routers/portfolio_transactions.py` |
+| 1 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
+| 2 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
+| 3 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
+| 4 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
+| 5 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
+| 6 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
+| 7 | 112 | `_build_workspace_summary_views` | `src/app/services/performance_workspace_service.py` |
+| 8 | 111 | `get_portfolio_workspace` | `src/app/services/foundation_service.py` |
+| 9 | 111 | `get_portfolio_transactions` | `src/app/routers/portfolio_transactions.py` |
+| 10 | 108 | `get_performance_horizon_comparison` | `src/app/services/performance_workspace_service.py` |
 
 ## Existing Blocking Gates
 
@@ -94,7 +94,7 @@ large-file and long-function hotspots in service, contract, and client code.
 The first enforcement candidates should be:
 
 1. no new service file above the current largest-file baseline,
-2. no new function above the current longest-function baseline of 143 lines,
+2. no new function above the current longest-function baseline of 135 lines,
 3. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
 4. no new architecture import-linter violations after contracts are reviewed.
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -77,7 +77,7 @@ Most recent local evidence:
 1. `make check`: 958 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
 3. `make ci`: 1,165 coverage tests passed.
-4. Coverage: 92.78%.
+4. Coverage: 92.80%.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -50,7 +50,7 @@ Most recent local PR-grade evidence:
 1. `make check`: 958 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
 3. `make ci`: 1,165 coverage tests passed.
-4. Total coverage: 92.78%, above the 84% floor.
+4. Total coverage: 92.80%, above the 84% floor.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Next Tightening Candidates

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -6,7 +6,7 @@ Mode: baseline/report-only
 | Dimension | Score | Baseline status | Next action |
 | --- | ---: | --- | --- |
 | Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
-| Coverage | 4/5 | 92.78% total coverage | Add targeted middleware/security/error tests |
+| Coverage | 4/5 | 92.80% total coverage | Add targeted middleware/security/error tests |
 | Modularity | 2/5 | Platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -7,7 +7,7 @@ Mode: baseline/report-only
 | --- | ---: | --- | --- |
 | Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
 | Coverage | 4/5 | 92.78% total coverage | Add targeted middleware/security/error tests |
-| Modularity | 2/5 | Advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
+| Modularity | 2/5 | Platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -53,7 +53,7 @@ performance workspace, advisor-brief orchestration, contract, and client modules
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
 | Unit/contract coverage | Healthy | 958 tests passed in latest `make check` evidence |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
-| Total coverage | Healthy | 92.78%, above the 84% floor |
+| Total coverage | Healthy | 92.80%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
 | Modularity | Improving, incomplete | Platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -39,7 +39,11 @@ finalization, and portfolio identity helpers, reducing `_parse_core_snapshot` fr
 narrative-state builder has now been split into source fallback, AI result classification,
 completed-output projection, unavailable-risk construction, and route-resolution helpers, reducing
 `_build_advisor_brief_narrative_state` from 144 lines to 30 lines and lowering the repository
-longest-function baseline to 143 lines. The remaining work is still substantial: large portfolio,
+longest-function baseline to 143 lines. Platform-capabilities orchestration has now been split
+into task assembly, primary-source classification, policy-result extraction, optional-source
+merging, shared source-result mapping, and response construction helpers, reducing
+`get_platform_capabilities` from 143 lines to 32 lines and lowering the repository
+longest-function baseline to 135 lines. The remaining work is still substantial: large portfolio,
 performance workspace, advisor-brief orchestration, contract, and client modules remain.
 
 ## Health Signals
@@ -51,7 +55,7 @@ performance workspace, advisor-brief orchestration, contract, and client modules
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.78%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
-| Modularity | Improving, incomplete | Advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -62,8 +66,8 @@ performance workspace, advisor-brief orchestration, contract, and client modules
    workspace, and workflow-cue adapters.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
-3. Continue splitting platform capability normalization into smaller feature/workflow helpers if
-   future changes expand the extracted module.
+3. Continue splitting platform capability normalization or orchestration helpers if future changes
+   expand the extracted modules.
 4. Continue extracting performance workspace service orchestration helpers behind stable response
    contracts; horizon parsing is now below the current function-size baseline.
 5. Continue splitting advisor-brief service orchestration around stable reviewed-narrative

--- a/src/app/services/platform_capabilities_service.py
+++ b/src/app/services/platform_capabilities_service.py
@@ -68,6 +68,39 @@ class PlatformCapabilitiesService:
         correlation_id: str,
     ) -> PlatformCapabilitiesResponse:
         evaluated_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        tasks, optional_sources = self._build_capability_tasks(
+            consumer_system=consumer_system,
+            tenant_id=tenant_id,
+            correlation_id=correlation_id,
+        )
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        sources, errors = self._primary_sources_from_results(results)
+        lotus_core_policy_payload = self._lotus_core_policy_from_result(
+            result=results[len(PRIMARY_CAPABILITY_SOURCES)],
+            errors=errors,
+        )
+        self._merge_optional_capability_sources(
+            results=results,
+            optional_sources=optional_sources,
+            sources=sources,
+            errors=errors,
+        )
+        return self._build_platform_capabilities_response(
+            consumer_system=consumer_system,
+            tenant_id=tenant_id,
+            sources=sources,
+            errors=errors,
+            lotus_core_policy_payload=lotus_core_policy_payload,
+            evaluated_at=evaluated_at,
+        )
+
+    def _build_capability_tasks(
+        self,
+        *,
+        consumer_system: str,
+        tenant_id: str,
+        correlation_id: str,
+    ) -> tuple[list[Any], list[str]]:
         tasks: list[Any] = [
             self._with_timeout(
                 self._lotus_core_query_client.get_capabilities(
@@ -122,64 +155,48 @@ class PlatformCapabilitiesService:
                 )
             )
             optional_sources.append("risk")
+        return tasks, optional_sources
 
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-
+    def _primary_sources_from_results(
+        self,
+        results: list[Any],
+    ) -> tuple[dict[str, dict[str, Any]], list[CapabilitySourceError]]:
         sources: dict[str, dict[str, Any]] = {}
         errors: list[CapabilitySourceError] = []
         for service_name, result in zip(PRIMARY_CAPABILITY_SOURCES, results[:5], strict=True):
-            if isinstance(result, BaseException):
-                errors.append(
-                    CapabilitySourceError(
-                        service=service_name,
-                        status_code=500,
-                        detail=self._exception_detail(result),
-                    )
-                )
-                continue
-
-            status_code, payload = cast(tuple[int, dict[str, Any]], result)
-            if status_code >= 400:
-                errors.append(
-                    CapabilitySourceError(
-                        service=service_name,
-                        status_code=status_code,
-                        detail=str(payload.get("detail", payload)),
-                    )
-                )
-                continue
-
-            sources[service_name] = payload
-
-        lotus_core_policy_payload: dict[str, Any] | None = None
-        lotus_core_policy_result = results[5]
-        if isinstance(lotus_core_policy_result, BaseException):
-            errors.append(
-                CapabilitySourceError(
-                    service="lotus_core_policy",
-                    status_code=500,
-                    detail=self._exception_detail(lotus_core_policy_result),
-                )
+            payload = self._payload_from_source_result(
+                result=result,
+                service_name=service_name,
+                errors=errors,
             )
-        else:
-            policy_status_code, policy_payload = cast(
-                tuple[int, dict[str, Any]], lotus_core_policy_result
-            )
-            if policy_status_code >= 400:
-                errors.append(
-                    CapabilitySourceError(
-                        service="lotus_core_policy",
-                        status_code=policy_status_code,
-                        detail=str(policy_payload.get("detail", policy_payload)),
-                    )
-                )
-            else:
-                lotus_core_policy_payload = policy_payload
+            if payload is not None:
+                sources[service_name] = payload
+        return sources, errors
 
+    def _lotus_core_policy_from_result(
+        self,
+        *,
+        result: Any,
+        errors: list[CapabilitySourceError],
+    ) -> dict[str, Any] | None:
+        return self._payload_from_source_result(
+            result=result,
+            service_name="lotus_core_policy",
+            errors=errors,
+        )
+
+    def _merge_optional_capability_sources(
+        self,
+        *,
+        results: list[Any],
+        optional_sources: list[str],
+        sources: dict[str, dict[str, Any]],
+        errors: list[CapabilitySourceError],
+    ) -> None:
         optional_result_map: dict[str, Any] = {}
-        for index, source in enumerate(optional_sources, start=6):
+        start_index = len(PRIMARY_CAPABILITY_SOURCES) + 1
+        for index, source in enumerate(optional_sources, start=start_index):
             optional_result_map[source] = results[index]
-
         self._merge_optional_source(
             optional_result_map=optional_result_map,
             source_name="risk",
@@ -188,6 +205,16 @@ class PlatformCapabilitiesService:
             errors=errors,
         )
 
+    def _build_platform_capabilities_response(
+        self,
+        *,
+        consumer_system: str,
+        tenant_id: str,
+        sources: dict[str, dict[str, Any]],
+        errors: list[CapabilitySourceError],
+        lotus_core_policy_payload: dict[str, Any] | None,
+        evaluated_at: str,
+    ) -> PlatformCapabilitiesResponse:
         normalized = self._build_normalized_capabilities(
             sources=sources,
             errors=errors,
@@ -204,6 +231,34 @@ class PlatformCapabilitiesService:
             normalized=normalized,
         )
         return PlatformCapabilitiesResponse(data=data)
+
+    def _payload_from_source_result(
+        self,
+        *,
+        result: Any,
+        service_name: str,
+        errors: list[CapabilitySourceError],
+    ) -> dict[str, Any] | None:
+        if isinstance(result, BaseException):
+            errors.append(
+                CapabilitySourceError(
+                    service=service_name,
+                    status_code=500,
+                    detail=self._exception_detail(result),
+                )
+            )
+            return None
+        status_code, payload = cast(tuple[int, dict[str, Any]], result)
+        if status_code >= 400:
+            errors.append(
+                CapabilitySourceError(
+                    service=service_name,
+                    status_code=status_code,
+                    detail=str(payload.get("detail", payload)),
+                )
+            )
+            return None
+        return payload
 
     async def _with_timeout(self, coroutine: Any) -> Any:
         return await asyncio.wait_for(coroutine, timeout=self._source_timeout_seconds)
@@ -301,26 +356,13 @@ class PlatformCapabilitiesService:
         result = optional_result_map.get(source_name)
         if result is None:
             return
-        if isinstance(result, BaseException):
-            errors.append(
-                CapabilitySourceError(
-                    service=gateway_source_name,
-                    status_code=500,
-                    detail=self._exception_detail(result),
-                )
-            )
-            return
-        status_code, payload = cast(tuple[int, dict[str, Any]], result)
-        if status_code >= 400:
-            errors.append(
-                CapabilitySourceError(
-                    service=gateway_source_name,
-                    status_code=status_code,
-                    detail=str(payload.get("detail", payload)),
-                )
-            )
-            return
-        sources[gateway_source_name] = payload
+        payload = self._payload_from_source_result(
+            result=result,
+            service_name=gateway_source_name,
+            errors=errors,
+        )
+        if payload is not None:
+            sources[gateway_source_name] = payload
 
     def _exception_detail(self, exc: BaseException) -> str:
         message = str(exc)


### PR DESCRIPTION
## Summary

Refactors platform-capabilities fan-out orchestration into focused helpers for task assembly, primary-source classification, lotus-core policy extraction, optional-source merging, shared result-to-error mapping, and response construction.

Behavior is intended to remain unchanged: source ordering, timeout wrapping, correlation/tenant propagation, partial-failure handling, optional risk handling, and normalized response construction are preserved.

## Measured improvement

- `get_platform_capabilities`: 143 lines -> 32 lines.
- Largest new platform-capabilities orchestration helper: 62 lines.
- Repository longest-function baseline: 143 lines -> 135 lines.
- Current longest function: `get_performance_attribution_trend` in `src/app/services/performance_workspace_service.py` at 135 lines.
- Quality reports and scorecard updated to reflect the new modularity baseline and current coverage evidence.

## Validation

- `python -m ruff check src\app\services\platform_capabilities_service.py tests\unit\test_platform_capabilities_service.py`
- `python -m ruff format --check src\app\services\platform_capabilities_service.py tests\unit\test_platform_capabilities_service.py`
- `python -m mypy src\app\services\platform_capabilities_service.py tests\unit\test_platform_capabilities_service.py`
- `python -m pytest tests\unit\test_platform_capabilities_service.py -q` -> 12 passed
- `make check` -> 958 unit/contract tests passed; ruff, format, monetary-float guard, mypy, and Workbench contract smoke passed
- `make ci` -> 207 integration tests passed; 1,165 coverage tests passed; total coverage 92.80%; pip-audit found no known vulnerabilities after governed `PYSEC-2026-161` exception
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` -> DiffCount 0
- `git fetch origin --prune; git branch -r --no-merged origin/main` -> no unmerged remote branches reported before PR

## Wiki

No wiki source change was needed for this behavior-preserving internal refactor; wiki check-only remains clean with DiffCount 0.