### PR TITLE
Refresh refactor quality evidence

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -35,8 +35,8 @@ report-only baseline is reviewed.
 
 The largest current modularity risks are:
 
-1. `src/app/services/portfolio_service.py` at 2,993 lines,
-2. `src/app/services/performance_workspace_service.py` at 1,724 lines,
+1. `src/app/services/portfolio_service.py` at 2,872 lines,
+2. `src/app/services/performance_workspace_service.py` at 1,607 lines,
 3. `src/app/services/advisor_brief_service.py` at 1,452 lines,
 4. `src/app/services/dpm_command_center_service.py` at 1,137 lines,
 5. `src/app/services/dpm_wave_service.py` at 1,001 lines.
@@ -103,7 +103,7 @@ been extracted to
 delegation over readiness status. Performance workspace capability-input derivation has been
 split into `PerformanceCapabilityInputs`, `build_performance_capability_inputs`, and
 `resolve_history_date_range`, reducing `build_workspace_capabilities` from 127 lines to 99 lines
-while keeping capability payload assembly in the original module. The current branch also splits
+while keeping capability payload assembly in the original module. Later merged slices also split
 portfolio workspace source/analytics assembly, portfolio insight-rule helpers, performance
 workspace summary/detail and horizon contexts, foundation workspace assembly, risk rolling and
 attribution orchestration, shell workspace descriptor specs, transaction query contracts, DPM
@@ -141,9 +141,12 @@ helpers. Risk rolling response mapping now delegates supportability enrichment a
 assembly to focused helpers. Risk drawdown routing now keeps OpenAPI query metadata in named
 descriptors separate from the public query dependency. Portfolio position-book mapping now lives in
 `src/app/services/portfolio_position_book.py`, and transaction-ledger request context plus row
-mapping now live in `src/app/services/portfolio_transaction_ledger.py`. `portfolio_service.py` is
-down to 2,968 lines. Portfolio liquidity upstream payload loading now lives in
-`src/app/services/portfolio_liquidity_payloads.py`. Lotus Core transaction query-parameter
+mapping now live in `src/app/services/portfolio_transaction_ledger.py`. Portfolio liquidity
+upstream payload loading now lives in `src/app/services/portfolio_liquidity_payloads.py`.
+Transaction request-context handling and final portfolio workspace response assembly have lowered
+`portfolio_service.py` to 2,872 lines. Performance workspace final response assembly now lives in
+`src/app/services/performance_workspace_response.py`, lowering
+`performance_workspace_service.py` to 1,607 lines. Lotus Core transaction query-parameter
 construction now lives in
 `src/app/clients/lotus_core_transaction_params.py`, reducing `lotus_core_query_client.py` to 574
 measured lines and removing `_portfolio_transaction_query_params` from the current top hotspot

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -130,6 +130,16 @@ The current portfolio liquidity payload slice extracts concurrent AUM, cash-bala
 cashflow upstream loading into `portfolio_liquidity_payloads.py`. This preserves liquidity endpoint
 behavior while reducing `portfolio_service.py` from 2,993 to 2,968 measured lines and removing
 `_load_portfolio_liquidity_payloads` from the top function-hotspot list.
