### PR TITLE
Extract portfolio workspace rebalance parser

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -35,7 +35,7 @@ report-only baseline is reviewed.
 
 The largest current modularity risks are:
 
-1. `src/app/services/portfolio_service.py` at 2,772 lines,
+1. `src/app/services/portfolio_service.py` at 2,729 lines,
 2. `src/app/services/performance_workspace_service.py` at 1,607 lines,
 3. `src/app/services/advisor_brief_service.py` at 1,452 lines,
 4. `src/app/services/dpm_command_center_service.py` at 1,137 lines,
@@ -144,9 +144,9 @@ descriptors separate from the public query dependency. Portfolio position-book m
 mapping now live in `src/app/services/portfolio_transaction_ledger.py`. Portfolio liquidity
 upstream payload loading now lives in `src/app/services/portfolio_liquidity_payloads.py`.
 Transaction request-context handling, transaction page-context handling, transaction client-kwargs
-mapping, portfolio workspace performance parsing, and final portfolio workspace response assembly
-have lowered `portfolio_service.py` to 2,772 lines. Performance workspace final response assembly
-now lives in
+mapping, portfolio workspace performance and rebalance parsing, and final portfolio workspace
+response assembly have lowered `portfolio_service.py` to 2,729 lines. Performance workspace final
+response assembly now lives in
 `src/app/services/performance_workspace_response.py`, lowering
 `performance_workspace_service.py` to 1,607 lines. Lotus Core transaction query-parameter
 construction now lives in

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -300,6 +300,12 @@ Most recent local evidence:
 50. Current portfolio workspace performance parser branch: `make ci` passed with 207 integration
     tests and 1,215 combined coverage tests; total coverage is 93.74%, and `pip-audit` found no
     known vulnerabilities after the governed `PYSEC-2026-161` exception.
+51. Current portfolio workspace rebalance parser branch: `make check` passed with ruff, format
+    check, monetary-float guard, mypy over 451 source files, Workbench/OpenAPI contract smoke, and
+    1,014 unit/contract tests.
+52. Current portfolio workspace rebalance parser branch: `make ci` passed with 207 integration
+    tests and 1,221 combined coverage tests; total coverage is 93.78%, and `pip-audit` found no
+    known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -150,6 +150,10 @@ lines while preserving the 49-line longest-function baseline and removing
 The current portfolio workspace performance parser slice moves upstream performance summary
 payload parsing into `portfolio_workspace_performance.py`, reducing `portfolio_service.py` from
 2,797 to 2,772 measured lines while preserving the 49-line longest-function baseline.
+The current portfolio workspace rebalance parser slice moves manage-owned rebalance run and
+supportability payload parsing into `portfolio_workspace_rebalance.py`, reducing
+`portfolio_service.py` from 2,772 to 2,729 measured lines while preserving the 49-line
+longest-function baseline.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -157,21 +161,21 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,301 |
-| Python source files under `src/app` | 450 |
-| Python test files under `tests` | 165 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,303 |
+| Python source files under `src/app` | 451 |
+| Python test files under `tests` | 166 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current portfolio workspace performance parser branch shows
-1,301 files under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 450 Python source
-files under `src/app`; and 165 Python test files under `tests`.
+Working-tree verification for the current portfolio workspace rebalance parser branch shows
+1,303 files under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 451 Python source
+files under `src/app`; and 166 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 2,772 | `src/app/services/portfolio_service.py` |
+| 1 | 2,729 | `src/app/services/portfolio_service.py` |
 | 2 | 2,123 | `src/app/contracts/portfolio.py` |
 | 3 | 1,940 | `src/app/contracts/risk_workspace.py` |
 | 4 | 1,731 | `src/app/contracts/reporting.py` |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,8 +5,8 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 450 source files, contract smoke, and 1,008 unit/contract tests; `make ci` passed with 207 integration tests, 1,215 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
-| Coverage | 4/5 | 93.74% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 451 source files, contract smoke, and 1,014 unit/contract tests; `make ci` passed with 207 integration tests, 1,221 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Coverage | 4/5 | 93.78% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
 | Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, and portfolio workspace rebalance parsing; `portfolio_service.py` is now 2,729 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
