### PR TITLE
Extract portfolio transaction ledger mapper

### DIFF
--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-06-05T11:44:33Z",
+  "generated_at": "2026-06-12T08:31:09Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:162:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -802,154 +802,154 @@
       "review_by": "2026-12-02"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2026:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/portfolio_service.py:1988:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2102:float(quantize_performance(period_return)) if period_return is not None else None",
+      "finding": "src/app/services/portfolio_service.py:2064:float(quantize_performance(period_return)) if period_return is not None else None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2228:market_value_base=float(",
+      "finding": "src/app/services/portfolio_service.py:2190:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2231:weight_pct=float(",
+      "finding": "src/app/services/portfolio_service.py:2193:weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2232:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
+      "finding": "src/app/services/portfolio_service.py:2194:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2274:price=float(quantize_price(item.get(\"price\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:2376:accumulator[\"gross_amount_portfolio_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2277:gross_amount=float(quantize_money(item.get(\"gross_transaction_amount\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:2379:accumulator[\"gross_amount_reporting_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2281:net_cost_base=float(quantize_money(item.get(\"net_cost\", 0)))",
+      "finding": "src/app/services/portfolio_service.py:2406:accumulator[\"net_amount_portfolio_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2448:accumulator[\"gross_amount_portfolio_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:2409:accumulator[\"net_amount_reporting_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2451:accumulator[\"gross_amount_reporting_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:2417:portfolio_amount: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2478:accumulator[\"net_amount_portfolio_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:2418:reporting_amount: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2481:accumulator[\"net_amount_reporting_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:2422:float(accumulator[\"amount_portfolio_currency\"]) + portfolio_amount",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2489:portfolio_amount: float,",
+      "finding": "src/app/services/portfolio_service.py:2425:float(accumulator[\"amount_reporting_currency\"]) + reporting_amount",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2490:reporting_amount: float,",
+      "finding": "src/app/services/portfolio_service.py:2448:def _activity_portfolio_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2494:float(accumulator[\"amount_portfolio_currency\"]) + portfolio_amount",
+      "finding": "src/app/services/portfolio_service.py:2455:def _activity_reporting_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2497:float(accumulator[\"amount_reporting_currency\"]) + reporting_amount",
+      "finding": "src/app/services/portfolio_service.py:2472:def _income_net_portfolio_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2520:def _activity_portfolio_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:2482:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2527:def _activity_reporting_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:2484:def _income_net_reporting_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2544:def _income_net_portfolio_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:2510:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2554:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
+      "finding": "src/app/services/portfolio_service.py:2523:def _absolute_money(self, value: Any) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2556:def _income_net_reporting_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:2526:return float(quantize_money(abs(float(value))))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2582:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
+      "finding": "src/app/services/portfolio_service.py:2588:reporting_currency_amount=float(quantize_money(payload.get(reporting_key, 0))),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2595:def _absolute_money(self, value: Any) -> float:",
+      "finding": "src/app/services/portfolio_transaction_ledger.py:77:price=float(quantize_price(item.get(\"price\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-11-19"
+      "review_by": "2026-12-09"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2598:return float(quantize_money(abs(float(value))))",
+      "finding": "src/app/services/portfolio_transaction_ledger.py:96:def optional_money(value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-11-19"
+      "review_by": "2026-12-09"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2660:reporting_currency_amount=float(quantize_money(payload.get(reporting_key, 0))),",
+      "finding": "src/app/services/portfolio_transaction_ledger.py:99:return float(quantize_money(value))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-11-19"
+      "review_by": "2026-12-09"
     }
   ]
 }

--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -35,11 +35,11 @@ report-only baseline is reviewed.
 
 The largest current modularity risks are:
 
-1. `src/app/services/portfolio_service.py` at 3,155 lines,
-2. `src/app/services/performance_workspace_service.py` at 1,673 lines,
-3. `src/app/services/advisor_brief_service.py` at 1,581 lines,
-4. `src/app/services/dpm_command_center_service.py` at 1,217 lines,
-5. `src/app/services/dpm_wave_service.py` at 1,030 lines.
+1. `src/app/services/portfolio_service.py` at 2,993 lines,
+2. `src/app/services/performance_workspace_service.py` at 1,724 lines,
+3. `src/app/services/advisor_brief_service.py` at 1,452 lines,
+4. `src/app/services/dpm_command_center_service.py` at 1,137 lines,
+5. `src/app/services/dpm_wave_service.py` at 1,001 lines.
 
 The prior longest function, `register_routers` in `src/app/router_registry.py`, has been split
 into explicit route-family groups and a short registration loop. The performance workspace