+The current merged transaction request-context slice separates transaction request context and
+cache-key construction from public ledger orchestration, reducing `portfolio_service.py` from
+2,968 to 2,898 measured lines while preserving upstream transaction filter and cache behavior.
+The current merged performance workspace response slice extracts summary-view and response-part
+assembly into `performance_workspace_response.py`, reducing `performance_workspace_service.py`
+from 1,724 to 1,607 measured lines while preserving the response contract.
+The current merged portfolio workspace response slice extracts response component/parts models and
+pure final response assembly into `portfolio_workspace_response.py`, reducing
+`portfolio_service.py` from 2,898 to 2,872 measured lines while preserving the 49-line
+longest-function baseline.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -137,25 +147,25 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 |
-| Python source files under `src/app` | 447 |
-| Python test files under `tests` | 162 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,297 |
+| Python source files under `src/app` | 449 |
+| Python test files under `tests` | 164 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current portfolio liquidity payload slice shows 1,265 files under
-`src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 447 Python source files under `src/app`;
-and 162 Python test files under `tests`.
+Working-tree verification for merged `main` after PR #351 shows 1,297 files under `src`, `tests`,
+`docs`, `wiki`, `.github`, and `scripts`; 449 Python source files under `src/app`; and 164 Python
+test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 2,968 | `src/app/services/portfolio_service.py` |
+| 1 | 2,872 | `src/app/services/portfolio_service.py` |
 | 2 | 2,123 | `src/app/contracts/portfolio.py` |
 | 3 | 1,940 | `src/app/contracts/risk_workspace.py` |
 | 4 | 1,731 | `src/app/contracts/reporting.py` |
-| 5 | 1,724 | `src/app/services/performance_workspace_service.py` |
+| 5 | 1,607 | `src/app/services/performance_workspace_service.py` |
 | 6 | 1,539 | `src/app/contracts/performance_workspace.py` |
 | 7 | 1,452 | `src/app/services/advisor_brief_service.py` |
 | 8 | 1,258 | `src/app/clients/dpm_client.py` |
@@ -168,14 +178,14 @@ and 162 Python test files under `tests`.
 | ---: | ---: | --- | --- |
 | 1 | 49 | `get_transaction_ledger` | `src/app/services/portfolio_service.py` |
 | 2 | 49 | `get_portfolio_transactions` | `src/app/clients/lotus_core_query_client.py` |
-| 3 | 48 | `_assemble_workspace_response` | `src/app/services/performance_workspace_service.py` |
-| 4 | 47 | `_get_portfolio_transactions_result` | `src/app/services/portfolio_service.py` |
-| 5 | 47 | `_build_workspace_descriptor_contract` | `src/app/services/platform_capabilities_shell.py` |
-| 6 | 47 | `_build_performance_workspace_response` | `src/app/services/performance_workspace_service.py` |
-| 7 | 46 | `get_portfolio_360` | `src/app/services/workbench_service.py` |
-| 8 | 46 | `_unpack_rebalance_supportability_summary` | `src/app/services/workbench_rebalance_snapshot.py` |
-| 9 | 46 | `_performance_payload_from_result` | `src/app/services/workbench_performance_snapshot.py` |
-| 10 | 46 | `_portfolio_transactions_request_context` | `src/app/services/portfolio_service.py` |
+| 3 | 47 | `_get_portfolio_transactions_result` | `src/app/services/portfolio_service.py` |
+| 4 | 47 | `_build_workspace_descriptor_contract` | `src/app/services/platform_capabilities_shell.py` |
+| 5 | 47 | `_build_performance_workspace_response` | `src/app/services/performance_workspace_service.py` |
+| 6 | 46 | `get_portfolio_360` | `src/app/services/workbench_service.py` |
+| 7 | 46 | `_unpack_rebalance_supportability_summary` | `src/app/services/workbench_rebalance_snapshot.py` |
+| 8 | 46 | `_performance_payload_from_result` | `src/app/services/workbench_performance_snapshot.py` |
+| 9 | 46 | `_assemble_portfolio_workspace_components` | `src/app/services/portfolio_service.py` |
+| 10 | 46 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
 
 ## Existing Blocking Gates
 
@@ -194,8 +204,9 @@ Current repo-native gates already cover:
 
 Most recent local evidence:
 
-1. Current branch: `make check` passed with ruff, format check, monetary-float guard, mypy over
-   447 source files, Workbench/OpenAPI contract smoke, and 996 unit/contract tests.
+1. Latest merged response-assembly slice: `make check` passed with ruff, format check,
+   monetary-float guard, mypy over 449 source files, Workbench/OpenAPI contract smoke, and 1,001
+   unit/contract tests.
 2. Current focused branch: `tests/unit/test_http_resilience.py` passed with 15 tests after JSON
    retry attempt extraction.
 3. Current focused branch: DPM proof-pack service tests passed with 8 tests after PM memo workflow
@@ -242,15 +253,20 @@ Most recent local evidence:
 34. Current focused branch: Workbench analytics tests passed with 7 selected tests.
 35. Current focused branch: Workbench rebalance tests passed with 3 selected tests.
 36. Current focused branch: portfolio readiness tests passed with 4 selected tests.
-37. Current branch PR-grade evidence: `make ci` passed with 207 integration tests.
-38. Current branch PR-grade evidence: `make ci` passed with 1,203 unit, contract, and integration
+37. PR #351 PR-grade evidence: `make ci` passed with 207 integration tests.
+38. PR #351 PR-grade evidence: `make ci` passed with 1,208 unit, contract, and integration
     coverage tests.
-39. Coverage: 93.69%, above the 84% floor.
+39. Coverage: 93.70%, above the 84% floor.
 40. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
 41. Current closure slice: `tests/unit/test_portfolio_position_book.py` plus focused portfolio
     service position/allocation tests passed with 9 selected tests after mapper extraction.
 42. Current transaction-ledger slice: `tests/unit/test_portfolio_transaction_ledger.py` plus
     `tests/unit/test_portfolio_service.py` passed with 48 selected tests after mapper extraction.
+43. Current performance workspace response slice: `tests/unit/test_performance_workspace_response.py`
+    passed with direct response assembly coverage.
+44. Current portfolio workspace response slice:
+    `tests/unit/test_portfolio_workspace_response.py tests/unit/test_portfolio_workspace_controls.py`
+    passed with 5 selected tests after response assembly extraction.
 
 ## Tooling Availability Baseline
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,36 +1,39 @@
 # Quality Scorecard
 
 Date: 2026-06-12
-Mode: PR-readiness evidence update
+Mode: merged-main evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | `make check` passed with lint, format, monetary-float guard, mypy, contract smoke, and 996 unit/contract tests; `make ci` passed with 207 integration tests, 1,203 coverage tests, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
-| Coverage | 4/5 | 93.69% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current slice preserves the 49-line longest-function baseline and extracts portfolio liquidity upstream payload loading into a reusable helper; `portfolio_service.py` drops from 2,993 to 2,968 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Build and test reliability | 5/5 | Latest merged hardening evidence includes `make check` with ruff, format, monetary-float guard, mypy over 449 source files, contract smoke, and 1,001 unit/contract tests; `make ci` passed with 207 integration tests, 1,208 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Coverage | 4/5 | 93.70% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
+| Modularity | 4/5 | Current merged state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, performance workspace response assembly, and portfolio workspace response assembly; `portfolio_service.py` is now 2,872 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
-| Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions | Normalize route/upstream errors |
-| Observability | 3/5 | Health/readiness/metrics/correlation/audit present; analytics async polling now separates per-attempt fanout logging from loop orchestration and preserves absolute result URLs under test | Enforce structured log and metric label rules |
-| Security | 4/5 | `pip-audit` passed in `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Quality scorecard and health evidence updated with current portfolio liquidity payload-loader metrics; no repo-local wiki source changes required for this code-focused extraction | Keep wiki synced and add diagrams over time |
-| Operations readiness | 3/5 | Existing CI/runbook docs; operational runbook now consolidated | Add incident playbooks and SLO checks |
+| Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
+| Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
+| Security | 4/5 | `pip-audit` passed in latest `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current merged metrics through PR #351 | Keep wiki synced and add diagrams over time |
+| Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
-Comparison point: `origin/main` at `8bed73e` versus the current portfolio liquidity payload-loader
-branch before merge.
+Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
+versus merged `main` after PRs #349, #350, and #351.
 
-| Measure | Before | After | Result |
+| Measure | Prior scorecard | Current merged `main` | Result |
 | --- | ---: | ---: | --- |
-| Branch commits over `origin/main` | 0 | 1 planned | Narrow closure branch ready for PR review |
-| Tracked `src/app` Python files | 446 | 447 | Added reusable portfolio liquidity payload loader |
-| Tracked test files | 161 | 162 | Added focused liquidity payload loader tests |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,297 | Added focused modules, tests, and quality evidence |
+| Tracked `src/app` Python files | 447 | 449 | Added focused portfolio/performance response helpers |
+| Tracked Python test files | 162 | 164 | Added focused request-context and response-assembly tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,993 lines | 2,968 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
+| Largest source file | 2,968 lines | 2,872 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
+| `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 994 | 996 | Added focused portfolio liquidity payload loader tests |
+| Local unit/contract tests | 996 | 1,001 | Added focused response/request boundary tests |
+| Local coverage tests | 1,203 | 1,208 | Added focused coverage while preserving total coverage |
+| Total coverage | 93.69% | 93.70% | Improved slightly |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
 ## Phase Gates