@@ -32,9 +32,9 @@ versus the current portfolio workspace rebalance parser branch after PRs #349, #
 | Largest source file | 2,968 lines | 2,729 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,008 | Added focused response/request boundary and workspace performance parser tests |
-| Local coverage tests | 1,203 | 1,215 | Added focused coverage while preserving total coverage |
-| Total coverage | 93.69% | 93.74% | Improved |
+| Local unit/contract tests | 996 | 1,014 | Added focused response/request boundary and workspace parser tests |
+| Local coverage tests | 1,203 | 1,221 | Added focused coverage while preserving total coverage |
+| Total coverage | 93.69% | 93.78% | Improved |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
 ## Phase Gates

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -7,29 +7,29 @@ Mode: feature-branch evidence refresh
 | --- | ---: | --- | --- |
 | Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 450 source files, contract smoke, and 1,008 unit/contract tests; `make ci` passed with 207 integration tests, 1,215 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 93.74% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, and portfolio workspace performance parsing; `portfolio_service.py` is now 2,772 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, and portfolio workspace rebalance parsing; `portfolio_service.py` is now 2,729 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in current branch `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after PR #354 and the current focused parser slice | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after PR #355 and the current focused rebalance parser slice | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
 Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
-versus the current portfolio workspace performance parser branch after PRs #349, #350, #351,
-#352, #353, and #354.
+versus the current portfolio workspace rebalance parser branch after PRs #349, #350, #351,
+#352, #353, #354, and #355.
 
 | Measure | Prior scorecard | Current branch | Result |
 | --- | ---: | ---: | --- |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,301 | Added focused modules, tests, and quality evidence |
-| Tracked `src/app` Python files | 447 | 450 | Added focused portfolio/performance response helpers and the workspace performance parser |
-| Tracked Python test files | 162 | 165 | Added focused request-context, response-assembly, and workspace performance parser tests |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,303 | Added focused modules, tests, and quality evidence |
+| Tracked `src/app` Python files | 447 | 451 | Added focused portfolio/performance response helpers and workspace parser modules |
+| Tracked Python test files | 162 | 166 | Added focused request-context, response-assembly, workspace performance parser, and workspace rebalance parser tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 2,772 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
+| Largest source file | 2,968 lines | 2,729 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
 | Local unit/contract tests | 996 | 1,008 | Added focused response/request boundary and workspace performance parser tests |
@@ -59,7 +59,7 @@ Candidate thresholds:
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
 5. no new function above the current maximum of 49 lines and no unclassified largest-file growth
-   above the current 2,772-line `portfolio_service.py` maximum.
+   above the current 2,729-line `portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -242,9 +242,9 @@ baseline.
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | merged `main` at `481e091`; remote server truth showed only `main` after PR #354 cleanup |
-| Unit/contract coverage | Healthy | 1,008 unit/contract tests passed in latest merged `make check`; focused workspace rebalance parser and portfolio service tests passed with 50 tests on this branch |
-| Integration coverage | Healthy | 207 integration tests passed in latest merged `make ci` |
-| Total coverage | Healthy | 1,215 coverage tests passed in latest merged `make ci`; total coverage is 93.74%, above the 84% floor |
+| Unit/contract coverage | Healthy | 1,014 unit/contract tests passed in current branch `make check`; focused workspace rebalance parser and portfolio service tests passed with 50 tests on this branch |
+| Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
+| Total coverage | Healthy | 1,221 coverage tests passed in current branch `make ci`; total coverage is 93.78%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
 | Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser slices reduce `portfolio_service.py` to 2,729 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -232,17 +232,21 @@ preserving the 49-line longest-function baseline.
 The current portfolio workspace performance parser slice moves upstream performance summary
 payload parsing into `portfolio_workspace_performance.py`, reducing `portfolio_service.py` from
 2,797 to 2,772 lines while preserving the 49-line longest-function baseline.
