### PR TITLE
Extract transaction page request context

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -35,7 +35,7 @@ report-only baseline is reviewed.
 
 The largest current modularity risks are:
 
-1. `src/app/services/portfolio_service.py` at 2,854 lines,
+1. `src/app/services/portfolio_service.py` at 2,797 lines,
 2. `src/app/services/performance_workspace_service.py` at 1,607 lines,
 3. `src/app/services/advisor_brief_service.py` at 1,452 lines,
 4. `src/app/services/dpm_command_center_service.py` at 1,137 lines,
@@ -143,9 +143,9 @@ descriptors separate from the public query dependency. Portfolio position-book m
 `src/app/services/portfolio_position_book.py`, and transaction-ledger request context plus row
 mapping now live in `src/app/services/portfolio_transaction_ledger.py`. Portfolio liquidity
 upstream payload loading now lives in `src/app/services/portfolio_liquidity_payloads.py`.
-Transaction request-context handling, transaction client-kwargs mapping, and final portfolio
-workspace response assembly have lowered `portfolio_service.py` to 2,854 lines. Performance
-workspace final response assembly now lives in
+Transaction request-context handling, transaction page-context handling, transaction client-kwargs
+mapping, and final portfolio workspace response assembly have lowered `portfolio_service.py` to
+2,797 lines. Performance workspace final response assembly now lives in
 `src/app/services/performance_workspace_response.py`, lowering
 `performance_workspace_service.py` to 1,607 lines. Lotus Core transaction query-parameter
 construction now lives in

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -281,6 +281,9 @@ Most recent local evidence:
 46. Current transaction client-kwargs branch: `make ci` passed with 207 integration tests and
     1,209 combined coverage tests; total coverage remained 93.70%, and `pip-audit` found no known
     vulnerabilities after the governed `PYSEC-2026-161` exception.
+47. Current transaction page-context branch: `make check` passed with ruff, format check,
+    monetary-float guard, mypy over 449 source files, Workbench/OpenAPI contract smoke, and 1,003
+    unit/contract tests.
 
 ## Tooling Availability Baseline
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -284,6 +284,9 @@ Most recent local evidence:
 47. Current transaction page-context branch: `make check` passed with ruff, format check,
     monetary-float guard, mypy over 449 source files, Workbench/OpenAPI contract smoke, and 1,003
     unit/contract tests.
+48. Current transaction page-context branch: `make ci` passed with 207 integration tests and 1,210
+    combined coverage tests; total coverage remained 93.70%, and `pip-audit` found no known
+    vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -143,6 +143,10 @@ longest-function baseline.
 The current transaction client-kwargs slice moves upstream argument projection into
 `portfolio_transaction_ledger.py`, reducing `portfolio_service.py` from 2,872 to 2,854 measured
 lines while preserving the 49-line longest-function baseline.
