### PR TITLE
Refactor performance evidence view orchestration

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -93,8 +93,11 @@ classification, policy-result extraction, optional-source merging, shared source
 and response construction helpers, reducing `get_platform_capabilities` from 143 lines to 32
 lines. The performance attribution trend orchestrator has been split into request-context,
 window-pair construction, attribution fan-out, and response assembly helpers, reducing
-`get_performance_attribution_trend` from 135 lines to 56 lines. The current longest function is
-`_build_evidence_view` in `src/app/services/performance_workspace_service.py` at 134 lines.
+`get_performance_attribution_trend` from 135 lines to 56 lines. The performance evidence-view
+orchestrator has now been split into request context, fetch state, requested-calculation
+selection, and explicit response builders, reducing `_build_evidence_view` from 134 lines to
+58 lines. The current longest function is `_build_portfolio_exception_summaries` in
+`src/app/services/portfolio_service.py` at 133 lines.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -37,9 +37,9 @@ yet enforced unless they are already covered by existing repo-native gates.
 | 3 | 2,043 | `src/app/contracts/risk_workspace.py` |
 | 4 | 1,840 | `src/app/contracts/reporting.py` |
 | 5 | 1,606 | `src/app/contracts/performance_workspace.py` |
-| 6 | 1,392 | `src/app/services/advisor_brief_service.py` |
+| 6 | 1,463 | `src/app/services/advisor_brief_service.py` |
 | 7 | 1,362 | `src/app/clients/dpm_client.py` |
-| 8 | 1,152 | `src/app/services/performance_workspace_service.py` |
+| 8 | 1,327 | `src/app/services/performance_workspace_service.py` |
 | 9 | 1,098 | `src/app/clients/advise_client.py` |
 | 10 | 1,032 | `src/app/services/dpm_command_center_service.py` |
 
@@ -47,16 +47,16 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Rank | Lines | Function | File |
 | ---: | ---: | --- | --- |
-| 1 | 134 | `_build_evidence_view` | `src/app/services/performance_workspace_service.py` |
-| 2 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
-| 3 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
-| 4 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
-| 5 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
-| 6 | 112 | `_build_workspace_summary_views` | `src/app/services/performance_workspace_service.py` |
-| 7 | 111 | `get_portfolio_workspace` | `src/app/services/foundation_service.py` |
-| 8 | 111 | `get_portfolio_transactions` | `src/app/routers/portfolio_transactions.py` |
-| 9 | 108 | `get_performance_horizon_comparison` | `src/app/services/performance_workspace_service.py` |
-| 10 | 107 | `get_rolling` | `src/app/services/risk_workspace_service.py` |
+| 1 | 133 | `_build_portfolio_exception_summaries` | `src/app/services/portfolio_service.py` |
+| 2 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
+| 3 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
+| 4 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
+| 5 | 112 | `_build_workspace_summary_views` | `src/app/services/performance_workspace_service.py` |
+| 6 | 111 | `get_portfolio_workspace` | `src/app/services/foundation_service.py` |
+| 7 | 111 | `get_portfolio_transactions` | `src/app/routers/portfolio_transactions.py` |
+| 8 | 108 | `get_performance_horizon_comparison` | `src/app/services/performance_workspace_service.py` |
+| 9 | 107 | `get_rolling` | `src/app/services/risk_workspace_service.py` |
+| 10 | 103 | `workspace_descriptors` | `src/app/services/platform_capabilities_shell.py` |
 
 ## Existing Blocking Gates
 
@@ -95,7 +95,7 @@ large-file and long-function hotspots in service, contract, and client code.
 The first enforcement candidates should be:
 
 1. no new service file above the current largest-file baseline,
-2. no new function above the current longest-function baseline of 134 lines,
+2. no new function above the current longest-function baseline of 133 lines,
 3. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
 4. no new architecture import-linter violations after contracts are reviewed.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -7,7 +7,7 @@ Mode: baseline/report-only
 | --- | ---: | --- | --- |
 | Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
 | Coverage | 4/5 | 92.80% total coverage | Add targeted middleware/security/error tests |
-| Modularity | 2/5 | Performance attribution trend orchestration, platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
+| Modularity | 2/5 | Performance evidence-view orchestration, performance attribution trend orchestration, platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -46,7 +46,10 @@ merging, shared source-result mapping, and response construction helpers, reduci
 longest-function baseline to 135 lines. Performance attribution trend orchestration has now been
 split into request-context, window-pair construction, attribution fan-out, and response assembly
 helpers, reducing `get_performance_attribution_trend` from 135 lines to 56 lines and lowering the