@@ -139,8 +139,12 @@ projection now delegates sparkline, unavailable-state, and partial-failure mappi
 helpers. Contribution summary merging now delegates detail-vs-summary selection policy to reusable
 helpers. Risk rolling response mapping now delegates supportability enrichment and fallback warning
 assembly to focused helpers. Risk drawdown routing now keeps OpenAPI query metadata in named
-descriptors separate from the public query dependency. The current longest functions are 54-line
-orchestration and mapper helpers.
+descriptors separate from the public query dependency. Portfolio position-book mapping now lives in
+`src/app/services/portfolio_position_book.py`, and transaction-ledger request context plus row
+mapping now live in `src/app/services/portfolio_transaction_ledger.py`. `portfolio_service.py` is
+down to 2,993 lines. The current longest functions are 49-line helpers:
+`get_transaction_ledger` in `portfolio_service.py` and `get_portfolio_transactions` in
+`lotus_core_query_client.py`.
 
 ## Progressive Enforcement
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,6 +1,6 @@
 # Quality Baseline Report
 
-Date: 2026-06-05
+Date: 2026-06-12
 Repository: `lotus-gateway`  
 Baseline phase: report-only
 
@@ -118,6 +118,10 @@ The current closure slice extracts portfolio position-book summary derivation, p
 valuation fallback handling, cash-position summarization, and top-position ranking into
 `portfolio_position_book.py`. This preserves allocation and position-book behavior while reducing
 `portfolio_service.py` from 3,337 to 3,241 lines and keeping the 49-line longest-function baseline.
+The current transaction-ledger slice extracts transaction-ledger request context and response-row
+mapping into `portfolio_transaction_ledger.py`. This preserves ledger metadata, transaction
+identifier, quantization, upstream filter, and cache behavior while reducing `portfolio_service.py`
+from 3,062 to 2,993 lines and keeping the 49-line longest-function baseline.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -125,30 +129,30 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,404 |
-| Python source files under `src/app` | 444 |
-| Python test files under `tests` | 160 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,262 |
+| Python source files under `src/app` | 445 |
+| Python test files under `tests` | 161 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current closure slice shows 1,404 files under `src`, `tests`,
-`docs`, `wiki`, `.github`, and `scripts`; 444 Python source files under `src/app`; and 160 Python
-test files under `tests`.
+Working-tree verification for the current transaction-ledger slice shows 1,262 files under `src`,
+`tests`, `docs`, `wiki`, `.github`, and `scripts`; 445 Python source files under `src/app`; and
+161 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 3,241 | `src/app/services/portfolio_service.py` |
-| 2 | 2,226 | `src/app/contracts/portfolio.py` |
-| 3 | 2,043 | `src/app/contracts/risk_workspace.py` |
-| 4 | 1,840 | `src/app/contracts/reporting.py` |
-| 5 | 1,836 | `src/app/services/performance_workspace_service.py` |
-| 6 | 1,607 | `src/app/services/advisor_brief_service.py` |
-| 7 | 1,606 | `src/app/contracts/performance_workspace.py` |
-| 8 | 1,362 | `src/app/clients/dpm_client.py` |
-| 9 | 1,217 | `src/app/services/dpm_command_center_service.py` |
-| 10 | 1,098 | `src/app/clients/advise_client.py` |
+| 1 | 2,993 | `src/app/services/portfolio_service.py` |
+| 2 | 2,123 | `src/app/contracts/portfolio.py` |
+| 3 | 1,940 | `src/app/contracts/risk_workspace.py` |
+| 4 | 1,731 | `src/app/contracts/reporting.py` |
+| 5 | 1,724 | `src/app/services/performance_workspace_service.py` |
+| 6 | 1,539 | `src/app/contracts/performance_workspace.py` |
+| 7 | 1,452 | `src/app/services/advisor_brief_service.py` |
+| 8 | 1,258 | `src/app/clients/dpm_client.py` |
+| 9 | 1,137 | `src/app/services/dpm_command_center_service.py` |
+| 10 | 1,012 | `src/app/clients/advise_client.py` |
 
 ## Largest Functions
 
