### PR TITLE
Extract core transaction query params

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -142,7 +142,10 @@ assembly to focused helpers. Risk drawdown routing now keeps OpenAPI query metad
 descriptors separate from the public query dependency. Portfolio position-book mapping now lives in
 `src/app/services/portfolio_position_book.py`, and transaction-ledger request context plus row
 mapping now live in `src/app/services/portfolio_transaction_ledger.py`. `portfolio_service.py` is
-down to 2,993 lines. The current longest functions are 49-line helpers:
+down to 2,993 lines. Lotus Core transaction query-parameter construction now lives in
+`src/app/clients/lotus_core_transaction_params.py`, reducing `lotus_core_query_client.py` to 574
+measured lines and removing `_portfolio_transaction_query_params` from the current top hotspot
+list. The current longest functions are 49-line helpers:
 `get_transaction_ledger` in `portfolio_service.py` and `get_portfolio_transactions` in
 `lotus_core_query_client.py`.
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -122,6 +122,10 @@ The current transaction-ledger slice extracts transaction-ledger request context
 mapping into `portfolio_transaction_ledger.py`. This preserves ledger metadata, transaction
 identifier, quantization, upstream filter, and cache behavior while reducing `portfolio_service.py`
 from 3,062 to 2,993 lines and keeping the 49-line longest-function baseline.
+The current Lotus Core transaction query-parameter slice extracts deterministic transaction-filter
+parameter construction into `lotus_core_transaction_params.py`. This preserves the public client
+signature and route contract while reducing `lotus_core_query_client.py` from 622 to 574 measured
+lines and removing `_portfolio_transaction_query_params` from the top function-hotspot list.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -129,15 +133,15 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,262 |
-| Python source files under `src/app` | 445 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,263 |
+| Python source files under `src/app` | 446 |
 | Python test files under `tests` | 161 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current transaction-ledger slice shows 1,262 files under `src`,
-`tests`, `docs`, `wiki`, `.github`, and `scripts`; 445 Python source files under `src/app`; and
-161 Python test files under `tests`.
+Working-tree verification for the current Lotus Core transaction query-parameter slice shows 1,263
+files under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 446 Python source files under
+`src/app`; and 161 Python test files under `tests`.
 
 ## Largest Source Files
 
@@ -164,10 +168,10 @@ Working-tree verification for the current transaction-ledger slice shows 1,262 f
 | 4 | 47 | `_get_portfolio_transactions_result` | `src/app/services/portfolio_service.py` |
 | 5 | 47 | `_build_workspace_descriptor_contract` | `src/app/services/platform_capabilities_shell.py` |
 | 6 | 47 | `_build_performance_workspace_response` | `src/app/services/performance_workspace_service.py` |
-| 7 | 47 | `_portfolio_transaction_query_params` | `src/app/clients/lotus_core_query_client.py` |
-| 8 | 46 | `get_portfolio_360` | `src/app/services/workbench_service.py` |
-| 9 | 46 | `_unpack_rebalance_supportability_summary` | `src/app/services/workbench_rebalance_snapshot.py` |
-| 10 | 46 | `_performance_payload_from_result` | `src/app/services/workbench_performance_snapshot.py` |
+| 7 | 46 | `get_portfolio_360` | `src/app/services/workbench_service.py` |
+| 8 | 46 | `_unpack_rebalance_supportability_summary` | `src/app/services/workbench_rebalance_snapshot.py` |
+| 9 | 46 | `_performance_payload_from_result` | `src/app/services/workbench_performance_snapshot.py` |
+| 10 | 46 | `_portfolio_transactions_request_context` | `src/app/services/portfolio_service.py` |
 
 ## Existing Blocking Gates
 
@@ -187,7 +191,7 @@ Current repo-native gates already cover:
 Most recent local evidence:
 
 1. Current branch: `make check` passed with ruff, format check, monetary-float guard, mypy over
-   445 source files, Workbench/OpenAPI contract smoke, and 993 unit/contract tests.
+   446 source files, Workbench/OpenAPI contract smoke, and 994 unit/contract tests.
 2. Current focused branch: `tests/unit/test_http_resilience.py` passed with 15 tests after JSON
    retry attempt extraction.
 3. Current focused branch: DPM proof-pack service tests passed with 8 tests after PM memo workflow
