### PR TITLE
Extract transaction client kwargs mapping

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -35,7 +35,7 @@ report-only baseline is reviewed.
 
 The largest current modularity risks are:
 
-1. `src/app/services/portfolio_service.py` at 2,872 lines,
+1. `src/app/services/portfolio_service.py` at 2,854 lines,
 2. `src/app/services/performance_workspace_service.py` at 1,607 lines,
 3. `src/app/services/advisor_brief_service.py` at 1,452 lines,
 4. `src/app/services/dpm_command_center_service.py` at 1,137 lines,
@@ -143,8 +143,9 @@ descriptors separate from the public query dependency. Portfolio position-book m
 `src/app/services/portfolio_position_book.py`, and transaction-ledger request context plus row
 mapping now live in `src/app/services/portfolio_transaction_ledger.py`. Portfolio liquidity
 upstream payload loading now lives in `src/app/services/portfolio_liquidity_payloads.py`.
-Transaction request-context handling and final portfolio workspace response assembly have lowered
-`portfolio_service.py` to 2,872 lines. Performance workspace final response assembly now lives in
+Transaction request-context handling, transaction client-kwargs mapping, and final portfolio
+workspace response assembly have lowered `portfolio_service.py` to 2,854 lines. Performance
+workspace final response assembly now lives in
 `src/app/services/performance_workspace_response.py`, lowering
 `performance_workspace_service.py` to 1,607 lines. Lotus Core transaction query-parameter
 construction now lives in

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -271,6 +271,12 @@ Most recent local evidence:
 44. Current portfolio workspace response slice:
     `tests/unit/test_portfolio_workspace_response.py tests/unit/test_portfolio_workspace_controls.py`
     passed with 5 selected tests after response assembly extraction.
+45. Current transaction client-kwargs branch: `make check` passed with ruff, format check,
+    monetary-float guard, mypy over 449 source files, Workbench/OpenAPI contract smoke, and 1,002
+    unit/contract tests.
+46. Current transaction client-kwargs branch: `make ci` passed with 207 integration tests and
+    1,209 combined coverage tests; total coverage remained 93.70%, and `pip-audit` found no known
+    vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -140,6 +140,9 @@ The current merged portfolio workspace response slice extracts response componen
 pure final response assembly into `portfolio_workspace_response.py`, reducing
 `portfolio_service.py` from 2,898 to 2,872 measured lines while preserving the 49-line
 longest-function baseline.
+The current transaction client-kwargs slice moves upstream argument projection into
+`portfolio_transaction_ledger.py`, reducing `portfolio_service.py` from 2,872 to 2,854 measured
+lines while preserving the 49-line longest-function baseline.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -153,15 +156,15 @@ yet enforced unless they are already covered by existing repo-native gates.
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for merged `main` after PR #351 shows 1,297 files under `src`, `tests`,
-`docs`, `wiki`, `.github`, and `scripts`; 449 Python source files under `src/app`; and 164 Python
-test files under `tests`.
+Working-tree verification for the current transaction client-kwargs branch shows 1,297 files under
+`src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 449 Python source files under `src/app`;
+and 164 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 2,872 | `src/app/services/portfolio_service.py` |
+| 1 | 2,854 | `src/app/services/portfolio_service.py` |
 | 2 | 2,123 | `src/app/contracts/portfolio.py` |
 | 3 | 1,940 | `src/app/contracts/risk_workspace.py` |
 | 4 | 1,731 | `src/app/contracts/reporting.py` |
@@ -229,7 +232,8 @@ Most recent local evidence:
     after policy state extraction.
 12. Current focused branch: performance workspace evidence-view tests passed with 3 selected tests
     after response-resolution extraction.
-13. Current focused branch: portfolio transaction-ledger tests passed with 4 selected tests.
+13. Current focused branch: portfolio transaction-ledger tests passed with 7 tests after
+    transaction client-kwargs mapping extraction.
 14. Current focused branch: portfolio workspace tests passed with 7 selected tests.
 15. Current focused branch: Lotus Core transaction client tests passed with 2 selected tests.
 16. Current focused branch: foundation optional-upstream tests passed with 4 selected tests.
@@ -253,8 +257,8 @@ Most recent local evidence:
 34. Current focused branch: Workbench analytics tests passed with 7 selected tests.
 35. Current focused branch: Workbench rebalance tests passed with 3 selected tests.
 36. Current focused branch: portfolio readiness tests passed with 4 selected tests.
-37. PR #351 PR-grade evidence: `make ci` passed with 207 integration tests.
-38. PR #351 PR-grade evidence: `make ci` passed with 1,208 unit, contract, and integration
+37. PR #352 PR-grade evidence: `make ci` passed with 207 integration tests.
+38. PR #352 PR-grade evidence: `make ci` passed with 1,208 unit, contract, and integration
     coverage tests.
 39. Coverage: 93.70%, above the 84% floor.
 40. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,34 +1,34 @@
 # Quality Scorecard
 
 Date: 2026-06-12
-Mode: merged-main evidence refresh
+Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
 | Build and test reliability | 5/5 | Latest merged hardening evidence includes `make check` with ruff, format, monetary-float guard, mypy over 449 source files, contract smoke, and 1,001 unit/contract tests; `make ci` passed with 207 integration tests, 1,208 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 93.70% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current merged state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, performance workspace response assembly, and portfolio workspace response assembly; `portfolio_service.py` is now 2,872 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction client-kwargs mapping, performance workspace response assembly, and portfolio workspace response assembly; `portfolio_service.py` is now 2,854 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in latest `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current merged metrics through PR #351 | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after PR #352 | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
 Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