@@ -54,8 +57,8 @@ Candidate thresholds:
 2. no new forbidden imports,
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
-5. no new function above the current branch maximum of 49 lines and no unclassified largest-file
-   growth above the current 2,968-line `portfolio_service.py` maximum.
+5. no new function above the current merged maximum of 49 lines and no unclassified largest-file
+   growth above the current 2,872-line `portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -54,7 +54,7 @@ extracted to `portfolio_exception_summaries.py`, reducing `portfolio_service.py`
 to 2,744 lines and reducing `_build_portfolio_exception_summaries` from 133 lines to a short
 readiness delegation. Performance workspace capability-input derivation has now been split into
 explicit capability input and history-date helpers, reducing `build_workspace_capabilities` from
-127 lines to 99 lines. The current branch has further split portfolio workspace source/analytics
+127 lines to 99 lines. A later hardening batch further split portfolio workspace source/analytics
 assembly, portfolio insight rules, performance workspace summary/detail and horizon contexts,
 foundation workspace assembly, risk rolling and attribution orchestration, shell workspace
 descriptor specs, transaction query contracts, DPM exception-summary workflow orchestration,
@@ -213,17 +213,27 @@ cashflow loading into `portfolio_liquidity_payloads.py`. It reduces `portfolio_s
 2,993 to 2,968 measured lines, removes `_load_portfolio_liquidity_payloads` from the top
 function-hotspot list, and preserves liquidity request parameter forwarding plus required upstream
 payload validation behavior.