+The current portfolio workspace rebalance parser slice moves manage-owned rebalance run and
+supportability payload parsing into `portfolio_workspace_rebalance.py`, reducing
+`portfolio_service.py` from 2,772 to 2,729 lines while preserving the 49-line longest-function
+baseline.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | merged `main` at `481e091`; remote server truth showed only `main` after PR #354 cleanup |
-| Unit/contract coverage | Healthy | 1,008 unit/contract tests passed in current branch `make check`; focused workspace performance parser and portfolio service tests passed with 49 tests on this branch |
-| Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
-| Total coverage | Healthy | 1,215 coverage tests passed in current branch `make ci`; total coverage is 93.74%, above the 84% floor |
+| Unit/contract coverage | Healthy | 1,008 unit/contract tests passed in latest merged `make check`; focused workspace rebalance parser and portfolio service tests passed with 50 tests on this branch |
+| Integration coverage | Healthy | 207 integration tests passed in latest merged `make ci` |
+| Total coverage | Healthy | 1,215 coverage tests passed in latest merged `make ci`; total coverage is 93.74%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser slices reduce `portfolio_service.py` to 2,772 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser slices reduce `portfolio_service.py` to 2,729 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -254,7 +258,8 @@ payload parsing into `portfolio_workspace_performance.py`, reducing `portfolio_s
    transaction-summary context loading, transaction page loading, book response assembly,
    transaction-ledger payload loading, workspace source gathering, position-book mapping,
    transaction-ledger response mapping, transaction client-kwargs mapping, and transaction page
-   context defaults, plus workspace performance parsing, are now separately testable.
+   context defaults, workspace performance parsing, and workspace rebalance parsing are now
+   separately testable.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -83,6 +83,11 @@ from app.services.portfolio_transaction_ledger import (
 )
 from app.services.portfolio_workspace_controls import build_workspace_control_capabilities
 from app.services.portfolio_workspace_performance import parse_workspace_performance_summary
+from app.services.portfolio_workspace_rebalance import (
+    parse_workspace_rebalance_summary,
+    parse_workspace_rebalance_supportability,
+    rebalance_summary_from_supportability,
+)
 from app.services.portfolio_workspace_response import (
     PortfolioWorkspaceComponents,
     PortfolioWorkspaceResponseParts,
@@ -1860,7 +1865,7 @@ class PortfolioService:
             partial_failures,
         )
         if result is None:
-            return self._rebalance_summary_from_supportability("NO_RUNS", supportability)
+            return rebalance_summary_from_supportability("NO_RUNS", supportability)
         payload = self._optional_payload(
             result,
             "lotus-manage",
@@ -1869,33 +1874,8 @@ class PortfolioService:
             partial_failures,
         )
         if payload is None:
-            return self._rebalance_summary_from_supportability("UNKNOWN", supportability)
-        items = payload.get("items", [])
-        if not isinstance(items, list) or not items:
-            return self._rebalance_summary_from_supportability("NO_RUNS", supportability)
-        latest = items[0]
-        if not isinstance(latest, dict):
-            return self._rebalance_summary_from_supportability("UNKNOWN", supportability)
-        return PortfolioRebalanceSummary(
-            status=str(latest.get("status", "UNKNOWN")),
-            last_run_at_utc=self._optional_str(latest.get("created_at")),
-            last_rebalance_run_id=self._optional_str(latest.get("rebalance_run_id")),
-            supportability=supportability,
-        )
-
-    def _rebalance_summary_from_supportability(
-        self,
-        status_value: str,
-        supportability: PortfolioRebalanceSupportabilitySummary | None,
-    ) -> PortfolioRebalanceSummary | None:
-        if supportability is None:
-            return None
-        return PortfolioRebalanceSummary(
-            status=status_value,
-            last_run_at_utc=None,
-            last_rebalance_run_id=None,
-            supportability=supportability,
-        )
+            return rebalance_summary_from_supportability("UNKNOWN", supportability)
+        return parse_workspace_rebalance_summary(payload, supportability)
 
     def _parse_workspace_rebalance_supportability(
         self,
@@ -1914,31 +1894,7 @@ class PortfolioService:
         )
         if payload is None:
             return None
-        supportability_payload = payload.get("supportability", payload)
-        if not isinstance(supportability_payload, dict):
-            warnings.append("PORTFOLIO_REBALANCE_SUPPORTABILITY_UNAVAILABLE")
-            partial_failures.append(
-                PortfolioPartialFailure(
-                    source_service="lotus-manage",
-                    error_code="PORTFOLIO_REBALANCE_SUPPORTABILITY_UNAVAILABLE",
-                    detail="lotus-manage supportability summary did not include an object payload",
-                )
-            )
-            return None
-        return PortfolioRebalanceSupportabilitySummary(
-            feature_key=(
-                self._optional_str(supportability_payload.get("feature_key"))
-                or "manage.observability.action_register_supportability"
-            ),
-            state=str(supportability_payload.get("state") or "unknown"),
-            reason=self._optional_str(supportability_payload.get("reason")),
-            freshness_bucket=self._optional_str(supportability_payload.get("freshness_bucket")),
-            run_count=self._optional_int(supportability_payload.get("run_count")),
-            operation_count=self._optional_int(supportability_payload.get("operation_count")),
-            workflow_decision_count=self._optional_int(
-                supportability_payload.get("workflow_decision_count")
-            ),
-        )
+        return parse_workspace_rebalance_supportability(payload, warnings, partial_failures)
 
     def _parse_operations(
         self,

--- a/src/app/services/portfolio_workspace_rebalance.py
+++ b/src/app/services/portfolio_workspace_rebalance.py
@@ -1,0 +1,86 @@
+from typing import Any
+
+from app.contracts.portfolio import (
+    PortfolioPartialFailure,
+    PortfolioRebalanceSummary,
+    PortfolioRebalanceSupportabilitySummary,
+)
+
+REBALANCE_SUPPORTABILITY_UNAVAILABLE = "PORTFOLIO_REBALANCE_SUPPORTABILITY_UNAVAILABLE"
+
+
+def parse_workspace_rebalance_summary(
+    payload: dict[str, Any],
+    supportability: PortfolioRebalanceSupportabilitySummary | None,
+) -> PortfolioRebalanceSummary | None:
+    items = payload.get("items", [])
+    if not isinstance(items, list) or not items:
+        return rebalance_summary_from_supportability("NO_RUNS", supportability)
+    latest = items[0]
+    if not isinstance(latest, dict):
+        return rebalance_summary_from_supportability("UNKNOWN", supportability)
+    return PortfolioRebalanceSummary(
+        status=str(latest.get("status", "UNKNOWN")),
+        last_run_at_utc=optional_text(latest.get("created_at")),
+        last_rebalance_run_id=optional_text(latest.get("rebalance_run_id")),
+        supportability=supportability,
+    )
+
+
+def rebalance_summary_from_supportability(
+    status_value: str,
+    supportability: PortfolioRebalanceSupportabilitySummary | None,
+) -> PortfolioRebalanceSummary | None:
+    if supportability is None:
+        return None
+    return PortfolioRebalanceSummary(
+        status=status_value,
+        last_run_at_utc=None,
+        last_rebalance_run_id=None,
+        supportability=supportability,
+    )
+
+
+def parse_workspace_rebalance_supportability(
+    payload: dict[str, Any],
+    warnings: list[str],
+    partial_failures: list[PortfolioPartialFailure],
+) -> PortfolioRebalanceSupportabilitySummary | None:
+    supportability_payload = payload.get("supportability", payload)
+    if not isinstance(supportability_payload, dict):
+        warnings.append(REBALANCE_SUPPORTABILITY_UNAVAILABLE)
+        partial_failures.append(
+            PortfolioPartialFailure(
+                source_service="lotus-manage",
+                error_code=REBALANCE_SUPPORTABILITY_UNAVAILABLE,
+                detail="lotus-manage supportability summary did not include an object payload",
+            )
+        )
+        return None
+    return PortfolioRebalanceSupportabilitySummary(
+        feature_key=(
+            optional_text(supportability_payload.get("feature_key"))
+            or "manage.observability.action_register_supportability"
+        ),
+        state=str(supportability_payload.get("state") or "unknown"),
+        reason=optional_text(supportability_payload.get("reason")),
+        freshness_bucket=optional_text(supportability_payload.get("freshness_bucket")),
+        run_count=optional_int(supportability_payload.get("run_count")),
+        operation_count=optional_int(supportability_payload.get("operation_count")),
+        workflow_decision_count=optional_int(supportability_payload.get("workflow_decision_count")),
+    )
+
+
+def optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/tests/unit/test_portfolio_workspace_rebalance.py
+++ b/tests/unit/test_portfolio_workspace_rebalance.py
@@ -1,0 +1,112 @@
+from app.contracts.portfolio import PortfolioPartialFailure
+from app.services.portfolio_workspace_rebalance import (
+    parse_workspace_rebalance_summary,
+    parse_workspace_rebalance_supportability,
+    rebalance_summary_from_supportability,
+)
+
+
+def test_parse_workspace_rebalance_summary_uses_latest_run() -> None:
+    supportability = parse_workspace_rebalance_supportability(
+        {
+            "supportability": {
+                "feature_key": "manage.observability.action_register_supportability",
+                "state": "ready",
+                "run_count": "3",
+                "operation_count": 12,
+                "workflow_decision_count": "5",
+            }
+        },
+        [],
+        [],
+    )
+
+    summary = parse_workspace_rebalance_summary(
+        {
+            "items": [
+                {
+                    "status": "APPROVED",
+                    "created_at": "2026-06-12T10:15:00Z",
+                    "rebalance_run_id": "run-123",
+                }
+            ]
+        },
+        supportability,
+    )
+
+    assert summary is not None
+    assert summary.status == "APPROVED"
+    assert summary.last_run_at_utc == "2026-06-12T10:15:00Z"
+    assert summary.last_rebalance_run_id == "run-123"
+    assert summary.supportability is supportability
+    assert summary.supportability is not None
+    assert summary.supportability.run_count == 3
+    assert summary.supportability.operation_count == 12
+    assert summary.supportability.workflow_decision_count == 5
+
+
+def test_parse_workspace_rebalance_summary_uses_no_runs_when_items_empty() -> None:
+    supportability = parse_workspace_rebalance_supportability({"state": "degraded"}, [], [])
+
+    summary = parse_workspace_rebalance_summary({"items": []}, supportability)
+
+    assert summary is not None
+    assert summary.status == "NO_RUNS"
+    assert summary.last_run_at_utc is None
+    assert summary.last_rebalance_run_id is None
+    assert summary.supportability is supportability
+
+
+def test_parse_workspace_rebalance_summary_uses_unknown_when_latest_is_malformed() -> None:
+    supportability = parse_workspace_rebalance_supportability({"state": "ready"}, [], [])
+
+    summary = parse_workspace_rebalance_summary({"items": ["not-a-run"]}, supportability)
+
+    assert summary is not None
+    assert summary.status == "UNKNOWN"
+    assert summary.supportability is supportability
+
+
+def test_rebalance_summary_from_supportability_requires_supportability() -> None:
+    assert rebalance_summary_from_supportability("NO_RUNS", None) is None
+
+
+def test_parse_workspace_rebalance_supportability_records_invalid_payload() -> None:
+    warnings: list[str] = []
+    partial_failures: list[PortfolioPartialFailure] = []
+
+    supportability = parse_workspace_rebalance_supportability(
+        {"supportability": []},
+        warnings,
+        partial_failures,
+    )
+
+    assert supportability is None
+    assert warnings == ["PORTFOLIO_REBALANCE_SUPPORTABILITY_UNAVAILABLE"]
+    assert len(partial_failures) == 1
+    assert partial_failures[0].source_service == "lotus-manage"
+    assert partial_failures[0].error_code == "PORTFOLIO_REBALANCE_SUPPORTABILITY_UNAVAILABLE"
+
+
+def test_parse_workspace_rebalance_supportability_defaults_and_invalid_counts() -> None:
+    supportability = parse_workspace_rebalance_supportability(
+        {
+            "state": None,
+            "reason": "source_unavailable",
+            "freshness_bucket": "stale",
+            "run_count": "not-an-int",
+            "operation_count": None,
+            "workflow_decision_count": "7",
+        },
+        [],
+        [],
+    )
+
+    assert supportability is not None
+    assert supportability.feature_key == "manage.observability.action_register_supportability"
+    assert supportability.state == "unknown"
+    assert supportability.reason == "source_unavailable"
+    assert supportability.freshness_bucket == "stale"
+    assert supportability.run_count is None
+    assert supportability.operation_count is None
+    assert supportability.workflow_decision_count == 7

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -91,11 +91,11 @@ transaction request-context, transaction page-context, transaction client-kwargs
 workspace response assembly, portfolio workspace performance parsing, and portfolio workspace
 rebalance parsing extractions, so it remains the largest-file hotspot but is trending down.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
-extraction. The current longest-function baseline is 49 lines. Local `make check` for the latest
-merged portfolio workspace performance parser branch passed with ruff, format check, monetary-float
-guard, mypy over 450 source files, Workbench/OpenAPI contract smoke, and 1,008 unit/contract tests.
-Local `make ci` passed with 207 integration tests, 1,215 coverage tests, 93.74 percent total
-coverage, and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette
-exception. GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity
-checks were green before PR #355 merged. The current portfolio workspace rebalance parser branch
-adds focused parser and portfolio service evidence with 50 passing unit tests.
+extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
+portfolio workspace rebalance parser branch passed with ruff, format check, monetary-float guard,
+mypy over 451 source files, Workbench/OpenAPI contract smoke, and 1,014 unit/contract tests. Local
+`make ci` passed with 207 integration tests, 1,221 coverage tests, 93.78 percent total coverage,
+and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette exception.
+GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were
+green before PR #355 merged. The current portfolio workspace rebalance parser branch adds focused
+parser and portfolio service evidence with 50 passing unit tests.

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -86,16 +86,16 @@ and rebalance supportability failure-recording splits then lowered the baseline 
 74 lines. The 50-commit enterprise-hardening branch then split shared analytics async polling,
 workspace-summary payload assembly, portfolio transaction-summary context loading, transaction
 page loading, and portfolio book response assembly, lowering the baseline to 62 lines.
-`portfolio_service.py` is now measured at 2,772 lines after portfolio liquidity loading,
+`portfolio_service.py` is now measured at 2,729 lines after portfolio liquidity loading,
 transaction request-context, transaction page-context, transaction client-kwargs, portfolio
-workspace response assembly, and portfolio workspace performance parsing extractions, so it
-remains the largest-file hotspot but is trending down.
+workspace response assembly, portfolio workspace performance parsing, and portfolio workspace
+rebalance parsing extractions, so it remains the largest-file hotspot but is trending down.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
-extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
-portfolio workspace performance parser branch passed with ruff, format check, monetary-float
+extraction. The current longest-function baseline is 49 lines. Local `make check` for the latest
+merged portfolio workspace performance parser branch passed with ruff, format check, monetary-float
 guard, mypy over 450 source files, Workbench/OpenAPI contract smoke, and 1,008 unit/contract tests.
 Local `make ci` passed with 207 integration tests, 1,215 coverage tests, 93.74 percent total
 coverage, and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette
 exception. GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity
-checks were green before PR #354 merged. The current portfolio workspace performance parser branch
-also adds focused parser and portfolio service evidence with 49 passing unit tests.
+checks were green before PR #355 merged. The current portfolio workspace rebalance parser branch
+adds focused parser and portfolio service evidence with 50 passing unit tests.


### PR DESCRIPTION
## Summary
- extract portfolio workspace rebalance run and supportability payload parsing into a focused helper
- add unit coverage for latest-run mapping, no-run fallback, malformed run payloads, invalid supportability payloads, and supportability defaults
- refresh quality/wiki evidence for the measured reduction in portfolio_service.py

## Validation
- python -m pytest tests/unit/test_portfolio_workspace_rebalance.py tests/unit/test_portfolio_service.py -q
- python -m pytest tests/unit/test_gateway_wiki_overview.py tests/unit/test_enterprise_readiness.py -q
- make check
- make ci

## Local evidence
- make check: 1,014 unit/contract tests passed; mypy over 451 source files
- make ci: 207 integration tests passed; 1,221 coverage tests passed; total coverage 93.78%; pip-audit found no known vulnerabilities after the governed PYSEC-2026-161 exception

## Wiki
- Updated repo-authored wiki source: wiki/Validation-and-CI.md
- Pre-merge check-only reports expected drift until branch is merged and wiki is published: Validation-and-CI.md