-versus merged `main` after PRs #349, #350, and #351.
+versus the current transaction client-kwargs branch after PRs #349, #350, #351, and #352.
 
-| Measure | Prior scorecard | Current merged `main` | Result |
+| Measure | Prior scorecard | Current branch | Result |
 | --- | ---: | ---: | --- |
 | Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,297 | Added focused modules, tests, and quality evidence |
 | Tracked `src/app` Python files | 447 | 449 | Added focused portfolio/performance response helpers |
 | Tracked Python test files | 162 | 164 | Added focused request-context and response-assembly tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 2,872 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
+| Largest source file | 2,968 lines | 2,854 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
 | Local unit/contract tests | 996 | 1,001 | Added focused response/request boundary tests |
@@ -57,8 +57,8 @@ Candidate thresholds:
 2. no new forbidden imports,
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
-5. no new function above the current merged maximum of 49 lines and no unclassified largest-file
-   growth above the current 2,872-line `portfolio_service.py` maximum.
+5. no new function above the current maximum of 49 lines and no unclassified largest-file growth
+   above the current 2,854-line `portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,7 +5,7 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Latest merged hardening evidence includes `make check` with ruff, format, monetary-float guard, mypy over 449 source files, contract smoke, and 1,001 unit/contract tests; `make ci` passed with 207 integration tests, 1,208 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 449 source files, contract smoke, and 1,002 unit/contract tests; `make ci` passed with 207 integration tests, 1,209 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 93.70% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
 | Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction client-kwargs mapping, performance workspace response assembly, and portfolio workspace response assembly; `portfolio_service.py` is now 2,854 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
@@ -31,8 +31,8 @@ versus the current transaction client-kwargs branch after PRs #349, #350, #351, 
 | Largest source file | 2,968 lines | 2,854 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,001 | Added focused response/request boundary tests |
-| Local coverage tests | 1,203 | 1,208 | Added focused coverage while preserving total coverage |
+| Local unit/contract tests | 996 | 1,002 | Added focused response/request boundary tests |
+| Local coverage tests | 1,203 | 1,209 | Added focused coverage while preserving total coverage |
 | Total coverage | 93.69% | 93.70% | Improved slightly |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -223,17 +223,20 @@ The current merged portfolio workspace response slice extracts response componen
 pure `PortfolioWorkspaceResponse` construction into `portfolio_workspace_response.py`, reducing
 `portfolio_service.py` from 2,898 to 2,872 lines while preserving the 49-line longest-function
 baseline.
+The current transaction client-kwargs slice moves upstream argument projection into
+`portfolio_transaction_ledger.py`, reducing `portfolio_service.py` from 2,872 to 2,854 lines while
+preserving the 49-line longest-function baseline.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | merged `main` at `52b89ab`; remote server truth showed only `main` after PR #351 cleanup |
-| Unit/contract coverage | Healthy | 1,001 unit/contract tests passed in PR #351 `make check`; focused portfolio workspace response/control tests passed with 5 tests |
-| Integration coverage | Healthy | 207 integration tests passed in PR #351 `make ci` |
-| Total coverage | Healthy | 1,208 coverage tests passed in PR #351 `make ci`; total coverage is 93.70%, above the 84% floor |
+| Branch hygiene | Healthy | merged `main` at `0c5dbbb`; remote server truth showed only `main` after PR #352 cleanup |
+| Unit/contract coverage | Healthy | 1,001 unit/contract tests passed in PR #352 `make check`; focused transaction-ledger mapper tests passed with 7 tests |
+| Integration coverage | Healthy | 207 integration tests passed in PR #352 `make ci` |
+| Total coverage | Healthy | 1,208 coverage tests passed in PR #352 `make ci`; total coverage is 93.70%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context slices reduce `portfolio_service.py` to 2,872 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context slices reduce `portfolio_service.py` to 2,854 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -243,8 +246,9 @@ baseline.
 1. Continue splitting `portfolio_service.py` into source-readiness, workspace, insight, and
    workflow-cue adapters. Exception-summary payload construction, workflow-action assembly,
    transaction-summary context loading, transaction page loading, book response assembly,
-   transaction-ledger payload loading, workspace source gathering, position-book mapping, and
-   transaction-ledger response mapping are now separately testable.
+   transaction-ledger payload loading, workspace source gathering, position-book mapping,
+   transaction-ledger response mapping, and transaction client-kwargs mapping are now separately
+   testable.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -232,9 +232,9 @@ preserving the 49-line longest-function baseline.
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | merged `main` at `0c5dbbb`; remote server truth showed only `main` after PR #352 cleanup |
-| Unit/contract coverage | Healthy | 1,001 unit/contract tests passed in PR #352 `make check`; focused transaction-ledger mapper tests passed with 7 tests |
-| Integration coverage | Healthy | 207 integration tests passed in PR #352 `make ci` |
-| Total coverage | Healthy | 1,208 coverage tests passed in PR #352 `make ci`; total coverage is 93.70%, above the 84% floor |
+| Unit/contract coverage | Healthy | 1,002 unit/contract tests passed in current branch `make check`; focused transaction-ledger mapper tests passed with 7 tests |
+| Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
+| Total coverage | Healthy | 1,209 coverage tests passed in current branch `make ci`; total coverage is 93.70%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
 | Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context slices reduce `portfolio_service.py` to 2,854 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -78,6 +78,7 @@ from app.services.portfolio_transaction_ledger import (
     build_portfolio_transactions_request_context,
     build_transaction_ledger_response,
     portfolio_transactions_cache_key,
+    portfolio_transactions_client_kwargs,
 )
 from app.services.portfolio_workspace_controls import build_workspace_control_capabilities
 from app.services.portfolio_workspace_response import (
@@ -499,26 +500,7 @@ class PortfolioService:
         context: PortfolioTransactionsRequestContext,
     ) -> tuple[int, dict[str, Any]]:
         return await self._lotus_core_query_client.get_portfolio_transactions(
-            portfolio_id=context.portfolio_id,
-            correlation_id=context.correlation_id,
-            as_of_date=context.as_of_date,
-            include_projected=context.include_projected,
-            skip=context.skip,
-            limit=context.limit,
-            sort_by=context.sort_by,
-            sort_order=context.sort_order,
-            transaction_type=context.transaction_type,
-            security_id=context.security_id,
-            instrument_id=context.instrument_id,
-            component_type=context.component_type,
-            linked_transaction_group_id=context.linked_transaction_group_id,
-            fx_contract_id=context.fx_contract_id,
-            swap_event_id=context.swap_event_id,
-            near_leg_group_id=context.near_leg_group_id,
-            far_leg_group_id=context.far_leg_group_id,
-            start_date=context.start_date,
-            end_date=context.end_date,
-            reporting_currency=context.reporting_currency,
+            **portfolio_transactions_client_kwargs(context),
         )
 
     async def _get_portfolio_readiness_result(

--- a/src/app/services/portfolio_transaction_ledger.py
+++ b/src/app/services/portfolio_transaction_ledger.py
@@ -106,6 +106,33 @@ def portfolio_transactions_cache_key(
     )
 
 
+def portfolio_transactions_client_kwargs(
+    context: PortfolioTransactionsRequestContext,
+) -> dict[str, Any]:
+    return {
+        "portfolio_id": context.portfolio_id,
+        "correlation_id": context.correlation_id,
+        "as_of_date": context.as_of_date,
+        "include_projected": context.include_projected,
+        "skip": context.skip,
+        "limit": context.limit,
+        "sort_by": context.sort_by,
+        "sort_order": context.sort_order,
+        "transaction_type": context.transaction_type,
+        "security_id": context.security_id,
+        "instrument_id": context.instrument_id,
+        "component_type": context.component_type,
+        "linked_transaction_group_id": context.linked_transaction_group_id,
+        "fx_contract_id": context.fx_contract_id,
+        "swap_event_id": context.swap_event_id,
+        "near_leg_group_id": context.near_leg_group_id,
+        "far_leg_group_id": context.far_leg_group_id,
+        "start_date": context.start_date,
+        "end_date": context.end_date,
+        "reporting_currency": context.reporting_currency,
+    }
+
+
 def build_transaction_ledger_response(
     *,
     context: PortfolioTransactionsRequestContext,

--- a/tests/unit/test_portfolio_transaction_ledger.py
+++ b/tests/unit/test_portfolio_transaction_ledger.py
@@ -4,6 +4,7 @@ from app.services.portfolio_transaction_ledger import (
     build_transaction_ledger_response,
     parse_transaction_views,
     portfolio_transactions_cache_key,
+    portfolio_transactions_client_kwargs,
 )
 
 
@@ -146,6 +147,54 @@ def test_portfolio_transactions_cache_key_includes_all_request_filters():
         "2026-03-31",
         "USD",
     )
+
+
+def test_portfolio_transactions_client_kwargs_include_all_request_filters():
+    context = build_portfolio_transactions_request_context(
+        portfolio_id="PF_1001",
+        correlation_id="corr-ledger",
+        as_of_date="2026-03-27",
+        include_projected=True,
+        skip=20,
+        limit=25,
+        transaction_type="DIVIDEND",
+        security_id="SEC_1",
+        instrument_id="INST_1",
+        component_type="CASH_DIVIDEND",
+        linked_transaction_group_id="LTG-1",
+        fx_contract_id="FXC-1",
+        swap_event_id="SWAP-1",
+        near_leg_group_id="NEAR-1",
+        far_leg_group_id="FAR-1",
+        sort_by="transaction_date",
+        sort_order="desc",
+        start_date="2026-01-01",
+        end_date="2026-03-31",
+        reporting_currency="USD",
+    )
+
+    assert portfolio_transactions_client_kwargs(context) == {
+        "portfolio_id": "PF_1001",
+        "correlation_id": "corr-ledger",
+        "as_of_date": "2026-03-27",
+        "include_projected": True,
+        "skip": 20,
+        "limit": 25,
+        "sort_by": "transaction_date",
+        "sort_order": "desc",
+        "transaction_type": "DIVIDEND",
+        "security_id": "SEC_1",
+        "instrument_id": "INST_1",
+        "component_type": "CASH_DIVIDEND",
+        "linked_transaction_group_id": "LTG-1",
+        "fx_contract_id": "FXC-1",
+        "swap_event_id": "SWAP-1",
+        "near_leg_group_id": "NEAR-1",
+        "far_leg_group_id": "FAR-1",
+        "start_date": "2026-01-01",
+        "end_date": "2026-03-31",
+        "reporting_currency": "USD",
+    }
 
 
 def test_build_transaction_ledger_response_falls_back_to_context_metadata():

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -90,10 +90,10 @@ page loading, and portfolio book response assembly, lowering the baseline to 62 
 transaction request-context, transaction client-kwargs, and portfolio workspace response assembly
 extractions, so it remains the largest-file hotspot but is trending down.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
-extraction. The current longest-function baseline is 49 lines. Local `make check` for PR #352
-passed with 1,001 unit/contract tests, and local `make ci` passed with 207 integration tests, 1,208
-coverage tests, 93.70 percent total coverage, and `pip-audit` reporting no known vulnerabilities
-after the governed FastAPI/Starlette exception. GitHub Feature Lane, PR Merge Gate, Quality
-Baseline, Docker build, and Docker parity checks were green before PR #352 merged. The current
-transaction client-kwargs branch adds focused transaction-ledger mapper evidence with 7 passing
-unit tests.
+extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
+transaction client-kwargs branch passed with 1,002 unit/contract tests, and local `make ci` passed
+with 207 integration tests, 1,209 coverage tests, 93.70 percent total coverage, and `pip-audit`
+reporting no known vulnerabilities after the governed FastAPI/Starlette exception. GitHub Feature
+Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were green before PR
+#352 merged. The current transaction client-kwargs branch adds focused transaction-ledger mapper
+evidence with 7 passing unit tests.

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -86,12 +86,14 @@ and rebalance supportability failure-recording splits then lowered the baseline 
 74 lines. The 50-commit enterprise-hardening branch then split shared analytics async polling,
 workspace-summary payload assembly, portfolio transaction-summary context loading, transaction
 page loading, and portfolio book response assembly, lowering the baseline to 62 lines.
-`portfolio_service.py` is now measured at 2,872 lines after portfolio liquidity loading,
-transaction request-context, and portfolio workspace response assembly extractions, so it remains
-the largest-file hotspot but is trending down. `performance_workspace_service.py` is now measured
-at 1,607 lines after response assembly extraction. The current merged longest-function baseline is
-49 lines. Local `make check` for PR #351 passed with 1,001 unit/contract tests, and local
-`make ci` passed with 207 integration tests, 1,208 coverage tests, 93.70 percent total coverage,
-and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette exception.
-GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were
-green before PR #351 merged.
+`portfolio_service.py` is now measured at 2,854 lines after portfolio liquidity loading,
+transaction request-context, transaction client-kwargs, and portfolio workspace response assembly
+extractions, so it remains the largest-file hotspot but is trending down.
+`performance_workspace_service.py` is now measured at 1,607 lines after response assembly
+extraction. The current longest-function baseline is 49 lines. Local `make check` for PR #352
+passed with 1,001 unit/contract tests, and local `make ci` passed with 207 integration tests, 1,208
+coverage tests, 93.70 percent total coverage, and `pip-audit` reporting no known vulnerabilities
+after the governed FastAPI/Starlette exception. GitHub Feature Lane, PR Merge Gate, Quality
+Baseline, Docker build, and Docker parity checks were green before PR #352 merged. The current
+transaction client-kwargs branch adds focused transaction-ledger mapper evidence with 7 passing
+unit tests.


### PR DESCRIPTION
## Summary
- Move portfolio transaction request-context to upstream-client kwargs projection into `portfolio_transaction_ledger.py`.
- Replace manual field expansion in `PortfolioService._fetch_portfolio_transactions` with the shared mapper.
- Add focused unit coverage for full transaction filter propagation and refresh quality/wiki evidence for the new measured hotspot state.

## Validation
- `python -m pytest tests/unit/test_portfolio_transaction_ledger.py` -> 7 passed
- `python -m pytest tests/unit/test_gateway_wiki_overview.py tests/unit/test_enterprise_readiness.py` -> 18 passed
- `make check` -> passed; 1,002 unit/contract tests
- `make ci` -> passed; 207 integration tests, 1,209 coverage tests, total coverage 93.70%, `pip-audit` no known vulnerabilities with governed `PYSEC-2026-161` exception
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` -> expected drift: `Validation-and-CI.md` because this branch updates repo-authored wiki source; publish after merge

## Notes
- Behavior-preserving refactor.
- `portfolio_service.py` measured at 2,854 lines after this slice.
- Longest-function baseline remains 49 lines.