@@ -158,12 +162,12 @@ test files under `tests`.
 | 2 | 49 | `get_portfolio_transactions` | `src/app/clients/lotus_core_query_client.py` |
 | 3 | 48 | `_assemble_workspace_response` | `src/app/services/performance_workspace_service.py` |
 | 4 | 47 | `_get_portfolio_transactions_result` | `src/app/services/portfolio_service.py` |
-| 5 | 47 | `_portfolio_transaction_query_params` | `src/app/clients/lotus_core_query_client.py` |
-| 6 | 47 | `_build_workspace_descriptor_contract` | `src/app/services/platform_capabilities_shell.py` |
-| 7 | 47 | `_build_workspace_descriptor_contract` | `src/app/services/platform_capabilities_shell.py` |
-| 8 | 47 | `_build_performance_workspace_response` | `src/app/services/performance_workspace_service.py` |
-| 9 | 46 | `get_portfolio_360` | `src/app/services/workbench_service.py` |
-| 10 | 46 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
+| 5 | 47 | `_build_workspace_descriptor_contract` | `src/app/services/platform_capabilities_shell.py` |
+| 6 | 47 | `_build_performance_workspace_response` | `src/app/services/performance_workspace_service.py` |
+| 7 | 47 | `_portfolio_transaction_query_params` | `src/app/clients/lotus_core_query_client.py` |
+| 8 | 46 | `get_portfolio_360` | `src/app/services/workbench_service.py` |
+| 9 | 46 | `_unpack_rebalance_supportability_summary` | `src/app/services/workbench_rebalance_snapshot.py` |
+| 10 | 46 | `_performance_payload_from_result` | `src/app/services/workbench_performance_snapshot.py` |
 
 ## Existing Blocking Gates
 
@@ -182,9 +186,8 @@ Current repo-native gates already cover:
 
 Most recent local evidence:
 
-1. Current branch: `make check` passed repeatedly through commit `1b2a4e5` with ruff, format check,
-   monetary-float guard, mypy over 443 source files, Workbench/OpenAPI contract smoke, and 986
-   unit/contract tests.
+1. Current branch: `make check` passed with ruff, format check, monetary-float guard, mypy over
+   445 source files, Workbench/OpenAPI contract smoke, and 993 unit/contract tests.
 2. Current focused branch: `tests/unit/test_http_resilience.py` passed with 15 tests after JSON
    retry attempt extraction.
 3. Current focused branch: DPM proof-pack service tests passed with 8 tests after PM memo workflow
@@ -231,14 +234,15 @@ Most recent local evidence:
 34. Current focused branch: Workbench analytics tests passed with 7 selected tests.
 35. Current focused branch: Workbench rebalance tests passed with 3 selected tests.
 36. Current focused branch: portfolio readiness tests passed with 4 selected tests.
-37. Current branch PR-grade evidence: `make ci` passed with 207 integration tests on commit
-    `1b2a4e5`.
-38. Current branch PR-grade evidence: `make ci` passed with 1,193 unit, contract, and integration
-    coverage tests on commit `1b2a4e5`.
-39. Coverage: 93.67%.
+37. Current branch PR-grade evidence: `make ci` passed with 207 integration tests.
+38. Current branch PR-grade evidence: `make ci` passed with 1,200 unit, contract, and integration
+    coverage tests.
+39. Coverage: 93.69%, above the 84% floor.
 40. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 41. Current closure slice: `tests/unit/test_portfolio_position_book.py` plus focused portfolio
     service position/allocation tests passed with 9 selected tests after mapper extraction.
+42. Current transaction-ledger slice: `tests/unit/test_portfolio_transaction_ledger.py` plus
+    `tests/unit/test_portfolio_service.py` passed with 48 selected tests after mapper extraction.
 
 ## Tooling Availability Baseline
 
@@ -254,7 +258,7 @@ large-file and long-function hotspots in service, contract, and client code.
 The first enforcement candidates should be:
 
 1. no new service file above the current largest-file baseline,
-2. no new function above the current longest-function baseline of 50 lines,
+2. no new function above the current longest-function baseline of 49 lines,
 3. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
 4. no new architecture import-linter violations after contracts are reviewed.
 
@@ -271,7 +275,7 @@ report-only quality checks. Baseline findings should be triaged before making th
 
 ## OpenAPI Gaps
 
-Current generated OpenAPI evidence on branch head `1b2a4e5`:
+Current generated OpenAPI evidence on branch head `62c7a7399944b380eca8ddc7be7ac987a2cd4654`:
 
 | Check | Count |
 | --- | ---: |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,38 +1,37 @@
 # Quality Scorecard
 