-repository longest-function baseline to 134 lines. The remaining work is still substantial: large
+repository longest-function baseline to 134 lines. Performance evidence-view orchestration has now
+been split into request context, fetch state, requested-calculation selection, and explicit response
+builders, reducing `_build_evidence_view` from 134 lines to 58 lines and lowering the repository
+longest-function baseline to 133 lines. The remaining work is still substantial: large
 portfolio, performance workspace, advisor-brief orchestration, contract, and client modules remain.
 
 ## Health Signals
@@ -58,7 +61,7 @@ portfolio, performance workspace, advisor-brief orchestration, contract, and cli
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
 | Total coverage | Healthy | 92.80%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
-| Modularity | Improving, incomplete | Performance attribution trend orchestration, platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Performance evidence-view orchestration, performance attribution trend orchestration, platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -71,9 +74,9 @@ portfolio, performance workspace, advisor-brief orchestration, contract, and cli
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes
    expand the extracted modules.
-4. Continue extracting performance workspace service evidence and summary orchestration helpers
-   behind stable response contracts; horizon parsing and attribution trend orchestration are now
-   below the current function-size baseline.
+4. Continue extracting performance workspace summary orchestration helpers behind stable response
+   contracts; horizon parsing, attribution trend orchestration, and evidence-view orchestration are
+   now below the current function-size baseline.
 5. Continue splitting advisor-brief service orchestration around stable reviewed-narrative
    contracts if future changes expand the remaining runtime or review helpers.
 6. Split large contract modules only when contract ownership boundaries are clear and tests remain

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -15,10 +15,12 @@ from app.contracts.performance_workspace import (
     MoneyWeightedReturnSummary,
     PerformanceAttributionTrendResponse,
     PerformanceBenchmarkOptionView,
+    PerformanceCalculationEvidenceView,
     PerformanceChartPoint,
     PerformanceComparativeSummary,
     PerformanceEvidenceView,
     PerformanceHorizonComparisonResponse,
+    PerformanceSourceSupportabilityView,
     PerformanceWorkspaceCapabilities,
     PerformanceWorkspaceDetailsResponse,
     PerformanceWorkspaceResponse,
@@ -165,6 +167,145 @@ class WorkspaceSummaryViews:
     @property
     def resolved_benchmark_code(self) -> str | None:
         return self.parsed_summary.resolved_benchmark_code
+
+
+@dataclass(frozen=True)
+class EvidenceViewRequestContext:
+    portfolio_id: str
+    as_of_date: str
+    period: str
+    basis: str
+    benchmark_code: str | None
+    contract_version: str
+    correlation_id: str
+    calculations: Sequence[tuple[str, str | None]]
+    source_results: Sequence[GatheredResult | None]
+
+
+@dataclass(frozen=True)
+class EvidenceViewFetchState:
+    source_supportability: list[PerformanceSourceSupportabilityView]
+    requested_items: list[tuple[str, str]]
+    evidence_items: list[PerformanceCalculationEvidenceView]
+
+    @property
+    def backed_count(self) -> int:
+        return sum(
+            1
+            for item in self.evidence_items
+            if item.execution_status is not None or item.lineage_status is not None
+        )
+
+    @property
+    def complete_count(self) -> int:
+        return sum(
+            1
+            for item in self.evidence_items
+            if item.execution_status == "complete" and item.lineage_status == "complete"
+        )
+
+
+def _build_evidence_requested_items(
+    calculations: Sequence[tuple[str, str | None]],
+) -> list[tuple[str, str]]:
+    return [
+        (role, calculation_id)
+        for role, calculation_id in calculations
+        if calculation_id is not None
+    ]
+
+
+def _build_empty_evidence_view_response(
+    *,
+    context: EvidenceViewRequestContext,
+    source_supportability: Sequence[PerformanceSourceSupportabilityView],
+) -> PerformanceEvidenceView:
+    return build_performance_evidence_view(
+        state="unavailable",
+        reason="No durable calculation evidence is available for the current selection.",
+        as_of_date=context.as_of_date,
+        period=context.period,
+        basis=context.basis,
+        benchmark_code=context.benchmark_code,
+        contract_version=context.contract_version,
+        limitations=["No durable calculation evidence is available."],
+        calculations=[],
+        source_supportability=source_supportability,
+    )
+
+
+def _build_unavailable_evidence_view_response(
+    *,
+    context: EvidenceViewRequestContext,
+    fetch_state: EvidenceViewFetchState,
+) -> PerformanceEvidenceView:
+    reason = "Gateway could not resolve execution or lineage evidence from lotus-performance."
+    return build_performance_evidence_view(
+        state="unavailable",
+        reason=reason,
+        as_of_date=context.as_of_date,
+        period=context.period,
+        basis=context.basis,
+        benchmark_code=context.benchmark_code,
+        contract_version=context.contract_version,
+        limitations=[reason],
+        calculations=fetch_state.evidence_items,
+        source_supportability=fetch_state.source_supportability,
+    )
+
+
+def _build_supported_evidence_view_response(
+    *,
+    context: EvidenceViewRequestContext,
+    fetch_state: EvidenceViewFetchState,
+) -> PerformanceEvidenceView:
+    evidence_state = resolve_evidence_state(
+        evidence_state="supported",
+        source_supportability=fetch_state.source_supportability,
+    )
+    evidence_reason = resolve_evidence_reason(
+        evidence_state=evidence_state,
+        supported_reason=(
+            "Execution status, upstream lineage, and artifact inventory "
+            "are exposed for the current performance view."
+        ),
+        source_supportability=fetch_state.source_supportability,
+    )
+    return build_performance_evidence_view(
+        state=evidence_state,
+        reason=evidence_reason,
+        as_of_date=context.as_of_date,
+        period=context.period,
+        basis=context.basis,
+        benchmark_code=context.benchmark_code,
+        contract_version=context.contract_version,
+        limitations=[] if evidence_state == "supported" else [evidence_reason],
+        calculations=fetch_state.evidence_items,
+        source_supportability=fetch_state.source_supportability,
+    )
+
+
+def _build_partial_evidence_view_response(
+    *,
+    context: EvidenceViewRequestContext,
+    fetch_state: EvidenceViewFetchState,
+) -> PerformanceEvidenceView:
+    reason = (
+        "One or more performance calculations still have pending, failed, "
+        "or unavailable lineage evidence."
+    )
+    return build_performance_evidence_view(
+        state="partial",
+        reason=reason,
+        as_of_date=context.as_of_date,
+        period=context.period,
+        basis=context.basis,
+        benchmark_code=context.benchmark_code,
+        contract_version=context.contract_version,
+        limitations=[reason],
+        calculations=fetch_state.evidence_items,
+        source_supportability=fetch_state.source_supportability,
+    )
 
 
 class PerformanceWorkspaceService:
@@ -1051,96 +1192,34 @@ class PerformanceWorkspaceService:
         warnings: list[str],
         partial_failures: list[WorkbenchPartialFailure],
     ) -> PerformanceEvidenceView | None:
