### PR TITLE
Refactor performance attribution trend orchestration

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -91,8 +91,10 @@ helpers, reducing `_build_advisor_brief_narrative_state` from 144 lines to 30 li
 platform-capabilities orchestration has been split into task assembly, primary-source
 classification, policy-result extraction, optional-source merging, shared source-result mapping,
 and response construction helpers, reducing `get_platform_capabilities` from 143 lines to 32
-lines. The current longest function is `get_performance_attribution_trend` in
-`src/app/services/performance_workspace_service.py` at 135 lines.
+lines. The performance attribution trend orchestrator has been split into request-context,
+window-pair construction, attribution fan-out, and response assembly helpers, reducing
+`get_performance_attribution_trend` from 135 lines to 56 lines. The current longest function is
+`_build_evidence_view` in `src/app/services/performance_workspace_service.py` at 134 lines.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -13,7 +13,8 @@ risk concentration mapper extraction, shared risk unavailable-envelope helper ex
 risk drawdown, rolling, attribution, and summary response module extraction, and platform
 capability normalization, shell-bootstrap, portfolio workspace-control boundary extraction, and
 performance horizon parser extraction, foundation core snapshot parser extraction,
-advisor-brief narrative-state extraction, and platform-capabilities orchestration extraction.
+advisor-brief narrative-state extraction, platform-capabilities orchestration extraction, and
+performance attribution trend orchestration extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -46,16 +47,16 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Rank | Lines | Function | File |
 | ---: | ---: | --- | --- |
-| 1 | 135 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
-| 2 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
-| 3 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
-| 4 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
-| 5 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
-| 6 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
-| 7 | 112 | `_build_workspace_summary_views` | `src/app/services/performance_workspace_service.py` |
-| 8 | 111 | `get_portfolio_workspace` | `src/app/services/foundation_service.py` |
-| 9 | 111 | `get_portfolio_transactions` | `src/app/routers/portfolio_transactions.py` |
-| 10 | 108 | `get_performance_horizon_comparison` | `src/app/services/performance_workspace_service.py` |
+| 1 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
+| 2 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
+| 3 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
+| 4 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
+| 5 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
+| 6 | 112 | `_build_workspace_summary_views` | `src/app/services/performance_workspace_service.py` |
+| 7 | 111 | `get_portfolio_workspace` | `src/app/services/foundation_service.py` |
+| 8 | 111 | `get_portfolio_transactions` | `src/app/routers/portfolio_transactions.py` |
+| 9 | 108 | `get_performance_horizon_comparison` | `src/app/services/performance_workspace_service.py` |
+| 10 | 107 | `get_rolling` | `src/app/services/risk_workspace_service.py` |
 
 ## Existing Blocking Gates
 
@@ -94,7 +95,7 @@ large-file and long-function hotspots in service, contract, and client code.
 The first enforcement candidates should be:
 
 1. no new service file above the current largest-file baseline,
-2. no new function above the current longest-function baseline of 135 lines,
+2. no new function above the current longest-function baseline of 134 lines,
 3. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
 4. no new architecture import-linter violations after contracts are reviewed.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -7,7 +7,7 @@ Mode: baseline/report-only
 | --- | ---: | --- | --- |
 | Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
 | Coverage | 4/5 | 92.80% total coverage | Add targeted middleware/security/error tests |
-| Modularity | 2/5 | Platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
+| Modularity | 2/5 | Performance attribution trend orchestration, platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -43,8 +43,11 @@ longest-function baseline to 143 lines. Platform-capabilities orchestration has 
 into task assembly, primary-source classification, policy-result extraction, optional-source
 merging, shared source-result mapping, and response construction helpers, reducing
 `get_platform_capabilities` from 143 lines to 32 lines and lowering the repository
-longest-function baseline to 135 lines. The remaining work is still substantial: large portfolio,
-performance workspace, advisor-brief orchestration, contract, and client modules remain.
+longest-function baseline to 135 lines. Performance attribution trend orchestration has now been
+split into request-context, window-pair construction, attribution fan-out, and response assembly
+helpers, reducing `get_performance_attribution_trend` from 135 lines to 56 lines and lowering the
+repository longest-function baseline to 134 lines. The remaining work is still substantial: large
+portfolio, performance workspace, advisor-brief orchestration, contract, and client modules remain.
 
 ## Health Signals
 
