### PR TITLE
Extract portfolio workspace performance parser

### DIFF
--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-06-12T08:31:09Z",
+  "generated_at": "2026-06-12T11:34:05Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:162:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -802,151 +802,157 @@
       "review_by": "2026-12-02"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1988:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/portfolio_service.py:1794:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2064:float(quantize_performance(period_return)) if period_return is not None else None",
+      "finding": "src/app/services/portfolio_service.py:1970:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2190:market_value_base=float(",
+      "finding": "src/app/services/portfolio_service.py:1973:weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2193:weight_pct=float(",
+      "finding": "src/app/services/portfolio_service.py:1974:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2194:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
+      "finding": "src/app/services/portfolio_service.py:2145:accumulator[\"gross_amount_portfolio_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2376:accumulator[\"gross_amount_portfolio_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:2148:accumulator[\"gross_amount_reporting_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2379:accumulator[\"gross_amount_reporting_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:2175:accumulator[\"net_amount_portfolio_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2406:accumulator[\"net_amount_portfolio_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:2178:accumulator[\"net_amount_reporting_currency\"] = float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2409:accumulator[\"net_amount_reporting_currency\"] = float(",
+      "finding": "src/app/services/portfolio_service.py:2186:portfolio_amount: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2417:portfolio_amount: float,",
+      "finding": "src/app/services/portfolio_service.py:2187:reporting_amount: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2418:reporting_amount: float,",
+      "finding": "src/app/services/portfolio_service.py:2191:float(accumulator[\"amount_portfolio_currency\"]) + portfolio_amount",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2422:float(accumulator[\"amount_portfolio_currency\"]) + portfolio_amount",
+      "finding": "src/app/services/portfolio_service.py:2194:float(accumulator[\"amount_reporting_currency\"]) + reporting_amount",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2425:float(accumulator[\"amount_reporting_currency\"]) + reporting_amount",
+      "finding": "src/app/services/portfolio_service.py:2217:def _activity_portfolio_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2448:def _activity_portfolio_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:2224:def _activity_reporting_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2455:def _activity_reporting_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:2241:def _income_net_portfolio_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2472:def _income_net_portfolio_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:2251:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2482:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
+      "finding": "src/app/services/portfolio_service.py:2253:def _income_net_reporting_amount(self, row: dict[str, Any]) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2484:def _income_net_reporting_amount(self, row: dict[str, Any]) -> float:",
+      "finding": "src/app/services/portfolio_service.py:2279:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2510:return float(quantize_money(gross - withholding - other_deductions - trade_fee))",
+      "finding": "src/app/services/portfolio_service.py:2292:def _absolute_money(self, value: Any) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2523:def _absolute_money(self, value: Any) -> float:",
+      "finding": "src/app/services/portfolio_service.py:2295:return float(quantize_money(abs(float(value))))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2526:return float(quantize_money(abs(float(value))))",
+      "finding": "src/app/services/portfolio_service.py:2357:reporting_currency_amount=float(quantize_money(payload.get(reporting_key, 0))),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:2588:reporting_currency_amount=float(quantize_money(payload.get(reporting_key, 0))),",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-11-19"
-    },
-    {
-      "finding": "src/app/services/portfolio_transaction_ledger.py:77:price=float(quantize_price(item.get(\"price\", 0)))",
+      "finding": "src/app/services/portfolio_transaction_ledger.py:213:price=float(quantize_price(item.get(\"price\", 0)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-12-09"
     },
     {
-      "finding": "src/app/services/portfolio_transaction_ledger.py:96:def optional_money(value: Any) -> float | None:",
+      "finding": "src/app/services/portfolio_transaction_ledger.py:232:def optional_money(value: Any) -> float | None:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-12-09"
     },
     {
-      "finding": "src/app/services/portfolio_transaction_ledger.py:99:return float(quantize_money(value))",
+      "finding": "src/app/services/portfolio_transaction_ledger.py:235:return float(quantize_money(value))",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/services/portfolio_workspace_performance.py:36:def quantized_performance_return(value: Any) -> float | None:",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/services/portfolio_workspace_performance.py:38:return float(quantize_performance(value)) if value is not None else None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-12-09"

--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -35,7 +35,7 @@ report-only baseline is reviewed.
 
 The largest current modularity risks are:
 
-1. `src/app/services/portfolio_service.py` at 2,797 lines,
+1. `src/app/services/portfolio_service.py` at 2,772 lines,
 2. `src/app/services/performance_workspace_service.py` at 1,607 lines,
 3. `src/app/services/advisor_brief_service.py` at 1,452 lines,
 4. `src/app/services/dpm_command_center_service.py` at 1,137 lines,
@@ -144,8 +144,9 @@ descriptors separate from the public query dependency. Portfolio position-book m
 mapping now live in `src/app/services/portfolio_transaction_ledger.py`. Portfolio liquidity
 upstream payload loading now lives in `src/app/services/portfolio_liquidity_payloads.py`.
 Transaction request-context handling, transaction page-context handling, transaction client-kwargs
-mapping, and final portfolio workspace response assembly have lowered `portfolio_service.py` to
-2,797 lines. Performance workspace final response assembly now lives in
+mapping, portfolio workspace performance parsing, and final portfolio workspace response assembly
+have lowered `portfolio_service.py` to 2,772 lines. Performance workspace final response assembly
+now lives in
 `src/app/services/performance_workspace_response.py`, lowering
 `performance_workspace_service.py` to 1,607 lines. Lotus Core transaction query-parameter
 construction now lives in

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -290,6 +290,12 @@ Most recent local evidence:
 48. Current transaction page-context branch: `make ci` passed with 207 integration tests and 1,210
     combined coverage tests; total coverage remained 93.70%, and `pip-audit` found no known
     vulnerabilities after the governed `PYSEC-2026-161` exception.
+49. Current portfolio workspace performance parser branch: `make check` passed with ruff, format
+    check, monetary-float guard, mypy over 450 source files, Workbench/OpenAPI contract smoke, and
+    1,008 unit/contract tests.
+50. Current portfolio workspace performance parser branch: `make ci` passed with 207 integration
+    tests and 1,215 combined coverage tests; total coverage is 93.74%, and `pip-audit` found no
+    known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -147,6 +147,9 @@ The current transaction page-context slice moves income/activity transaction pag
 `portfolio_transaction_ledger.py`, reducing `portfolio_service.py` from 2,854 to 2,797 measured
 lines while preserving the 49-line longest-function baseline and removing
 `_get_portfolio_transactions_result` from the top hotspot list.
+The current portfolio workspace performance parser slice moves upstream performance summary
+payload parsing into `portfolio_workspace_performance.py`, reducing `portfolio_service.py` from
+2,797 to 2,772 measured lines while preserving the 49-line longest-function baseline.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -154,21 +157,21 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,297 |
-| Python source files under `src/app` | 449 |
-| Python test files under `tests` | 164 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,301 |
+| Python source files under `src/app` | 450 |
+| Python test files under `tests` | 165 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current transaction page-context branch shows 1,297 files under
-`src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 449 Python source files under `src/app`;
-and 164 Python test files under `tests`.
+Working-tree verification for the current portfolio workspace performance parser branch shows
+1,301 files under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 450 Python source
+files under `src/app`; and 165 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 2,797 | `src/app/services/portfolio_service.py` |
+| 1 | 2,772 | `src/app/services/portfolio_service.py` |
 | 2 | 2,123 | `src/app/contracts/portfolio.py` |
 | 3 | 1,940 | `src/app/contracts/risk_workspace.py` |
 | 4 | 1,731 | `src/app/contracts/reporting.py` |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,30 +5,31 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 449 source files, contract smoke, and 1,003 unit/contract tests; `make ci` passed with 207 integration tests, 1,210 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Build and test reliability | 5/5 | Latest merged evidence includes `make check` with ruff, format, monetary-float guard, mypy over 449 source files, contract smoke, and 1,003 unit/contract tests; `make ci` passed with 207 integration tests, 1,210 coverage tests, Docker-equivalent GitHub gates, and dependency audit; the current branch adds focused portfolio workspace performance parser tests | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 93.70% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, and portfolio workspace response assembly; `portfolio_service.py` is now 2,797 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, and portfolio workspace performance parsing; `portfolio_service.py` is now 2,772 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in latest `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after PR #353 | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after PR #354 and the current focused parser slice | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
 Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
-versus the current transaction page-context branch after PRs #349, #350, #351, #352, and #353.
+versus the current portfolio workspace performance parser branch after PRs #349, #350, #351,
+#352, #353, and #354.
 
 | Measure | Prior scorecard | Current branch | Result |
 | --- | ---: | ---: | --- |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,297 | Added focused modules, tests, and quality evidence |
-| Tracked `src/app` Python files | 447 | 449 | Added focused portfolio/performance response helpers |
-| Tracked Python test files | 162 | 164 | Added focused request-context and response-assembly tests |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,301 | Added focused modules, tests, and quality evidence |
+| Tracked `src/app` Python files | 447 | 450 | Added focused portfolio/performance response helpers and the workspace performance parser |
+| Tracked Python test files | 162 | 165 | Added focused request-context, response-assembly, and workspace performance parser tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 2,797 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
+| Largest source file | 2,968 lines | 2,772 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
 | Local unit/contract tests | 996 | 1,003 | Added focused response/request boundary tests |
@@ -58,7 +59,7 @@ Candidate thresholds:
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
 5. no new function above the current maximum of 49 lines and no unclassified largest-file growth
-   above the current 2,797-line `portfolio_service.py` maximum.
+   above the current 2,772-line `portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,14 +5,14 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Latest merged evidence includes `make check` with ruff, format, monetary-float guard, mypy over 449 source files, contract smoke, and 1,003 unit/contract tests; `make ci` passed with 207 integration tests, 1,210 coverage tests, Docker-equivalent GitHub gates, and dependency audit; the current branch adds focused portfolio workspace performance parser tests | Keep Docker parity blocking in PR Merge Gate |
-| Coverage | 4/5 | 93.70% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 450 source files, contract smoke, and 1,008 unit/contract tests; `make ci` passed with 207 integration tests, 1,215 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Coverage | 4/5 | 93.74% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
 | Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, and portfolio workspace performance parsing; `portfolio_service.py` is now 2,772 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
-| Security | 4/5 | `pip-audit` passed in latest `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
+| Security | 4/5 | `pip-audit` passed in current branch `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
 | Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after PR #354 and the current focused parser slice | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
@@ -32,9 +32,9 @@ versus the current portfolio workspace performance parser branch after PRs #349,
 | Largest source file | 2,968 lines | 2,772 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,003 | Added focused response/request boundary tests |
-| Local coverage tests | 1,203 | 1,210 | Added focused coverage while preserving total coverage |
-| Total coverage | 93.69% | 93.70% | Improved slightly |
+| Local unit/contract tests | 996 | 1,008 | Added focused response/request boundary and workspace performance parser tests |
+| Local coverage tests | 1,203 | 1,215 | Added focused coverage while preserving total coverage |
+| Total coverage | 93.69% | 93.74% | Improved |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
 ## Phase Gates

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -229,17 +229,20 @@ preserving the 49-line longest-function baseline.
 The current transaction page-context slice moves income/activity transaction page defaults into
 `portfolio_transaction_ledger.py`, reducing `portfolio_service.py` from 2,854 to 2,797 lines while
 preserving the 49-line longest-function baseline.
+The current portfolio workspace performance parser slice moves upstream performance summary
+payload parsing into `portfolio_workspace_performance.py`, reducing `portfolio_service.py` from
+2,797 to 2,772 lines while preserving the 49-line longest-function baseline.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | merged `main` at `ab656b9`; remote server truth showed only `main` after PR #353 cleanup |
-| Unit/contract coverage | Healthy | 1,003 unit/contract tests passed in current branch `make check`; focused transaction-ledger mapper tests passed with 8 tests on this branch |
+| Branch hygiene | Healthy | merged `main` at `481e091`; remote server truth showed only `main` after PR #354 cleanup |
+| Unit/contract coverage | Healthy | 1,003 unit/contract tests passed in latest merged `make check`; focused workspace performance parser and portfolio service tests passed with 49 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
 | Total coverage | Healthy | 1,210 coverage tests passed in current branch `make ci`; total coverage is 93.70%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context slices reduce `portfolio_service.py` to 2,797 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser slices reduce `portfolio_service.py` to 2,772 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -251,7 +254,7 @@ preserving the 49-line longest-function baseline.
    transaction-summary context loading, transaction page loading, book response assembly,
    transaction-ledger payload loading, workspace source gathering, position-book mapping,
    transaction-ledger response mapping, transaction client-kwargs mapping, and transaction page
-   context defaults are now separately testable.
+   context defaults, plus workspace performance parsing, are now separately testable.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -238,9 +238,9 @@ payload parsing into `portfolio_workspace_performance.py`, reducing `portfolio_s
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | merged `main` at `481e091`; remote server truth showed only `main` after PR #354 cleanup |
-| Unit/contract coverage | Healthy | 1,003 unit/contract tests passed in latest merged `make check`; focused workspace performance parser and portfolio service tests passed with 49 tests on this branch |
+| Unit/contract coverage | Healthy | 1,008 unit/contract tests passed in current branch `make check`; focused workspace performance parser and portfolio service tests passed with 49 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
-| Total coverage | Healthy | 1,210 coverage tests passed in current branch `make ci`; total coverage is 93.70%, above the 84% floor |
+| Total coverage | Healthy | 1,215 coverage tests passed in current branch `make ci`; total coverage is 93.74%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
 | Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser slices reduce `portfolio_service.py` to 2,772 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -82,6 +82,7 @@ from app.services.portfolio_transaction_ledger import (
     portfolio_transactions_client_kwargs,
 )
 from app.services.portfolio_workspace_controls import build_workspace_control_capabilities
+from app.services.portfolio_workspace_performance import parse_workspace_performance_summary
 from app.services.portfolio_workspace_response import (
     PortfolioWorkspaceComponents,
     PortfolioWorkspaceResponseParts,
@@ -1844,33 +1845,7 @@ class PortfolioService:
         )
         if payload is None:
             return None
-        results_by_period = payload.get("results_by_period", payload.get("resultsByPeriod", {}))
-        if not isinstance(results_by_period, dict):
-            warnings.append("PORTFOLIO_PERFORMANCE_INVALID")
-            return None
-        period_key = "YTD" if "YTD" in results_by_period else next(iter(results_by_period), None)
-        if period_key is None:
-            return None
-        period_payload = results_by_period.get(period_key, {})
-        if not isinstance(period_payload, dict):
-            return None
-        portfolio_payload = period_payload.get("portfolio", {})
-        if not isinstance(portfolio_payload, dict):
-            return None
-        summary_payload = portfolio_payload.get("summary", {})
-        if not isinstance(summary_payload, dict):
-            return None
-        period_return_payload = summary_payload.get("period_return", {})
-        if not isinstance(period_return_payload, dict):
-            return None
-        period_return = period_return_payload.get("base")
-        try:
-            return_pct = (
-                float(quantize_performance(period_return)) if period_return is not None else None
-            )
-        except (TypeError, ValueError):
-            return_pct = None
-        return PortfolioPerformanceSummary(period=str(period_key), return_pct=return_pct)
+        return parse_workspace_performance_summary(payload, warnings)
 
     def _parse_workspace_rebalance(
         self,

--- a/src/app/services/portfolio_workspace_performance.py
+++ b/src/app/services/portfolio_workspace_performance.py
@@ -1,0 +1,40 @@
+from typing import Any
+
+from app.contracts.portfolio import PortfolioPerformanceSummary
+from app.precision_policy import quantize_performance
+
+
+def parse_workspace_performance_summary(
+    payload: dict[str, Any],
+    warnings: list[str],
+) -> PortfolioPerformanceSummary | None:
+    results_by_period = payload.get("results_by_period", payload.get("resultsByPeriod", {}))
+    if not isinstance(results_by_period, dict):
+        warnings.append("PORTFOLIO_PERFORMANCE_INVALID")
+        return None
+    period_key = "YTD" if "YTD" in results_by_period else next(iter(results_by_period), None)
+    if period_key is None:
+        return None
+    period_payload = results_by_period.get(period_key, {})
+    if not isinstance(period_payload, dict):
+        return None
+    portfolio_payload = period_payload.get("portfolio", {})
+    if not isinstance(portfolio_payload, dict):
+        return None
+    summary_payload = portfolio_payload.get("summary", {})
+    if not isinstance(summary_payload, dict):
+        return None
+    period_return_payload = summary_payload.get("period_return", {})
+    if not isinstance(period_return_payload, dict):
+        return None
+    return PortfolioPerformanceSummary(
+        period=str(period_key),
+        return_pct=quantized_performance_return(period_return_payload.get("base")),
+    )
+
+
+def quantized_performance_return(value: Any) -> float | None:
+    try:
+        return float(quantize_performance(value)) if value is not None else None
+    except (TypeError, ValueError):
+        return None

--- a/tests/unit/test_portfolio_workspace_performance.py
+++ b/tests/unit/test_portfolio_workspace_performance.py
@@ -1,0 +1,90 @@
+from app.services.portfolio_workspace_performance import parse_workspace_performance_summary
+
+
+def test_parse_workspace_performance_summary_prefers_ytd_period() -> None:
+    warnings: list[str] = []
+
+    summary = parse_workspace_performance_summary(
+        {
+            "results_by_period": {
+                "1Y": {
+                    "portfolio": {
+                        "summary": {"period_return": {"base": "0.10123"}},
+                    }
+                },
+                "YTD": {
+                    "portfolio": {
+                        "summary": {"period_return": {"base": "0.05123"}},
+                    }
+                },
+            }
+        },
+        warnings,
+    )
+
+    assert summary is not None
+    assert summary.period == "YTD"
+    assert summary.return_pct == 0.05123
+    assert warnings == []
+
+
+def test_parse_workspace_performance_summary_falls_back_to_first_period() -> None:
+    warnings: list[str] = []
+
+    summary = parse_workspace_performance_summary(
+        {
+            "resultsByPeriod": {
+                "1Y": {
+                    "portfolio": {
+                        "summary": {"period_return": {"base": "0.10123"}},
+                    }
+                }
+            }
+        },
+        warnings,
+    )
+
+    assert summary is not None
+    assert summary.period == "1Y"
+    assert summary.return_pct == 0.10123
+    assert warnings == []
+
+
+def test_parse_workspace_performance_summary_records_invalid_period_container() -> None:
+    warnings: list[str] = []
+
+    summary = parse_workspace_performance_summary({"results_by_period": []}, warnings)
+
+    assert summary is None
+    assert warnings == ["PORTFOLIO_PERFORMANCE_INVALID"]
+
+
+def test_parse_workspace_performance_summary_ignores_malformed_period_payload() -> None:
+    warnings: list[str] = []
+
+    summary = parse_workspace_performance_summary({"results_by_period": {"YTD": []}}, warnings)
+
+    assert summary is None
+    assert warnings == []
+
+
+def test_parse_workspace_performance_summary_preserves_invalid_return_as_none() -> None:
+    warnings: list[str] = []
+
+    summary = parse_workspace_performance_summary(
+        {
+            "results_by_period": {
+                "YTD": {
+                    "portfolio": {
+                        "summary": {"period_return": {"base": "not-a-number"}},
+                    }
+                }
+            }
+        },
+        warnings,
+    )
+
+    assert summary is not None
+    assert summary.period == "YTD"
+    assert summary.return_pct is None
+    assert warnings == []

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -86,15 +86,15 @@ and rebalance supportability failure-recording splits then lowered the baseline 
 74 lines. The 50-commit enterprise-hardening branch then split shared analytics async polling,
 workspace-summary payload assembly, portfolio transaction-summary context loading, transaction
 page loading, and portfolio book response assembly, lowering the baseline to 62 lines.
-`portfolio_service.py` is now measured at 2,797 lines after portfolio liquidity loading,
-transaction request-context, transaction page-context, transaction client-kwargs, and portfolio
-workspace response assembly extractions, so it remains the largest-file hotspot but is trending
-down.
+`portfolio_service.py` is now measured at 2,772 lines after portfolio liquidity loading,
+transaction request-context, transaction page-context, transaction client-kwargs, portfolio
+workspace response assembly, and portfolio workspace performance parsing extractions, so it
+remains the largest-file hotspot but is trending down.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
 extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
 transaction page-context branch passed with 1,003 unit/contract tests, and local `make ci` passed
 with 207 integration tests, 1,210 coverage tests, 93.70 percent total coverage, and `pip-audit`
 reporting no known vulnerabilities after the governed FastAPI/Starlette exception. GitHub Feature
 Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were green before PR
-#353 merged. The current transaction page-context branch adds focused transaction-ledger mapper
-evidence with 8 passing unit tests.
+#354 merged. The current portfolio workspace performance parser branch adds focused parser and
+portfolio service evidence with 49 passing unit tests.

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -92,9 +92,10 @@ workspace response assembly, and portfolio workspace performance parsing extract
 remains the largest-file hotspot but is trending down.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
 extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
-transaction page-context branch passed with 1,003 unit/contract tests, and local `make ci` passed
-with 207 integration tests, 1,210 coverage tests, 93.70 percent total coverage, and `pip-audit`
-reporting no known vulnerabilities after the governed FastAPI/Starlette exception. GitHub Feature
-Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were green before PR
-#354 merged. The current portfolio workspace performance parser branch adds focused parser and
-portfolio service evidence with 49 passing unit tests.
+portfolio workspace performance parser branch passed with ruff, format check, monetary-float
+guard, mypy over 450 source files, Workbench/OpenAPI contract smoke, and 1,008 unit/contract tests.
+Local `make ci` passed with 207 integration tests, 1,215 coverage tests, 93.74 percent total
+coverage, and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette
+exception. GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity
+checks were green before PR #354 merged. The current portfolio workspace performance parser branch
+also adds focused parser and portfolio service evidence with 49 passing unit tests.


### PR DESCRIPTION
## Summary
- extract portfolio workspace performance summary parsing into a focused service helper
- add unit coverage for YTD selection, camelCase fallback, malformed payload handling, and invalid return conversion
- refresh quality/wiki evidence and monetary-float allowlist for the moved quantized performance conversion

## Validation
- python -m pytest tests/unit/test_gateway_wiki_overview.py tests/unit/test_enterprise_readiness.py tests/unit/test_portfolio_workspace_performance.py tests/unit/test_portfolio_service.py -q
- make check
- make ci

## Wiki
- Updated repo-authored wiki source: wiki/Validation-and-CI.md
- Pre-merge check-only reports expected drift until branch is merged and wiki is published: Validation-and-CI.md