-Date: 2026-06-05
+Date: 2026-06-12
 Mode: PR-readiness evidence update
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | `make ci` passed on `bfc21ae` with lint, format, mypy, migration smoke, 207 integration tests, 1,193 coverage tests, and dependency audit; current closure slice has focused position-book tests green | Keep Docker parity blocking in PR Merge Gate |
-| Coverage | 4/5 | 93.67% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current closure slice preserves the 49-line longest-function baseline and extracts portfolio position-book summary, valuation, ranking, and parsing into a reusable mapper; `portfolio_service.py` drops from 3,337 to 3,241 lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Build and test reliability | 5/5 | `make check` passed with lint, format, monetary-float guard, mypy, contract smoke, and 993 unit/contract tests; `make ci` passed with 207 integration tests, 1,200 coverage tests, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Coverage | 4/5 | 93.69% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
+| Modularity | 4/5 | Current slice preserves the 49-line longest-function baseline and extracts transaction-ledger request context plus response-row mapping into a reusable mapper; `portfolio_service.py` drops from 3,062 to 2,993 lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit present; analytics async polling now separates per-attempt fanout logging from loop orchestration and preserves absolute result URLs under test | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Quality scorecard and health evidence updated with current closure-slice metrics; no repo-local wiki source changes required for this code-focused mapper extraction | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Quality scorecard and health evidence updated with current transaction-ledger metrics; no repo-local wiki source changes required for this code-focused mapper extraction | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs; operational runbook now consolidated | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
-Comparison point: `origin/main` at `bfc21aee92ec01f857c740f03e5a92bf020517fd` versus the current
-closure branch before merge.
+Comparison point: `origin/main` at `62c7a7399944b380eca8ddc7be7ac987a2cd4654` versus the current
+transaction-ledger branch before merge.
 
 | Measure | Before | After | Result |
 | --- | ---: | ---: | --- |
 | Branch commits over `origin/main` | 0 | 1 planned | Narrow closure branch ready for PR review |
-| Tracked `src/app` Python files | 443 | 444 | Added reusable position-book mapper |
-| Tracked test files | 159 | 160 | Added focused mapper tests |
-| Longest function | 50 lines | 49 lines | Improved |
-| Top function hotspot count at 50 lines | 2 | 0 | Improved |
-| Largest source file | 3,337 lines | 3,241 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
+| Tracked `src/app` Python files | 444 | 445 | Added reusable transaction-ledger mapper |
+| Tracked test files | 160 | 161 | Added focused mapper tests |
+| Longest function | 49 lines | 49 lines | Preserved |
+| Top function hotspot count at 49 lines | 2 | 2 | Preserved |
+| Largest source file | 3,062 lines | 2,993 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local coverage tests | prior branch evidence 1,176 | 1,193 | Improved |
-| Total coverage | 93.47% | 93.67% | Improved |
-| Dependency audit | governed pass | governed pass, no known vulnerabilities | Preserved |
+| Local unit/contract tests | 993 | 993 | Preserved |
+| Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
 ## Phase Gates
 
@@ -56,7 +55,7 @@ Candidate thresholds:
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
 5. no new function above the current branch maximum of 49 lines and no unclassified largest-file
