### PR TITLE
Extract portfolio liquidity payload loader

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -142,7 +142,9 @@ assembly to focused helpers. Risk drawdown routing now keeps OpenAPI query metad
 descriptors separate from the public query dependency. Portfolio position-book mapping now lives in
 `src/app/services/portfolio_position_book.py`, and transaction-ledger request context plus row
 mapping now live in `src/app/services/portfolio_transaction_ledger.py`. `portfolio_service.py` is
-down to 2,993 lines. Lotus Core transaction query-parameter construction now lives in
+down to 2,968 lines. Portfolio liquidity upstream payload loading now lives in
+`src/app/services/portfolio_liquidity_payloads.py`. Lotus Core transaction query-parameter
+construction now lives in
 `src/app/clients/lotus_core_transaction_params.py`, reducing `lotus_core_query_client.py` to 574
 measured lines and removing `_portfolio_transaction_query_params` from the current top hotspot
 list. The current longest functions are 49-line helpers:

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -126,6 +126,10 @@ The current Lotus Core transaction query-parameter slice extracts deterministic 
 parameter construction into `lotus_core_transaction_params.py`. This preserves the public client
 signature and route contract while reducing `lotus_core_query_client.py` from 622 to 574 measured
 lines and removing `_portfolio_transaction_query_params` from the top function-hotspot list.