+The current merged transaction request-context slice separates transaction request construction
+and cache-key responsibility from the public ledger method, reducing `portfolio_service.py` from
+2,968 to 2,898 lines while preserving upstream filter, cache, and ledger response behavior.
+The current merged performance workspace response slice extracts summary-view and response-part
+assembly into `performance_workspace_response.py`, reducing `performance_workspace_service.py`
+from 1,724 to 1,607 lines and making response contract construction directly unit-testable.
+The current merged portfolio workspace response slice extracts response component/parts models and
+pure `PortfolioWorkspaceResponse` construction into `portfolio_workspace_response.py`, reducing
+`portfolio_service.py` from 2,898 to 2,872 lines while preserving the 49-line longest-function
+baseline.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | active focused portfolio liquidity payload-loader branch over `origin/main` `8bed73e`; intended to merge and delete before handoff |
-| Unit/contract coverage | Healthy | 996 unit/contract tests passed in current-branch `make check`; focused liquidity payload and portfolio service tests passed with 46 tests |
-| Integration coverage | Healthy | 207 integration tests passed in current-branch `make ci` |
-| Total coverage | Healthy | 1,203 coverage tests passed in current-branch `make ci`; total coverage is 93.69%, above the 84% floor |
+| Branch hygiene | Healthy | merged `main` at `52b89ab`; remote server truth showed only `main` after PR #351 cleanup |
+| Unit/contract coverage | Healthy | 1,001 unit/contract tests passed in PR #351 `make check`; focused portfolio workspace response/control tests passed with 5 tests |
+| Integration coverage | Healthy | 207 integration tests passed in PR #351 `make ci` |
+| Total coverage | Healthy | 1,208 coverage tests passed in PR #351 `make ci`; total coverage is 93.70%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; portfolio liquidity upstream loading is extracted and `portfolio_service.py` is reduced to 2,968 measured lines; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context slices reduce `portfolio_service.py` to 2,872 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -58,7 +58,7 @@ repository longest-function baseline from 133 lines to 127 lines and reduced
 `portfolio_service.py` from 2,839 lines to 2,744 lines while preserving focused portfolio insight
 and router contract tests. The performance workspace capability-input extraction then lowered the
 repository longest-function baseline from 127 lines to 119 lines while adding focused capability
