### PR TITLE
Extract portfolio source readiness parser

### DIFF
--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -35,7 +35,7 @@ report-only baseline is reviewed.
 
 The largest current modularity risks are:
 
-1. `src/app/services/portfolio_service.py` at 2,729 lines,
+1. `src/app/services/portfolio_service.py` at 2,629 lines,
 2. `src/app/services/performance_workspace_service.py` at 1,607 lines,
 3. `src/app/services/advisor_brief_service.py` at 1,452 lines,
 4. `src/app/services/dpm_command_center_service.py` at 1,137 lines,
@@ -144,9 +144,9 @@ descriptors separate from the public query dependency. Portfolio position-book m
 mapping now live in `src/app/services/portfolio_transaction_ledger.py`. Portfolio liquidity
 upstream payload loading now lives in `src/app/services/portfolio_liquidity_payloads.py`.
 Transaction request-context handling, transaction page-context handling, transaction client-kwargs
-mapping, portfolio workspace performance and rebalance parsing, and final portfolio workspace
-response assembly have lowered `portfolio_service.py` to 2,729 lines. Performance workspace final
-response assembly now lives in
+mapping, portfolio workspace performance and rebalance parsing, portfolio source-readiness parsing,
+and final portfolio workspace response assembly have lowered `portfolio_service.py` to 2,629
+lines. Performance workspace final response assembly now lives in
 `src/app/services/performance_workspace_response.py`, lowering
 `performance_workspace_service.py` to 1,607 lines. Lotus Core transaction query-parameter
 construction now lives in

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -154,6 +154,10 @@ The current portfolio workspace rebalance parser slice moves manage-owned rebala
 supportability payload parsing into `portfolio_workspace_rebalance.py`, reducing
 `portfolio_service.py` from 2,772 to 2,729 measured lines while preserving the 49-line
 longest-function baseline.
+The current portfolio source-readiness parser slice moves source-readiness bucket, reason,
+supportability, and indicator mapping into `portfolio_source_readiness.py`, reducing
+`portfolio_service.py` from 2,729 to 2,629 measured lines while preserving the 49-line
+longest-function baseline.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -161,21 +165,21 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,303 |
-| Python source files under `src/app` | 451 |
-| Python test files under `tests` | 166 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,305 |
+| Python source files under `src/app` | 452 |
+| Python test files under `tests` | 167 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current portfolio workspace rebalance parser branch shows
-1,303 files under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 451 Python source
-files under `src/app`; and 166 Python test files under `tests`.
+Working-tree verification for the current portfolio source-readiness parser branch shows 1,305
+files under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 452 Python source files
+under `src/app`; and 167 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 2,729 | `src/app/services/portfolio_service.py` |
+| 1 | 2,629 | `src/app/services/portfolio_service.py` |
 | 2 | 2,123 | `src/app/contracts/portfolio.py` |
 | 3 | 1,940 | `src/app/contracts/risk_workspace.py` |
 | 4 | 1,731 | `src/app/contracts/reporting.py` |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -310,6 +310,12 @@ Most recent local evidence:
 52. Current portfolio workspace rebalance parser branch: `make ci` passed with 207 integration
     tests and 1,221 combined coverage tests; total coverage is 93.78%, and `pip-audit` found no
     known vulnerabilities after the governed `PYSEC-2026-161` exception.
+53. Current portfolio source-readiness parser branch: `make check` passed with ruff, format check,
+    monetary-float guard, mypy over 452 source files, Workbench/OpenAPI contract smoke, and 1,024
+    unit/contract tests.
+54. Current portfolio source-readiness parser branch: `make ci` passed with 207 integration tests
+    and 1,231 combined coverage tests; total coverage is 93.89%, and `pip-audit` found no known
+    vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,8 +5,8 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 451 source files, contract smoke, and 1,014 unit/contract tests; `make ci` passed with 207 integration tests, 1,221 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
-| Coverage | 4/5 | 93.78% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 452 source files, contract smoke, and 1,024 unit/contract tests; `make ci` passed with 207 integration tests, 1,231 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Coverage | 4/5 | 93.89% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
 | Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, and portfolio source-readiness parsing; `portfolio_service.py` is now 2,629 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
@@ -32,9 +32,9 @@ versus the current portfolio source-readiness parser branch after PRs #349, #350
 | Largest source file | 2,968 lines | 2,629 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,014 | Added focused response/request boundary and workspace parser tests |