+The current transaction page-context slice moves income/activity transaction page defaults into
+`portfolio_transaction_ledger.py`, reducing `portfolio_service.py` from 2,854 to 2,797 measured
+lines while preserving the 49-line longest-function baseline and removing
+`_get_portfolio_transactions_result` from the top hotspot list.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -156,7 +160,7 @@ yet enforced unless they are already covered by existing repo-native gates.
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current transaction client-kwargs branch shows 1,297 files under
+Working-tree verification for the current transaction page-context branch shows 1,297 files under
 `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 449 Python source files under `src/app`;
 and 164 Python test files under `tests`.
 
@@ -164,7 +168,7 @@ and 164 Python test files under `tests`.
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 2,854 | `src/app/services/portfolio_service.py` |
+| 1 | 2,797 | `src/app/services/portfolio_service.py` |
 | 2 | 2,123 | `src/app/contracts/portfolio.py` |
 | 3 | 1,940 | `src/app/contracts/risk_workspace.py` |
 | 4 | 1,731 | `src/app/contracts/reporting.py` |
@@ -181,14 +185,14 @@ and 164 Python test files under `tests`.
 | ---: | ---: | --- | --- |
 | 1 | 49 | `get_transaction_ledger` | `src/app/services/portfolio_service.py` |
 | 2 | 49 | `get_portfolio_transactions` | `src/app/clients/lotus_core_query_client.py` |
-| 3 | 47 | `_get_portfolio_transactions_result` | `src/app/services/portfolio_service.py` |
-| 4 | 47 | `_build_workspace_descriptor_contract` | `src/app/services/platform_capabilities_shell.py` |
-| 5 | 47 | `_build_performance_workspace_response` | `src/app/services/performance_workspace_service.py` |
-| 6 | 46 | `get_portfolio_360` | `src/app/services/workbench_service.py` |
-| 7 | 46 | `_unpack_rebalance_supportability_summary` | `src/app/services/workbench_rebalance_snapshot.py` |
-| 8 | 46 | `_performance_payload_from_result` | `src/app/services/workbench_performance_snapshot.py` |
-| 9 | 46 | `_assemble_portfolio_workspace_components` | `src/app/services/portfolio_service.py` |
-| 10 | 46 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
+| 3 | 47 | `_build_workspace_descriptor_contract` | `src/app/services/platform_capabilities_shell.py` |
+| 4 | 47 | `_build_performance_workspace_response` | `src/app/services/performance_workspace_service.py` |
+| 5 | 46 | `get_portfolio_360` | `src/app/services/workbench_service.py` |
+| 6 | 46 | `_unpack_rebalance_supportability_summary` | `src/app/services/workbench_rebalance_snapshot.py` |
+| 7 | 46 | `_performance_payload_from_result` | `src/app/services/workbench_performance_snapshot.py` |
+| 8 | 46 | `_assemble_portfolio_workspace_components` | `src/app/services/portfolio_service.py` |
+| 9 | 46 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
+| 10 | 46 | `build_horizon_row_return_fields` | `src/app/services/performance_workspace_horizon.py` |
 
 ## Existing Blocking Gates
 
@@ -232,8 +236,8 @@ Most recent local evidence:
     after policy state extraction.
 12. Current focused branch: performance workspace evidence-view tests passed with 3 selected tests
     after response-resolution extraction.
-13. Current focused branch: portfolio transaction-ledger tests passed with 7 tests after
-    transaction client-kwargs mapping extraction.
+13. Current focused branch: portfolio transaction-ledger tests passed with 8 tests after
+    transaction page-context extraction.
 14. Current focused branch: portfolio workspace tests passed with 7 selected tests.
 15. Current focused branch: Lotus Core transaction client tests passed with 2 selected tests.
 16. Current focused branch: foundation optional-upstream tests passed with 4 selected tests.
@@ -257,8 +261,8 @@ Most recent local evidence:
 34. Current focused branch: Workbench analytics tests passed with 7 selected tests.
 35. Current focused branch: Workbench rebalance tests passed with 3 selected tests.
 36. Current focused branch: portfolio readiness tests passed with 4 selected tests.
-37. PR #352 PR-grade evidence: `make ci` passed with 207 integration tests.
-38. PR #352 PR-grade evidence: `make ci` passed with 1,208 unit, contract, and integration
+37. PR #353 PR-grade evidence: `make ci` passed with 207 integration tests.
+38. PR #353 PR-grade evidence: `make ci` passed with 1,209 unit, contract, and integration
     coverage tests.
 39. Coverage: 93.70%, above the 84% floor.
 40. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,7 +5,7 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 449 source files, contract smoke, and 1,002 unit/contract tests; `make ci` passed with 207 integration tests, 1,209 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 449 source files, contract smoke, and 1,003 unit/contract tests; latest `make ci` evidence passed with 207 integration tests, 1,209 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 93.70% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
 | Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, and portfolio workspace response assembly; `portfolio_service.py` is now 2,797 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
@@ -31,7 +31,7 @@ versus the current transaction page-context branch after PRs #349, #350, #351, #
 | Largest source file | 2,968 lines | 2,797 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,002 | Added focused response/request boundary tests |
+| Local unit/contract tests | 996 | 1,003 | Added focused response/request boundary tests |
 | Local coverage tests | 1,203 | 1,209 | Added focused coverage while preserving total coverage |
 | Total coverage | 93.69% | 93.70% | Improved slightly |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -7,19 +7,19 @@ Mode: feature-branch evidence refresh
 | --- | ---: | --- | --- |
 | Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 449 source files, contract smoke, and 1,002 unit/contract tests; `make ci` passed with 207 integration tests, 1,209 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 93.70% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction client-kwargs mapping, performance workspace response assembly, and portfolio workspace response assembly; `portfolio_service.py` is now 2,854 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, and portfolio workspace response assembly; `portfolio_service.py` is now 2,797 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in latest `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after PR #352 | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after PR #353 | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
 Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
