### PR TITLE
Extract portfolio transaction request context

### DIFF
--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -75,7 +75,9 @@ from app.services.portfolio_position_book import (
 )
 from app.services.portfolio_transaction_ledger import (
     PortfolioTransactionsRequestContext,
+    build_portfolio_transactions_request_context,
     build_transaction_ledger_response,
+    portfolio_transactions_cache_key,
 )
 from app.services.portfolio_workspace_controls import build_workspace_control_capabilities
 from app.services.upstream_envelope import safe_upstream_detail
@@ -476,7 +478,7 @@ class PortfolioService:
         end_date: str | None,
         reporting_currency: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
-        context = self._portfolio_transactions_request_context(
+        context = build_portfolio_transactions_request_context(
             portfolio_id=portfolio_id,
             correlation_id=correlation_id,
             as_of_date=as_of_date,
@@ -500,87 +502,13 @@ class PortfolioService:
         )
         return await self._get_portfolio_transactions_result_for_context(context)
 
-    def _portfolio_transactions_request_context(
-        self,
-        *,
-        portfolio_id: str,
-        correlation_id: str,
-        as_of_date: str | None,
-        include_projected: bool,
-        skip: int,
-        limit: int,
-        transaction_type: str | None,
-        security_id: str | None,
-        instrument_id: str | None,
-        component_type: str | None,
-        linked_transaction_group_id: str | None,
-        fx_contract_id: str | None,
-        swap_event_id: str | None,
-        near_leg_group_id: str | None,
-        far_leg_group_id: str | None,
-        sort_by: str,
-        sort_order: str,
-        start_date: str | None,
-        end_date: str | None,
-        reporting_currency: str | None,
-    ) -> PortfolioTransactionsRequestContext:
-        return PortfolioTransactionsRequestContext(
-            portfolio_id=portfolio_id,
-            correlation_id=correlation_id,
-            as_of_date=as_of_date,
-            include_projected=include_projected,
-            skip=skip,
-            limit=limit,
-            transaction_type=transaction_type,
-            security_id=security_id,
-            instrument_id=instrument_id,
-            component_type=component_type,
-            linked_transaction_group_id=linked_transaction_group_id,
-            fx_contract_id=fx_contract_id,
-            swap_event_id=swap_event_id,
-            near_leg_group_id=near_leg_group_id,
-            far_leg_group_id=far_leg_group_id,
-            sort_by=sort_by,
-            sort_order=sort_order,
-            start_date=start_date,
-            end_date=end_date,
-            reporting_currency=reporting_currency,
-        )
-
     async def _get_portfolio_transactions_result_for_context(
         self,
         context: PortfolioTransactionsRequestContext,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get_cached_upstream_result(
-            self._portfolio_transactions_cache_key(context),
+            portfolio_transactions_cache_key(context),
             lambda: self._fetch_portfolio_transactions(context),
-        )
-
-    def _portfolio_transactions_cache_key(
-        self,
-        context: PortfolioTransactionsRequestContext,
-    ) -> tuple[object, ...]:
-        return (
-            "transactions",
-            context.portfolio_id,
-            context.as_of_date,
-            context.include_projected,
-            context.skip,
-            context.limit,
-            context.transaction_type,
-            context.security_id,
-            context.instrument_id,
-            context.component_type,
-            context.linked_transaction_group_id,
-            context.fx_contract_id,
-            context.swap_event_id,
-            context.near_leg_group_id,
-            context.far_leg_group_id,
-            context.sort_by,
-            context.sort_order,
-            context.start_date,
-            context.end_date,
-            context.reporting_currency,
         )
 
     async def _fetch_portfolio_transactions(
@@ -1645,7 +1573,7 @@ class PortfolioService:
         end_date: str | None = None,
         reporting_currency: str | None = None,
     ) -> PortfolioTransactionLedgerResponse:
-        context = self._portfolio_transactions_request_context(
+        context = build_portfolio_transactions_request_context(
             portfolio_id=portfolio_id,
             correlation_id=correlation_id,
             as_of_date=as_of_date,

--- a/src/app/services/portfolio_transaction_ledger.py
+++ b/src/app/services/portfolio_transaction_ledger.py
@@ -32,6 +32,80 @@ class PortfolioTransactionsRequestContext:
     reporting_currency: str | None
 
 
+def build_portfolio_transactions_request_context(
+    *,
+    portfolio_id: str,
+    correlation_id: str,
+    as_of_date: str | None,
+    include_projected: bool,
+    skip: int,
+    limit: int,
+    transaction_type: str | None,
+    security_id: str | None,
+    instrument_id: str | None,
+    component_type: str | None,
+    linked_transaction_group_id: str | None,
+    fx_contract_id: str | None,
+    swap_event_id: str | None,
+    near_leg_group_id: str | None,
+    far_leg_group_id: str | None,
+    sort_by: str,
+    sort_order: str,
+    start_date: str | None,
+    end_date: str | None,
+    reporting_currency: str | None,
+) -> PortfolioTransactionsRequestContext:
+    return PortfolioTransactionsRequestContext(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+        as_of_date=as_of_date,
+        include_projected=include_projected,
+        skip=skip,
+        limit=limit,
+        transaction_type=transaction_type,
+        security_id=security_id,
+        instrument_id=instrument_id,
+        component_type=component_type,
+        linked_transaction_group_id=linked_transaction_group_id,
+        fx_contract_id=fx_contract_id,
+        swap_event_id=swap_event_id,
+        near_leg_group_id=near_leg_group_id,
+        far_leg_group_id=far_leg_group_id,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        start_date=start_date,
+        end_date=end_date,
+        reporting_currency=reporting_currency,
+    )
+
+
+def portfolio_transactions_cache_key(
+    context: PortfolioTransactionsRequestContext,
+) -> tuple[object, ...]:
+    return (
+        "transactions",
+        context.portfolio_id,
+        context.as_of_date,
+        context.include_projected,
+        context.skip,
+        context.limit,
+        context.transaction_type,
+        context.security_id,
+        context.instrument_id,
+        context.component_type,
+        context.linked_transaction_group_id,
+        context.fx_contract_id,
+        context.swap_event_id,
+        context.near_leg_group_id,
+        context.far_leg_group_id,
+        context.sort_by,
+        context.sort_order,
+        context.start_date,
+        context.end_date,
+        context.reporting_currency,
+    )
+
+
 def build_transaction_ledger_response(
     *,
     context: PortfolioTransactionsRequestContext,

--- a/tests/unit/test_portfolio_transaction_ledger.py
+++ b/tests/unit/test_portfolio_transaction_ledger.py
@@ -1,7 +1,9 @@
 from app.services.portfolio_transaction_ledger import (
     PortfolioTransactionsRequestContext,
+    build_portfolio_transactions_request_context,
     build_transaction_ledger_response,
     parse_transaction_views,
+    portfolio_transactions_cache_key,
 )
 
 
@@ -51,6 +53,99 @@ def test_build_transaction_ledger_response_preserves_source_metadata():
     assert response.total == 30
     assert response.skip == 20
     assert response.limit == 10
+
+
+def test_build_portfolio_transactions_request_context_preserves_filters():
+    context = build_portfolio_transactions_request_context(
+        portfolio_id="PF_1001",
+        correlation_id="corr-ledger",
+        as_of_date="2026-03-27",
+        include_projected=False,
+        skip=10,
+        limit=50,
+        transaction_type="FX_FORWARD",
+        security_id="SEC_1",
+        instrument_id="INST_1",
+        component_type="FX_CONTRACT_OPEN",
+        linked_transaction_group_id="LTG-FX-2026-0001",
+        fx_contract_id="FXC-2026-0001",
+        swap_event_id="FXSWAP-2026-0001",
+        near_leg_group_id="FXSWAP-2026-0001-NEAR",
+        far_leg_group_id="FXSWAP-2026-0001-FAR",
+        sort_by="settlement_date",
+        sort_order="asc",
+        start_date="2026-01-01",
+        end_date="2026-03-31",
+        reporting_currency="CHF",
+    )
+
+    assert context.portfolio_id == "PF_1001"
+    assert context.correlation_id == "corr-ledger"
+    assert context.include_projected is False
+    assert context.skip == 10
+    assert context.limit == 50
+    assert context.transaction_type == "FX_FORWARD"
+    assert context.security_id == "SEC_1"
+    assert context.instrument_id == "INST_1"
+    assert context.component_type == "FX_CONTRACT_OPEN"
+    assert context.linked_transaction_group_id == "LTG-FX-2026-0001"
+    assert context.fx_contract_id == "FXC-2026-0001"
+    assert context.swap_event_id == "FXSWAP-2026-0001"
+    assert context.near_leg_group_id == "FXSWAP-2026-0001-NEAR"
+    assert context.far_leg_group_id == "FXSWAP-2026-0001-FAR"
+    assert context.sort_by == "settlement_date"
+    assert context.sort_order == "asc"
+    assert context.start_date == "2026-01-01"
+    assert context.end_date == "2026-03-31"
+    assert context.reporting_currency == "CHF"
+
+
+def test_portfolio_transactions_cache_key_includes_all_request_filters():
+    context = build_portfolio_transactions_request_context(
+        portfolio_id="PF_1001",
+        correlation_id="corr-ledger",
+        as_of_date="2026-03-27",
+        include_projected=True,
+        skip=20,
+        limit=25,
+        transaction_type="DIVIDEND",
+        security_id="SEC_1",
+        instrument_id="INST_1",
+        component_type="CASH_DIVIDEND",
+        linked_transaction_group_id="LTG-1",
+        fx_contract_id="FXC-1",
+        swap_event_id="SWAP-1",
+        near_leg_group_id="NEAR-1",
+        far_leg_group_id="FAR-1",
+        sort_by="transaction_date",
+        sort_order="desc",
+        start_date="2026-01-01",
+        end_date="2026-03-31",
+        reporting_currency="USD",
+    )
+
+    assert portfolio_transactions_cache_key(context) == (
+        "transactions",
+        "PF_1001",
+        "2026-03-27",
+        True,
+        20,
+        25,
+        "DIVIDEND",
+        "SEC_1",
+        "INST_1",
+        "CASH_DIVIDEND",
+        "LTG-1",
+        "FXC-1",
+        "SWAP-1",
+        "NEAR-1",
+        "FAR-1",
+        "transaction_date",
+        "desc",
+        "2026-01-01",
+        "2026-03-31",
+        "USD",
+    )
 
 
 def test_build_transaction_ledger_response_falls_back_to_context_metadata():


### PR DESCRIPTION
## Summary
- Move portfolio transaction request-context construction into `portfolio_transaction_ledger.py` next to the ledger context and response mapper.
- Move the deterministic transaction cache-key field ordering into the same ledger module.
- Keep `PortfolioService` responsible for upstream fetch orchestration only.

## Validation
- Focused: `python -m pytest tests\unit\test_portfolio_transaction_ledger.py tests\unit\test_portfolio_service.py -q` -> 50 passed
- `make check` -> ruff, format, monetary-float guard, mypy over 447 source files, Workbench contract smoke, 998 unit/contract tests passed
- `make ci` -> 207 integration tests passed; 1,205 coverage tests passed; total coverage 93.69%; `pip-audit` reported no known vulnerabilities with governed `PYSEC-2026-161` exception

## Quality Evidence
- `src/app/services/portfolio_service.py`: 2,968 -> 2,898 lines
- `src/app/services/portfolio_transaction_ledger.py`: 89 -> 163 lines
- Longest-function ceiling remains 49 lines
- `_portfolio_transactions_request_context` removed from hotspot list

## Governance
- Repo profile: Experience API
- Behavior change: none intended
- OpenAPI/API contract impact: none
- Docs/wiki impact: no durable operator or contract truth changed, so no wiki source update required
- Stranded truth: no unmerged remote branches before implementation