-| Local coverage tests | 1,203 | 1,221 | Added focused coverage while preserving total coverage |
-| Total coverage | 93.69% | 93.78% | Improved |
+| Local unit/contract tests | 996 | 1,024 | Added focused response/request boundary, workspace parser, and source-readiness parser tests |
+| Local coverage tests | 1,203 | 1,231 | Added focused coverage while preserving total coverage |
+| Total coverage | 93.69% | 93.89% | Improved |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
 ## Phase Gates

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -7,29 +7,29 @@ Mode: feature-branch evidence refresh
 | --- | ---: | --- | --- |
 | Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 451 source files, contract smoke, and 1,014 unit/contract tests; `make ci` passed with 207 integration tests, 1,221 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 93.78% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, and portfolio workspace rebalance parsing; `portfolio_service.py` is now 2,729 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, and portfolio source-readiness parsing; `portfolio_service.py` is now 2,629 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in current branch `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after PR #355 and the current focused rebalance parser slice | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after PR #356 and the current focused source-readiness parser slice | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
 Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
-versus the current portfolio workspace rebalance parser branch after PRs #349, #350, #351,
-#352, #353, #354, and #355.
+versus the current portfolio source-readiness parser branch after PRs #349, #350, #351, #352,
+#353, #354, #355, and #356.
 
 | Measure | Prior scorecard | Current branch | Result |
 | --- | ---: | ---: | --- |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,303 | Added focused modules, tests, and quality evidence |
-| Tracked `src/app` Python files | 447 | 451 | Added focused portfolio/performance response helpers and workspace parser modules |
-| Tracked Python test files | 162 | 166 | Added focused request-context, response-assembly, workspace performance parser, and workspace rebalance parser tests |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,305 | Added focused modules, tests, and quality evidence |
+| Tracked `src/app` Python files | 447 | 452 | Added focused portfolio/performance response helpers and workspace/readiness parser modules |
+| Tracked Python test files | 162 | 167 | Added focused request-context, response-assembly, workspace parser, and source-readiness parser tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 2,729 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
+| Largest source file | 2,968 lines | 2,629 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
 | Local unit/contract tests | 996 | 1,014 | Added focused response/request boundary and workspace parser tests |
@@ -59,7 +59,7 @@ Candidate thresholds:
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
 5. no new function above the current maximum of 49 lines and no unclassified largest-file growth
-   above the current 2,729-line `portfolio_service.py` maximum.
+   above the current 2,629-line `portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -245,10 +245,10 @@ baseline.
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | merged `main` at `481e091`; remote server truth showed only `main` after PR #354 cleanup |
-| Unit/contract coverage | Healthy | 1,014 unit/contract tests passed in latest merged `make check`; focused source-readiness parser and portfolio service tests passed with 54 tests on this branch |
-| Integration coverage | Healthy | 207 integration tests passed in latest merged `make ci` |
-| Total coverage | Healthy | 1,221 coverage tests passed in latest merged `make ci`; total coverage is 93.78%, above the 84% floor |
+| Branch hygiene | Healthy | Current source-readiness parser branch was created from clean `main` after PR #356; final remote/local cleanup remains a post-merge gate |
+| Unit/contract coverage | Healthy | 1,024 unit/contract tests passed in current branch `make check`; focused source-readiness parser and portfolio service tests passed with 54 tests on this branch |
+| Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
+| Total coverage | Healthy | 1,231 coverage tests passed in current branch `make ci`; total coverage is 93.89%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
 | Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser slices reduce `portfolio_service.py` to 2,629 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -236,17 +236,21 @@ The current portfolio workspace rebalance parser slice moves manage-owned rebala
 supportability payload parsing into `portfolio_workspace_rebalance.py`, reducing
 `portfolio_service.py` from 2,772 to 2,729 lines while preserving the 49-line longest-function
 baseline.