+The current portfolio liquidity payload slice extracts concurrent AUM, cash-balance, and projected
+cashflow upstream loading into `portfolio_liquidity_payloads.py`. This preserves liquidity endpoint
+behavior while reducing `portfolio_service.py` from 2,993 to 2,968 measured lines and removing
+`_load_portfolio_liquidity_payloads` from the top function-hotspot list.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -133,21 +137,21 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,263 |
-| Python source files under `src/app` | 446 |
-| Python test files under `tests` | 161 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 |
+| Python source files under `src/app` | 447 |
+| Python test files under `tests` | 162 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current Lotus Core transaction query-parameter slice shows 1,263
-files under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 446 Python source files under
-`src/app`; and 161 Python test files under `tests`.
+Working-tree verification for the current portfolio liquidity payload slice shows 1,265 files under
+`src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 447 Python source files under `src/app`;
+and 162 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 2,993 | `src/app/services/portfolio_service.py` |
+| 1 | 2,968 | `src/app/services/portfolio_service.py` |
 | 2 | 2,123 | `src/app/contracts/portfolio.py` |
 | 3 | 1,940 | `src/app/contracts/risk_workspace.py` |
 | 4 | 1,731 | `src/app/contracts/reporting.py` |
@@ -191,7 +195,7 @@ Current repo-native gates already cover:
 Most recent local evidence:
 
 1. Current branch: `make check` passed with ruff, format check, monetary-float guard, mypy over
-   446 source files, Workbench/OpenAPI contract smoke, and 994 unit/contract tests.
+   447 source files, Workbench/OpenAPI contract smoke, and 996 unit/contract tests.
 2. Current focused branch: `tests/unit/test_http_resilience.py` passed with 15 tests after JSON
    retry attempt extraction.
 3. Current focused branch: DPM proof-pack service tests passed with 8 tests after PM memo workflow
@@ -239,7 +243,7 @@ Most recent local evidence:
 35. Current focused branch: Workbench rebalance tests passed with 3 selected tests.
 36. Current focused branch: portfolio readiness tests passed with 4 selected tests.
 37. Current branch PR-grade evidence: `make ci` passed with 207 integration tests.
-38. Current branch PR-grade evidence: `make ci` passed with 1,201 unit, contract, and integration
+38. Current branch PR-grade evidence: `make ci` passed with 1,203 unit, contract, and integration
     coverage tests.
 39. Coverage: 93.69%, above the 84% floor.
 40. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,32 +5,32 @@ Mode: PR-readiness evidence update
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | `make check` passed with lint, format, monetary-float guard, mypy, contract smoke, and 994 unit/contract tests; `make ci` passed with 207 integration tests, 1,201 coverage tests, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Build and test reliability | 5/5 | `make check` passed with lint, format, monetary-float guard, mypy, contract smoke, and 996 unit/contract tests; `make ci` passed with 207 integration tests, 1,203 coverage tests, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 93.69% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current slice preserves the 49-line longest-function baseline and extracts Lotus Core transaction query-parameter construction into a reusable mapper; `lotus_core_query_client.py` drops from 622 to 574 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Modularity | 4/5 | Current slice preserves the 49-line longest-function baseline and extracts portfolio liquidity upstream payload loading into a reusable helper; `portfolio_service.py` drops from 2,993 to 2,968 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit present; analytics async polling now separates per-attempt fanout logging from loop orchestration and preserves absolute result URLs under test | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Quality scorecard and health evidence updated with current Lotus Core transaction query-parameter metrics; no repo-local wiki source changes required for this code-focused mapper extraction | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Quality scorecard and health evidence updated with current portfolio liquidity payload-loader metrics; no repo-local wiki source changes required for this code-focused extraction | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs; operational runbook now consolidated | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
-Comparison point: `origin/main` at `58984a2` versus the current Lotus Core transaction
-query-parameter branch before merge.
+Comparison point: `origin/main` at `8bed73e` versus the current portfolio liquidity payload-loader
+branch before merge.
 
 | Measure | Before | After | Result |
 | --- | ---: | ---: | --- |
 | Branch commits over `origin/main` | 0 | 1 planned | Narrow closure branch ready for PR review |
-| Tracked `src/app` Python files | 445 | 446 | Added reusable Lotus Core transaction query-parameter mapper |
-| Tracked test files | 161 | 161 | Added focused mapper test to an existing upstream-client test file |
+| Tracked `src/app` Python files | 446 | 447 | Added reusable portfolio liquidity payload loader |
+| Tracked test files | 161 | 162 | Added focused liquidity payload loader tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,993 lines | 2,993 lines | Preserved; `portfolio_service.py` remains largest residual hotspot |
+| Largest source file | 2,993 lines | 2,968 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 993 | 994 | Added focused Lotus Core transaction query-parameter mapper test |
+| Local unit/contract tests | 994 | 996 | Added focused portfolio liquidity payload loader tests |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
 ## Phase Gates
@@ -55,7 +55,7 @@ Candidate thresholds:
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
 5. no new function above the current branch maximum of 49 lines and no unclassified largest-file
-   growth above the current 2,993-line `portfolio_service.py` maximum.
+   growth above the current 2,968-line `portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -208,17 +208,22 @@ construction into `lotus_core_transaction_params.py`. It reduces `lotus_core_que
 622 to 574 measured lines, removes `_portfolio_transaction_query_params` from the top
 function-hotspot list, and preserves the public client method signature plus route-level filter
 contract.
+The current portfolio liquidity payload slice extracts concurrent AUM, cash-balance, and projected
+cashflow loading into `portfolio_liquidity_payloads.py`. It reduces `portfolio_service.py` from
+2,993 to 2,968 measured lines, removes `_load_portfolio_liquidity_payloads` from the top
+function-hotspot list, and preserves liquidity request parameter forwarding plus required upstream
+payload validation behavior.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | active focused Lotus Core transaction query-parameter branch over `origin/main` `58984a2`; intended to merge and delete before handoff |
-| Unit/contract coverage | Healthy | 994 unit/contract tests passed in current-branch `make check`; focused upstream-client tests passed with 177 tests |
+| Branch hygiene | Healthy | active focused portfolio liquidity payload-loader branch over `origin/main` `8bed73e`; intended to merge and delete before handoff |
+| Unit/contract coverage | Healthy | 996 unit/contract tests passed in current-branch `make check`; focused liquidity payload and portfolio service tests passed with 46 tests |
 | Integration coverage | Healthy | 207 integration tests passed in current-branch `make ci` |
-| Total coverage | Healthy | 1,201 coverage tests passed in current-branch `make ci`; total coverage is 93.69%, above the 84% floor |
+| Total coverage | Healthy | 1,203 coverage tests passed in current-branch `make ci`; total coverage is 93.69%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; Lotus Core transaction query-parameter mapping is extracted and `lotus_core_query_client.py` is reduced to 574 measured lines; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; portfolio liquidity upstream loading is extracted and `portfolio_service.py` is reduced to 2,968 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |

--- a/src/app/services/portfolio_liquidity_payloads.py
+++ b/src/app/services/portfolio_liquidity_payloads.py
@@ -1,0 +1,71 @@
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+UpstreamResult = tuple[int, dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class PortfolioLiquidityLoadRequest:
+    portfolio_id: str
+    correlation_id: str
+    as_of_date: str | None
+    reporting_currency: str | None
+
+
+@dataclass(frozen=True)
+class PortfolioLiquidityPayloads:
+    aum_result: UpstreamResult
+    cash_balances_result: UpstreamResult
+    cashflow_result: UpstreamResult
+    aum_payload: dict[str, Any]
+    cash_balances_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class PortfolioLiquidityPayloadLoaders:
+    query_aum_result: Callable[..., Awaitable[UpstreamResult]]
+    query_cash_balances_result: Callable[..., Awaitable[UpstreamResult]]
+    get_cashflow_projection_result: Callable[..., Awaitable[UpstreamResult]]
+    require_payload: Callable[..., dict[str, Any]]
+
+
+async def load_portfolio_liquidity_payloads(
+    request: PortfolioLiquidityLoadRequest,
+    loaders: PortfolioLiquidityPayloadLoaders,
+) -> PortfolioLiquidityPayloads:
+    aum_result, cash_balances_result, cashflow_result = await asyncio.gather(
+        loaders.query_aum_result(
+            correlation_id=request.correlation_id,
+            portfolio_id=request.portfolio_id,
+            as_of_date=request.as_of_date,
+            reporting_currency=request.reporting_currency,
+        ),
+        loaders.query_cash_balances_result(
+            portfolio_id=request.portfolio_id,
+            correlation_id=request.correlation_id,
+            as_of_date=request.as_of_date,
+            reporting_currency=request.reporting_currency,
+        ),
+        loaders.get_cashflow_projection_result(
+            portfolio_id=request.portfolio_id,
+            correlation_id=request.correlation_id,
+            as_of_date=request.as_of_date,
+            include_projected=True,
+            horizon_days=10,
+        ),
+    )
+    return PortfolioLiquidityPayloads(
+        aum_result=aum_result,
+        cash_balances_result=cash_balances_result,
+        cashflow_result=cashflow_result,
+        aum_payload=loaders.require_payload(
+            result=aum_result,
+            unavailable_detail_prefix="lotus-core aum unavailable",
+        ),
+        cash_balances_payload=loaders.require_payload(
+            result=cash_balances_result,
+            unavailable_detail_prefix="lotus-core cash balances unavailable",
+        ),
+    )

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -62,6 +62,12 @@ from app.services.portfolio_exception_summaries import (
     build_portfolio_exception_summaries,
 )
 from app.services.portfolio_insights import build_portfolio_insights
+from app.services.portfolio_liquidity_payloads import (
+    PortfolioLiquidityLoadRequest,
+    PortfolioLiquidityPayloadLoaders,
+    PortfolioLiquidityPayloads,
+    load_portfolio_liquidity_payloads,
+)
 from app.services.portfolio_position_book import (
     build_top_positions,
     parse_position_book_summary,
@@ -126,15 +132,6 @@ class PortfolioAllocationResults:
     aum_result: UpstreamResult
     positions_result: UpstreamResult
     allocation_result: UpstreamResult
-
-
-@dataclass(frozen=True)
-class PortfolioLiquidityPayloads:
-    aum_result: UpstreamResult
-    cash_balances_result: UpstreamResult
-    cashflow_result: UpstreamResult
-    aum_payload: dict[str, Any]
-    cash_balances_payload: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -1388,42 +1385,18 @@ class PortfolioService:
         as_of_date: str | None,
         reporting_currency: str | None,
     ) -> PortfolioLiquidityPayloads:
-        (
-            aum_result,
-            cash_balances_result,
-            cashflow_result,
-        ) = await asyncio.gather(
-            self._query_aum_result(
-                correlation_id=correlation_id,
-                portfolio_id=portfolio_id,
-                as_of_date=as_of_date,
-                reporting_currency=reporting_currency,
-            ),
-            self._query_cash_balances_result(
+        return await load_portfolio_liquidity_payloads(
+            PortfolioLiquidityLoadRequest(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
                 as_of_date=as_of_date,
                 reporting_currency=reporting_currency,
             ),
-            self._get_cashflow_projection_result(
-                portfolio_id=portfolio_id,
-                correlation_id=correlation_id,
-                as_of_date=as_of_date,
-                include_projected=True,
-                horizon_days=10,
-            ),
-        )
-        return PortfolioLiquidityPayloads(
-            aum_result=aum_result,
-            cash_balances_result=cash_balances_result,
-            cashflow_result=cashflow_result,
-            aum_payload=self._require_payload(
-                result=aum_result,
-                unavailable_detail_prefix="lotus-core aum unavailable",
-            ),
-            cash_balances_payload=self._require_payload(
-                result=cash_balances_result,
-                unavailable_detail_prefix="lotus-core cash balances unavailable",
+            PortfolioLiquidityPayloadLoaders(
+                query_aum_result=self._query_aum_result,
+                query_cash_balances_result=self._query_cash_balances_result,
+                get_cashflow_projection_result=self._get_cashflow_projection_result,
+                require_payload=self._require_payload,
             ),
         )
 

--- a/tests/unit/test_portfolio_liquidity_payloads.py
+++ b/tests/unit/test_portfolio_liquidity_payloads.py
@@ -1,0 +1,108 @@
+from typing import Any
+
+import pytest
+
+from app.services.portfolio_liquidity_payloads import (
+    PortfolioLiquidityLoadRequest,
+    PortfolioLiquidityPayloadLoaders,
+    load_portfolio_liquidity_payloads,
+)
+
+
+@pytest.mark.asyncio
+async def test_load_portfolio_liquidity_payloads_passes_source_parameters():
+    calls: dict[str, dict[str, Any]] = {}
+
+    async def query_aum_result(**kwargs):
+        calls["aum"] = kwargs
+        return 200, {"portfolios": [{"portfolio_id": "PF_1001"}]}
+
+    async def query_cash_balances_result(**kwargs):
+        calls["cash_balances"] = kwargs
+        return 200, {"cash_accounts": []}
+
+    async def get_cashflow_projection_result(**kwargs):
+        calls["cashflow"] = kwargs
+        return 200, {"points": []}
+
+    def require_payload(**kwargs):
+        result = kwargs["result"]
+        return result[1]
+
+    payloads = await load_portfolio_liquidity_payloads(
+        PortfolioLiquidityLoadRequest(
+            portfolio_id="PF_1001",
+            correlation_id="corr-liquidity",
+            as_of_date="2026-03-27",
+            reporting_currency="SGD",
+        ),
+        PortfolioLiquidityPayloadLoaders(
+            query_aum_result=query_aum_result,
+            query_cash_balances_result=query_cash_balances_result,
+            get_cashflow_projection_result=get_cashflow_projection_result,
+            require_payload=require_payload,
+        ),
+    )
+
+    assert calls == {
+        "aum": {
+            "correlation_id": "corr-liquidity",
+            "portfolio_id": "PF_1001",
+            "as_of_date": "2026-03-27",
+            "reporting_currency": "SGD",
+        },
+        "cash_balances": {
+            "portfolio_id": "PF_1001",
+            "correlation_id": "corr-liquidity",
+            "as_of_date": "2026-03-27",
+            "reporting_currency": "SGD",
+        },
+        "cashflow": {
+            "portfolio_id": "PF_1001",
+            "correlation_id": "corr-liquidity",
+            "as_of_date": "2026-03-27",
+            "include_projected": True,
+            "horizon_days": 10,
+        },
+    }
+    assert payloads.aum_payload == {"portfolios": [{"portfolio_id": "PF_1001"}]}
+    assert payloads.cash_balances_payload == {"cash_accounts": []}
+    assert payloads.cashflow_result == (200, {"points": []})
+
+
+@pytest.mark.asyncio
+async def test_load_portfolio_liquidity_payloads_uses_source_specific_required_prefixes():
+    prefixes: list[str] = []
+
+    async def query_aum_result(**_kwargs):
+        return 503, {"detail": "aum unavailable"}
+
+    async def query_cash_balances_result(**_kwargs):
+        return 503, {"detail": "cash unavailable"}
+
+    async def get_cashflow_projection_result(**_kwargs):
+        return 200, {"points": []}
+
+    def require_payload(**kwargs):
+        prefixes.append(kwargs["unavailable_detail_prefix"])
+        return kwargs["result"][1]
+
+    await load_portfolio_liquidity_payloads(
+        PortfolioLiquidityLoadRequest(
+            portfolio_id="PF_1001",
+            correlation_id="corr-liquidity",
+            as_of_date=None,
+            reporting_currency=None,
+        ),
+        PortfolioLiquidityPayloadLoaders(
+            query_aum_result=query_aum_result,
+            query_cash_balances_result=query_cash_balances_result,
+            get_cashflow_projection_result=get_cashflow_projection_result,
+            require_payload=require_payload,
+        ),
+    )
+
+    assert prefixes == [
+        "lotus-core aum unavailable",
+        "lotus-core cash balances unavailable",
+    ]


### PR DESCRIPTION
## Summary
- Extract portfolio liquidity upstream payload loading into `portfolio_liquidity_payloads.py`.
- Preserve liquidity endpoint response behavior, required AUM/cash payload validation, projected cashflow partial-failure behavior, and upstream request parameter forwarding.
- Add focused tests for liquidity payload loader parameter forwarding and required-payload prefixes.
- Refresh quality evidence for the measured service-file reduction.

## Hotspot Evidence
- `portfolio_service.py`: 2,993 -> 2,968 measured lines.
- `_load_portfolio_liquidity_payloads` removed from the top function-hotspot list.
- Longest-function baseline remains 49 lines.
- `portfolio_service.py` remains the largest source-file hotspot.

## Validation
- `python -m pytest tests/unit/test_portfolio_liquidity_payloads.py tests/unit/test_portfolio_service.py -q`: 46 passed.
- `make check`: ruff, format, monetary-float guard, mypy over 447 source files, Workbench/OpenAPI contract smoke, and 996 unit/contract tests passed.
- `make ci`: 207 integration tests passed; 1,203 coverage tests passed; total coverage 93.69%; `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception.
- `C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway`: DiffCount 0.

## Governance
- Stranded truth check: no remote branches unmerged into `origin/main`.
- No API behavior, OpenAPI contract shape, wiki source, or upstream domain authority change.