### PR TITLE
Extract performance workspace capability inputs

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -99,8 +99,11 @@ selection, and explicit response builders, reducing `_build_evidence_view` from 
 58 lines. Portfolio exception-summary construction has been extracted to
 `src/app/services/portfolio_exception_summaries.py`, reducing `portfolio_service.py` from 2,839 to
 2,744 lines and reducing `_build_portfolio_exception_summaries` from 133 lines to a short
-delegation over readiness status. The current longest function is `build_workspace_capabilities`
-in `src/app/services/performance_workspace_capabilities.py` at 127 lines.
+delegation over readiness status. Performance workspace capability-input derivation has been
+split into `PerformanceCapabilityInputs`, `build_performance_capability_inputs`, and
+`resolve_history_date_range`, reducing `build_workspace_capabilities` from 127 lines to 99 lines
+while keeping capability payload assembly in the original module. The current longest function is
+`get_portfolio_workspace` in `src/app/services/portfolio_service.py` at 119 lines.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -15,7 +15,7 @@ normalization, shell-bootstrap, portfolio workspace-control boundary extraction,
 horizon parser extraction, foundation core snapshot parser extraction, advisor-brief
 narrative-state extraction, platform-capabilities orchestration extraction, performance
 attribution trend orchestration extraction, performance evidence-view orchestration extraction,
-and portfolio exception-summary extraction.
+portfolio exception-summary extraction, and performance workspace capability-input extraction.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -48,16 +48,16 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Rank | Lines | Function | File |
 | ---: | ---: | --- | --- |
-| 1 | 127 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
-| 2 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
-| 3 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
-| 4 | 112 | `_build_workspace_summary_views` | `src/app/services/performance_workspace_service.py` |
-| 5 | 111 | `get_portfolio_workspace` | `src/app/services/foundation_service.py` |
-| 6 | 111 | `get_portfolio_transactions` | `src/app/routers/portfolio_transactions.py` |
-| 7 | 108 | `get_performance_horizon_comparison` | `src/app/services/performance_workspace_service.py` |
-| 8 | 107 | `get_rolling` | `src/app/services/risk_workspace_service.py` |
-| 9 | 103 | `workspace_descriptors` | `src/app/services/platform_capabilities_shell.py` |
-| 10 | 100 | `get_attribution` | `src/app/services/risk_workspace_service.py` |
+| 1 | 119 | `get_portfolio_workspace` | `src/app/services/portfolio_service.py` |
+| 2 | 116 | `_build_portfolio_insights` | `src/app/services/portfolio_service.py` |
+| 3 | 112 | `_build_workspace_summary_views` | `src/app/services/performance_workspace_service.py` |
+| 4 | 111 | `get_portfolio_workspace` | `src/app/services/foundation_service.py` |
+| 5 | 111 | `get_portfolio_transactions` | `src/app/routers/portfolio_transactions.py` |
+| 6 | 108 | `get_performance_horizon_comparison` | `src/app/services/performance_workspace_service.py` |
+| 7 | 107 | `get_rolling` | `src/app/services/risk_workspace_service.py` |
+| 8 | 103 | `workspace_descriptors` | `src/app/services/platform_capabilities_shell.py` |
+| 9 | 100 | `get_attribution` | `src/app/services/risk_workspace_service.py` |
+| 10 | 99 | `build_workspace_capabilities` | `src/app/services/performance_workspace_capabilities.py` |
 
 ## Existing Blocking Gates
 
@@ -76,10 +76,10 @@ Current repo-native gates already cover:
 
 Most recent local evidence:
 
-1. `make check`: 961 unit/contract tests passed.
+1. `make check`: 964 unit/contract tests passed.
 2. `make ci`: 207 integration tests passed.
-3. `make ci`: 1,168 coverage tests passed.
-4. Coverage: 92.83%.
+3. `make ci`: 1,171 coverage tests passed.
+4. Coverage: 92.84%.
 5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline
@@ -96,7 +96,7 @@ large-file and long-function hotspots in service, contract, and client code.
 The first enforcement candidates should be:
 
 1. no new service file above the current largest-file baseline,
-2. no new function above the current longest-function baseline of 127 lines,
+2. no new function above the current longest-function baseline of 119 lines,
 3. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
 4. no new architecture import-linter violations after contracts are reviewed.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -6,8 +6,8 @@ Mode: baseline/report-only
 | Dimension | Score | Baseline status | Next action |
 | --- | ---: | --- | --- |
 | Build and test reliability | 4/5 | Strong repo-native gates and green PR lanes | Keep Docker parity blocking |
-| Coverage | 4/5 | 92.83% total coverage | Add targeted middleware/security/error tests |
-| Modularity | 2/5 | Portfolio exception summaries, performance evidence-view orchestration, performance attribution trend orchestration, platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
+| Coverage | 4/5 | 92.84% total coverage | Add targeted middleware/security/error tests |
+| Modularity | 2/5 | Performance workspace capability inputs, portfolio exception summaries, performance evidence-view orchestration, performance attribution trend orchestration, platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; large services and contracts remain | Continue extraction slices |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 3/5 | Good generated OpenAPI; minor description/tag/error gaps | Add Spectral artifact and explicit API tests |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |
@@ -37,7 +37,7 @@ Candidate thresholds:
 2. no new forbidden imports,
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
-5. no new file/function above the current baseline maxima of 2,744 file lines and 127 function lines.
+5. no new file/function above the current baseline maxima of 2,744 file lines and 119 function lines.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -52,7 +52,9 @@ builders, reducing `_build_evidence_view` from 134 lines to 58 lines and lowerin
 longest-function baseline to 133 lines. Portfolio exception-summary construction has now been
 extracted to `portfolio_exception_summaries.py`, reducing `portfolio_service.py` from 2,839 lines
 to 2,744 lines and reducing `_build_portfolio_exception_summaries` from 133 lines to a short
-readiness delegation. The repository longest-function baseline is now 127 lines. The remaining
+readiness delegation. Performance workspace capability-input derivation has now been split into
+explicit capability input and history-date helpers, reducing `build_workspace_capabilities` from
+127 lines to 99 lines. The repository longest-function baseline is now 119 lines. The remaining
 work is still substantial: large portfolio, performance workspace, advisor-brief orchestration,
 contract, and client modules remain.
 
@@ -61,11 +63,11 @@ contract, and client modules remain.
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | clean `main` before the router-registry split |
-| Unit/contract coverage | Healthy | 961 tests passed in latest `make check` evidence |
+| Unit/contract coverage | Healthy | 964 tests passed in latest `make check` evidence |
 | Integration coverage | Healthy | 207 integration tests passed in recent `make ci` evidence |
-| Total coverage | Healthy | 92.83%, above the 84% floor |
+| Total coverage | Healthy | 92.84%, above the 84% floor |
 | Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception |
-| Modularity | Improving, incomplete | Portfolio exception summaries, performance evidence-view orchestration, performance attribution trend orchestration, platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Performance workspace capability inputs, portfolio exception summaries, performance evidence-view orchestration, performance attribution trend orchestration, platform-capabilities orchestration, advisor-brief narrative state, foundation snapshot parser, performance horizon parser, portfolio workspace controls, platform capability normalization, and shell bootstrap extracted; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | Generated OpenAPI has only small description/tag/error gaps |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -80,8 +82,8 @@ contract, and client modules remain.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes
    expand the extracted modules.
 4. Continue extracting performance workspace summary orchestration helpers behind stable response