-        source_supportability = build_source_supportability(source_results)
-        requested_items = [
-            (role, calculation_id)
-            for role, calculation_id in calculations
-            if calculation_id is not None
-        ]
-        if not requested_items:
-            return build_performance_evidence_view(
-                state="unavailable",
-                reason="No durable calculation evidence is available for the current selection.",
-                as_of_date=as_of_date,
-                period=period,
-                basis=basis,
-                benchmark_code=benchmark_code,
-                contract_version=contract_version,
-                limitations=["No durable calculation evidence is available."],
-                calculations=[],
-                source_supportability=source_supportability,
+        request_context = EvidenceViewRequestContext(
+            portfolio_id=portfolio_id,
+            as_of_date=as_of_date,
+            period=period,
+            basis=basis,
+            benchmark_code=benchmark_code,
+            contract_version=contract_version,
+            correlation_id=correlation_id,
+            calculations=calculations,
+            source_results=source_results,
+        )
+        fetch_state = await self._fetch_evidence_view_state(request_context)
+        if not fetch_state.requested_items:
+            return _build_empty_evidence_view_response(
+                context=request_context,
+                source_supportability=fetch_state.source_supportability,
             )
-
-        evidence_items = await asyncio.gather(
-            *[
-                fetch_calculation_evidence(
-                    analytics_client=self._analytics_client,
-                    portfolio_id=portfolio_id,
-                    calculation_role=role,
-                    calculation_id=calculation_id,
-                    correlation_id=correlation_id,
-                    poll_interval_seconds=LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS,
-                )
-                for role, calculation_id in requested_items
-            ]
-        )
-
-        backed_count = sum(
-            1
-            for item in evidence_items
-            if item.execution_status is not None or item.lineage_status is not None
-        )
-        complete_count = sum(
-            1
-            for item in evidence_items
-            if item.execution_status == "complete" and item.lineage_status == "complete"
-        )
-        if backed_count == 0:
+        if fetch_state.backed_count == 0:
             warnings.append("PERFORMANCE_EVIDENCE_UNAVAILABLE")
-            return build_performance_evidence_view(
-                state="unavailable",
-                reason=(
-                    "Gateway could not resolve execution or lineage evidence "
-                    "from lotus-performance."
-                ),
-                as_of_date=as_of_date,
-                period=period,
-                basis=basis,
-                benchmark_code=benchmark_code,
-                contract_version=contract_version,
-                limitations=[
-                    "Gateway could not resolve execution or lineage evidence "
-                    "from lotus-performance."
-                ],
-                calculations=evidence_items,
-                source_supportability=source_supportability,
+            return _build_unavailable_evidence_view_response(
+                context=request_context,
+                fetch_state=fetch_state,
             )
-        if complete_count == len(evidence_items):
-            evidence_state = resolve_evidence_state(
-                evidence_state="supported",
-                source_supportability=source_supportability,
+        if fetch_state.complete_count == len(fetch_state.evidence_items):
+            return _build_supported_evidence_view_response(
+                context=request_context,
+                fetch_state=fetch_state,
             )
-            evidence_reason = resolve_evidence_reason(
-                evidence_state=evidence_state,
-                supported_reason=(
-                    "Execution status, upstream lineage, and artifact inventory "
-                    "are exposed for the current performance view."
-                ),
-                source_supportability=source_supportability,
-            )
-            return build_performance_evidence_view(
-                state=evidence_state,
-                reason=evidence_reason,
-                as_of_date=as_of_date,
-                period=period,
-                basis=basis,
-                benchmark_code=benchmark_code,
-                contract_version=contract_version,
-                limitations=[] if evidence_state == "supported" else [evidence_reason],
-                calculations=evidence_items,
-                source_supportability=source_supportability,
-            )
-
         warnings.append("PERFORMANCE_EVIDENCE_PARTIAL")
         partial_failures.append(
             build_performance_failure(
@@ -1152,23 +1231,39 @@ class PerformanceWorkspaceService:
                 ),
             )
         )
-        return build_performance_evidence_view(
-            state="partial",
-            reason=(
-                "One or more performance calculations still have pending, failed, "
-                "or unavailable lineage evidence."
-            ),
-            as_of_date=as_of_date,
-            period=period,
-            basis=basis,
-            benchmark_code=benchmark_code,
-            contract_version=contract_version,
-            limitations=[
-                "One or more performance calculations still have pending, failed, "
-                "or unavailable lineage evidence."
-            ],
-            calculations=evidence_items,
-            source_supportability=source_supportability,
+        return _build_partial_evidence_view_response(
+            context=request_context,
+            fetch_state=fetch_state,
+        )
+
+    async def _fetch_evidence_view_state(
+        self,
+        context: EvidenceViewRequestContext,
+    ) -> EvidenceViewFetchState:
+        requested_items = _build_evidence_requested_items(context.calculations)
+        if not requested_items:
+            return EvidenceViewFetchState(
+                source_supportability=build_source_supportability(context.source_results),
+                requested_items=[],
+                evidence_items=[],
+            )
+        evidence_items = await asyncio.gather(
+            *[
+                fetch_calculation_evidence(
+                    analytics_client=self._analytics_client,
+                    portfolio_id=context.portfolio_id,
+                    calculation_role=role,
+                    calculation_id=calculation_id,
+                    correlation_id=context.correlation_id,
+                    poll_interval_seconds=LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS,
+                )
+                for role, calculation_id in requested_items
+            ]
+        )
+        return EvidenceViewFetchState(
+            source_supportability=build_source_supportability(context.source_results),
+            requested_items=requested_items,
+            evidence_items=list(evidence_items),
         )
 
     async def _determine_report_end_date(


### PR DESCRIPTION
## Summary
- Split performance evidence-view orchestration into typed request/fetch state and explicit response builders.
- Preserved the existing warning and partial-failure behavior for unavailable and partial evidence states.
- Updated quality evidence docs to record the new long-function baseline.

## Measured improvement
- `_build_evidence_view`: 134 lines -> 58 lines.
- New repository longest-function baseline: 133 lines (`_build_portfolio_exception_summaries`).
- Performance workspace evidence tests continue covering supported, unavailable, stale-source, pending-lineage, eventually-complete lineage, and missing execution/lineage states.

## Validation
- `python -m ruff check src\\app\\services\\performance_workspace_service.py tests\\unit\\test_performance_workspace_service.py tests\\unit\\test_performance_workspace_evidence.py`
- `python -m ruff format --check src\\app\\services\\performance_workspace_service.py tests\\unit\\test_performance_workspace_service.py tests\\unit\\test_performance_workspace_evidence.py`
- `python -m mypy src\\app\\services\\performance_workspace_service.py tests\\unit\\test_performance_workspace_service.py tests\\unit\\test_performance_workspace_evidence.py`
- `python -m pytest tests\\unit\\test_performance_workspace_service.py tests\\unit\\test_performance_workspace_evidence.py -q` (46 passed)
- `make check` (958 unit/contract tests passed)
- `make ci` (207 integration tests passed; 1,165 coverage tests passed; 92.82% total coverage; `pip-audit` clean with governed `PYSEC-2026-161` exception)
- Stranded-truth preflight: no unmerged remote branches over `origin/main`.
- Wiki preflight: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reported DiffCount 0.