@@ -235,7 +239,7 @@ Most recent local evidence:
 35. Current focused branch: Workbench rebalance tests passed with 3 selected tests.
 36. Current focused branch: portfolio readiness tests passed with 4 selected tests.
 37. Current branch PR-grade evidence: `make ci` passed with 207 integration tests.
-38. Current branch PR-grade evidence: `make ci` passed with 1,200 unit, contract, and integration
+38. Current branch PR-grade evidence: `make ci` passed with 1,201 unit, contract, and integration
     coverage tests.
 39. Coverage: 93.69%, above the 84% floor.
 40. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
@@ -275,7 +279,7 @@ report-only quality checks. Baseline findings should be triaged before making th
 
 ## OpenAPI Gaps
 
-Current generated OpenAPI evidence on branch head `62c7a7399944b380eca8ddc7be7ac987a2cd4654`:
+Current generated OpenAPI evidence for this working-tree baseline:
 
 | Check | Count |
 | --- | ---: |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,32 +5,32 @@ Mode: PR-readiness evidence update
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | `make check` passed with lint, format, monetary-float guard, mypy, contract smoke, and 993 unit/contract tests; `make ci` passed with 207 integration tests, 1,200 coverage tests, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Build and test reliability | 5/5 | `make check` passed with lint, format, monetary-float guard, mypy, contract smoke, and 994 unit/contract tests; `make ci` passed with 207 integration tests, 1,201 coverage tests, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 93.69% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current slice preserves the 49-line longest-function baseline and extracts transaction-ledger request context plus response-row mapping into a reusable mapper; `portfolio_service.py` drops from 3,062 to 2,993 lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Modularity | 4/5 | Current slice preserves the 49-line longest-function baseline and extracts Lotus Core transaction query-parameter construction into a reusable mapper; `lotus_core_query_client.py` drops from 622 to 574 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit present; analytics async polling now separates per-attempt fanout logging from loop orchestration and preserves absolute result URLs under test | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Quality scorecard and health evidence updated with current transaction-ledger metrics; no repo-local wiki source changes required for this code-focused mapper extraction | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Quality scorecard and health evidence updated with current Lotus Core transaction query-parameter metrics; no repo-local wiki source changes required for this code-focused mapper extraction | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs; operational runbook now consolidated | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
-Comparison point: `origin/main` at `62c7a7399944b380eca8ddc7be7ac987a2cd4654` versus the current
-transaction-ledger branch before merge.
+Comparison point: `origin/main` at `58984a2` versus the current Lotus Core transaction
+query-parameter branch before merge.
 
 | Measure | Before | After | Result |
 | --- | ---: | ---: | --- |
 | Branch commits over `origin/main` | 0 | 1 planned | Narrow closure branch ready for PR review |
-| Tracked `src/app` Python files | 444 | 445 | Added reusable transaction-ledger mapper |
-| Tracked test files | 160 | 161 | Added focused mapper tests |
+| Tracked `src/app` Python files | 445 | 446 | Added reusable Lotus Core transaction query-parameter mapper |
+| Tracked test files | 161 | 161 | Added focused mapper test to an existing upstream-client test file |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 3,062 lines | 2,993 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
+| Largest source file | 2,993 lines | 2,993 lines | Preserved; `portfolio_service.py` remains largest residual hotspot |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 993 | 993 | Preserved |
+| Local unit/contract tests | 993 | 994 | Added focused Lotus Core transaction query-parameter mapper test |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
 ## Phase Gates

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -203,17 +203,22 @@ metadata assembly, transaction row parsing, event-identifier preservation, and q
 conversion into `portfolio_transaction_ledger.py`. It reduces `portfolio_service.py` from 3,062 to
 2,993 lines while preserving the 49-line longest-function baseline and keeping upstream request,
 cache, and filter pass-through behavior in `PortfolioService`.