-versus the current transaction client-kwargs branch after PRs #349, #350, #351, and #352.
+versus the current transaction page-context branch after PRs #349, #350, #351, #352, and #353.
 
 | Measure | Prior scorecard | Current branch | Result |
 | --- | ---: | ---: | --- |
@@ -28,7 +28,7 @@ versus the current transaction client-kwargs branch after PRs #349, #350, #351, 
 | Tracked Python test files | 162 | 164 | Added focused request-context and response-assembly tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 2,854 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
+| Largest source file | 2,968 lines | 2,797 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
 | Local unit/contract tests | 996 | 1,002 | Added focused response/request boundary tests |
@@ -58,7 +58,7 @@ Candidate thresholds:
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
 5. no new function above the current maximum of 49 lines and no unclassified largest-file growth
-   above the current 2,854-line `portfolio_service.py` maximum.
+   above the current 2,797-line `portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,7 +5,7 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 449 source files, contract smoke, and 1,003 unit/contract tests; latest `make ci` evidence passed with 207 integration tests, 1,209 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 449 source files, contract smoke, and 1,003 unit/contract tests; `make ci` passed with 207 integration tests, 1,210 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 93.70% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
 | Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, and portfolio workspace response assembly; `portfolio_service.py` is now 2,797 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
@@ -32,7 +32,7 @@ versus the current transaction page-context branch after PRs #349, #350, #351, #
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
 | Local unit/contract tests | 996 | 1,003 | Added focused response/request boundary tests |
-| Local coverage tests | 1,203 | 1,209 | Added focused coverage while preserving total coverage |
+| Local coverage tests | 1,203 | 1,210 | Added focused coverage while preserving total coverage |
 | Total coverage | 93.69% | 93.70% | Improved slightly |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -235,7 +235,7 @@ preserving the 49-line longest-function baseline.
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | merged `main` at `ab656b9`; remote server truth showed only `main` after PR #353 cleanup |
-| Unit/contract coverage | Healthy | 1,002 unit/contract tests passed in PR #353 `make check`; focused transaction-ledger mapper tests passed with 8 tests on this branch |
+| Unit/contract coverage | Healthy | 1,003 unit/contract tests passed in current branch `make check`; focused transaction-ledger mapper tests passed with 8 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
 | Total coverage | Healthy | 1,209 coverage tests passed in current branch `make ci`; total coverage is 93.70%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -237,7 +237,7 @@ preserving the 49-line longest-function baseline.
 | Branch hygiene | Healthy | merged `main` at `ab656b9`; remote server truth showed only `main` after PR #353 cleanup |
 | Unit/contract coverage | Healthy | 1,003 unit/contract tests passed in current branch `make check`; focused transaction-ledger mapper tests passed with 8 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
-| Total coverage | Healthy | 1,209 coverage tests passed in current branch `make ci`; total coverage is 93.70%, above the 84% floor |
+| Total coverage | Healthy | 1,210 coverage tests passed in current branch `make ci`; total coverage is 93.70%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
 | Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context slices reduce `portfolio_service.py` to 2,797 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -226,17 +226,20 @@ baseline.
 The current transaction client-kwargs slice moves upstream argument projection into
 `portfolio_transaction_ledger.py`, reducing `portfolio_service.py` from 2,872 to 2,854 lines while
 preserving the 49-line longest-function baseline.
+The current transaction page-context slice moves income/activity transaction page defaults into
+`portfolio_transaction_ledger.py`, reducing `portfolio_service.py` from 2,854 to 2,797 lines while
+preserving the 49-line longest-function baseline.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | merged `main` at `0c5dbbb`; remote server truth showed only `main` after PR #352 cleanup |
-| Unit/contract coverage | Healthy | 1,002 unit/contract tests passed in current branch `make check`; focused transaction-ledger mapper tests passed with 7 tests |
+| Branch hygiene | Healthy | merged `main` at `ab656b9`; remote server truth showed only `main` after PR #353 cleanup |
+| Unit/contract coverage | Healthy | 1,002 unit/contract tests passed in PR #353 `make check`; focused transaction-ledger mapper tests passed with 8 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
 | Total coverage | Healthy | 1,209 coverage tests passed in current branch `make ci`; total coverage is 93.70%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context slices reduce `portfolio_service.py` to 2,854 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context slices reduce `portfolio_service.py` to 2,797 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -247,8 +250,8 @@ preserving the 49-line longest-function baseline.
    workflow-cue adapters. Exception-summary payload construction, workflow-action assembly,
    transaction-summary context loading, transaction page loading, book response assembly,
    transaction-ledger payload loading, workspace source gathering, position-book mapping,
-   transaction-ledger response mapping, and transaction client-kwargs mapping are now separately
-   testable.
+   transaction-ledger response mapping, transaction client-kwargs mapping, and transaction page
+   context defaults are now separately testable.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -77,6 +77,7 @@ from app.services.portfolio_transaction_ledger import (
     PortfolioTransactionsRequestContext,
     build_portfolio_transactions_request_context,
     build_transaction_ledger_response,
+    build_transaction_rows_page_request_context,
     portfolio_transactions_cache_key,
     portfolio_transactions_client_kwargs,
 )
@@ -437,54 +438,6 @@ class PortfolioService:
                 reporting_currency=reporting_currency,
             ),
         )
-
-    async def _get_portfolio_transactions_result(
-        self,
-        portfolio_id: str,
-        correlation_id: str,
-        *,
-        as_of_date: str | None,
-        include_projected: bool,
-        skip: int,
-        limit: int,
-        transaction_type: str | None,
-        security_id: str | None,
-        instrument_id: str | None,
-        component_type: str | None,
-        linked_transaction_group_id: str | None,
-        fx_contract_id: str | None,
-        swap_event_id: str | None,
-        near_leg_group_id: str | None,
-        far_leg_group_id: str | None,
-        sort_by: str,
-        sort_order: str,
-        start_date: str | None,
-        end_date: str | None,
-        reporting_currency: str | None = None,
-    ) -> tuple[int, dict[str, Any]]:
-        context = build_portfolio_transactions_request_context(
-            portfolio_id=portfolio_id,
-            correlation_id=correlation_id,
-            as_of_date=as_of_date,
-            include_projected=include_projected,
-            skip=skip,
-            limit=limit,
-            transaction_type=transaction_type,
-            security_id=security_id,
-            instrument_id=instrument_id,
-            component_type=component_type,
-            linked_transaction_group_id=linked_transaction_group_id,
-            fx_contract_id=fx_contract_id,
-            swap_event_id=swap_event_id,
-            near_leg_group_id=near_leg_group_id,
-            far_leg_group_id=far_leg_group_id,
-            sort_by=sort_by,
-            sort_order=sort_order,
-            start_date=start_date,
-            end_date=end_date,
-            reporting_currency=reporting_currency,
-        )
-        return await self._get_portfolio_transactions_result_for_context(context)
 
     async def _get_portfolio_transactions_result_for_context(
         self,
@@ -2126,28 +2079,17 @@ class PortfolioService:
         end_date: str,
         reporting_currency: str | None,
     ) -> dict[str, Any]:
-        status_code, payload = await self._get_portfolio_transactions_result(
+        context = build_transaction_rows_page_request_context(
             portfolio_id=portfolio_id,
             correlation_id=correlation_id,
             as_of_date=as_of_date,
-            include_projected=False,
             skip=skip,
             limit=limit,
-            transaction_type=None,
-            security_id=None,
-            instrument_id=None,
-            component_type=None,
-            linked_transaction_group_id=None,
-            fx_contract_id=None,
-            swap_event_id=None,
-            near_leg_group_id=None,
-            far_leg_group_id=None,
-            sort_by="transaction_date",
-            sort_order="asc",
             start_date=start_date,
             end_date=end_date,
             reporting_currency=reporting_currency,
         )
+        status_code, payload = await self._get_portfolio_transactions_result_for_context(context)
         return self._require_payload(
             result=(status_code, payload),
             unavailable_detail_prefix="lotus-core transactions unavailable",

--- a/src/app/services/portfolio_transaction_ledger.py
+++ b/src/app/services/portfolio_transaction_ledger.py
@@ -79,6 +79,41 @@ def build_portfolio_transactions_request_context(
     )
 
 
+def build_transaction_rows_page_request_context(
+    *,
+    portfolio_id: str,
+    correlation_id: str,
+    as_of_date: str | None,
+    skip: int,
+    limit: int,
+    start_date: str,
+    end_date: str,
+    reporting_currency: str | None,
+) -> PortfolioTransactionsRequestContext:
+    return build_portfolio_transactions_request_context(
+        portfolio_id=portfolio_id,
+        correlation_id=correlation_id,
+        as_of_date=as_of_date,
+        include_projected=False,
+        skip=skip,
+        limit=limit,
+        transaction_type=None,
+        security_id=None,
+        instrument_id=None,
+        component_type=None,
+        linked_transaction_group_id=None,
+        fx_contract_id=None,
+        swap_event_id=None,
+        near_leg_group_id=None,
+        far_leg_group_id=None,
+        sort_by="transaction_date",
+        sort_order="asc",
+        start_date=start_date,
+        end_date=end_date,
+        reporting_currency=reporting_currency,
+    )
+
+
 def portfolio_transactions_cache_key(
     context: PortfolioTransactionsRequestContext,
 ) -> tuple[object, ...]:

--- a/tests/unit/test_portfolio_transaction_ledger.py
+++ b/tests/unit/test_portfolio_transaction_ledger.py
@@ -2,6 +2,7 @@ from app.services.portfolio_transaction_ledger import (
     PortfolioTransactionsRequestContext,
     build_portfolio_transactions_request_context,
     build_transaction_ledger_response,
+    build_transaction_rows_page_request_context,
     parse_transaction_views,
     portfolio_transactions_cache_key,
     portfolio_transactions_client_kwargs,
@@ -195,6 +196,40 @@ def test_portfolio_transactions_client_kwargs_include_all_request_filters():
         "end_date": "2026-03-31",
         "reporting_currency": "USD",
     }
+
+
+def test_build_transaction_rows_page_request_context_uses_summary_page_defaults():
+    context = build_transaction_rows_page_request_context(
+        portfolio_id="PF_1001",
+        correlation_id="corr-summary-page",
+        as_of_date="2026-03-27",
+        skip=100,
+        limit=50,
+        start_date="2026-01-01",
+        end_date="2026-03-31",
+        reporting_currency="CHF",
+    )
+
+    assert context.portfolio_id == "PF_1001"
+    assert context.correlation_id == "corr-summary-page"
+    assert context.as_of_date == "2026-03-27"
+    assert context.include_projected is False
+    assert context.skip == 100
+    assert context.limit == 50
+    assert context.sort_by == "transaction_date"
+    assert context.sort_order == "asc"
+    assert context.start_date == "2026-01-01"
+    assert context.end_date == "2026-03-31"
+    assert context.reporting_currency == "CHF"
+    assert context.transaction_type is None
+    assert context.security_id is None
+    assert context.instrument_id is None
+    assert context.component_type is None
+    assert context.linked_transaction_group_id is None
+    assert context.fx_contract_id is None
+    assert context.swap_event_id is None
+    assert context.near_leg_group_id is None
+    assert context.far_leg_group_id is None
 
 
 def test_build_transaction_ledger_response_falls_back_to_context_metadata():

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -93,7 +93,7 @@ down.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
 extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
 transaction page-context branch passed with 1,003 unit/contract tests, and local `make ci` passed
-with 207 integration tests, 1,209 coverage tests, 93.70 percent total coverage, and `pip-audit`
+with 207 integration tests, 1,210 coverage tests, 93.70 percent total coverage, and `pip-audit`
 reporting no known vulnerabilities after the governed FastAPI/Starlette exception. GitHub Feature
 Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were green before PR
 #353 merged. The current transaction page-context branch adds focused transaction-ledger mapper

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -92,7 +92,7 @@ workspace response assembly extractions, so it remains the largest-file hotspot 
 down.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
 extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
-transaction client-kwargs branch passed with 1,002 unit/contract tests, and local `make ci` passed
+transaction page-context branch passed with 1,003 unit/contract tests, and local `make ci` passed
 with 207 integration tests, 1,209 coverage tests, 93.70 percent total coverage, and `pip-audit`
 reporting no known vulnerabilities after the governed FastAPI/Starlette exception. GitHub Feature
 Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were green before PR

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -86,14 +86,15 @@ and rebalance supportability failure-recording splits then lowered the baseline 
 74 lines. The 50-commit enterprise-hardening branch then split shared analytics async polling,
 workspace-summary payload assembly, portfolio transaction-summary context loading, transaction
 page loading, and portfolio book response assembly, lowering the baseline to 62 lines.
-`portfolio_service.py` is now measured at 2,854 lines after portfolio liquidity loading,
-transaction request-context, transaction client-kwargs, and portfolio workspace response assembly
-extractions, so it remains the largest-file hotspot but is trending down.
+`portfolio_service.py` is now measured at 2,797 lines after portfolio liquidity loading,
+transaction request-context, transaction page-context, transaction client-kwargs, and portfolio
+workspace response assembly extractions, so it remains the largest-file hotspot but is trending
+down.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
 extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
 transaction client-kwargs branch passed with 1,002 unit/contract tests, and local `make ci` passed
 with 207 integration tests, 1,209 coverage tests, 93.70 percent total coverage, and `pip-audit`
 reporting no known vulnerabilities after the governed FastAPI/Starlette exception. GitHub Feature
 Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were green before PR
-#352 merged. The current transaction client-kwargs branch adds focused transaction-ledger mapper
-evidence with 7 passing unit tests.
+#353 merged. The current transaction page-context branch adds focused transaction-ledger mapper
+evidence with 8 passing unit tests.


### PR DESCRIPTION
## Summary
- Move income/activity transaction page request defaults into `portfolio_transaction_ledger.py`.
- Remove the now-redundant `PortfolioService._get_portfolio_transactions_result` wrapper and route page loading through the shared context/cached upstream path.
- Add focused unit coverage for transaction page defaults and refresh quality/wiki evidence.

## Validation
- `python -m pytest tests/unit/test_portfolio_transaction_ledger.py` -> 8 passed
- `python -m pytest tests/unit/test_gateway_wiki_overview.py tests/unit/test_enterprise_readiness.py` -> 18 passed
- `make check` -> passed; 1,003 unit/contract tests
- `make ci` -> passed; 207 integration tests, 1,210 coverage tests, total coverage 93.70%, `pip-audit` no known vulnerabilities with governed `PYSEC-2026-161` exception
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` -> expected drift: `Validation-and-CI.md` because this branch updates repo-authored wiki source; publish after merge

## Notes
- Behavior-preserving refactor.
- `portfolio_service.py` measured at 2,797 lines after this slice.
- Longest-function baseline remains 49 lines.
- `_get_portfolio_transactions_result` is removed from the top hotspot list.