### PR TITLE
Extract portfolio workflow mapper

### DIFF
--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -162,6 +162,11 @@ The current portfolio transaction summary mapper slice moves income/activity res
 money aggregation, tax bucketing, and transaction-date filtering into
 `portfolio_transaction_summary.py`, reducing `portfolio_service.py` from 2,629 to 2,438 measured
 lines while preserving the 49-line longest-function baseline.
+The current portfolio workflow mapper slice moves workflow launch cues, readiness status labels,
+empty-book action sequencing, and supported-cue action ordering into `portfolio_workflow.py`,
+reducing `portfolio_service.py` from 2,438 to 2,076 measured lines while preserving the 49-line
+longest-function baseline. The largest source-file hotspot is now the portfolio contract module,
+not the portfolio orchestration service.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -169,22 +174,22 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,313 |
-| Python source files under `src/app` | 453 |
-| Python test files under `tests` | 168 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,317 |
+| Python source files under `src/app` | 454 |
+| Python test files under `tests` | 169 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current portfolio transaction summary mapper branch shows 1,313
-files under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 453 Python source files
-under `src/app`; and 168 Python test files under `tests`.
+Working-tree verification for the current portfolio workflow mapper branch shows 1,317 files under
+`src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 454 Python source files under
+`src/app`; and 169 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 2,438 | `src/app/services/portfolio_service.py` |
-| 2 | 2,226 | `src/app/contracts/portfolio.py` |
+| 1 | 2,226 | `src/app/contracts/portfolio.py` |
+| 2 | 2,076 | `src/app/services/portfolio_service.py` |
 | 3 | 2,043 | `src/app/contracts/risk_workspace.py` |
 | 4 | 1,840 | `src/app/contracts/reporting.py` |
 | 5 | 1,704 | `src/app/services/performance_workspace_service.py` |
@@ -203,11 +208,11 @@ under `src/app`; and 168 Python test files under `tests`.
 | 3 | 47 | `_build_workspace_descriptor_contract` | `src/app/services/platform_capabilities_shell.py` |
 | 4 | 47 | `_build_performance_workspace_response` | `src/app/services/performance_workspace_service.py` |
 | 5 | 46 | `get_portfolio_360` | `src/app/services/workbench_service.py` |
-| 6 | 46 | `_unpack_rebalance_supportability_summary` | `src/app/services/workbench_rebalance_snapshot.py` |
-| 7 | 46 | `_performance_payload_from_result` | `src/app/services/workbench_performance_snapshot.py` |
-| 8 | 46 | `_assemble_portfolio_workspace_components` | `src/app/services/portfolio_service.py` |
-| 9 | 46 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
-| 10 | 46 | `build_horizon_row_return_fields` | `src/app/services/performance_workspace_horizon.py` |
+| 6 | 46 | `get_performance_attribution_trend` | `src/app/services/performance_workspace_service.py` |
+| 7 | 46 | `build_horizon_row_return_fields` | `src/app/services/performance_workspace_horizon.py` |
+| 8 | 46 | `_unpack_rebalance_supportability_summary` | `src/app/services/workbench_rebalance_snapshot.py` |
+| 9 | 46 | `_performance_payload_from_result` | `src/app/services/workbench_performance_snapshot.py` |
+| 10 | 46 | `_parse_core_snapshot` | `src/app/services/foundation_service.py` |
 
 ## Existing Blocking Gates
 
@@ -328,6 +333,14 @@ Most recent local evidence:
 57. Current portfolio transaction summary mapper branch: `make ci` passed with 207 integration
     tests and 1,236 combined coverage tests; total coverage is 93.95%, and `pip-audit` found no
     known vulnerabilities after the governed `PYSEC-2026-161` exception.
+58. Current portfolio workflow mapper branch: focused validation passed with ruff, mypy over the
+    touched service modules, diff whitespace checks, and 46 workflow/portfolio service unit tests.
+59. Current portfolio workflow mapper branch: `make check` passed with ruff, format check,
+    monetary-float guard, mypy over 454 source files, Workbench/OpenAPI contract smoke, and 1,031
+    unit/contract tests.
+60. Current portfolio workflow mapper branch: `make ci` passed with 207 integration tests and
+    1,238 combined coverage tests; total coverage is 94.00%, and `pip-audit` found no known
+    vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,36 +5,36 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 453 source files, contract smoke, and 1,029 unit/contract tests; `make ci` passed with 207 integration tests, 1,236 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
-| Coverage | 4/5 | 93.95% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, and portfolio transaction summary mapping; `portfolio_service.py` is now 2,438 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 454 source files, contract smoke, and 1,031 unit/contract tests; `make ci` passed with 207 integration tests, 1,238 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Coverage | 4/5 | 94.00% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
+| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, and portfolio workflow mapping; `portfolio_service.py` is now 2,076 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in current branch `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after PR #357 and the current focused transaction summary mapper slice | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused portfolio workflow mapper slice | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
 Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
-versus the current portfolio transaction summary mapper branch after PRs #349, #350, #351, #352,
-#353, #354, #355, #356, and #357.
+versus the current portfolio workflow mapper branch after PRs #349, #350, #351, #352, #353, #354,
+#355, #356, #357, and #358.
 
 | Measure | Prior scorecard | Current branch | Result |
 | --- | ---: | ---: | --- |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,313 | Added focused modules, tests, and quality evidence |
-| Tracked `src/app` Python files | 447 | 453 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary parser modules |
-| Tracked Python test files | 162 | 168 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, and transaction summary mapper tests |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,317 | Added focused modules, tests, and quality evidence |
+| Tracked `src/app` Python files | 447 | 454 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper modules |
+| Tracked Python test files | 162 | 169 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, and workflow mapper tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 2,438 lines | Improved; `portfolio_service.py` remains largest residual hotspot |
+| Largest source file | 2,968 lines | 2,226 lines | Improved; `src/app/contracts/portfolio.py` is now the largest residual hotspot |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,029 | Added focused response/request boundary, workspace parser, source-readiness parser, and transaction summary mapper tests |
-| Local coverage tests | 1,203 | 1,236 | Added focused coverage while preserving total coverage |
-| Total coverage | 93.69% | 93.95% | Improved |
+| Local unit/contract tests | 996 | 1,031 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, and workflow mapper tests |
+| Local coverage tests | 1,203 | 1,238 | Added focused coverage while preserving total coverage |
+| Total coverage | 93.69% | 94.00% | Improved |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
 ## Phase Gates