+The current Lotus Core transaction query-parameter slice extracts deterministic query-parameter
+construction into `lotus_core_transaction_params.py`. It reduces `lotus_core_query_client.py` from
+622 to 574 measured lines, removes `_portfolio_transaction_query_params` from the top
+function-hotspot list, and preserves the public client method signature plus route-level filter
+contract.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | active focused transaction-ledger branch over `origin/main` `62c7a7399944b380eca8ddc7be7ac987a2cd4654`; intended to merge and delete before handoff |
-| Unit/contract coverage | Healthy | 993 tests passed in current-branch `make check`; focused transaction-ledger mapper tests pass |
+| Branch hygiene | Healthy | active focused Lotus Core transaction query-parameter branch over `origin/main` `58984a2`; intended to merge and delete before handoff |
+| Unit/contract coverage | Healthy | 994 unit/contract tests passed in current-branch `make check`; focused upstream-client tests passed with 177 tests |
 | Integration coverage | Healthy | 207 integration tests passed in current-branch `make ci` |
-| Total coverage | Healthy | 1,200 coverage tests passed in current-branch `make ci`; total coverage is 93.69%, above the 84% floor |
+| Total coverage | Healthy | 1,201 coverage tests passed in current-branch `make ci`; total coverage is 93.69%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; portfolio transaction-ledger mapping is extracted and `portfolio_service.py` is reduced to 2,993 lines; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; Lotus Core transaction query-parameter mapping is extracted and `lotus_core_query_client.py` is reduced to 574 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |

--- a/src/app/clients/lotus_core_query_client.py
+++ b/src/app/clients/lotus_core_query_client.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from app.clients.lotus_core_transaction_params import build_portfolio_transaction_query_params
 from app.clients.observed_fanout import request_observed_fanout
 from app.clients.upstream_headers import build_upstream_headers
 
@@ -189,7 +190,7 @@ class LotusCoreQueryClient:
             operation="core.portfolios.transactions.list",
             path=f"/portfolios/{portfolio_id}/transactions",
             correlation_id=correlation_id,
-            params=self._portfolio_transaction_query_params(
+            params=build_portfolio_transaction_query_params(
                 limit=limit,
                 skip=skip,
                 sort_by=sort_by,
@@ -210,54 +211,6 @@ class LotusCoreQueryClient:
                 reporting_currency=reporting_currency,
             ),
         )