+The current portfolio source-readiness parser slice moves source-readiness bucket, reason,
+supportability, and indicator mapping into `portfolio_source_readiness.py`, reducing
+`portfolio_service.py` from 2,729 to 2,629 lines while preserving the 49-line longest-function
+baseline.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | merged `main` at `481e091`; remote server truth showed only `main` after PR #354 cleanup |
-| Unit/contract coverage | Healthy | 1,014 unit/contract tests passed in current branch `make check`; focused workspace rebalance parser and portfolio service tests passed with 50 tests on this branch |
-| Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
-| Total coverage | Healthy | 1,221 coverage tests passed in current branch `make ci`; total coverage is 93.78%, above the 84% floor |
+| Unit/contract coverage | Healthy | 1,014 unit/contract tests passed in latest merged `make check`; focused source-readiness parser and portfolio service tests passed with 54 tests on this branch |
+| Integration coverage | Healthy | 207 integration tests passed in latest merged `make ci` |
+| Total coverage | Healthy | 1,221 coverage tests passed in latest merged `make ci`; total coverage is 93.78%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser slices reduce `portfolio_service.py` to 2,729 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser slices reduce `portfolio_service.py` to 2,629 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -258,8 +262,8 @@ baseline.
    transaction-summary context loading, transaction page loading, book response assembly,
    transaction-ledger payload loading, workspace source gathering, position-book mapping,
    transaction-ledger response mapping, transaction client-kwargs mapping, and transaction page
