### PR TITLE
Extract performance workspace response assembly

### DIFF
--- a/src/app/services/performance_workspace_response.py
+++ b/src/app/services/performance_workspace_response.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Protocol, TypeAlias
+
+from app.contracts.performance_workspace import (
+    AttributionSummaryView,
+    ContributionSummaryView,
+    MoneyWeightedReturnSummary,
+    PerformanceBenchmarkOptionView,
+    PerformanceChartPoint,
+    PerformanceComparativeSummary,
+    PerformanceEvidenceView,
+    PerformanceWorkspaceCapabilities,
+    PerformanceWorkspaceResponse,
+)
+from app.contracts.workbench import WorkbenchOverviewResponse, WorkbenchPartialFailure
+from app.services.performance_workspace_summary import ParsedWorkspaceSummary
+
+UpstreamPayload: TypeAlias = dict[str, Any]
+UpstreamResult: TypeAlias = tuple[int, UpstreamPayload]
+GatheredResult: TypeAlias = UpstreamResult | BaseException
+
+
+class WorkspaceResponseContext(Protocol):
+    @property
+    def overview(self) -> WorkbenchOverviewResponse: ...
+
+    @property
+    def warnings(self) -> list[str]: ...
+
+    @property
+    def partial_failures(self) -> list[WorkbenchPartialFailure]: ...
+
+    @property
+    def report_end_date(self) -> str: ...
+
+    @property
+    def report_start_date(self) -> date: ...
+
+    @property
+    def effective_period(self) -> str: ...
+
+    @property
+    def chart_frequency(self) -> str: ...
+
+    @property
+    def contribution_dimension(self) -> str: ...
+
+    @property
+    def attribution_dimension(self) -> str: ...
+
+    @property
+    def detail_basis(self) -> str: ...
+
+    @property
+    def requested_chart_frequency_supported(self) -> bool: ...
+
+    @property
+    def requested_contribution_dimension_supported(self) -> bool: ...
+
+    @property
+    def requested_attribution_dimension_supported(self) -> bool: ...
+
+    @property
+    def segment(self) -> str: ...
+
+
+@dataclass(frozen=True)
+class WorkspaceSummaryViews:
+    workspace_summary_result: GatheredResult
+    parsed_summary: ParsedWorkspaceSummary
+    contribution: ContributionSummaryView | None
+    attribution: AttributionSummaryView | None
+    contribution_detail_result: GatheredResult | None
+    attribution_detail_result: GatheredResult | None
+
+    @property
+    def net_performance(self) -> PerformanceComparativeSummary:
+        return self.parsed_summary.net_performance
+
+    @property
+    def gross_performance(self) -> PerformanceComparativeSummary:
+        return self.parsed_summary.gross_performance
+
+    @property
+    def net_chart(self) -> list[PerformanceChartPoint]:
+        return self.parsed_summary.net_chart
+
+    @property
+    def gross_chart(self) -> list[PerformanceChartPoint]:
+        return self.parsed_summary.gross_chart
+
+    @property
+    def money_weighted_return(self) -> MoneyWeightedReturnSummary | None:
+        return self.parsed_summary.money_weighted_return
+
+    @property
+    def resolved_benchmark_code(self) -> str | None:
+        return self.parsed_summary.resolved_benchmark_code
+
+
+@dataclass(frozen=True)
+class WorkspaceResponseComponents:
+    benchmark_code: str | None
+    benchmark_options: list[PerformanceBenchmarkOptionView]
+    evidence_view: PerformanceEvidenceView | None
+    capabilities: PerformanceWorkspaceCapabilities
+
+
+@dataclass(frozen=True)
+class WorkspaceResponseContextFields:
+    contract_version: str
+    as_of_date: str
+    period: str
+    report_start_date: str
+    report_end_date: str
+    chart_frequency: str
+    contribution_dimension: str
+    attribution_dimension: str
+    detail_basis: str
+    requested_chart_frequency_supported: bool
+    requested_contribution_dimension_supported: bool
+    requested_attribution_dimension_supported: bool
+    segment: str
+
+
+def assemble_performance_workspace_response(
+    *,
+    portfolio_id: str,
+    correlation_id: str,
+    context: WorkspaceResponseContext,
+    summary_views: WorkspaceSummaryViews,
+    response_components: WorkspaceResponseComponents,
+) -> PerformanceWorkspaceResponse:
+    context_fields = workspace_response_context_fields(context)
+    return PerformanceWorkspaceResponse(
+        correlation_id=correlation_id,
+        contract_version=context_fields.contract_version,
+        portfolio_id=portfolio_id,
+        as_of_date=context_fields.as_of_date,
+        period=context_fields.period,
+        report_start_date=context_fields.report_start_date,
+        report_end_date=context_fields.report_end_date,
+        chart_frequency=context_fields.chart_frequency,
+        contribution_dimension=context_fields.contribution_dimension,
+        attribution_dimension=context_fields.attribution_dimension,
+        detail_basis=context_fields.detail_basis,
+        requested_chart_frequency_supported=context_fields.requested_chart_frequency_supported,
+        requested_contribution_dimension_supported=(
+            context_fields.requested_contribution_dimension_supported
+        ),
+        requested_attribution_dimension_supported=(
+            context_fields.requested_attribution_dimension_supported
+        ),
+        segment=context_fields.segment,
+        benchmark_code=response_components.benchmark_code,
+        benchmark_options=response_components.benchmark_options,
+        capabilities=response_components.capabilities,
+        evidence_view=response_components.evidence_view,
+        portfolio=context.overview.portfolio,
+        overview=context.overview.overview,
+        net_performance=summary_views.net_performance,
+        gross_performance=summary_views.gross_performance,
+        money_weighted_return=summary_views.money_weighted_return,
+        net_chart=summary_views.net_chart,
+        gross_chart=summary_views.gross_chart,
+        contribution=summary_views.contribution,
+        attribution=summary_views.attribution,
+        warnings=context.warnings,
+        partial_failures=context.partial_failures,
+    )
+
+
+def workspace_response_context_fields(
+    context: WorkspaceResponseContext,
+) -> WorkspaceResponseContextFields:
+    return WorkspaceResponseContextFields(
+        contract_version=context.overview.contract_version,
+        as_of_date=context.overview.as_of_date,
+        period=context.effective_period,
+        report_start_date=context.report_start_date.isoformat(),
+        report_end_date=context.report_end_date,
+        chart_frequency=context.chart_frequency,
+        contribution_dimension=context.contribution_dimension,
+        attribution_dimension=context.attribution_dimension,
+        detail_basis=context.detail_basis,
+        requested_chart_frequency_supported=context.requested_chart_frequency_supported,
+        requested_contribution_dimension_supported=(
+            context.requested_contribution_dimension_supported
+        ),
+        requested_attribution_dimension_supported=context.requested_attribution_dimension_supported,
+        segment=context.segment,
+    )

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -12,16 +12,11 @@ from app.config import settings
 from app.contracts.performance_workspace import (
     AttributionSummaryView,
     ContributionSummaryView,
-    MoneyWeightedReturnSummary,
     PerformanceAttributionTrendResponse,
-    PerformanceBenchmarkOptionView,
     PerformanceCalculationEvidenceView,
-    PerformanceChartPoint,
-    PerformanceComparativeSummary,
     PerformanceEvidenceView,
     PerformanceHorizonComparisonResponse,
     PerformanceSourceSupportabilityView,
-    PerformanceWorkspaceCapabilities,
     PerformanceWorkspaceDetailsResponse,
     PerformanceWorkspaceResponse,
     PerformanceWorkspaceSummaryResponse,
@@ -83,6 +78,12 @@ from app.services.performance_workspace_reference import (
     analytics_reference_cache_key,
     resolve_performance_report_end_date,
 )
+from app.services.performance_workspace_response import (
+    GatheredResult,
+    WorkspaceResponseComponents,
+    WorkspaceSummaryViews,
+    assemble_performance_workspace_response,
+)
 from app.services.performance_workspace_summary import (
     ParsedWorkspaceSummary,
     parse_workspace_summary_result,
@@ -97,7 +98,6 @@ LINEAGE_COMPLETION_POLL_INTERVAL_SECONDS = 0.25
 
 UpstreamPayload: TypeAlias = dict[str, Any]
 UpstreamResult: TypeAlias = tuple[int, UpstreamPayload]
-GatheredResult: TypeAlias = UpstreamResult | BaseException
 
 
 @dataclass(frozen=True)
@@ -208,65 +208,6 @@ class HorizonComparisonChartFrequencyContext:
 
 
 @dataclass(frozen=True)
-class WorkspaceSummaryViews:
-    workspace_summary_result: GatheredResult
-    parsed_summary: ParsedWorkspaceSummary
-    contribution: ContributionSummaryView | None
-    attribution: AttributionSummaryView | None
-    contribution_detail_result: GatheredResult | None
-    attribution_detail_result: GatheredResult | None
-
-    @property
-    def net_performance(self) -> PerformanceComparativeSummary:
-        return self.parsed_summary.net_performance
-
-    @property
-    def gross_performance(self) -> PerformanceComparativeSummary:
-        return self.parsed_summary.gross_performance
-
-    @property
-    def net_chart(self) -> list[PerformanceChartPoint]:
-        return self.parsed_summary.net_chart
-
-    @property
-    def gross_chart(self) -> list[PerformanceChartPoint]:
-        return self.parsed_summary.gross_chart
-
-    @property
-    def money_weighted_return(self) -> MoneyWeightedReturnSummary | None:
-        return self.parsed_summary.money_weighted_return
-
-    @property
-    def resolved_benchmark_code(self) -> str | None:
-        return self.parsed_summary.resolved_benchmark_code
-
-
-@dataclass(frozen=True)
-class WorkspaceResponseComponents:
-    benchmark_code: str | None
-    benchmark_options: list[PerformanceBenchmarkOptionView]
-    evidence_view: PerformanceEvidenceView | None
-    capabilities: PerformanceWorkspaceCapabilities
-
-
-@dataclass(frozen=True)
-class WorkspaceResponseContextFields:
-    contract_version: str
-    as_of_date: str
-    period: str
-    report_start_date: str
-    report_end_date: str
-    chart_frequency: str
-    contribution_dimension: str
-    attribution_dimension: str
-    detail_basis: str
-    requested_chart_frequency_supported: bool
-    requested_contribution_dimension_supported: bool
-    requested_attribution_dimension_supported: bool
-    segment: str
-
-
-@dataclass(frozen=True)
 class WorkspaceDetailViews:
     contribution: ContributionSummaryView | None
     attribution: AttributionSummaryView | None
@@ -308,30 +249,6 @@ class EvidenceViewFetchState:
             for item in self.evidence_items
             if item.execution_status == "complete" and item.lineage_status == "complete"
         )
-
-
-def _workspace_response_context_fields(
-    context: WorkspaceRequestContext,
-) -> WorkspaceResponseContextFields:
-    return WorkspaceResponseContextFields(
-        contract_version=context.overview.contract_version,
-        as_of_date=context.overview.as_of_date,
-        period=context.effective_period,
-        report_start_date=context.report_start_date.isoformat(),
-        report_end_date=context.report_end_date,
-        chart_frequency=context.chart_frequency,
-        contribution_dimension=context.contribution_dimension,
-        attribution_dimension=context.attribution_dimension,
-        detail_basis=context.detail_basis,
-        requested_chart_frequency_supported=context.requested_chart_frequency_supported,
-        requested_contribution_dimension_supported=(
-            context.requested_contribution_dimension_supported
-        ),
-        requested_attribution_dimension_supported=(
-            context.requested_attribution_dimension_supported
-        ),
-        segment=context.segment,
-    )
 
 
 def _build_evidence_requested_items(
@@ -1136,7 +1053,7 @@ class PerformanceWorkspaceService:
             include_detail_blocks=include_detail_blocks,
             prefer_independent_detail_analytics=prefer_independent_detail_analytics,
         )
-        return self._assemble_workspace_response(
+        return assemble_performance_workspace_response(
             portfolio_id=portfolio_id,
             correlation_id=correlation_id,
             context=context,
@@ -1633,55 +1550,6 @@ class PerformanceWorkspaceService:
                 summary_views.contribution_detail_result,
                 summary_views.attribution_detail_result,
             ],
-            warnings=context.warnings,
-            partial_failures=context.partial_failures,
-        )
-
-    def _assemble_workspace_response(
-        self,
-        *,
-        portfolio_id: str,
-        correlation_id: str,
-        context: WorkspaceRequestContext,
-        summary_views: WorkspaceSummaryViews,
-        response_components: WorkspaceResponseComponents,
-    ) -> PerformanceWorkspaceResponse:
-        context_fields = _workspace_response_context_fields(context)
-        return PerformanceWorkspaceResponse(
-            correlation_id=correlation_id,
-            contract_version=context_fields.contract_version,
-            portfolio_id=portfolio_id,
-            as_of_date=context_fields.as_of_date,
-            period=context_fields.period,
-            report_start_date=context_fields.report_start_date,
-            report_end_date=context_fields.report_end_date,
-            chart_frequency=context_fields.chart_frequency,
-            contribution_dimension=context_fields.contribution_dimension,
-            attribution_dimension=context_fields.attribution_dimension,
-            detail_basis=context_fields.detail_basis,
-            requested_chart_frequency_supported=(
-                context_fields.requested_chart_frequency_supported
-            ),
-            requested_contribution_dimension_supported=(
-                context_fields.requested_contribution_dimension_supported
-            ),
-            requested_attribution_dimension_supported=(
-                context_fields.requested_attribution_dimension_supported
-            ),
-            segment=context_fields.segment,
-            benchmark_code=response_components.benchmark_code,
-            benchmark_options=response_components.benchmark_options,
-            capabilities=response_components.capabilities,
-            evidence_view=response_components.evidence_view,
-            portfolio=context.overview.portfolio,
-            overview=context.overview.overview,
-            net_performance=summary_views.net_performance,
-            gross_performance=summary_views.gross_performance,
-            money_weighted_return=summary_views.money_weighted_return,
-            net_chart=summary_views.net_chart,
-            gross_chart=summary_views.gross_chart,
-            contribution=summary_views.contribution,
-            attribution=summary_views.attribution,
             warnings=context.warnings,
             partial_failures=context.partial_failures,
         )

--- a/tests/unit/test_performance_workspace_response.py
+++ b/tests/unit/test_performance_workspace_response.py
@@ -1,0 +1,177 @@
+from dataclasses import dataclass
+from datetime import date
+
+from app.contracts.performance_workspace import (
+    PerformanceBenchmarkOptionView,
+    PerformanceChartPoint,
+    PerformanceComparativeSummary,
+)
+from app.contracts.workbench import (
+    WorkbenchOverviewResponse,
+    WorkbenchOverviewSummary,
+    WorkbenchPartialFailure,
+    WorkbenchPortfolioSummary,
+)
+from app.services.performance_workspace_capabilities import build_workspace_capabilities
+from app.services.performance_workspace_response import (
+    WorkspaceResponseComponents,
+    WorkspaceSummaryViews,
+    assemble_performance_workspace_response,
+    workspace_response_context_fields,
+)
+from app.services.performance_workspace_summary import ParsedWorkspaceSummary
+
+
+@dataclass(frozen=True)
+class _WorkspaceContext:
+    overview: WorkbenchOverviewResponse
+    warnings: list[str]
+    partial_failures: list[WorkbenchPartialFailure]
+    report_end_date: str
+    report_start_date: date
+    effective_period: str
+    chart_frequency: str
+    contribution_dimension: str
+    attribution_dimension: str
+    detail_basis: str
+    requested_chart_frequency_supported: bool
+    requested_contribution_dimension_supported: bool
+    requested_attribution_dimension_supported: bool
+    segment: str
+
+
+def _context() -> _WorkspaceContext:
+    return _WorkspaceContext(
+        overview=WorkbenchOverviewResponse(
+            correlation_id="corr-workspace-source",
+            contract_version="v-test",
+            as_of_date="2026-03-27",
+            portfolio=WorkbenchPortfolioSummary(
+                portfolio_id="PF_1001",
+                client_id="CIF_1001",
+                base_currency="USD",
+                booking_center_code="SG",
+            ),
+            overview=WorkbenchOverviewSummary(
+                market_value_base=508_870.0,
+                cash_weight_pct=46.25,
+                position_count=3,
+            ),
+        ),
+        warnings=["FOUNDATION_WARNING"],
+        partial_failures=[
+            WorkbenchPartialFailure(
+                source_service="lotus-performance",
+                error_code="ATTRIBUTION_PARTIAL",
+                detail="Attribution detail is partially available.",
+            )
+        ],
+        report_end_date="2026-03-27",
+        report_start_date=date(2026, 1, 1),
+        effective_period="YTD",
+        chart_frequency="MONTHLY",
+        contribution_dimension="asset_class",
+        attribution_dimension="sector",
+        detail_basis="NET",
+        requested_chart_frequency_supported=False,
+        requested_contribution_dimension_supported=True,
+        requested_attribution_dimension_supported=False,
+        segment="2026-01-01:2026-03-27",
+    )
+
+
+def _summary_views() -> WorkspaceSummaryViews:
+    parsed_summary = ParsedWorkspaceSummary(
+        net_performance=PerformanceComparativeSummary(
+            metric_basis="NET",
+            portfolio_return_pct=5.12,
+            benchmark_return_pct=4.9,
+            active_return_pct=0.22,
+        ),
+        gross_performance=PerformanceComparativeSummary(
+            metric_basis="GROSS",
+            portfolio_return_pct=5.2,
+        ),
+        net_chart=[
+            PerformanceChartPoint(
+                label="2026-03",
+                frequency="MONTHLY",
+                portfolio_return_pct=1.2,
+            )
+        ],
+        gross_chart=[],
+        money_weighted_return=None,
+        contribution=None,
+        attribution=None,
+        resolved_benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+    )
+    return WorkspaceSummaryViews(
+        workspace_summary_result=(200, {"calculation_id": "calc-workspace-summary"}),
+        parsed_summary=parsed_summary,
+        contribution=None,
+        attribution=None,
+        contribution_detail_result=None,
+        attribution_detail_result=None,
+    )
+
+
+def test_workspace_response_context_fields_preserve_supported_flags() -> None:
+    fields = workspace_response_context_fields(_context())
+
+    assert fields.contract_version == "v-test"
+    assert fields.as_of_date == "2026-03-27"
+    assert fields.period == "YTD"
+    assert fields.report_start_date == "2026-01-01"
+    assert fields.report_end_date == "2026-03-27"
+    assert fields.requested_chart_frequency_supported is False
+    assert fields.requested_contribution_dimension_supported is True
+    assert fields.requested_attribution_dimension_supported is False
+    assert fields.segment == "2026-01-01:2026-03-27"
+
+
+def test_assemble_performance_workspace_response_preserves_context_and_components() -> None:
+    context = _context()
+    summary_views = _summary_views()
+    capabilities = build_workspace_capabilities(
+        benchmark_code=summary_views.resolved_benchmark_code,
+        net_performance=summary_views.net_performance,
+        net_chart=summary_views.net_chart,
+        contribution=summary_views.contribution,
+        attribution=summary_views.attribution,
+        evidence_view=None,
+    )
+
+    response = assemble_performance_workspace_response(
+        portfolio_id="PF_1001",
+        correlation_id="corr-performance-workspace",
+        context=context,
+        summary_views=summary_views,
+        response_components=WorkspaceResponseComponents(
+            benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+            benchmark_options=[
+                PerformanceBenchmarkOptionView(
+                    benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+                    benchmark_name="Global Balanced 60/40",
+                    is_assigned=True,
+                )
+            ],
+            evidence_view=None,
+            capabilities=capabilities,
+        ),
+    )
+
+    assert response.correlation_id == "corr-performance-workspace"
+    assert response.contract_version == "v-test"
+    assert response.portfolio_id == "PF_1001"
+    assert response.report_start_date == "2026-01-01"
+    assert response.requested_chart_frequency_supported is False
+    assert response.requested_attribution_dimension_supported is False
+    assert response.benchmark_code == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert response.benchmark_options[0].is_assigned is True
+    assert response.capabilities.benchmark_comparison.state == "supported"
+    assert response.portfolio.client_id == "CIF_1001"
+    assert response.overview.position_count == 3
+    assert response.net_performance.portfolio_return_pct == 5.12
+    assert response.net_chart[0].label == "2026-03"
+    assert response.warnings == ["FOUNDATION_WARNING"]
+    assert response.partial_failures[0].error_code == "ATTRIBUTION_PARTIAL"


### PR DESCRIPTION
## Summary
- Extract performance workspace response assembly into `performance_workspace_response.py`.
- Move response-specific summary/component dataclasses with the assembler so `PerformanceWorkspaceService` stays focused on orchestration and upstream dependency loading.
- Add focused mapper tests for context metadata, support flags, benchmark options, capability wiring, warnings, and partial failures.

## Validation
- Focused: `python -m pytest tests\unit\test_performance_workspace_response.py tests\unit\test_performance_workspace_service.py -q` -> 38 passed
- `make check` -> ruff, format, monetary-float guard, mypy over 448 source files, Workbench contract smoke, 1,000 unit/contract tests passed
- `make ci` -> 207 integration tests passed; 1,207 coverage tests passed; total coverage 93.70%; `pip-audit` reported no known vulnerabilities with governed `PYSEC-2026-161` exception

## Quality Evidence
- `src/app/services/performance_workspace_service.py`: 1,724 -> 1,607 lines
- New focused mapper module: `src/app/services/performance_workspace_response.py` at 161 lines
- `_assemble_workspace_response` removed from the top hotspot list
- Longest-function ceiling remains 49 lines

## Governance
- Repo profile: Experience API
- Behavior change: none intended
- OpenAPI/API contract impact: none
- Docs/wiki impact: no durable operator or contract truth changed, so no wiki source update required
- Stranded truth: no open PRs or unmerged remote branches before implementation