### PR TITLE
Extract portfolio workspace response assembly

### DIFF
--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -80,6 +80,11 @@ from app.services.portfolio_transaction_ledger import (
     portfolio_transactions_cache_key,
 )
 from app.services.portfolio_workspace_controls import build_workspace_control_capabilities
+from app.services.portfolio_workspace_response import (
+    PortfolioWorkspaceComponents,
+    PortfolioWorkspaceResponseParts,
+    assemble_portfolio_workspace_response,
+)
 from app.services.upstream_envelope import safe_upstream_detail
 from app.services.workspace_client_protocols import (
     PortfolioCoreClient,
@@ -134,28 +139,6 @@ class PortfolioAllocationResults:
     aum_result: UpstreamResult
     positions_result: UpstreamResult
     allocation_result: UpstreamResult
-
-
-@dataclass(frozen=True)
-class PortfolioWorkspaceComponents:
-    portfolio: PortfolioIdentity
-    profile: PortfolioProfile
-    summary: PortfolioSummary
-    cashflow_outlook: PortfolioCashflowOutlook | None
-    performance: PortfolioPerformanceSummary | None
-    rebalance: PortfolioRebalanceSummary | None
-    operations: PortfolioOperationalReadiness | None
-    warnings: list[str]
-    partial_failures: list[PortfolioPartialFailure]
-
-
-@dataclass(frozen=True)
-class PortfolioWorkspaceResponseParts:
-    reporting: PortfolioReportingReadiness
-    control_capabilities: PortfolioWorkspaceControlCapabilities
-    workflow_cues: list[PortfolioWorkflowLaunchCue]
-    warnings: list[str]
-    partial_failures: list[PortfolioPartialFailure]
 
 
 @dataclass(frozen=True)
@@ -801,10 +784,6 @@ class PortfolioService:
             analytics_results=analytics_results,
         )
 
-        portfolio = components.portfolio
-        profile = components.profile
-        summary = components.summary
-
         response_parts = self._build_portfolio_workspace_response_parts(
             portfolio_id=portfolio_id,
             components=components,
@@ -814,22 +793,12 @@ class PortfolioService:
             reporting_currency=reporting_currency,
         )
 