-
-    def _portfolio_transaction_query_params(
-        self,
-        *,
-        limit: int,
-        skip: int,
-        sort_by: str,
-        sort_order: str,
-        include_projected: bool,
-        as_of_date: str | None,
-        transaction_type: str | None,
-        security_id: str | None,
-        instrument_id: str | None,
-        component_type: str | None,
-        linked_transaction_group_id: str | None,
-        fx_contract_id: str | None,
-        swap_event_id: str | None,
-        near_leg_group_id: str | None,
-        far_leg_group_id: str | None,
-        start_date: str | None,
-        end_date: str | None,
-        reporting_currency: str | None,
-    ) -> dict[str, Any]:
-        params: dict[str, Any] = {
-            "limit": limit,
-            "skip": skip,
-            "sort_by": sort_by,
-            "sort_order": sort_order,
-            "include_projected": str(include_projected).lower(),
-        }
-        params.update(
-            self._optional_params(
-                as_of_date=as_of_date,
-                transaction_type=transaction_type,
-                security_id=security_id,
-                instrument_id=instrument_id,
-                component_type=component_type,
-                linked_transaction_group_id=linked_transaction_group_id,
-                fx_contract_id=fx_contract_id,
-                swap_event_id=swap_event_id,
-                near_leg_group_id=near_leg_group_id,
-                far_leg_group_id=far_leg_group_id,
-                start_date=start_date,
-                end_date=end_date,
-                reporting_currency=reporting_currency,
-            )
-        )
-        return params
 
     async def get_cashflow_projection(
         self,

--- a/src/app/clients/lotus_core_transaction_params.py
+++ b/src/app/clients/lotus_core_transaction_params.py
@@ -1,0 +1,48 @@
+from typing import Any
+
+
+def build_portfolio_transaction_query_params(
+    *,
+    limit: int,
+    skip: int,
+    sort_by: str,
+    sort_order: str,
+    include_projected: bool,
+    as_of_date: str | None,
+    transaction_type: str | None,
+    security_id: str | None,
+    instrument_id: str | None,
+    component_type: str | None,
+    linked_transaction_group_id: str | None,
+    fx_contract_id: str | None,
+    swap_event_id: str | None,
+    near_leg_group_id: str | None,
+    far_leg_group_id: str | None,
+    start_date: str | None,
+    end_date: str | None,
+    reporting_currency: str | None,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "limit": limit,
+        "skip": skip,
+        "sort_by": sort_by,
+        "sort_order": sort_order,
+        "include_projected": str(include_projected).lower(),
+    }
+    optional_params = {
+        "as_of_date": as_of_date,
+        "transaction_type": transaction_type,
+        "security_id": security_id,
+        "instrument_id": instrument_id,
+        "component_type": component_type,
+        "linked_transaction_group_id": linked_transaction_group_id,
+        "fx_contract_id": fx_contract_id,
+        "swap_event_id": swap_event_id,
+        "near_leg_group_id": near_leg_group_id,
+        "far_leg_group_id": far_leg_group_id,
+        "start_date": start_date,
+        "end_date": end_date,
+        "reporting_currency": reporting_currency,
+    }
+    params.update({key: value for key, value in optional_params.items() if value is not None})
+    return params

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -11,6 +11,7 @@ from app.clients.lotus_ai_client import LotusAiClient
 from app.clients.lotus_analytics_client import LotusAnalyticsClient
 from app.clients.lotus_core_ingestion_client import LotusCoreIngestionClient
 from app.clients.lotus_core_query_client import LotusCoreQueryClient
+from app.clients.lotus_core_transaction_params import build_portfolio_transaction_query_params
 from app.clients.reporting_client import ReportingClient
 from app.middleware.correlation import trace_id_var
 
@@ -1405,6 +1406,36 @@ async def test_lotus_core_query_client_transaction_route_supports_advanced_filte
         "far_leg_group_id": "FXSWAP-2026-0001-FAR",
         "start_date": "2026-03-01",
         "end_date": "2026-03-27",
+    }
+
+
+def test_lotus_core_transaction_query_params_omit_unset_optional_filters():
+    assert build_portfolio_transaction_query_params(
+        limit=10,
+        skip=0,
+        sort_by="transaction_date",
+        sort_order="desc",
+        include_projected=False,
+        as_of_date=None,
+        transaction_type=None,
+        security_id=None,
+        instrument_id=None,
+        component_type=None,
+        linked_transaction_group_id=None,
+        fx_contract_id=None,
+        swap_event_id=None,
+        near_leg_group_id=None,
+        far_leg_group_id=None,
+        start_date=None,
+        end_date=None,
+        reporting_currency="SGD",
+    ) == {
+        "limit": 10,
+        "skip": 0,
+        "sort_by": "transaction_date",
+        "sort_order": "desc",
+        "include_projected": "false",
+        "reporting_currency": "SGD",
     }
 
 


### PR DESCRIPTION
## Summary
- Extract deterministic Lotus Core portfolio transaction query-parameter construction into `lotus_core_transaction_params.py`.
- Keep the public `LotusCoreQueryClient.get_portfolio_transactions` signature and route contract unchanged.
- Add focused coverage for optional-filter omission and projection flag serialization.
- Refresh quality evidence for the removed private mapper hotspot.

## Hotspot Evidence
- `lotus_core_query_client.py`: 622 -> 574 measured lines.
- `_portfolio_transaction_query_params` removed from the top function-hotspot list.
- Longest-function baseline remains 49 lines.
- `portfolio_service.py` remains the largest source file at 2,993 measured lines.

## Validation
- `python -m pytest tests/unit/test_upstream_clients.py -q`: 177 passed.
- `make check`: ruff, format, monetary-float guard, mypy over 446 source files, Workbench/OpenAPI contract smoke, and 994 unit/contract tests passed.
- `make ci`: 207 integration tests passed; 1,201 coverage tests passed; total coverage 93.69%; `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception.
- `C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway`: DiffCount 0.

## Governance
- Stranded truth check: no remote branches unmerged into `origin/main`.
- No API behavior, OpenAPI contract shape, wiki source, or upstream domain authority change.