@@ -55,7 +58,7 @@ performance workspace, advisor-brief orchestration, contract, and client modules
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.80%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
-| Modularity | Improving, incomplete | Platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Performance attribution trend orchestration, platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -68,8 +71,9 @@ performance workspace, advisor-brief orchestration, contract, and client modules
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes
    expand the extracted modules.
-4. Continue extracting performance workspace service orchestration helpers behind stable response
-   contracts; horizon parsing is now below the current function-size baseline.
+4. Continue extracting performance workspace service evidence and summary orchestration helpers
+   behind stable response contracts; horizon parsing and attribution trend orchestration are now
+   below the current function-size baseline.
 5. Continue splitting advisor-brief service orchestration around stable reviewed-narrative
    contracts if future changes expand the remaining runtime or review helpers.
 6. Split large contract modules only when contract ownership boundaries are clear and tests remain

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -119,6 +119,21 @@ class WorkspaceRequestContext:
 
 
 @dataclass(frozen=True)
+class AttributionTrendRequestContext:
+    overview: WorkbenchOverviewResponse
+    warnings: list[str]
+    partial_failures: list[WorkbenchPartialFailure]
+    report_end_date: str
+    report_start_date: date
+    effective_period: str
+    chart_frequency: str
+    attribution_dimension: str
+    requested_chart_frequency_supported: bool
+    requested_attribution_dimension_supported: bool
+    benchmark_code: str | None
+
+
+@dataclass(frozen=True)
 class WorkspaceSummaryViews:
     workspace_summary_result: GatheredResult
     parsed_summary: ParsedWorkspaceSummary
@@ -436,6 +451,62 @@ class PerformanceWorkspaceService:
         explicit_start_date: str | None = None,
         explicit_end_date: str | None = None,
     ) -> PerformanceAttributionTrendResponse:
+        context = await self._build_attribution_trend_request_context(
+            portfolio_id=portfolio_id,
+            correlation_id=correlation_id,
+            period=period,
+            chart_frequency=chart_frequency,
+            attribution_dimension=attribution_dimension,
+            benchmark_code=benchmark_code,
+            explicit_start_date=explicit_start_date,
+            explicit_end_date=explicit_end_date,
+        )
+        if context.benchmark_code is None:
+            context.warnings.append("ATTRIBUTION_TREND_UNAVAILABLE_NO_BENCHMARK")
+            return self._build_attribution_trend_response(
+                portfolio_id=portfolio_id,
+                correlation_id=correlation_id,
+                detail_basis=detail_basis,
+                context=context,
+                rows=[],
+            )
+
+        window_pairs = self._build_attribution_trend_window_pairs(context)
+        attribution_results = await self._fetch_attribution_trend_results(
+            portfolio_id=portfolio_id,
+            correlation_id=correlation_id,
+            detail_basis=detail_basis,
+            context=context,
+            window_pairs=window_pairs,
+        )
+        rows = parse_attribution_trend_results(
+            results=attribution_results,
+            window_pairs=window_pairs,
+            chart_frequency=context.chart_frequency,
+            requested_period="EXPLICIT",
+            warnings=context.warnings,
+            partial_failures=context.partial_failures,
+        )
+        return self._build_attribution_trend_response(
+            portfolio_id=portfolio_id,
+            correlation_id=correlation_id,
+            detail_basis=detail_basis,
+            context=context,
+            rows=rows,
+        )
+
+    async def _build_attribution_trend_request_context(
+        self,
+        *,
+        portfolio_id: str,
+        correlation_id: str,
+        period: str,
+        chart_frequency: str,
+        attribution_dimension: str,
+        benchmark_code: str | None,
+        explicit_start_date: str | None,
+        explicit_end_date: str | None,
+    ) -> AttributionTrendRequestContext:
         async with server_timing_span("perf-overview"):
             overview = await self._get_cached_workspace_overview(
                 portfolio_id=portfolio_id,
@@ -458,24 +529,21 @@ class PerformanceWorkspaceService:
             explicit_start_date=explicit_start_date,
             explicit_end_date=explicit_end_date,
         )