@@ -59,7 +59,7 @@ Candidate thresholds:
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
 5. no new function above the current maximum of 49 lines and no unclassified largest-file growth
-   above the current 2,438-line `portfolio_service.py` maximum.
+   above the current 2,226-line `src/app/contracts/portfolio.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -244,17 +244,21 @@ The current portfolio transaction summary mapper slice moves income/activity res
 money aggregation, tax bucketing, and transaction-date filtering into
 `portfolio_transaction_summary.py`, reducing `portfolio_service.py` from 2,629 to 2,438 lines
 while preserving the 49-line longest-function baseline.
+The current portfolio workflow mapper slice moves workflow launch cue construction, readiness
+status labels, empty-book setup sequencing, and supported-cue action ordering into
+`portfolio_workflow.py`, reducing `portfolio_service.py` from 2,438 to 2,076 lines while
+preserving the 49-line longest-function baseline.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | Current transaction summary mapper branch was created from clean `main` after PR #357; final remote/local cleanup remains a post-merge gate |
-| Unit/contract coverage | Healthy | 1,029 unit/contract tests passed in current branch `make check`; focused transaction summary, portfolio service, and transaction ledger tests passed with 57 tests on this branch |
+| Branch hygiene | Healthy | Current workflow mapper branch was created from clean `main` after PR #358; final remote/local cleanup remains a post-merge gate |
+| Unit/contract coverage | Healthy | 1,031 unit/contract tests passed in current branch `make check`; focused workflow mapper and portfolio service tests passed with 46 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
-| Total coverage | Healthy | 1,236 coverage tests passed in current branch `make ci`; total coverage is 93.95%, above the 84% floor |
+| Total coverage | Healthy | 1,238 coverage tests passed in current branch `make ci`; total coverage is 94.00%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser slices reduce `portfolio_service.py` to 2,438 measured lines and `performance_workspace_service.py` to 1,607 measured lines; several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper slices reduce `portfolio_service.py` to 2,076 measured lines and `performance_workspace_service.py` to 1,607 measured lines; large contracts and several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -262,12 +266,13 @@ while preserving the 49-line longest-function baseline.
 ## Primary Refactor Backlog
 
 1. Continue splitting `portfolio_service.py` into source-readiness, workspace, insight, and
-   workflow-cue adapters. Exception-summary payload construction, workflow-action assembly,
+   workflow adapters. Exception-summary payload construction, workflow-action assembly,
    transaction-summary context loading, transaction page loading, book response assembly,
    transaction-ledger payload loading, workspace source gathering, position-book mapping,
    transaction-ledger response mapping, transaction client-kwargs mapping, transaction page
    context defaults, workspace performance parsing, workspace rebalance parsing, source readiness
-   parsing, and transaction summary mapping are now separately testable.
+   parsing, transaction summary mapping, and workflow cue/action mapping are now separately
+   testable.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -31,7 +31,6 @@ from app.contracts.portfolio import (
     PortfolioPositionView,
     PortfolioProfile,
     PortfolioProjectedCashflowResponse,
-    PortfolioReadinessIndicator,
     PortfolioReadinessResponse,
     PortfolioRebalanceSummary,
     PortfolioRebalanceSupportabilitySummary,
@@ -39,8 +38,6 @@ from app.contracts.portfolio import (
     PortfolioSummary,
     PortfolioTopPosition,
     PortfolioTransactionLedgerResponse,
-    PortfolioWorkflowAction,
-    PortfolioWorkflowLaunchCue,
     PortfolioWorkflowResponse,
     PortfolioWorkspaceControlCapabilities,
     PortfolioWorkspaceResponse,
@@ -86,6 +83,15 @@ from app.services.portfolio_transaction_summary import (
     build_income_summary_response,
     transaction_date_in_range,
     transaction_date_value,
+)
+from app.services.portfolio_workflow import (
+    build_readiness_indicators,
+    build_workflow_actions,
+    build_workflow_cues,
+    holdings_readiness_status,
+    pricing_readiness_status,
+    reporting_status_label,
+    transactions_readiness_status,
 )
 from app.services.portfolio_workspace_controls import build_workspace_control_capabilities
 from app.services.portfolio_workspace_performance import parse_workspace_performance_summary
@@ -188,105 +194,7 @@ class PortfolioBookSourceResults:
     portfolio_result: UpstreamResult
 
 
-@dataclass(frozen=True)
-class PortfolioWorkflowActionSpec:
-    title: str
-    impact: str
-    target: str
-    href: str
-    cta_label: str
-    recommended: bool = False
-
-
-EMPTY_PORTFOLIO_WORKFLOW_ACTION_SPECS: tuple[PortfolioWorkflowActionSpec, ...] = (
-    PortfolioWorkflowActionSpec(
-        title="Fund portfolio",
-        impact=(
-            "Create opening liquidity so balances, allocation, and readiness checks become "
-            "meaningful."
-        ),
-        target="Target: cash funding and opening balance setup",
-        href="operations",
-        cta_label="Fund now",
-        recommended=True,
-    ),
-    PortfolioWorkflowActionSpec(
-        title="Book first trade",
-        impact="Activate the holdings book and create the first investable position.",
-        target="Target: transaction entry and execution workflow",
-        href="operations",
-        cta_label="Book trade",
-    ),
-    PortfolioWorkflowActionSpec(
-        title="Publish pricing",
-        impact="Enable valuation, allocation, and downstream reporting coverage.",
-        target="Target: pricing publication and valuation refresh",
-        href="operations",
-        cta_label="Publish prices",
-    ),
-    PortfolioWorkflowActionSpec(
-        title="Review holdings",
-        impact="Confirm the funded book, position weights, and coverage after valuation.",
-        target="Target: holdings and allocation review",
-        href="#portfolio-insights",
-        cta_label="Open holdings",
-    ),
-    PortfolioWorkflowActionSpec(
-        title="Open performance",
-        impact="Review return analytics once holdings are funded and valued.",
-        target="Target: performance workspace after valuation is available",
-        href="performance",
-        cta_label="Open performance",
-    ),
-)
-
-
 class PortfolioService:
-    _WORKFLOW_DEFINITIONS: dict[str, dict[str, str | int]] = {
-        "performance": {
-            "order": 0,
-            "title": "Review performance",
-            "cta_label": "Performance",
-            "target_label": "Performance",
-            "impact": (
-                "Review portfolio return, benchmark context, and contribution once the book "
-                "is valued."
-            ),
-        },
-        "holdings": {
-            "order": 1,
-            "title": "Review holdings",
-            "cta_label": "Holdings",
-            "target_label": "Holdings",
-            "impact": (
-                "Confirm funded positions, valuations, and portfolio weights before client review."
-            ),
-        },
-        "transactions": {
-            "order": 2,
-            "title": "Review transactions",
-            "cta_label": "Transactions",
-            "target_label": "Transactions",
-            "impact": "Inspect recent funding, trading, and cash activity affecting the book.",
-        },
-        "risk": {
-            "order": 3,
-            "title": "Review suitability",
-            "cta_label": "Suitability",
-            "target_label": "Suitability",
-            "impact": (
-                "Validate suitability, exposure, and mandate fit before the next client action."
-            ),
-        },
-        "proposal": {
-            "order": 4,
-            "title": "Prepare recommendation",
-            "cta_label": "Recommendation",
-            "target_label": "Recommendation",
-            "impact": "Prepare the next recommended portfolio action or client proposal.",
-        },
-    }
-
     def __init__(
         self,
         lotus_core_query_client: PortfolioCoreClient,
@@ -759,7 +667,7 @@ class PortfolioService:
                 effective_as_of_date=resolved_as_of_date,
                 requested_reporting_currency=reporting_currency,
             ),
-            workflow_cues=self._build_workflow_cues(portfolio_id),
+            workflow_cues=build_workflow_cues(portfolio_id),
             warnings=components.warnings,
             partial_failures=components.partial_failures,
         )
@@ -935,7 +843,7 @@ class PortfolioService:
         indicators = build_source_readiness_indicators(
             payload=source_payload,
             detailed_view=False,
-        ) or self._build_readiness_indicators(
+        ) or build_readiness_indicators(
             workspace=workspace,
             positions=positions.positions,
             allocation_views=allocations.views,
@@ -1044,10 +952,9 @@ class PortfolioService:
                 as_of_date=as_of_date,
             ),
         )
-        actions = self._build_workflow_actions(
+        actions = build_workflow_actions(
             portfolio_id=portfolio_id,
             summary=workspace.summary,
-            operations=workspace.operations,
             workflow_cues=workspace.workflow_cues,
             transaction_total=transactions.total,
         )
@@ -1992,106 +1899,6 @@ class PortfolioService:
             row_count=summary.position_count,
         )
 
-    def _build_workflow_cues(self, portfolio_id: str) -> list[PortfolioWorkflowLaunchCue]:
-        return [
-            PortfolioWorkflowLaunchCue(
-                key="holdings",
-                label="Holdings",
-                href=f"/portfolio?portfolioId={portfolio_id}#portfolio-drilldown",
-            ),
-            PortfolioWorkflowLaunchCue(
-                key="transactions",
-                label="Transactions",
-                href=f"/portfolio?portfolioId={portfolio_id}#portfolio-drilldown",
-            ),
-            PortfolioWorkflowLaunchCue(
-                key="performance",
-                label="Performance",
-                href=f"/performance?portfolioId={portfolio_id}",
-            ),
-        ]
-
-    def _build_readiness_indicators(
-        self,
-        *,
-        workspace: PortfolioWorkspaceResponse,
-        positions: list[PortfolioPositionView],
-        allocation_views: list[PortfolioAllocationView],
-        transaction_total: int,
-        detailed_view: bool,
-    ) -> list[PortfolioReadinessIndicator]:
-        holdings_status = self._holdings_readiness_status(
-            position_count=workspace.summary.position_count,
-            positions=positions,
-        )
-        pricing_status = self._pricing_readiness_status(
-            positions=positions,
-            allocation_views=allocation_views,
-        )
-        transactions_status = self._transactions_readiness_status(
-            transaction_total=transaction_total,
-            operations=workspace.operations,
-        )
-        reporting_status = self._reporting_status_label(
-            workspace.reporting.status,
-            workspace.reporting.row_count,
-        )
-        return self._readiness_indicators_from_statuses(
-            holdings_status=holdings_status,
-            pricing_status=pricing_status,
-            transactions_status=transactions_status,
-            reporting_status=reporting_status,
-            detailed_view=detailed_view,
-        )
-
-    def _readiness_indicators_from_statuses(
-        self,
-        *,
-        holdings_status: str,
-        pricing_status: str,
-        transactions_status: str,
-        reporting_status: str,
-        detailed_view: bool,
-    ) -> list[PortfolioReadinessIndicator]:
-        insights_href = "#portfolio-drilldown" if detailed_view else "#portfolio-insights"
-
-        return [
-            self._readiness_indicator(
-                key="holdings",
-                label="Holdings",
-                status=holdings_status,
-                href=insights_href,
-            ),
-            self._readiness_indicator(
-                key="pricing",
-                label="Pricing",
-                status=pricing_status,
-                href="#portfolio-attention",
-            ),
-            self._readiness_indicator(
-                key="transactions",
-                label="Transactions",
-                status=transactions_status,
-                href=insights_href,
-            ),
-            self._readiness_indicator(
-                key="reporting",
-                label="Reporting",
-                status=reporting_status,
-                href="#portfolio-health",
-            ),
-        ]
-
-    def _readiness_indicator(
-        self, *, key: str, label: str, status: str, href: str
-    ) -> PortfolioReadinessIndicator:
-        return PortfolioReadinessIndicator(
-            key=key,
-            label=label,
-            status=status,
-            href=href,
-        )
-
     def _build_portfolio_exception_summaries(
         self,
         *,
@@ -2102,19 +1909,19 @@ class PortfolioService:
     ) -> list[PortfolioExceptionSummary]:
         return build_portfolio_exception_summaries(
             readiness=PortfolioExceptionReadiness(
-                holdings_status=self._holdings_readiness_status(
+                holdings_status=holdings_readiness_status(
                     position_count=workspace.summary.position_count,
                     positions=positions,
                 ),
-                pricing_status=self._pricing_readiness_status(
+                pricing_status=pricing_readiness_status(
                     positions=positions,
                     allocation_views=allocation_views,
                 ),
-                transaction_status=self._transactions_readiness_status(
+                transaction_status=transactions_readiness_status(
                     transaction_total=transaction_total,
                     operations=workspace.operations,
                 ),
-                reporting_status=self._reporting_status_label(
+                reporting_status=reporting_status_label(
                     workspace.reporting.status,
                     workspace.reporting.row_count,
                 ),
@@ -2142,184 +1949,15 @@ class PortfolioService:
             positions=positions,
             top_positions=top_positions,
             activity_summary=activity_summary,
-            pricing_status=self._pricing_readiness_status(
+            pricing_status=pricing_readiness_status(
                 positions=positions,
                 allocation_views=allocation_views,
             ),
-            reporting_status=self._reporting_status_label(
+            reporting_status=reporting_status_label(
                 workspace.reporting.status,
                 workspace.reporting.row_count,
             ),
         )
-
-    def _build_workflow_actions(
-        self,
-        *,
-        portfolio_id: str,
-        summary: PortfolioSummary,
-        operations: PortfolioOperationalReadiness | None,
-        workflow_cues: list[PortfolioWorkflowLaunchCue],
-        transaction_total: int,
-    ) -> list[PortfolioWorkflowAction]:
-        if self._is_empty_portfolio_workflow(summary, transaction_total):
-            return self._build_empty_portfolio_workflow_actions(portfolio_id)
-        return self._build_supported_cue_workflow_actions(workflow_cues)
-
-    def _build_empty_portfolio_workflow_actions(
-        self,
-        portfolio_id: str,
-    ) -> list[PortfolioWorkflowAction]:
-        return [
-            PortfolioWorkflowAction(
-                sequence=index + 1,
-                title=spec.title,
-                impact=spec.impact,
-                target=spec.target,
-                href=self._workflow_action_spec_href(spec, portfolio_id),
-                cta_label=spec.cta_label,
-                recommended=spec.recommended,
-            )
-            for index, spec in enumerate(EMPTY_PORTFOLIO_WORKFLOW_ACTION_SPECS)
-        ]
-
-    def _build_supported_cue_workflow_actions(
-        self,
-        workflow_cues: list[PortfolioWorkflowLaunchCue],
-    ) -> list[PortfolioWorkflowAction]:
-        ordered_cues = sorted(
-            self._supported_workflow_cues(self._dedupe_workflow_cues(workflow_cues)),
-            key=lambda cue: self._workflow_order_rank(cue.key),
-        )
-        return [
-            self._build_supported_cue_workflow_action(
-                cue=cue,
-                sequence=index + 1,
-                recommended=index == 0,
-            )
-            for index, cue in enumerate(ordered_cues)
-        ]
-
-    def _build_supported_cue_workflow_action(
-        self,
-        *,
-        cue: PortfolioWorkflowLaunchCue,
-        sequence: int,
-        recommended: bool,
-    ) -> PortfolioWorkflowAction:
-        return PortfolioWorkflowAction(
-            sequence=sequence,
-            title=self._workflow_task_label(cue.key),
-            impact=self._workflow_impact_label(cue.key),
-            target=f"Target: {self._workflow_target_label(cue.key)} workflow for this portfolio",
-            href=cue.href,
-            cta_label=self._workflow_cta_label(cue.key),
-            recommended=recommended,
-        )
-
-    def _is_empty_portfolio_workflow(
-        self,
-        summary: PortfolioSummary,
-        transaction_total: int,
-    ) -> bool:
-        return (
-            summary.position_count == 0
-            and summary.cash_balance_count == 0
-            and transaction_total == 0
-        )
-
-    def _workflow_action_spec_href(
-        self,
-        spec: PortfolioWorkflowActionSpec,
-        portfolio_id: str,
-    ) -> str:
-        if spec.href == "operations":
-            return f"/workbench?portfolioId={portfolio_id}"
-        if spec.href == "performance":
-            return f"/performance?portfolioId={portfolio_id}"
-        return spec.href
-
-    def _holdings_readiness_status(
-        self, *, position_count: int, positions: list[PortfolioPositionView]
-    ) -> str:
-        if position_count > 0 and positions:
-            return "Ready"
-        if position_count > 0:
-            return "Partial"
-        return "Missing"
-
-    def _pricing_readiness_status(
-        self,
-        *,
-        positions: list[PortfolioPositionView],
-        allocation_views: list[PortfolioAllocationView],
-    ) -> str:
-        has_valued_holdings = any((position.market_value_base or 0) > 0 for position in positions)
-        if has_valued_holdings and allocation_views:
-            return "Ready"
-        if positions or allocation_views:
-            return "Partial"
-        return "Missing"
-
-    def _transactions_readiness_status(
-        self,
-        *,
-        transaction_total: int,
-        operations: PortfolioOperationalReadiness | None,
-    ) -> str:
-        if transaction_total > 0:
-            return "Ready"
-        if operations and operations.latest_booked_transaction_date:
-            return "Partial"
-        return "Missing"
-
-    def _reporting_status_label(self, status: str, row_count: int) -> str:
-        normalized = status.upper()
-        if normalized in {"READY", "COMPLETE"}:
-            return "Ready"
-        if normalized == "EMPTY":
-            return "Empty"
-        if normalized == "PENDING" or row_count > 0:
-            return "Partial"
-        return "Missing"
-
-    def _dedupe_workflow_cues(
-        self, workflow_cues: list[PortfolioWorkflowLaunchCue]
-    ) -> list[PortfolioWorkflowLaunchCue]:
-        unique: list[PortfolioWorkflowLaunchCue] = []
-        seen: set[str] = set()
-        for cue in workflow_cues:
-            if cue.key in seen:
-                continue
-            seen.add(cue.key)
-            unique.append(cue)
-        return unique
-
-    def _supported_workflow_cues(
-        self, workflow_cues: list[PortfolioWorkflowLaunchCue]
-    ) -> list[PortfolioWorkflowLaunchCue]:
-        return [cue for cue in workflow_cues if cue.key in self._WORKFLOW_DEFINITIONS]
-
-    def _workflow_order_rank(self, key: str) -> int:
-        definition = self._WORKFLOW_DEFINITIONS.get(key)
-        return int(definition["order"]) if definition is not None else 99
-
-    def _workflow_task_label(self, key: str) -> str:
-        definition = self._WORKFLOW_DEFINITIONS.get(key)
-        return str(definition["title"]) if definition is not None else "Open workflow"
-
-    def _workflow_cta_label(self, key: str) -> str:
-        definition = self._WORKFLOW_DEFINITIONS.get(key)
-        return str(definition["cta_label"]) if definition is not None else "Open workflow"
-
-    def _workflow_target_label(self, key: str) -> str:
-        definition = self._WORKFLOW_DEFINITIONS.get(key)
-        return str(definition["target_label"]) if definition is not None else "Workflow"
-
-    def _workflow_impact_label(self, key: str) -> str:
-        definition = self._WORKFLOW_DEFINITIONS.get(key)
-        if definition is None:
-            return "Open the next available workflow for this portfolio."
-        return str(definition["impact"])
 
     def _parse_look_through_capability(
         self, payload: Any

--- a/src/app/services/portfolio_workflow.py
+++ b/src/app/services/portfolio_workflow.py
@@ -1,0 +1,380 @@
+from dataclasses import dataclass
+
+from app.contracts.portfolio import (
+    PortfolioAllocationView,
+    PortfolioOperationalReadiness,
+    PortfolioPositionView,
+    PortfolioReadinessIndicator,
+    PortfolioSummary,
+    PortfolioWorkflowAction,
+    PortfolioWorkflowLaunchCue,
+    PortfolioWorkspaceResponse,
+)
+
+
+@dataclass(frozen=True)
+class PortfolioWorkflowActionSpec:
+    title: str
+    impact: str
+    target: str
+    href: str
+    cta_label: str
+    recommended: bool = False
+
+
+EMPTY_PORTFOLIO_WORKFLOW_ACTION_SPECS: tuple[PortfolioWorkflowActionSpec, ...] = (
+    PortfolioWorkflowActionSpec(
+        title="Fund portfolio",
+        impact=(
+            "Create opening liquidity so balances, allocation, and readiness checks become "
+            "meaningful."
+        ),
+        target="Target: cash funding and opening balance setup",
+        href="operations",
+        cta_label="Fund now",
+        recommended=True,
+    ),
+    PortfolioWorkflowActionSpec(
+        title="Book first trade",
+        impact="Activate the holdings book and create the first investable position.",
+        target="Target: transaction entry and execution workflow",
+        href="operations",
+        cta_label="Book trade",
+    ),
+    PortfolioWorkflowActionSpec(
+        title="Publish pricing",
+        impact="Enable valuation, allocation, and downstream reporting coverage.",
+        target="Target: pricing publication and valuation refresh",
+        href="operations",
+        cta_label="Publish prices",
+    ),
+    PortfolioWorkflowActionSpec(
+        title="Review holdings",
+        impact="Confirm the funded book, position weights, and coverage after valuation.",
+        target="Target: holdings and allocation review",
+        href="#portfolio-insights",
+        cta_label="Open holdings",
+    ),
+    PortfolioWorkflowActionSpec(
+        title="Open performance",
+        impact="Review return analytics once holdings are funded and valued.",
+        target="Target: performance workspace after valuation is available",
+        href="performance",
+        cta_label="Open performance",
+    ),
+)
+
+WORKFLOW_DEFINITIONS: dict[str, dict[str, str | int]] = {
+    "performance": {
+        "order": 0,
+        "title": "Review performance",
+        "cta_label": "Performance",
+        "target_label": "Performance",
+        "impact": (
+            "Review portfolio return, benchmark context, and contribution once the book is valued."
+        ),
+    },
+    "holdings": {
+        "order": 1,
+        "title": "Review holdings",
+        "cta_label": "Holdings",
+        "target_label": "Holdings",
+        "impact": (
+            "Confirm funded positions, valuations, and portfolio weights before client review."
+        ),
+    },
+    "transactions": {
+        "order": 2,
+        "title": "Review transactions",
+        "cta_label": "Transactions",
+        "target_label": "Transactions",
+        "impact": "Inspect recent funding, trading, and cash activity affecting the book.",
+    },
+    "risk": {
+        "order": 3,
+        "title": "Review suitability",
+        "cta_label": "Suitability",
+        "target_label": "Suitability",
+        "impact": "Validate suitability, exposure, and mandate fit before the next client action.",
+    },
+    "proposal": {
+        "order": 4,
+        "title": "Prepare recommendation",
+        "cta_label": "Recommendation",
+        "target_label": "Recommendation",
+        "impact": "Prepare the next recommended portfolio action or client proposal.",
+    },
+}
+
+
+def build_workflow_cues(portfolio_id: str) -> list[PortfolioWorkflowLaunchCue]:
+    return [
+        PortfolioWorkflowLaunchCue(
+            key="holdings",
+            label="Holdings",
+            href=f"/portfolio?portfolioId={portfolio_id}#portfolio-drilldown",
+        ),
+        PortfolioWorkflowLaunchCue(
+            key="transactions",
+            label="Transactions",
+            href=f"/portfolio?portfolioId={portfolio_id}#portfolio-drilldown",
+        ),
+        PortfolioWorkflowLaunchCue(
+            key="performance",
+            label="Performance",
+            href=f"/performance?portfolioId={portfolio_id}",
+        ),
+    ]
+
+
+def build_readiness_indicators(
+    *,
+    workspace: PortfolioWorkspaceResponse,
+    positions: list[PortfolioPositionView],
+    allocation_views: list[PortfolioAllocationView],
+    transaction_total: int,
+    detailed_view: bool,
+) -> list[PortfolioReadinessIndicator]:
+    return readiness_indicators_from_statuses(
+        holdings_status=holdings_readiness_status(
+            position_count=workspace.summary.position_count,
+            positions=positions,
+        ),
+        pricing_status=pricing_readiness_status(
+            positions=positions,
+            allocation_views=allocation_views,
+        ),
+        transactions_status=transactions_readiness_status(
+            transaction_total=transaction_total,
+            operations=workspace.operations,
+        ),
+        reporting_status=reporting_status_label(
+            workspace.reporting.status,
+            workspace.reporting.row_count,
+        ),
+        detailed_view=detailed_view,
+    )
+
+
+def readiness_indicators_from_statuses(
+    *,
+    holdings_status: str,
+    pricing_status: str,
+    transactions_status: str,
+    reporting_status: str,
+    detailed_view: bool,
+) -> list[PortfolioReadinessIndicator]:
+    insights_href = "#portfolio-drilldown" if detailed_view else "#portfolio-insights"
+
+    return [
+        readiness_indicator(
+            key="holdings",
+            label="Holdings",
+            status=holdings_status,
+            href=insights_href,
+        ),
+        readiness_indicator(
+            key="pricing",
+            label="Pricing",
+            status=pricing_status,
+            href="#portfolio-attention",
+        ),
+        readiness_indicator(
+            key="transactions",
+            label="Transactions",
+            status=transactions_status,
+            href=insights_href,
+        ),
+        readiness_indicator(
+            key="reporting",
+            label="Reporting",
+            status=reporting_status,
+            href="#portfolio-health",
+        ),
+    ]
+
+
+def readiness_indicator(
+    *, key: str, label: str, status: str, href: str
+) -> PortfolioReadinessIndicator:
+    return PortfolioReadinessIndicator(
+        key=key,
+        label=label,
+        status=status,
+        href=href,
+    )
+
+
+def build_workflow_actions(
+    *,
+    portfolio_id: str,
+    summary: PortfolioSummary,
+    workflow_cues: list[PortfolioWorkflowLaunchCue],
+    transaction_total: int,
+) -> list[PortfolioWorkflowAction]:
+    if is_empty_portfolio_workflow(summary, transaction_total):
+        return build_empty_portfolio_workflow_actions(portfolio_id)
+    return build_supported_cue_workflow_actions(workflow_cues)
+
+
+def build_empty_portfolio_workflow_actions(
+    portfolio_id: str,
+) -> list[PortfolioWorkflowAction]:
+    return [
+        PortfolioWorkflowAction(
+            sequence=index + 1,
+            title=spec.title,
+            impact=spec.impact,
+            target=spec.target,
+            href=workflow_action_spec_href(spec, portfolio_id),
+            cta_label=spec.cta_label,
+            recommended=spec.recommended,
+        )
+        for index, spec in enumerate(EMPTY_PORTFOLIO_WORKFLOW_ACTION_SPECS)
+    ]
+
+
+def build_supported_cue_workflow_actions(
+    workflow_cues: list[PortfolioWorkflowLaunchCue],
+) -> list[PortfolioWorkflowAction]:
+    ordered_cues = sorted(
+        supported_workflow_cues(dedupe_workflow_cues(workflow_cues)),
+        key=lambda cue: workflow_order_rank(cue.key),
+    )
+    return [
+        build_supported_cue_workflow_action(
+            cue=cue,
+            sequence=index + 1,
+            recommended=index == 0,
+        )
+        for index, cue in enumerate(ordered_cues)
+    ]
+
+
+def build_supported_cue_workflow_action(
+    *,
+    cue: PortfolioWorkflowLaunchCue,
+    sequence: int,
+    recommended: bool,
+) -> PortfolioWorkflowAction:
+    return PortfolioWorkflowAction(
+        sequence=sequence,
+        title=workflow_task_label(cue.key),
+        impact=workflow_impact_label(cue.key),
+        target=f"Target: {workflow_target_label(cue.key)} workflow for this portfolio",
+        href=cue.href,
+        cta_label=workflow_cta_label(cue.key),
+        recommended=recommended,
+    )
+
+
+def is_empty_portfolio_workflow(
+    summary: PortfolioSummary,
+    transaction_total: int,
+) -> bool:
+    return (
+        summary.position_count == 0 and summary.cash_balance_count == 0 and transaction_total == 0
+    )
+
+
+def workflow_action_spec_href(
+    spec: PortfolioWorkflowActionSpec,
+    portfolio_id: str,
+) -> str:
+    if spec.href == "operations":
+        return f"/workbench?portfolioId={portfolio_id}"
+    if spec.href == "performance":
+        return f"/performance?portfolioId={portfolio_id}"
+    return spec.href
+
+
+def holdings_readiness_status(
+    *, position_count: int, positions: list[PortfolioPositionView]
+) -> str:
+    if position_count > 0 and positions:
+        return "Ready"
+    if position_count > 0:
+        return "Partial"
+    return "Missing"
+
+
+def pricing_readiness_status(
+    *,
+    positions: list[PortfolioPositionView],
+    allocation_views: list[PortfolioAllocationView],
+) -> str:
+    has_valued_holdings = any((position.market_value_base or 0) > 0 for position in positions)
+    if has_valued_holdings and allocation_views:
+        return "Ready"
+    if positions or allocation_views:
+        return "Partial"
+    return "Missing"
+
+
+def transactions_readiness_status(
+    *,
+    transaction_total: int,
+    operations: PortfolioOperationalReadiness | None,
+) -> str:
+    if transaction_total > 0:
+        return "Ready"
+    if operations and operations.latest_booked_transaction_date:
+        return "Partial"
+    return "Missing"
+
+
+def reporting_status_label(status: str, row_count: int) -> str:
+    normalized = status.upper()
+    if normalized in {"READY", "COMPLETE"}:
+        return "Ready"
+    if normalized == "EMPTY":
+        return "Empty"
+    if normalized == "PENDING" or row_count > 0:
+        return "Partial"
+    return "Missing"
+
+
+def dedupe_workflow_cues(
+    workflow_cues: list[PortfolioWorkflowLaunchCue],
+) -> list[PortfolioWorkflowLaunchCue]:
+    unique: list[PortfolioWorkflowLaunchCue] = []
+    seen: set[str] = set()
+    for cue in workflow_cues:
+        if cue.key in seen:
+            continue
+        seen.add(cue.key)
+        unique.append(cue)
+    return unique
+
+
+def supported_workflow_cues(
+    workflow_cues: list[PortfolioWorkflowLaunchCue],
+) -> list[PortfolioWorkflowLaunchCue]:
+    return [cue for cue in workflow_cues if cue.key in WORKFLOW_DEFINITIONS]
+
+
+def workflow_order_rank(key: str) -> int:
+    definition = WORKFLOW_DEFINITIONS.get(key)
+    return int(definition["order"]) if definition is not None else 99
+
+
+def workflow_task_label(key: str) -> str:
+    definition = WORKFLOW_DEFINITIONS.get(key)
+    return str(definition["title"]) if definition is not None else "Open workflow"
+
+
+def workflow_cta_label(key: str) -> str:
+    definition = WORKFLOW_DEFINITIONS.get(key)
+    return str(definition["cta_label"]) if definition is not None else "Open workflow"
+
+
+def workflow_target_label(key: str) -> str:
+    definition = WORKFLOW_DEFINITIONS.get(key)
+    return str(definition["target_label"]) if definition is not None else "Workflow"
+
+
+def workflow_impact_label(key: str) -> str:
+    definition = WORKFLOW_DEFINITIONS.get(key)
+    if definition is None:
+        return "Open the next available workflow for this portfolio."
+    return str(definition["impact"])

--- a/tests/unit/test_portfolio_service.py
+++ b/tests/unit/test_portfolio_service.py
@@ -3,7 +3,6 @@ from typing import Any
 import pytest
 from fastapi import HTTPException
 
-from app.contracts.portfolio import PortfolioSummary, PortfolioWorkflowLaunchCue
 from app.services.portfolio_service import PortfolioService
 
 
@@ -1206,94 +1205,6 @@ async def test_portfolio_workflow_uses_latest_transaction_probe_for_activity_pre
             "reporting_currency": None,
         }
     ]
-
-
-def test_build_workflow_actions_dedupes_and_ignores_unsupported_cues():
-    service = PortfolioService(_StubLotusCoreQueryClient())
-
-    actions = service._build_workflow_actions(
-        portfolio_id="PF_1001",
-        summary=PortfolioSummary(
-            assets_under_management_base=1000.0,
-            invested_market_value_base=900.0,
-            cash_market_value_base=100.0,
-            cash_weight_pct=10.0,
-            position_count=2,
-            cash_balance_count=1,
-        ),
-        operations=None,
-        workflow_cues=[
-            PortfolioWorkflowLaunchCue(
-                key="holdings",
-                label="Holdings",
-                href="/portfolio?portfolioId=PF_1001#portfolio-drilldown",
-            ),
-            PortfolioWorkflowLaunchCue(
-                key="custom",
-                label="Custom",
-                href="/custom",
-            ),
-            PortfolioWorkflowLaunchCue(
-                key="performance",
-                label="Performance",
-                href="/performance?portfolioId=PF_1001",
-            ),
-            PortfolioWorkflowLaunchCue(
-                key="holdings",
-                label="Holdings",
-                href="/portfolio?portfolioId=PF_1001#portfolio-drilldown",
-            ),
-        ],
-        transaction_total=3,
-    )
-
-    assert [action.title for action in actions] == [
-        "Review performance",
-        "Review holdings",
-    ]
-    assert [action.cta_label for action in actions] == [
-        "Performance",
-        "Holdings",
-    ]
-    assert actions[0].recommended is True
-
-
-def test_build_workflow_actions_returns_empty_portfolio_setup_sequence():
-    service = PortfolioService(_StubLotusCoreQueryClient())
-
-    actions = service._build_workflow_actions(
-        portfolio_id="PF_EMPTY",
-        summary=PortfolioSummary(
-            assets_under_management_base=0.0,
-            invested_market_value_base=0.0,
-            cash_market_value_base=0.0,
-            cash_weight_pct=0.0,
-            position_count=0,
-            cash_balance_count=0,
-        ),
-        operations=None,
-        workflow_cues=[],
-        transaction_total=0,
-    )
-
-    assert [action.title for action in actions] == [
-        "Fund portfolio",
-        "Book first trade",
-        "Publish pricing",
-        "Review holdings",
-        "Open performance",
-    ]
-    assert [action.sequence for action in actions] == [1, 2, 3, 4, 5]
-    assert [action.target for action in actions] == [
-        "Target: cash funding and opening balance setup",
-        "Target: transaction entry and execution workflow",
-        "Target: pricing publication and valuation refresh",
-        "Target: holdings and allocation review",
-        "Target: performance workspace after valuation is available",
-    ]
-    assert actions[0].recommended is True
-    assert actions[0].href == "/workbench?portfolioId=PF_EMPTY"
-    assert actions[-1].href == "/performance?portfolioId=PF_EMPTY"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_portfolio_workflow.py
+++ b/tests/unit/test_portfolio_workflow.py
@@ -1,0 +1,123 @@
+from app.contracts.portfolio import PortfolioSummary, PortfolioWorkflowLaunchCue
+from app.services.portfolio_workflow import (
+    build_workflow_actions,
+    build_workflow_cues,
+    holdings_readiness_status,
+    reporting_status_label,
+    transactions_readiness_status,
+)
+
+
+def test_build_workflow_cues_uses_portfolio_scoped_routes() -> None:
+    cues = build_workflow_cues("PF_1001")
+
+    assert [cue.model_dump() for cue in cues] == [
+        {
+            "key": "holdings",
+            "label": "Holdings",
+            "href": "/portfolio?portfolioId=PF_1001#portfolio-drilldown",
+        },
+        {
+            "key": "transactions",
+            "label": "Transactions",
+            "href": "/portfolio?portfolioId=PF_1001#portfolio-drilldown",
+        },
+        {
+            "key": "performance",
+            "label": "Performance",
+            "href": "/performance?portfolioId=PF_1001",
+        },
+    ]
+
+
+def test_build_workflow_actions_dedupes_and_ignores_unsupported_cues() -> None:
+    actions = build_workflow_actions(
+        portfolio_id="PF_1001",
+        summary=PortfolioSummary(
+            assets_under_management_base=1000.0,
+            invested_market_value_base=900.0,
+            cash_market_value_base=100.0,
+            cash_weight_pct=10.0,
+            position_count=2,
+            cash_balance_count=1,
+        ),
+        workflow_cues=[
+            PortfolioWorkflowLaunchCue(
+                key="holdings",
+                label="Holdings",
+                href="/portfolio?portfolioId=PF_1001#portfolio-drilldown",
+            ),
+            PortfolioWorkflowLaunchCue(
+                key="custom",
+                label="Custom",
+                href="/custom",
+            ),
+            PortfolioWorkflowLaunchCue(
+                key="performance",
+                label="Performance",
+                href="/performance?portfolioId=PF_1001",
+            ),
+            PortfolioWorkflowLaunchCue(
+                key="holdings",
+                label="Holdings",
+                href="/portfolio?portfolioId=PF_1001#portfolio-drilldown",
+            ),
+        ],
+        transaction_total=3,
+    )
+
+    assert [action.title for action in actions] == [
+        "Review performance",
+        "Review holdings",
+    ]
+    assert [action.cta_label for action in actions] == [
+        "Performance",
+        "Holdings",
+    ]
+    assert actions[0].recommended is True
+
+
+def test_build_workflow_actions_returns_empty_portfolio_setup_sequence() -> None:
+    actions = build_workflow_actions(
+        portfolio_id="PF_EMPTY",
+        summary=PortfolioSummary(
+            assets_under_management_base=0.0,
+            invested_market_value_base=0.0,
+            cash_market_value_base=0.0,
+            cash_weight_pct=0.0,
+            position_count=0,
+            cash_balance_count=0,
+        ),
+        workflow_cues=[],
+        transaction_total=0,
+    )
+
+    assert [action.title for action in actions] == [
+        "Fund portfolio",
+        "Book first trade",
+        "Publish pricing",
+        "Review holdings",
+        "Open performance",
+    ]
+    assert [action.sequence for action in actions] == [1, 2, 3, 4, 5]
+    assert [action.target for action in actions] == [
+        "Target: cash funding and opening balance setup",
+        "Target: transaction entry and execution workflow",
+        "Target: pricing publication and valuation refresh",
+        "Target: holdings and allocation review",
+        "Target: performance workspace after valuation is available",
+    ]
+    assert actions[0].recommended is True
+    assert actions[0].href == "/workbench?portfolioId=PF_EMPTY"
+    assert actions[-1].href == "/performance?portfolioId=PF_EMPTY"
+
+
+def test_readiness_status_helpers_preserve_gateway_labels() -> None:
+    assert holdings_readiness_status(position_count=2, positions=[]) == "Partial"
+    assert holdings_readiness_status(position_count=0, positions=[]) == "Missing"
+    assert reporting_status_label("COMPLETE", row_count=0) == "Ready"
+    assert reporting_status_label("EMPTY", row_count=0) == "Empty"
+    assert reporting_status_label("UNKNOWN", row_count=3) == "Partial"
+    assert reporting_status_label("UNKNOWN", row_count=0) == "Missing"
+    assert transactions_readiness_status(transaction_total=1, operations=None) == "Ready"
+    assert transactions_readiness_status(transaction_total=0, operations=None) == "Missing"

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -86,17 +86,18 @@ and rebalance supportability failure-recording splits then lowered the baseline 
 74 lines. The 50-commit enterprise-hardening branch then split shared analytics async polling,
 workspace-summary payload assembly, portfolio transaction-summary context loading, transaction
 page loading, and portfolio book response assembly, lowering the baseline to 62 lines.
-`portfolio_service.py` is now measured at 2,438 lines after portfolio liquidity loading,
+`portfolio_service.py` is now measured at 2,076 lines after portfolio liquidity loading,
 transaction request-context, transaction page-context, transaction client-kwargs, portfolio
 workspace response assembly, portfolio workspace performance parsing, and portfolio workspace
-rebalance parsing, portfolio source-readiness parsing, and portfolio transaction summary mapping
-extractions, so it remains the largest-file hotspot but is trending down.
+rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, and
+portfolio workflow mapping extractions. The largest-file hotspot has moved to the portfolio
+contract module at 2,226 lines.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
 extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
-portfolio transaction summary mapper branch passed with ruff, format check, monetary-float guard,
-mypy over 453 source files, Workbench/OpenAPI contract smoke, and 1,029 unit/contract tests. Local
-`make ci` passed with 207 integration tests, 1,236 coverage tests, 93.95 percent total coverage,
+portfolio workflow mapper branch passed with ruff, format check, monetary-float guard, mypy over
+454 source files, Workbench/OpenAPI contract smoke, and 1,031 unit/contract tests. Local
+`make ci` passed with 207 integration tests, 1,238 coverage tests, 94.00 percent total coverage,
 and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette exception.
 GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were
-green before PR #357 merged. The current portfolio transaction summary mapper branch adds focused
-transaction summary, portfolio service, and transaction ledger evidence with 57 passing unit tests.
+green before PR #358 merged. The current portfolio workflow mapper branch adds focused workflow
+mapper and portfolio service evidence with 46 passing unit tests.


### PR DESCRIPTION
## Summary
- Extract portfolio workflow launch cues, readiness status labels, empty-book setup sequencing, and supported-cue action ordering into src/app/services/portfolio_workflow.py.
- Keep PortfolioService focused on orchestration while preserving existing workflow/readiness response behavior.
- Add focused workflow mapper tests and refresh quality/wiki evidence for the new hotspot metrics.

## Validation
- python -m ruff check src/app/services/portfolio_service.py src/app/services/portfolio_workflow.py tests/unit/test_portfolio_service.py tests/unit/test_portfolio_workflow.py`n- python -m mypy src/app/services/portfolio_service.py src/app/services/portfolio_workflow.py`n- python -m pytest tests/unit/test_portfolio_workflow.py tests/unit/test_portfolio_service.py -q (46 passed)
- python -m pytest tests/unit/test_gateway_wiki_overview.py tests/unit/test_enterprise_readiness.py -q (18 passed)
- make check (1,031 unit/contract tests passed)
- make ci (207 integration tests passed; 1,238 coverage tests passed; total coverage 94.00%; pip-audit no known vulnerabilities after governed PYSEC-2026-161 exception)

## Wiki
- Repo-authored wiki/Validation-and-CI.md changed with current branch evidence.
- Pre-merge check-only reports expected drift for Validation-and-CI.md; publish after merge and re-run check-only to restore synchronization.