-   contracts; horizon parsing, attribution trend orchestration, and evidence-view orchestration are
-   now below the current function-size baseline.
+   contracts; capability-input derivation, horizon parsing, attribution trend orchestration, and
+   evidence-view orchestration are now below the current function-size baseline.
 5. Continue splitting advisor-brief service orchestration around stable reviewed-narrative
    contracts if future changes expand the remaining runtime or review helpers.
 6. Split large contract modules only when contract ownership boundaries are clear and tests remain

--- a/src/app/services/performance_workspace_capabilities.py
+++ b/src/app/services/performance_workspace_capabilities.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from app.contracts.performance_workspace import (
     AttributionSummaryView,
@@ -15,6 +16,19 @@ from app.services.performance_workspace_controls import SUPPORTED_WORKSPACE_FREQ
 
 SUPPORTED_CONTRIBUTION_DIMENSIONS = ("asset_class", "sector", "country")
 SUPPORTED_ATTRIBUTION_DIMENSIONS = ("asset_class", "sector", "country", "currency")
+
+
+@dataclass(frozen=True)
+class PerformanceCapabilityInputs:
+    has_return_history: bool
+    has_benchmark: bool
+    has_benchmark_returns: bool
+    has_contribution_detail: bool
+    has_position_ranking: bool
+    has_attribution_detail: bool
+    has_attribution_summary: bool
+    earliest_history_date: str | None
+    latest_history_date: str | None
 
 
 def build_module_capability(
@@ -50,40 +64,12 @@ def build_workspace_capabilities(
     evidence_view: PerformanceEvidenceView | None,
     include_detail_blocks: bool = True,
 ) -> PerformanceWorkspaceCapabilities:
-    has_return_history = len(net_chart) > 0
-    has_benchmark = bool(benchmark_code)
-    has_benchmark_returns = (
-        net_performance.benchmark_return_pct is not None
-        and net_performance.active_return_pct is not None
-    )
-    has_contribution_detail = bool(
-        contribution and (contribution.levels or contribution.position_rows)
-    )
-    has_position_ranking = bool(contribution and contribution.position_rows)
-    has_attribution_detail = bool(attribution and any(level.rows for level in attribution.levels))
-    has_attribution_summary = bool(
-        attribution
-        and (
-            attribution.levels
-            or attribution.active_return_pct is not None
-            or attribution.sum_of_effects_pct is not None
-            or attribution.residual_pct is not None
-        )
-    )
-    dated_history = [
-        point
-        for point in net_chart
-        if point.period_start is not None or point.period_end is not None
-    ]
-    earliest_history_date = (
-        min(point.period_start or point.period_end or "" for point in dated_history)
-        if dated_history
-        else None
-    )
-    latest_history_date = (
-        max(point.period_end or point.period_start or "" for point in dated_history)
-        if dated_history
-        else None
+    inputs = build_performance_capability_inputs(
+        benchmark_code=benchmark_code,
+        net_performance=net_performance,
+        net_chart=net_chart,
+        contribution=contribution,
+        attribution=attribution,
     )
 
     return PerformanceWorkspaceCapabilities(
@@ -95,11 +81,11 @@ def build_workspace_capabilities(
             build_module_capability(
                 "supported",
                 "Time-series return observations are available for the selected horizon.",
-                earliest_available_date=earliest_history_date,
-                latest_available_date=latest_history_date,
+                earliest_available_date=inputs.earliest_history_date,
+                latest_available_date=inputs.latest_history_date,
                 supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
             )
-            if has_return_history
+            if inputs.has_return_history
             else build_module_capability(
                 "unavailable",
                 "Published return observations are not available for the selected horizon.",
@@ -110,17 +96,17 @@ def build_workspace_capabilities(
             build_module_capability(
                 "supported",
                 "Benchmark-relative return metrics are available.",
-                earliest_available_date=earliest_history_date,
-                latest_available_date=latest_history_date,
+                earliest_available_date=inputs.earliest_history_date,
+                latest_available_date=inputs.latest_history_date,
             )
-            if has_benchmark and has_benchmark_returns
+            if inputs.has_benchmark and inputs.has_benchmark_returns
             else build_module_capability(
                 "partial",
                 "A benchmark is assigned, but benchmark-relative returns are incomplete.",
-                earliest_available_date=earliest_history_date,
-                latest_available_date=latest_history_date,
+                earliest_available_date=inputs.earliest_history_date,
+                latest_available_date=inputs.latest_history_date,
             )
-            if has_benchmark
+            if inputs.has_benchmark
             else build_module_capability(
                 "unavailable",
                 "No benchmark is assigned to this mandate.",
@@ -132,7 +118,7 @@ def build_workspace_capabilities(
                 "The workspace supports benchmark-aware horizon comparisons.",
                 supported_frequencies=SUPPORTED_WORKSPACE_FREQUENCIES,
             )
-            if has_benchmark
+            if inputs.has_benchmark
             else build_module_capability(
                 "partial",
                 (
@@ -144,8 +130,8 @@ def build_workspace_capabilities(
         ),
         contribution_ranking=build_contribution_capability(
             include_detail_blocks=include_detail_blocks,
-            has_position_ranking=has_position_ranking,
-            has_contribution_detail=has_contribution_detail,
+            has_position_ranking=inputs.has_position_ranking,
+            has_contribution_detail=inputs.has_contribution_detail,
             supported_reason="Position-level contribution ranking is available.",
             aggregate_reason="Contribution exists, but only aggregate rows are available.",
             unavailable_reason=(
@@ -154,18 +140,71 @@ def build_workspace_capabilities(
         ),
         attribution_detail=build_attribution_capability(
             include_detail_blocks=include_detail_blocks,
-            has_attribution_detail=has_attribution_detail,
-            has_attribution_summary=has_attribution_summary,
+            has_attribution_detail=inputs.has_attribution_detail,
+            has_attribution_summary=inputs.has_attribution_summary,
         ),
         contribution_detail=build_contribution_capability(
             include_detail_blocks=include_detail_blocks,
-            has_position_ranking=has_position_ranking,
-            has_contribution_detail=has_contribution_detail,
+            has_position_ranking=inputs.has_position_ranking,
+            has_contribution_detail=inputs.has_contribution_detail,
             supported_reason="Contribution detail is available for the current selection.",
             aggregate_reason="Contribution exists, but only aggregate rows are available.",
             unavailable_reason="Contribution detail is not available for the current selection.",
         ),
         evidence=build_evidence_capability(evidence_view=evidence_view),
+    )
+
+
+def build_performance_capability_inputs(
+    *,
+    benchmark_code: str | None,
+    net_performance: PerformanceComparativeSummary,
+    net_chart: list[PerformanceChartPoint],
+    contribution: ContributionSummaryView | None,
+    attribution: AttributionSummaryView | None,
+) -> PerformanceCapabilityInputs:
+    earliest_history_date, latest_history_date = resolve_history_date_range(net_chart)
+    return PerformanceCapabilityInputs(
+        has_return_history=bool(net_chart),
+        has_benchmark=bool(benchmark_code),
+        has_benchmark_returns=(
+            net_performance.benchmark_return_pct is not None
+            and net_performance.active_return_pct is not None
+        ),
+        has_contribution_detail=bool(
+            contribution and (contribution.levels or contribution.position_rows)
+        ),
+        has_position_ranking=bool(contribution and contribution.position_rows),
+        has_attribution_detail=bool(
+            attribution and any(level.rows for level in attribution.levels)
+        ),
+        has_attribution_summary=bool(
+            attribution
+            and (
+                attribution.levels
+                or attribution.active_return_pct is not None
+                or attribution.sum_of_effects_pct is not None
+                or attribution.residual_pct is not None
+            )
+        ),
+        earliest_history_date=earliest_history_date,
+        latest_history_date=latest_history_date,
+    )
+
+
+def resolve_history_date_range(
+    net_chart: list[PerformanceChartPoint],
+) -> tuple[str | None, str | None]:
+    dated_history = [
+        point
+        for point in net_chart
+        if point.period_start is not None or point.period_end is not None
+    ]
+    if not dated_history:
+        return None, None
+    return (
+        min(point.period_start or point.period_end or "" for point in dated_history),
+        max(point.period_end or point.period_start or "" for point in dated_history),
     )
 
 

--- a/tests/unit/test_performance_workspace_capabilities.py
+++ b/tests/unit/test_performance_workspace_capabilities.py
@@ -1,9 +1,17 @@
 from app.contracts.performance_workspace import (
+    AttributionLevelView,
+    AttributionSummaryView,
+    ContributionLevelView,
+    ContributionSummaryView,
     PerformanceChartPoint,
     PerformanceComparativeSummary,
     PerformanceEvidenceView,
 )
-from app.services.performance_workspace_capabilities import build_workspace_capabilities
+from app.services.performance_workspace_capabilities import (
+    build_performance_capability_inputs,
+    build_workspace_capabilities,
+    resolve_history_date_range,
+)
 
 
 def test_build_workspace_capabilities_reports_supported_benchmark_history() -> None:
@@ -58,3 +66,98 @@ def test_build_workspace_capabilities_reports_partial_without_benchmark() -> Non
     assert capabilities.contribution_ranking.state == "unavailable"
     assert capabilities.attribution_detail.state == "unavailable"
     assert capabilities.evidence.state == "unavailable"
+
+
+def test_resolve_history_date_range_uses_start_and_end_fallbacks() -> None:
+    earliest, latest = resolve_history_date_range(
+        [
+            PerformanceChartPoint(
+                label="2026-02",
+                frequency="monthly",
+                period_start=None,
+                period_end="2026-02-28",
+            ),
+            PerformanceChartPoint(
+                label="2026-01",
+                frequency="monthly",
+                period_start="2026-01-01",
+                period_end=None,
+            ),
+            PerformanceChartPoint(label="Total", frequency="monthly"),
+        ]
+    )
+
+    assert earliest == "2026-01-01"
+    assert latest == "2026-02-28"
+
+
+def test_build_performance_capability_inputs_detects_aggregate_only_detail() -> None:
+    inputs = build_performance_capability_inputs(
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+        net_performance=PerformanceComparativeSummary(
+            metric_basis="NET",
+            benchmark_return_pct=0.03,
+            active_return_pct=0.01,
+        ),
+        net_chart=[],
+        contribution=ContributionSummaryView(
+            metric_basis="NET",
+            levels=[ContributionLevelView(level=1, name="asset_class")],
+        ),
+        attribution=AttributionSummaryView(
+            metric_basis="NET",
+            active_return_pct=0.01,
+            levels=[
+                AttributionLevelView(
+                    dimension="asset_class",
+                    total_effect_pct=0.01,
+                    rows=[],
+                )
+            ],
+        ),
+    )
+
+    assert inputs.has_benchmark is True
+    assert inputs.has_benchmark_returns is True
+    assert inputs.has_contribution_detail is True
+    assert inputs.has_position_ranking is False
+    assert inputs.has_attribution_summary is True
+    assert inputs.has_attribution_detail is False
+
+
+def test_build_workspace_capabilities_reports_aggregate_only_fallbacks() -> None:
+    capabilities = build_workspace_capabilities(
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+        net_performance=PerformanceComparativeSummary(
+            metric_basis="NET",
+            benchmark_return_pct=0.03,
+            active_return_pct=0.01,
+        ),
+        net_chart=[],
+        contribution=ContributionSummaryView(
+            metric_basis="NET",
+            levels=[ContributionLevelView(level=1, name="asset_class")],
+        ),
+        attribution=AttributionSummaryView(
+            metric_basis="NET",
+            active_return_pct=0.01,
+            levels=[
+                AttributionLevelView(
+                    dimension="asset_class",
+                    total_effect_pct=0.01,
+                    rows=[],
+                )
+            ],
+        ),
+        evidence_view=PerformanceEvidenceView(state="partial", reason="Evidence partial."),
+    )
+
+    assert capabilities.contribution_ranking.state == "partial"
+    assert capabilities.contribution_ranking.coverage_level == "aggregate"
+    assert capabilities.contribution_ranking.fallback_available is True
+    assert capabilities.contribution_detail.state == "partial"
+    assert capabilities.attribution_detail.state == "partial"
+    assert capabilities.attribution_detail.coverage_level == "summary"
+    assert capabilities.attribution_detail.fallback_available is True
+    assert capabilities.evidence.state == "partial"
+    assert capabilities.evidence.coverage_level == "calculation"

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -11,8 +11,8 @@
   [docs/architecture.md](../docs/architecture.md) and
   [quality/architecture_rules.md](../quality/architecture_rules.md)
 - current enterprise-hardening evidence records `portfolio_service.py` at 2,744 lines after the
-  portfolio exception-summary extraction, with the repository longest-function baseline reduced to
-  127 lines
+  portfolio exception-summary extraction and records performance workspace capability-input
+  extraction with the repository longest-function baseline reduced to 119 lines
 
 ## Route-family map
 
@@ -79,3 +79,6 @@
 12. portfolio exception-summary payload construction is isolated in
     `src/app/services/portfolio_exception_summaries.py`; `PortfolioService` keeps readiness
     orchestration while the compact exception-summary contract remains separately testable.
+13. performance workspace capability state derivation is isolated behind
+    `PerformanceCapabilityInputs` and `resolve_history_date_range`; capability payload assembly
+    remains in `src/app/services/performance_workspace_capabilities.py`.

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -56,4 +56,6 @@ Current baseline truth lives in:
 Latest enterprise-hardening evidence: the portfolio exception-summary extraction lowered the
 repository longest-function baseline from 133 lines to 127 lines and reduced
 `portfolio_service.py` from 2,839 lines to 2,744 lines while preserving focused portfolio insight
-and router contract tests.
+and router contract tests. The performance workspace capability-input extraction then lowered the
+repository longest-function baseline from 127 lines to 119 lines while adding focused capability
+input, history-date, and aggregate-only fallback tests.


### PR DESCRIPTION
## Summary
- extracted performance workspace capability-input derivation into `PerformanceCapabilityInputs`, `build_performance_capability_inputs`, and `resolve_history_date_range`
- preserved `build_workspace_capabilities` payload assembly while reducing its line count from 127 to 99
- updated quality baseline, scorecard, architecture evidence, and repo-authored wiki source

## Measured improvement
- `build_workspace_capabilities`: 127 lines -> 99 lines
- repository longest-function baseline: 127 lines -> 119 lines (`get_portfolio_workspace`)
- focused tests added for capability-input derivation, history-date fallback handling, and aggregate-only capability fallbacks

## Validation
- `python -m ruff check src/app/services/performance_workspace_capabilities.py tests/unit/test_performance_workspace_capabilities.py`
- `python -m pytest tests/unit/test_performance_workspace_capabilities.py -q` (5 passed)
- `python -m pytest tests/unit/test_performance_workspace_capabilities.py tests/unit/test_performance_workspace_service.py -q` (41 passed)
- `python -m mypy src/app/services/performance_workspace_capabilities.py`
- `make check` (964 unit/contract tests passed)
- `make ci` (207 integration tests passed; 1,171 coverage tests passed; total coverage 92.84%; pip-audit clean after governed exception)

## Governance
- stranded-truth scan: no remote branches unmerged into `origin/main`
- wiki check-only reports expected pre-merge drift in `Architecture.md` and `Validation-and-CI.md` because this PR updates repo-authored wiki source; publish after merge
- no API contract behavior change intended