-   growth above the current 3,241-line `portfolio_service.py` maximum.
+   growth above the current 2,993-line `portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,6 +1,6 @@
 # Refactor Health Report
 
-Date: 2026-06-05
+Date: 2026-06-12
 Phase: baseline/report-only
 
 ## Current Direction
@@ -198,17 +198,22 @@ preserving the 49-line longest-function baseline. `portfolio_service.py` remains
 hotspot even though the position-book mapper is now separately testable. The remaining work is
 still substantial: large portfolio, performance workspace, advisor-brief orchestration, contract,
 and client modules remain.
+The current transaction-ledger slice extracts `PortfolioTransactionsRequestContext`, response
+metadata assembly, transaction row parsing, event-identifier preservation, and quantized amount
+conversion into `portfolio_transaction_ledger.py`. It reduces `portfolio_service.py` from 3,062 to
+2,993 lines while preserving the 49-line longest-function baseline and keeping upstream request,
+cache, and filter pass-through behavior in `PortfolioService`.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | active focused closure branch over `origin/main`; intended to merge and delete before handoff |
-| Unit/contract coverage | Healthy | 986 tests passed in current-branch `make check` evidence through commit `1b2a4e5`; focused position-book mapper tests pass in closure slice |
-| Integration coverage | Healthy | 207 integration tests passed in current-branch `make ci` evidence on commit `1b2a4e5`; closure branch will rerun repo-native gates before merge |
-| Total coverage | Healthy | 93.67%, above the 84% floor |
-| Security audit | Governed | `pip-audit` passes with one documented FastAPI/Starlette exception and no known vulnerabilities on commit `1b2a4e5` |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; portfolio position-book mapping is extracted and `portfolio_service.py` is reduced to 3,241 lines; several service files remain above 1,000 lines |
+| Branch hygiene | Healthy | active focused transaction-ledger branch over `origin/main` `62c7a7399944b380eca8ddc7be7ac987a2cd4654`; intended to merge and delete before handoff |
+| Unit/contract coverage | Healthy | 993 tests passed in current-branch `make check`; focused transaction-ledger mapper tests pass |
+| Integration coverage | Healthy | 207 integration tests passed in current-branch `make ci` |
+| Total coverage | Healthy | 1,200 coverage tests passed in current-branch `make ci`; total coverage is 93.69%, above the 84% floor |
+| Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; portfolio transaction-ledger mapping is extracted and `portfolio_service.py` is reduced to 2,993 lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -218,8 +223,8 @@ and client modules remain.
 1. Continue splitting `portfolio_service.py` into source-readiness, workspace, insight, and
    workflow-cue adapters. Exception-summary payload construction, workflow-action assembly,
    transaction-summary context loading, transaction page loading, book response assembly,
-   transaction-ledger payload loading, workspace source gathering, and position-book mapping are
-   now separately testable.
+   transaction-ledger payload loading, workspace source gathering, position-book mapping, and
+   transaction-ledger response mapping are now separately testable.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -46,7 +46,6 @@ from app.contracts.portfolio import (
     PortfolioSupportabilitySummary,
     PortfolioTopPosition,
     PortfolioTransactionLedgerResponse,
-    PortfolioTransactionView,
     PortfolioWorkflowAction,
     PortfolioWorkflowLaunchCue,
     PortfolioWorkflowResponse,
@@ -56,8 +55,6 @@ from app.contracts.portfolio import (
 from app.precision_policy import (
     quantize_money,
     quantize_performance,
-    quantize_price,
-    quantize_quantity,
 )
 from app.services.async_ttl_cache import AsyncTtlCache
 from app.services.portfolio_exception_summaries import (
@@ -69,6 +66,10 @@ from app.services.portfolio_position_book import (
     build_top_positions,
     parse_position_book_summary,
     parse_positions,
+)
+from app.services.portfolio_transaction_ledger import (
+    PortfolioTransactionsRequestContext,
+    build_transaction_ledger_response,
 )
 from app.services.portfolio_workspace_controls import build_workspace_control_capabilities
 from app.services.upstream_envelope import safe_upstream_detail
@@ -181,30 +182,6 @@ class PortfolioWorkspaceAssemblyState:
     portfolio_payload: dict[str, Any]
     warnings: list[str]
     partial_failures: list[PortfolioPartialFailure]
-
-
-@dataclass(frozen=True)
-class PortfolioTransactionsRequestContext:
-    portfolio_id: str
-    correlation_id: str
-    as_of_date: str | None
-    include_projected: bool
-    skip: int
-    limit: int
-    transaction_type: str | None
-    security_id: str | None
-    instrument_id: str | None
-    component_type: str | None
-    linked_transaction_group_id: str | None
-    fx_contract_id: str | None
-    swap_event_id: str | None
-    near_leg_group_id: str | None
-    far_leg_group_id: str | None
-    sort_by: str
-    sort_order: str
-    start_date: str | None
-    end_date: str | None
-    reporting_currency: str | None
 
 
 @dataclass(frozen=True)
@@ -1738,25 +1715,10 @@ class PortfolioService:
         context: PortfolioTransactionsRequestContext,
         result_payload: dict[str, Any],
     ) -> PortfolioTransactionLedgerResponse:
-        transactions = [
-            self._parse_transaction_view(item)
-            for item in result_payload.get("transactions", [])
-            if isinstance(item, dict)
-        ]
-        return PortfolioTransactionLedgerResponse(
-            correlation_id=context.correlation_id,
+        return build_transaction_ledger_response(
+            context=context,
             contract_version=settings.contract_version,
-            portfolio_id=context.portfolio_id,
-            as_of_date=(
-                str(result_payload.get("as_of_date"))
-                if result_payload.get("as_of_date")
-                else context.as_of_date
-            ),
-            include_projected=context.include_projected,
-            total=int(result_payload.get("total", len(transactions))),
-            skip=int(result_payload.get("skip", context.skip)),
-            limit=int(result_payload.get("limit", context.limit)),
-            transactions=transactions,
+            result_payload=result_payload,
         )
 
     async def get_income_summary(
@@ -2260,40 +2222,6 @@ class PortfolioService:
                 )
             )
         return balances
-
-    def _parse_transaction_view(self, item: dict[str, Any]) -> PortfolioTransactionView:
-        return PortfolioTransactionView(
-            transaction_id=str(item.get("transaction_id", "")),
-            transaction_date=str(item.get("transaction_date", "")),
-            settlement_date=self._optional_str(item.get("settlement_date")),
-            transaction_type=str(item.get("transaction_type", "")),
-            component_type=self._optional_str(item.get("component_type")),
-            security_id=str(item.get("security_id", "")),
-            instrument_id=str(item.get("instrument_id", "")),
-            quantity=float(quantize_quantity(item.get("quantity", 0))),
-            price=float(quantize_price(item.get("price", 0)))
-            if item.get("price") is not None
-            else None,
-            gross_amount=float(quantize_money(item.get("gross_transaction_amount", 0)))
-            if item.get("gross_transaction_amount") is not None
-            else None,
-            currency=self._optional_str(item.get("currency")),
-            net_cost_base=float(quantize_money(item.get("net_cost", 0)))
-            if item.get("net_cost") is not None
-            else None,
-            realized_gain_loss_base=float(quantize_money(item.get("realized_gain_loss", 0)))
-            if item.get("realized_gain_loss") is not None
-            else None,
-            settlement_status=self._optional_str(item.get("settlement_status")),
-            source_system=self._optional_str(item.get("source_system")),
-            cash_entry_mode=self._optional_str(item.get("cash_entry_mode")),
-            economic_event_id=self._optional_str(item.get("economic_event_id")),
-            linked_transaction_group_id=self._optional_str(item.get("linked_transaction_group_id")),
-            fx_contract_id=self._optional_str(item.get("fx_contract_id")),
-            swap_event_id=self._optional_str(item.get("swap_event_id")),
-            near_leg_group_id=self._optional_str(item.get("near_leg_group_id")),
-            far_leg_group_id=self._optional_str(item.get("far_leg_group_id")),
-        )
 
     async def _list_transaction_rows(
         self,

--- a/src/app/services/portfolio_transaction_ledger.py
+++ b/src/app/services/portfolio_transaction_ledger.py
@@ -1,0 +1,106 @@
+from dataclasses import dataclass
+from typing import Any
+
+from app.contracts.portfolio import (
+    PortfolioTransactionLedgerResponse,
+    PortfolioTransactionView,
+)
+from app.precision_policy import quantize_money, quantize_price, quantize_quantity
+
+
+@dataclass(frozen=True)
+class PortfolioTransactionsRequestContext:
+    portfolio_id: str
+    correlation_id: str
+    as_of_date: str | None
+    include_projected: bool
+    skip: int
+    limit: int
+    transaction_type: str | None
+    security_id: str | None
+    instrument_id: str | None
+    component_type: str | None
+    linked_transaction_group_id: str | None
+    fx_contract_id: str | None
+    swap_event_id: str | None
+    near_leg_group_id: str | None
+    far_leg_group_id: str | None
+    sort_by: str
+    sort_order: str
+    start_date: str | None
+    end_date: str | None
+    reporting_currency: str | None
+
+
+def build_transaction_ledger_response(
+    *,
+    context: PortfolioTransactionsRequestContext,
+    contract_version: str,
+    result_payload: dict[str, Any],
+) -> PortfolioTransactionLedgerResponse:
+    transactions = parse_transaction_views(result_payload)
+    return PortfolioTransactionLedgerResponse(
+        correlation_id=context.correlation_id,
+        contract_version=contract_version,
+        portfolio_id=context.portfolio_id,
+        as_of_date=(
+            str(result_payload.get("as_of_date"))
+            if result_payload.get("as_of_date")
+            else context.as_of_date
+        ),
+        include_projected=context.include_projected,
+        total=int(result_payload.get("total", len(transactions))),
+        skip=int(result_payload.get("skip", context.skip)),
+        limit=int(result_payload.get("limit", context.limit)),
+        transactions=transactions,
+    )
+
+
+def parse_transaction_views(payload: dict[str, Any]) -> list[PortfolioTransactionView]:
+    return [
+        parse_transaction_view(item)
+        for item in payload.get("transactions", [])
+        if isinstance(item, dict)
+    ]
+
+
+def parse_transaction_view(item: dict[str, Any]) -> PortfolioTransactionView:
+    return PortfolioTransactionView(
+        transaction_id=str(item.get("transaction_id", "")),
+        transaction_date=str(item.get("transaction_date", "")),
+        settlement_date=optional_str(item.get("settlement_date")),
+        transaction_type=str(item.get("transaction_type", "")),
+        component_type=optional_str(item.get("component_type")),
+        security_id=str(item.get("security_id", "")),
+        instrument_id=str(item.get("instrument_id", "")),
+        quantity=float(quantize_quantity(item.get("quantity", 0))),
+        price=float(quantize_price(item.get("price", 0)))
+        if item.get("price") is not None
+        else None,
+        gross_amount=optional_money(item.get("gross_transaction_amount")),
+        currency=optional_str(item.get("currency")),
+        net_cost_base=optional_money(item.get("net_cost")),
+        realized_gain_loss_base=optional_money(item.get("realized_gain_loss")),
+        settlement_status=optional_str(item.get("settlement_status")),
+        source_system=optional_str(item.get("source_system")),
+        cash_entry_mode=optional_str(item.get("cash_entry_mode")),
+        economic_event_id=optional_str(item.get("economic_event_id")),
+        linked_transaction_group_id=optional_str(item.get("linked_transaction_group_id")),
+        fx_contract_id=optional_str(item.get("fx_contract_id")),
+        swap_event_id=optional_str(item.get("swap_event_id")),
+        near_leg_group_id=optional_str(item.get("near_leg_group_id")),
+        far_leg_group_id=optional_str(item.get("far_leg_group_id")),
+    )
+
+
+def optional_money(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(quantize_money(value))
+
+
+def optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/tests/unit/test_portfolio_transaction_ledger.py
+++ b/tests/unit/test_portfolio_transaction_ledger.py
@@ -1,0 +1,136 @@
+from app.services.portfolio_transaction_ledger import (
+    PortfolioTransactionsRequestContext,
+    build_transaction_ledger_response,
+    parse_transaction_views,
+)
+
+
+def _request_context() -> PortfolioTransactionsRequestContext:
+    return PortfolioTransactionsRequestContext(
+        portfolio_id="PF_1001",
+        correlation_id="corr-ledger",
+        as_of_date="2026-03-27",
+        include_projected=True,
+        skip=20,
+        limit=25,
+        transaction_type=None,
+        security_id=None,
+        instrument_id=None,
+        component_type=None,
+        linked_transaction_group_id=None,
+        fx_contract_id=None,
+        swap_event_id=None,
+        near_leg_group_id=None,
+        far_leg_group_id=None,
+        sort_by="transaction_date",
+        sort_order="desc",
+        start_date=None,
+        end_date=None,
+        reporting_currency="USD",
+    )
+
+
+def test_build_transaction_ledger_response_preserves_source_metadata():
+    response = build_transaction_ledger_response(
+        context=_request_context(),
+        contract_version="v-test",
+        result_payload={
+            "as_of_date": "2026-03-28",
+            "total": 30,
+            "skip": 20,
+            "limit": 10,
+            "transactions": [],
+        },
+    )
+
+    assert response.correlation_id == "corr-ledger"
+    assert response.contract_version == "v-test"
+    assert response.portfolio_id == "PF_1001"
+    assert response.as_of_date == "2026-03-28"
+    assert response.include_projected is True
+    assert response.total == 30
+    assert response.skip == 20
+    assert response.limit == 10
+
+
+def test_build_transaction_ledger_response_falls_back_to_context_metadata():
+    response = build_transaction_ledger_response(
+        context=_request_context(),
+        contract_version="v-test",
+        result_payload={"transactions": []},
+    )
+
+    assert response.as_of_date == "2026-03-27"
+    assert response.total == 0
+    assert response.skip == 20
+    assert response.limit == 25
+
+
+def test_parse_transaction_views_quantizes_amounts_and_preserves_event_identifiers():
+    transactions = parse_transaction_views(
+        {
+            "transactions": [
+                "ignored",
+                {
+                    "transaction_id": "TX_1",
+                    "transaction_date": "2026-03-27T09:30:00Z",
+                    "settlement_date": "2026-03-29",
+                    "transaction_type": "FX_FORWARD",
+                    "component_type": "FX_CONTRACT_OPEN",
+                    "security_id": "EQ_1",
+                    "instrument_id": "INST_EQ_1",
+                    "quantity": "10.1234567",
+                    "price": "70.123456",
+                    "gross_transaction_amount": "700.129",
+                    "currency": "USD",
+                    "net_cost": "700.129",
+                    "realized_gain_loss": "15.129",
+                    "settlement_status": "SETTLED",
+                    "source_system": "lotus-core",
+                    "cash_entry_mode": "BOOKED",
+                    "economic_event_id": "EVT-2026-0001",
+                    "linked_transaction_group_id": "LTG-FX-2026-0001",
+                    "fx_contract_id": "FXC-2026-0001",
+                    "swap_event_id": "FXSWAP-2026-0001",
+                    "near_leg_group_id": "FXSWAP-2026-0001-NEAR",
+                    "far_leg_group_id": "FXSWAP-2026-0001-FAR",
+                },
+            ]
+        }
+    )
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert transaction.transaction_id == "TX_1"
+    assert transaction.quantity == 10.123457
+    assert transaction.price == 70.123456
+    assert transaction.gross_amount == 700.13
+    assert transaction.net_cost_base == 700.13
+    assert transaction.realized_gain_loss_base == 15.13
+    assert transaction.component_type == "FX_CONTRACT_OPEN"
+    assert transaction.linked_transaction_group_id == "LTG-FX-2026-0001"
+    assert transaction.fx_contract_id == "FXC-2026-0001"
+    assert transaction.swap_event_id == "FXSWAP-2026-0001"
+    assert transaction.near_leg_group_id == "FXSWAP-2026-0001-NEAR"
+    assert transaction.far_leg_group_id == "FXSWAP-2026-0001-FAR"
+
+
+def test_parse_transaction_views_preserves_missing_optional_amounts():
+    transaction = parse_transaction_views(
+        {
+            "transactions": [
+                {
+                    "transaction_id": "TX_2",
+                    "transaction_date": "2026-03-27",
+                    "transaction_type": "DIVIDEND",
+                    "security_id": "EQ_1",
+                    "instrument_id": "INST_EQ_1",
+                }
+            ]
+        }
+    )[0]
+
+    assert transaction.price is None
+    assert transaction.gross_amount is None
+    assert transaction.net_cost_base is None
+    assert transaction.realized_gain_loss_base is None


### PR DESCRIPTION
## Summary
- Extract transaction-ledger request context and response-row mapping into src/app/services/portfolio_transaction_ledger.py.
- Keep PortfolioService responsible for upstream request orchestration, cache behavior, and filter pass-through.
- Add focused mapper tests for metadata fallback, quantized amounts, optional amount handling, and event identifiers.
- Refresh monetary-float allowlist and quality evidence for the moved quantized float conversions and measured hotspot changes.

## Evidence
- python -m pytest tests/unit/test_portfolio_transaction_ledger.py tests/unit/test_portfolio_service.py -q: 48 passed
- make check: ruff, format, monetary-float guard, mypy over 445 source files, Workbench contract smoke, 993 unit/contract tests passed
- make ci: ruff, format, monetary-float guard, mypy, Workbench contract smoke, migration smoke, 207 integration tests passed, 1,200 coverage tests passed, total coverage 93.69%, pip-audit no known vulnerabilities after governed PYSEC-2026-161 exception
- C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway: DiffCount 0

## Governance
- Stranded truth: git fetch origin --prune and git branch -r --no-merged origin/main showed no unmerged remote branches.
- Wiki decision: no repo-local wiki source change required; this is code-focused mapper extraction plus quality/allowlist evidence refresh.
- Behavior: intended behavior-preserving refactor; no API contract shape change.

## Metrics
- portfolio_service.py: 3,062 lines -> 2,993 lines.
- New portfolio_transaction_ledger.py: 93 lines.
- Longest-function baseline remains 49 lines.