-        (
-            resolved_frequency,
-            requested_chart_frequency_supported,
-        ) = normalize_workspace_chart_frequency(
-            chart_frequency=chart_frequency,
-            warnings=warnings,
-            warning_code="PERFORMANCE_ATTRIBUTION_TREND_CHART_FREQUENCY_NORMALIZED",
+        resolved_frequency, requested_chart_frequency_supported = (
+            normalize_workspace_chart_frequency(
+                chart_frequency=chart_frequency,
+                warnings=warnings,
+                warning_code="PERFORMANCE_ATTRIBUTION_TREND_CHART_FREQUENCY_NORMALIZED",
+            )
         )
-        (
-            resolved_attribution_dimension,
-            requested_attribution_dimension_supported,
-        ) = normalize_workspace_dimension(
-            requested_dimension=attribution_dimension,
-            supported_dimensions=SUPPORTED_ATTRIBUTION_DIMENSIONS,
-            warnings=warnings,
-            warning_code="PERFORMANCE_ATTRIBUTION_TREND_DIMENSION_NORMALIZED",
+        resolved_attribution_dimension, requested_attribution_dimension_supported = (
+            normalize_workspace_dimension(
+                requested_dimension=attribution_dimension,
+                supported_dimensions=SUPPORTED_ATTRIBUTION_DIMENSIONS,
+                warnings=warnings,
+                warning_code="PERFORMANCE_ATTRIBUTION_TREND_DIMENSION_NORMALIZED",
+            )
         )
-
         async with server_timing_span("perf-benchmark"):
             resolved_benchmark_code, _ = await fetch_benchmark_context(
                 cache=self._upstream_cache,
@@ -487,76 +555,88 @@ class PerformanceWorkspaceService:
                 benchmark_code=benchmark_code,
                 include_benchmark_catalog=False,
             )
-
-        if not resolved_benchmark_code:
-            warnings.append("ATTRIBUTION_TREND_UNAVAILABLE_NO_BENCHMARK")
-            return PerformanceAttributionTrendResponse(
-                correlation_id=correlation_id,
-                contract_version=overview.contract_version,
-                portfolio_id=portfolio_id,
-                as_of_date=overview.as_of_date,
-                period=effective_period,
-                report_start_date=report_start_date.isoformat(),
-                report_end_date=report_end_date,
-                chart_frequency=resolved_frequency,
-                detail_basis=detail_basis,
-                attribution_dimension=resolved_attribution_dimension,
-                requested_chart_frequency_supported=requested_chart_frequency_supported,
-                requested_attribution_dimension_supported=requested_attribution_dimension_supported,
-                benchmark_code=None,
-                rows=[],
-                warnings=warnings,
-                partial_failures=partial_failures,
-            )
-
-        window_pairs = build_attribution_trend_windows(
-            start_date=report_start_date,
-            end_date=date.fromisoformat(report_end_date),
+        return AttributionTrendRequestContext(
+            overview=overview,
+            warnings=warnings,
+            partial_failures=partial_failures,
+            report_end_date=report_end_date,
+            report_start_date=report_start_date,
+            effective_period=effective_period,
             chart_frequency=resolved_frequency,
+            attribution_dimension=resolved_attribution_dimension,
+            requested_chart_frequency_supported=requested_chart_frequency_supported,
+            requested_attribution_dimension_supported=(requested_attribution_dimension_supported),
+            benchmark_code=resolved_benchmark_code,
         )
+
+    def _build_attribution_trend_window_pairs(
+        self,
+        context: AttributionTrendRequestContext,
+    ) -> list[tuple[date, date]]:
+        return build_attribution_trend_windows(
+            start_date=context.report_start_date,
+            end_date=date.fromisoformat(context.report_end_date),
+            chart_frequency=context.chart_frequency,
+        )
+
+    async def _fetch_attribution_trend_results(
+        self,
+        *,
+        portfolio_id: str,
+        correlation_id: str,
+        detail_basis: str,
+        context: AttributionTrendRequestContext,
+        window_pairs: list[tuple[date, date]],
+    ) -> Sequence[GatheredResult]:
+        if context.benchmark_code is None:
+            return []
         async with server_timing_span("perf-attribution"):
-            attribution_results = await asyncio.gather(
-                *[
+            gathered = await asyncio.gather(
+                *(
                     self._analytics_client.get_attribution_analytics(
                         portfolio_id=portfolio_id,
                         report_start_date=window_start.isoformat(),
                         report_end_date=window_end.isoformat(),
                         period="EXPLICIT",
                         metric_basis=detail_basis,
-                        benchmark_id=resolved_benchmark_code,
-                        dimension=resolved_attribution_dimension,
+                        benchmark_id=context.benchmark_code,
+                        dimension=context.attribution_dimension,
                         correlation_id=correlation_id,
                     )
                     for window_start, window_end in window_pairs
-                ],
+                ),
                 return_exceptions=True,
             )
-        rows = parse_attribution_trend_results(
-            results=attribution_results,
-            window_pairs=window_pairs,
-            chart_frequency=resolved_frequency,
-            requested_period="EXPLICIT",
-            warnings=warnings,
-            partial_failures=partial_failures,
-        )
+        return cast(Sequence[GatheredResult], gathered)
 
+    def _build_attribution_trend_response(
+        self,
+        *,
+        portfolio_id: str,
+        correlation_id: str,
+        detail_basis: str,
+        context: AttributionTrendRequestContext,
+        rows: Sequence[Any],
+    ) -> PerformanceAttributionTrendResponse:
         return PerformanceAttributionTrendResponse(
             correlation_id=correlation_id,
-            contract_version=overview.contract_version,
+            contract_version=context.overview.contract_version,
             portfolio_id=portfolio_id,
-            as_of_date=overview.as_of_date,
-            period=effective_period,
-            report_start_date=report_start_date.isoformat(),
-            report_end_date=report_end_date,
-            chart_frequency=resolved_frequency,
+            as_of_date=context.overview.as_of_date,
+            period=context.effective_period,
+            report_start_date=context.report_start_date.isoformat(),
+            report_end_date=context.report_end_date,
+            chart_frequency=context.chart_frequency,
             detail_basis=detail_basis,
-            attribution_dimension=resolved_attribution_dimension,
-            requested_chart_frequency_supported=requested_chart_frequency_supported,
-            requested_attribution_dimension_supported=requested_attribution_dimension_supported,
-            benchmark_code=resolved_benchmark_code,
-            rows=rows,
-            warnings=warnings,
-            partial_failures=partial_failures,
+            attribution_dimension=context.attribution_dimension,
+            requested_chart_frequency_supported=context.requested_chart_frequency_supported,
+            requested_attribution_dimension_supported=(
+                context.requested_attribution_dimension_supported
+            ),
+            benchmark_code=context.benchmark_code,
+            rows=list(rows),
+            warnings=context.warnings,
+            partial_failures=context.partial_failures,
         )
 
     async def _build_performance_workspace_response(


### PR DESCRIPTION
## Summary

Refactors performance attribution-trend orchestration into focused helpers for request-context resolution, attribution trend window construction, attribution fan-out, and response assembly.

Behavior is intended to remain unchanged: overview/reference lookup, requested-window resolution, chart-frequency and attribution-dimension normalization, benchmark resolution, no-benchmark fallback response, attribution fan-out, partial-failure propagation, and response fields are preserved.

## Measured improvement

- `get_performance_attribution_trend`: 135 lines -> 56 lines.
- Repository longest-function baseline: 135 lines -> 134 lines.
- Current longest function: `_build_evidence_view` in `src/app/services/performance_workspace_service.py` at 134 lines.
- Quality reports and scorecard updated to reflect the new modularity baseline.

## Validation

- `python -m ruff check src\app\services\performance_workspace_service.py tests\unit\test_performance_workspace_service.py tests\unit\test_performance_workspace_attribution.py`
- `python -m ruff format --check src\app\services\performance_workspace_service.py tests\unit\test_performance_workspace_service.py tests\unit\test_performance_workspace_attribution.py`
- `python -m mypy src\app\services\performance_workspace_service.py tests\unit\test_performance_workspace_service.py tests\unit\test_performance_workspace_attribution.py`
- `python -m pytest tests\unit\test_performance_workspace_service.py tests\unit\test_performance_workspace_attribution.py -q` -> 43 passed
- `make check` -> 958 unit/contract tests passed; ruff, format, monetary-float guard, mypy, and Workbench contract smoke passed
- `make ci` -> 207 integration tests passed; 1,165 coverage tests passed; total coverage 92.80%; pip-audit found no known vulnerabilities after governed `PYSEC-2026-161` exception
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` -> DiffCount 0
- `git fetch origin --prune; git branch -r --no-merged origin/main` -> no unmerged remote branches reported before PR

## Wiki

No wiki source change was needed for this behavior-preserving internal refactor; wiki check-only remains clean with DiffCount 0.