-        return PortfolioWorkspaceResponse(
+        return assemble_portfolio_workspace_response(
             correlation_id=correlation_id,
             contract_version=settings.contract_version,
             as_of_date=resolved_as_of_date,
-            portfolio=portfolio,
-            profile=profile,
-            summary=summary,
-            cashflow_outlook=components.cashflow_outlook,
-            performance=components.performance,
-            rebalance=components.rebalance,
-            reporting=response_parts.reporting,
-            operations=components.operations,
-            control_capabilities=response_parts.control_capabilities,
-            workflow_cues=response_parts.workflow_cues,
-            warnings=response_parts.warnings,
-            partial_failures=response_parts.partial_failures,
+            components=components,
+            response_parts=response_parts,
         )
 
     def _build_portfolio_workspace_response_parts(

--- a/src/app/services/portfolio_workspace_response.py
+++ b/src/app/services/portfolio_workspace_response.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.contracts.portfolio import (
+    PortfolioCashflowOutlook,
+    PortfolioIdentity,
+    PortfolioOperationalReadiness,
+    PortfolioPartialFailure,
+    PortfolioPerformanceSummary,
+    PortfolioProfile,
+    PortfolioRebalanceSummary,
+    PortfolioReportingReadiness,
+    PortfolioSummary,
+    PortfolioWorkflowLaunchCue,
+    PortfolioWorkspaceControlCapabilities,
+    PortfolioWorkspaceResponse,
+)
+
+
+@dataclass(frozen=True)
+class PortfolioWorkspaceComponents:
+    portfolio: PortfolioIdentity
+    profile: PortfolioProfile
+    summary: PortfolioSummary
+    cashflow_outlook: PortfolioCashflowOutlook | None
+    performance: PortfolioPerformanceSummary | None
+    rebalance: PortfolioRebalanceSummary | None
+    operations: PortfolioOperationalReadiness | None
+    warnings: list[str]
+    partial_failures: list[PortfolioPartialFailure]
+
+
+@dataclass(frozen=True)
+class PortfolioWorkspaceResponseParts:
+    reporting: PortfolioReportingReadiness
+    control_capabilities: PortfolioWorkspaceControlCapabilities
+    workflow_cues: list[PortfolioWorkflowLaunchCue]
+    warnings: list[str]
+    partial_failures: list[PortfolioPartialFailure]
+
+
+def assemble_portfolio_workspace_response(
+    *,
+    correlation_id: str,
+    contract_version: str,
+    as_of_date: str,
+    components: PortfolioWorkspaceComponents,
+    response_parts: PortfolioWorkspaceResponseParts,
+) -> PortfolioWorkspaceResponse:
+    return PortfolioWorkspaceResponse(
+        correlation_id=correlation_id,
+        contract_version=contract_version,
+        as_of_date=as_of_date,
+        portfolio=components.portfolio,
+        profile=components.profile,
+        summary=components.summary,
+        cashflow_outlook=components.cashflow_outlook,
+        performance=components.performance,
+        rebalance=components.rebalance,
+        reporting=response_parts.reporting,
+        operations=components.operations,
+        control_capabilities=response_parts.control_capabilities,
+        workflow_cues=response_parts.workflow_cues,
+        warnings=response_parts.warnings,
+        partial_failures=response_parts.partial_failures,
+    )

--- a/tests/unit/test_portfolio_workspace_response.py
+++ b/tests/unit/test_portfolio_workspace_response.py
@@ -1,0 +1,87 @@
+from app.contracts.portfolio import (
+    PortfolioIdentity,
+    PortfolioPartialFailure,
+    PortfolioProfile,
+    PortfolioReportingReadiness,
+    PortfolioSummary,
+    PortfolioWorkflowLaunchCue,
+)
+from app.services.portfolio_workspace_controls import build_workspace_control_capabilities
+from app.services.portfolio_workspace_response import (
+    PortfolioWorkspaceComponents,
+    PortfolioWorkspaceResponseParts,
+    assemble_portfolio_workspace_response,
+)
+
+
+def test_assemble_portfolio_workspace_response_preserves_contract_parts() -> None:
+    portfolio = PortfolioIdentity(
+        portfolio_id="PF_1001",
+        display_name="Global Balanced",
+        client_id="CIF_1",
+        base_currency="USD",
+        booking_center_code="SGPB",
+    )
+    profile = PortfolioProfile(status="ACTIVE", portfolio_type="ADVISORY")
+    summary = PortfolioSummary(
+        assets_under_management_base=1_000_000.0,
+        invested_market_value_base=900_000.0,
+        cash_market_value_base=100_000.0,
+        cash_weight_pct=10.0,
+        position_count=12,
+        cash_balance_count=2,
+    )
+    partial_failure = PortfolioPartialFailure(
+        source_service="lotus-core",
+        error_code="PORTFOLIO_CASHFLOW_UNAVAILABLE",
+        detail="cashflow temporarily unavailable",
+    )
+    components = PortfolioWorkspaceComponents(
+        portfolio=portfolio,
+        profile=profile,
+        summary=summary,
+        cashflow_outlook=None,
+        performance=None,
+        rebalance=None,
+        operations=None,
+        warnings=["PORTFOLIO_CASHFLOW_UNAVAILABLE"],
+        partial_failures=[partial_failure],
+    )
+    workflow_cue = PortfolioWorkflowLaunchCue(
+        key="performance",
+        label="Performance",
+        href="/performance?portfolioId=PF_1001",
+    )
+    response_parts = PortfolioWorkspaceResponseParts(
+        reporting=PortfolioReportingReadiness(status="READY", row_count=3),
+        control_capabilities=build_workspace_control_capabilities(
+            portfolio=portfolio,
+            profile=profile,
+            requested_as_of_date="2026-03-27",
+            effective_as_of_date="2026-03-27",
+            requested_reporting_currency="SGD",
+        ),
+        workflow_cues=[workflow_cue],
+        warnings=components.warnings,
+        partial_failures=components.partial_failures,
+    )
+
+    response = assemble_portfolio_workspace_response(
+        correlation_id="corr-portfolio-workspace",
+        contract_version="v-test",
+        as_of_date="2026-03-27",
+        components=components,
+        response_parts=response_parts,
+    )
+
+    assert response.correlation_id == "corr-portfolio-workspace"
+    assert response.contract_version == "v-test"
+    assert response.as_of_date == "2026-03-27"
+    assert response.portfolio == portfolio
+    assert response.profile == profile
+    assert response.summary == summary
+    assert response.reporting == response_parts.reporting
+    assert response.control_capabilities == response_parts.control_capabilities
+    assert response.workflow_cues == [workflow_cue]
+    assert response.warnings == ["PORTFOLIO_CASHFLOW_UNAVAILABLE"]
+    assert response.partial_failures == [partial_failure]


### PR DESCRIPTION
## Summary
- Extract portfolio workspace response component/parts models and pure response assembly into `portfolio_workspace_response.py`.
- Keep `PortfolioService` responsible for upstream loading/parsing while delegating final workspace contract construction.
- Add focused unit coverage for the extracted assembly contract.

## Quality evidence
- Focused: `python -m pytest tests/unit/test_portfolio_workspace_response.py tests/unit/test_portfolio_workspace_controls.py` - 5 passed.
- Touched-file lint: `python -m ruff check src/app/services/portfolio_service.py src/app/services/portfolio_workspace_response.py tests/unit/test_portfolio_workspace_response.py` - passed.
- Feature Lane: `make check` - passed; Ruff, format, monetary-float guard, mypy over 449 source files, workbench contract smoke, 1001 unit/contract tests.
- PR Merge Gate local: `make ci` - passed; 207 integration tests, 1208 coverage tests, total coverage 93.70%, `pip-audit` no known vulnerabilities with governed `PYSEC-2026-161` exception.

## Hotspot impact
- `src/app/services/portfolio_service.py`: 2,898 -> 2,872 lines.
- Longest-function baseline unchanged at 49 lines; this slice improves module boundary and testability rather than function length.
- New extracted module `src/app/services/portfolio_workspace_response.py` is 100% covered in the local coverage run.

## Governance
- Behavior-preserving internal refactor; no API, OpenAPI, runtime, migration, or durable documentation truth changed.
- No wiki source update required.
- Stranded truth baseline: no unmerged remote branches before implementation.