-input, history-date, and aggregate-only fallback tests. The current branch batch further lowered
+input, history-date, and aggregate-only fallback tests. That branch batch further lowered
 the repository longest-function baseline from 119 lines to 99 lines, reduced
 `portfolio_service.py` from 2,744 lines to 2,700 lines, added focused portfolio insight-rule tests,
 and passed `make check` with 967 unit/contract tests. The latest focused batch split DPM
@@ -86,11 +86,12 @@ and rebalance supportability failure-recording splits then lowered the baseline 
 74 lines. The 50-commit enterprise-hardening branch then split shared analytics async polling,
 workspace-summary payload assembly, portfolio transaction-summary context loading, transaction
 page loading, and portfolio book response assembly, lowering the baseline to 62 lines.
-`portfolio_service.py` is now measured at 3,155 lines after explicit typed workspace component,
-transaction-summary, transaction-page, and book assembly helpers, so it remains the largest-file
-hotspot. Local `make check` remains green with 967 unit/contract tests on commit `6836e69`, and
-local `make ci` passes on commit `e1e7980` with 207 integration tests, 1,174 coverage tests,
-93.32 percent total coverage, and `pip-audit` reporting no known vulnerabilities after the
-governed FastAPI/Starlette exception. The latest focused slices have local router/service/contract,
-boundary, lint, format, mypy, and monetary-float evidence. GitHub Feature Lane and Quality
-Baseline runs remain the authoritative remote evidence and must be rechecked before PR readiness.
+`portfolio_service.py` is now measured at 2,872 lines after portfolio liquidity loading,
+transaction request-context, and portfolio workspace response assembly extractions, so it remains
+the largest-file hotspot but is trending down. `performance_workspace_service.py` is now measured
+at 1,607 lines after response assembly extraction. The current merged longest-function baseline is
+49 lines. Local `make check` for PR #351 passed with 1,001 unit/contract tests, and local
+`make ci` passed with 207 integration tests, 1,208 coverage tests, 93.70 percent total coverage,
+and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette exception.
+GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were
+green before PR #351 merged.


### PR DESCRIPTION
## Summary
- Refresh refactor quality evidence to current merged `main` after PRs #349-#351.
- Update baseline report, scorecard, health report, architecture rules, and wiki validation evidence with current file/function/test/coverage metrics.
- Keep the next-hardening backlog focused on measured hotspots and governance gaps.

## Quality evidence
- Focused docs/wiki tests: `python -m pytest tests/unit/test_gateway_wiki_overview.py tests/unit/test_enterprise_readiness.py` - 18 passed.
- Feature Lane local: `make check` - passed; ruff, format, monetary-float guard, mypy over 449 source files, workbench contract smoke, 1,001 unit/contract tests.
- PR Merge Gate local: `make ci` - passed; 207 integration tests, 1,208 coverage tests, total coverage 93.70%, `pip-audit` no known vulnerabilities with governed `PYSEC-2026-161` exception.

## Updated measurements
- Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts`: 1,297.
- Python source files under `src/app`: 449.
- Python test files under `tests`: 164.
- Largest source file: `src/app/services/portfolio_service.py` at 2,872 lines.
- Current longest-function baseline: 49 lines.
- `src/app/services/performance_workspace_service.py`: 1,607 lines.

## Governance
- Documentation/wiki-source change only; no runtime, API, OpenAPI, contract, migration, or behavior change.
- Stranded truth baseline: no unmerged remote branches before implementation.
- Wiki check before merge reports expected source/published drift for `Validation-and-CI.md`; publish after merge and re-check to return `DiffCount 0`.