-   context defaults, workspace performance parsing, and workspace rebalance parsing are now
-   separately testable.
+   context defaults, workspace performance parsing, workspace rebalance parsing, and source
+   readiness parsing are now separately testable.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -35,15 +35,12 @@ from app.contracts.portfolio import (
     PortfolioPositionView,
     PortfolioProfile,
     PortfolioProjectedCashflowResponse,
-    PortfolioReadinessBucket,
     PortfolioReadinessIndicator,
-    PortfolioReadinessReason,
     PortfolioReadinessResponse,
     PortfolioRebalanceSummary,
     PortfolioRebalanceSupportabilitySummary,
     PortfolioReportingReadiness,
     PortfolioSummary,
-    PortfolioSupportabilitySummary,
     PortfolioTopPosition,
     PortfolioTransactionLedgerResponse,
     PortfolioWorkflowAction,
@@ -72,6 +69,12 @@ from app.services.portfolio_position_book import (
     build_top_positions,
     parse_position_book_summary,
     parse_positions,
+)
+from app.services.portfolio_source_readiness import (
+    build_source_readiness_indicators,
+    parse_portfolio_supportability,
+    parse_readiness_bucket,
+    parse_readiness_reasons,
 )
 from app.services.portfolio_transaction_ledger import (
     PortfolioTransactionsRequestContext,
@@ -937,7 +940,7 @@ class PortfolioService:
         transactions: PortfolioTransactionLedgerResponse,
         source_payload: dict[str, Any] | None,
     ) -> PortfolioReadinessResponse:
-        indicators = self._build_source_readiness_indicators(
+        indicators = build_source_readiness_indicators(
             payload=source_payload,
             detailed_view=False,
         ) or self._build_readiness_indicators(
@@ -952,14 +955,14 @@ class PortfolioService:
             contract_version=settings.contract_version,
             portfolio_id=portfolio_id,
             as_of_date=workspace.as_of_date,
-            holdings=self._parse_readiness_bucket((source_payload or {}).get("holdings")),
-            pricing=self._parse_readiness_bucket((source_payload or {}).get("pricing")),
-            transactions=self._parse_readiness_bucket((source_payload or {}).get("transactions")),
-            reporting=self._parse_readiness_bucket((source_payload or {}).get("reporting")),
-            blocking_reasons=self._parse_readiness_reasons(
+            holdings=parse_readiness_bucket((source_payload or {}).get("holdings")),
+            pricing=parse_readiness_bucket((source_payload or {}).get("pricing")),
+            transactions=parse_readiness_bucket((source_payload or {}).get("transactions")),
+            reporting=parse_readiness_bucket((source_payload or {}).get("reporting")),
+            blocking_reasons=parse_readiness_reasons(
                 (source_payload or {}).get("blocking_reasons")
             ),
-            supportability=self._parse_portfolio_supportability(
+            supportability=parse_portfolio_supportability(
                 (source_payload or {}).get("supportability")
             ),
             indicators=indicators,
@@ -2682,115 +2685,6 @@ class PortfolioService:
             effective_mode=effective_mode,
             applied=bool(payload.get("applied", False)),
         )
-
-    def _parse_readiness_bucket(self, payload: Any) -> PortfolioReadinessBucket | None:
-        if not isinstance(payload, dict):
-            return None
-        status_value = self._optional_str(payload.get("status"))
-        if status_value is None:
-            return None
-        return PortfolioReadinessBucket(
-            status=self._map_source_readiness_status(status_value),
-            reasons=self._parse_readiness_reasons(payload.get("reasons")),
-        )
-
-    def _parse_readiness_reasons(self, payload: Any) -> list[PortfolioReadinessReason]:
-        if not isinstance(payload, list):
-            return []
-        reasons: list[PortfolioReadinessReason] = []
-        for item in payload:
-            if not isinstance(item, dict):
-                continue
-            code = self._optional_str(item.get("code"))
-            if code is None:
-                continue
-            reasons.append(
-                PortfolioReadinessReason(
-                    code=code,
-                    detail=self._optional_str(item.get("detail")),
-                )
-            )
-        return reasons
-
-    def _parse_portfolio_supportability(
-        self, payload: Any
-    ) -> PortfolioSupportabilitySummary | None:
-        if not isinstance(payload, dict):
-            return None
-        state = self._optional_str(payload.get("state"))
-        reason = self._optional_str(payload.get("reason"))
-        if state is None or reason is None:
-            return None
-        return PortfolioSupportabilitySummary(
-            feature_key=(
-                self._optional_str(payload.get("feature_key"))
-                or "core.observability.portfolio_supportability"
-            ),
-            state=state,
-            reason=reason,
-            freshness_bucket=self._map_portfolio_supportability_freshness(
-                payload.get("freshness_bucket")
-            ),
-            ready_domains=self._optional_int(payload.get("ready_domains")) or 0,
-            pending_domains=self._optional_int(payload.get("pending_domains")) or 0,
-            blocked_domains=self._optional_int(payload.get("blocked_domains")) or 0,
-            no_activity_domains=self._optional_int(payload.get("no_activity_domains")) or 0,
-        )
-
-    def _map_portfolio_supportability_freshness(self, value: Any) -> str:
-        normalized = str(value or "").strip().lower()
-        if normalized in {"fresh", "current"}:
-            return "fresh"
-        if normalized == "stale":
-            return "stale"
-        return "unknown"
-
-    def _build_source_readiness_indicators(
-        self, payload: dict[str, Any] | None, detailed_view: bool
-    ) -> list[PortfolioReadinessIndicator]:
-        if payload is None:
-            return []
-        return [
-            PortfolioReadinessIndicator(
-                key="holdings",
-                label="Holdings",
-                status=self._map_source_readiness_status(payload.get("holdings", {}).get("status")),
-                href="#portfolio-drilldown" if detailed_view else "#portfolio-insights",
-            ),
-            PortfolioReadinessIndicator(
-                key="pricing",
-                label="Pricing",
-                status=self._map_source_readiness_status(payload.get("pricing", {}).get("status")),
-                href="#portfolio-attention",
-            ),
-            PortfolioReadinessIndicator(
-                key="transactions",
-                label="Transactions",
-                status=self._map_source_readiness_status(
-                    payload.get("transactions", {}).get("status")
-                ),
-                href="#portfolio-drilldown" if detailed_view else "#portfolio-insights",
-            ),
-            PortfolioReadinessIndicator(
-                key="reporting",
-                label="Reporting",
-                status=self._map_source_readiness_status(
-                    payload.get("reporting", {}).get("status")
-                ),
-                href="#portfolio-health",
-            ),
-        ]
-
-    def _map_source_readiness_status(self, status_value: Any) -> str:
-        normalized = str(status_value or "").strip().upper()
-        mapping = {
-            "READY": "Ready",
-            "PENDING": "Pending",
-            "BLOCKED": "Blocked",
-            "FAILED": "Blocked",
-            "EMPTY": "Empty",
-        }
-        return mapping.get(normalized, "Pending" if normalized else "Unknown")
 
     def _optional_payload(
         self,

--- a/src/app/services/portfolio_source_readiness.py
+++ b/src/app/services/portfolio_source_readiness.py
@@ -1,0 +1,130 @@
+from typing import Any
+
+from app.contracts.portfolio import (
+    PortfolioReadinessBucket,
+    PortfolioReadinessIndicator,
+    PortfolioReadinessReason,
+    PortfolioSupportabilitySummary,
+)
+
+
+def parse_readiness_bucket(payload: Any) -> PortfolioReadinessBucket | None:
+    if not isinstance(payload, dict):
+        return None
+    status_value = optional_text(payload.get("status"))
+    if status_value is None:
+        return None
+    return PortfolioReadinessBucket(
+        status=map_source_readiness_status(status_value),
+        reasons=parse_readiness_reasons(payload.get("reasons")),
+    )
+
+
+def parse_readiness_reasons(payload: Any) -> list[PortfolioReadinessReason]:
+    if not isinstance(payload, list):
+        return []
+    reasons: list[PortfolioReadinessReason] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        code = optional_text(item.get("code"))
+        if code is None:
+            continue
+        reasons.append(
+            PortfolioReadinessReason(
+                code=code,
+                detail=optional_text(item.get("detail")),
+            )
+        )
+    return reasons
+
+
+def parse_portfolio_supportability(payload: Any) -> PortfolioSupportabilitySummary | None:
+    if not isinstance(payload, dict):
+        return None
+    state = optional_text(payload.get("state"))
+    reason = optional_text(payload.get("reason"))
+    if state is None or reason is None:
+        return None
+    return PortfolioSupportabilitySummary(
+        feature_key=(
+            optional_text(payload.get("feature_key"))
+            or "core.observability.portfolio_supportability"
+        ),
+        state=state,
+        reason=reason,
+        freshness_bucket=map_portfolio_supportability_freshness(payload.get("freshness_bucket")),
+        ready_domains=optional_int(payload.get("ready_domains")) or 0,
+        pending_domains=optional_int(payload.get("pending_domains")) or 0,
+        blocked_domains=optional_int(payload.get("blocked_domains")) or 0,
+        no_activity_domains=optional_int(payload.get("no_activity_domains")) or 0,
+    )
+
+
+def build_source_readiness_indicators(
+    payload: dict[str, Any] | None, detailed_view: bool
+) -> list[PortfolioReadinessIndicator]:
+    if payload is None:
+        return []
+    return [
+        PortfolioReadinessIndicator(
+            key="holdings",
+            label="Holdings",
+            status=map_source_readiness_status(payload.get("holdings", {}).get("status")),
+            href="#portfolio-drilldown" if detailed_view else "#portfolio-insights",
+        ),
+        PortfolioReadinessIndicator(
+            key="pricing",
+            label="Pricing",
+            status=map_source_readiness_status(payload.get("pricing", {}).get("status")),
+            href="#portfolio-attention",
+        ),
+        PortfolioReadinessIndicator(
+            key="transactions",
+            label="Transactions",
+            status=map_source_readiness_status(payload.get("transactions", {}).get("status")),
+            href="#portfolio-drilldown" if detailed_view else "#portfolio-insights",
+        ),
+        PortfolioReadinessIndicator(
+            key="reporting",
+            label="Reporting",
+            status=map_source_readiness_status(payload.get("reporting", {}).get("status")),
+            href="#portfolio-health",
+        ),
+    ]
+
+
+def map_source_readiness_status(status_value: Any) -> str:
+    normalized = str(status_value or "").strip().upper()
+    mapping = {
+        "READY": "Ready",
+        "PENDING": "Pending",
+        "BLOCKED": "Blocked",
+        "FAILED": "Blocked",
+        "EMPTY": "Empty",
+    }
+    return mapping.get(normalized, "Pending" if normalized else "Unknown")
+
+
+def map_portfolio_supportability_freshness(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"fresh", "current"}:
+        return "fresh"
+    if normalized == "stale":
+        return "stale"
+    return "unknown"
+
+
+def optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/tests/unit/test_portfolio_source_readiness.py
+++ b/tests/unit/test_portfolio_source_readiness.py
@@ -1,0 +1,123 @@
+from app.services.portfolio_source_readiness import (
+    build_source_readiness_indicators,
+    map_portfolio_supportability_freshness,
+    map_source_readiness_status,
+    parse_portfolio_supportability,
+    parse_readiness_bucket,
+    parse_readiness_reasons,
+)
+
+
+def test_parse_readiness_bucket_maps_status_and_reasons() -> None:
+    bucket = parse_readiness_bucket(
+        {
+            "status": "FAILED",
+            "reasons": [
+                {"code": "NO_PRICE", "detail": "latest price unavailable"},
+                {"detail": "missing code"},
+                "not-a-reason",
+            ],
+        }
+    )
+
+    assert bucket is not None
+    assert bucket.status == "Blocked"
+    assert len(bucket.reasons) == 1
+    assert bucket.reasons[0].code == "NO_PRICE"
+    assert bucket.reasons[0].detail == "latest price unavailable"
+
+
+def test_parse_readiness_bucket_requires_object_and_status() -> None:
+    assert parse_readiness_bucket(None) is None
+    assert parse_readiness_bucket({"reasons": []}) is None
+
+
+def test_parse_readiness_reasons_ignores_non_list_payload() -> None:
+    assert parse_readiness_reasons({"code": "NO_PRICE"}) == []
+
+
+def test_parse_portfolio_supportability_defaults_feature_and_counts() -> None:
+    supportability = parse_portfolio_supportability(
+        {
+            "state": "ready",
+            "reason": "all_domains_ready",
+            "freshness_bucket": "current",
+            "ready_domains": "3",
+            "pending_domains": None,
+            "blocked_domains": "bad-count",
+            "no_activity_domains": 1,
+        }
+    )
+
+    assert supportability is not None
+    assert supportability.feature_key == "core.observability.portfolio_supportability"
+    assert supportability.state == "ready"
+    assert supportability.reason == "all_domains_ready"
+    assert supportability.freshness_bucket == "fresh"
+    assert supportability.ready_domains == 3
+    assert supportability.pending_domains == 0
+    assert supportability.blocked_domains == 0
+    assert supportability.no_activity_domains == 1
+
+
+def test_parse_portfolio_supportability_requires_state_and_reason() -> None:
+    assert parse_portfolio_supportability([]) is None
+    assert parse_portfolio_supportability({"state": "ready"}) is None
+    assert parse_portfolio_supportability({"reason": "missing_state"}) is None
+
+
+def test_build_source_readiness_indicators_maps_detail_mode_links() -> None:
+    indicators = build_source_readiness_indicators(
+        {
+            "holdings": {"status": "READY"},
+            "pricing": {"status": "EMPTY"},
+            "transactions": {"status": "pending"},
+            "reporting": {"status": "blocked"},
+        },
+        detailed_view=True,
+    )
+
+    assert [indicator.key for indicator in indicators] == [
+        "holdings",
+        "pricing",
+        "transactions",
+        "reporting",
+    ]
+    assert [indicator.status for indicator in indicators] == [
+        "Ready",
+        "Empty",
+        "Pending",
+        "Blocked",
+    ]
+    assert indicators[0].href == "#portfolio-drilldown"
+    assert indicators[2].href == "#portfolio-drilldown"
+
+
+def test_build_source_readiness_indicators_maps_summary_mode_links() -> None:
+    indicators = build_source_readiness_indicators(
+        {"holdings": {"status": "READY"}, "transactions": {"status": "READY"}},
+        detailed_view=False,
+    )
+
+    assert indicators[0].href == "#portfolio-insights"
+    assert indicators[2].href == "#portfolio-insights"
+    assert indicators[1].status == "Unknown"
+    assert indicators[3].status == "Unknown"
+
+
+def test_build_source_readiness_indicators_requires_payload() -> None:
+    assert build_source_readiness_indicators(None, detailed_view=False) == []
+
+
+def test_map_source_readiness_status_defaults_are_stable() -> None:
+    assert map_source_readiness_status("READY") == "Ready"
+    assert map_source_readiness_status("FAILED") == "Blocked"
+    assert map_source_readiness_status("unexpected") == "Pending"
+    assert map_source_readiness_status(None) == "Unknown"
+
+
+def test_map_portfolio_supportability_freshness_defaults_are_stable() -> None:
+    assert map_portfolio_supportability_freshness("fresh") == "fresh"
+    assert map_portfolio_supportability_freshness("current") == "fresh"
+    assert map_portfolio_supportability_freshness("stale") == "stale"
+    assert map_portfolio_supportability_freshness("unknown-value") == "unknown"

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -92,10 +92,10 @@ workspace response assembly, portfolio workspace performance parsing, and portfo
 rebalance parsing, and portfolio source-readiness parsing extractions, so it remains the
 largest-file hotspot but is trending down.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
-extraction. The current longest-function baseline is 49 lines. Local `make check` for the latest
-merged portfolio workspace rebalance parser branch passed with ruff, format check, monetary-float guard,
-mypy over 451 source files, Workbench/OpenAPI contract smoke, and 1,014 unit/contract tests. Local
-`make ci` passed with 207 integration tests, 1,221 coverage tests, 93.78 percent total coverage,
+extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
+portfolio source-readiness parser branch passed with ruff, format check, monetary-float guard,
+mypy over 452 source files, Workbench/OpenAPI contract smoke, and 1,024 unit/contract tests. Local
+`make ci` passed with 207 integration tests, 1,231 coverage tests, 93.89 percent total coverage,
 and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette exception.
 GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were
 green before PR #356 merged. The current portfolio source-readiness parser branch adds focused

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -86,16 +86,17 @@ and rebalance supportability failure-recording splits then lowered the baseline 
 74 lines. The 50-commit enterprise-hardening branch then split shared analytics async polling,
 workspace-summary payload assembly, portfolio transaction-summary context loading, transaction
 page loading, and portfolio book response assembly, lowering the baseline to 62 lines.
-`portfolio_service.py` is now measured at 2,729 lines after portfolio liquidity loading,
+`portfolio_service.py` is now measured at 2,629 lines after portfolio liquidity loading,
 transaction request-context, transaction page-context, transaction client-kwargs, portfolio
 workspace response assembly, portfolio workspace performance parsing, and portfolio workspace
-rebalance parsing extractions, so it remains the largest-file hotspot but is trending down.
+rebalance parsing, and portfolio source-readiness parsing extractions, so it remains the
+largest-file hotspot but is trending down.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
-extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
-portfolio workspace rebalance parser branch passed with ruff, format check, monetary-float guard,
+extraction. The current longest-function baseline is 49 lines. Local `make check` for the latest
+merged portfolio workspace rebalance parser branch passed with ruff, format check, monetary-float guard,
 mypy over 451 source files, Workbench/OpenAPI contract smoke, and 1,014 unit/contract tests. Local
 `make ci` passed with 207 integration tests, 1,221 coverage tests, 93.78 percent total coverage,
 and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette exception.
 GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were
-green before PR #355 merged. The current portfolio workspace rebalance parser branch adds focused
-parser and portfolio service evidence with 50 passing unit tests.
+green before PR #356 merged. The current portfolio source-readiness parser branch adds focused
+parser and portfolio service evidence with 54 passing unit tests.


### PR DESCRIPTION
## Summary
- Extract portfolio source-readiness bucket, reason, supportability, and indicator mapping into `portfolio_source_readiness.py`.
- Add focused unit coverage for readiness status, supportability defaults, malformed payloads, and detail/summary indicator links.
- Refresh quality and wiki evidence to the current source-readiness parser branch metrics.

## Validation
- `python -m ruff format src/app/services/portfolio_service.py src/app/services/portfolio_source_readiness.py tests/unit/test_portfolio_source_readiness.py`
- `python -m ruff check src/app/services/portfolio_service.py src/app/services/portfolio_source_readiness.py tests/unit/test_portfolio_source_readiness.py`
- `python -m pytest tests/unit/test_portfolio_source_readiness.py tests/unit/test_portfolio_service.py -q` (54 passed)
- `python -m pytest tests/unit/test_gateway_wiki_overview.py tests/unit/test_enterprise_readiness.py tests/unit/test_portfolio_source_readiness.py tests/unit/test_portfolio_service.py -q` (72 passed)
- `make check` (ruff, format check, monetary-float guard, mypy over 452 source files, Workbench/OpenAPI contract smoke, 1,024 unit/contract tests)
- `make ci` (207 integration tests, 1,231 combined coverage tests, 93.89% total coverage, `pip-audit` found no known vulnerabilities after governed `PYSEC-2026-161` exception)
- `python -m pytest tests/unit/test_gateway_wiki_overview.py tests/unit/test_enterprise_readiness.py -q` (18 passed)
- `git diff --check`

## Governance
- Stranded truth scan: `git fetch origin --prune`; `git branch -r --no-merged origin/main` returned no unmerged remote branches.
- Wiki source changed: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reports expected drift in `Validation-and-CI.md` before merge/publication.
- Tiering: Experience API slice; Feature Lane and PR Merge Gate are PR-blocking, heavier platform end-to-end evidence is not required because this is behavior-preserving payload parsing extraction with unit and integration coverage.