### PR TITLE
Extract portfolio workflow contracts

### DIFF
--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -167,6 +167,10 @@ empty-book action sequencing, and supported-cue action ordering into `portfolio_
 reducing `portfolio_service.py` from 2,438 to 2,076 measured lines while preserving the 49-line
 longest-function baseline. The largest source-file hotspot is now the portfolio contract module,
 not the portfolio orchestration service.
+The current portfolio workflow contract slice moves readiness and workflow response contracts into
+`portfolio_workflow.py`, keeps `app.contracts.portfolio` as the compatibility import surface, and
+reduces `portfolio.py` from 2,226 to 1,974 measured lines while preserving OpenAPI schema names and
+the 49-line longest-function baseline.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -174,23 +178,23 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,317 |
-| Python source files under `src/app` | 454 |
-| Python test files under `tests` | 169 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,321 |
+| Python source files under `src/app` | 455 |
+| Python test files under `tests` | 170 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current portfolio workflow mapper branch shows 1,317 files under
-`src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 454 Python source files under
-`src/app`; and 169 Python test files under `tests`.
+Working-tree verification for the current portfolio workflow contract branch shows 1,321 files
+under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 455 Python source files under
+`src/app`; and 170 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 2,226 | `src/app/contracts/portfolio.py` |
-| 2 | 2,076 | `src/app/services/portfolio_service.py` |
-| 3 | 2,043 | `src/app/contracts/risk_workspace.py` |
+| 1 | 2,076 | `src/app/services/portfolio_service.py` |
+| 2 | 2,043 | `src/app/contracts/risk_workspace.py` |
+| 3 | 1,974 | `src/app/contracts/portfolio.py` |
 | 4 | 1,840 | `src/app/contracts/reporting.py` |
 | 5 | 1,704 | `src/app/services/performance_workspace_service.py` |
 | 6 | 1,607 | `src/app/services/advisor_brief_service.py` |
@@ -340,6 +344,15 @@ Most recent local evidence:
     unit/contract tests.
 60. Current portfolio workflow mapper branch: `make ci` passed with 207 integration tests and
     1,238 combined coverage tests; total coverage is 94.00%, and `pip-audit` found no known
+    vulnerabilities after the governed `PYSEC-2026-161` exception.
+61. Current portfolio workflow contract branch: focused validation passed with ruff, mypy over the
+    touched contract/router/service modules, and 23 workflow contract/source-readiness/OpenAPI
+    contract tests.
+62. Current portfolio workflow contract branch: `make check` passed with ruff, format check,
+    monetary-float guard, mypy over 455 source files, Workbench/OpenAPI contract smoke, and 1,032
+    unit/contract tests.
+63. Current portfolio workflow contract branch: `make ci` passed with 207 integration tests and
+    1,239 combined coverage tests; total coverage is 94.01%, and `pip-audit` found no known
     vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,36 +5,36 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 454 source files, contract smoke, and 1,031 unit/contract tests; `make ci` passed with 207 integration tests, 1,238 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
-| Coverage | 4/5 | 94.00% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, and portfolio workflow mapping; `portfolio_service.py` is now 2,076 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 455 source files, contract smoke, and 1,032 unit/contract tests; `make ci` passed with 207 integration tests, 1,239 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Coverage | 4/5 | 94.01% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
+| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, and portfolio workflow contracts; `portfolio_service.py` is now 2,076 measured lines and `portfolio.py` is now 1,974 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in current branch `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused portfolio workflow mapper slice | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused portfolio workflow contract slice | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
 Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
-versus the current portfolio workflow mapper branch after PRs #349, #350, #351, #352, #353, #354,
-#355, #356, #357, and #358.
+versus the current portfolio workflow contract branch after PRs #349, #350, #351, #352, #353,
+#354, #355, #356, #357, #358, and #359.
 
 | Measure | Prior scorecard | Current branch | Result |
 | --- | ---: | ---: | --- |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,317 | Added focused modules, tests, and quality evidence |
-| Tracked `src/app` Python files | 447 | 454 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper modules |
-| Tracked Python test files | 162 | 169 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, and workflow mapper tests |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,321 | Added focused modules, tests, and quality evidence |
+| Tracked `src/app` Python files | 447 | 455 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper and contract modules |
+| Tracked Python test files | 162 | 170 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, and workflow contract tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 2,226 lines | Improved; `src/app/contracts/portfolio.py` is now the largest residual hotspot |
+| Largest source file | 2,968 lines | 2,076 lines | Improved; `src/app/services/portfolio_service.py` is again the largest residual hotspot after reducing `portfolio.py` |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,031 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, and workflow mapper tests |
-| Local coverage tests | 1,203 | 1,238 | Added focused coverage while preserving total coverage |
-| Total coverage | 93.69% | 94.00% | Improved |
+| Local unit/contract tests | 996 | 1,032 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, and workflow contract tests |
+| Local coverage tests | 1,203 | 1,239 | Added focused coverage while preserving total coverage |
+| Total coverage | 93.69% | 94.01% | Improved |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
 ## Phase Gates
@@ -59,7 +59,7 @@ Candidate thresholds:
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
 5. no new function above the current maximum of 49 lines and no unclassified largest-file growth
-   above the current 2,226-line `src/app/contracts/portfolio.py` maximum.
+   above the current 2,076-line `src/app/services/portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -248,17 +248,20 @@ The current portfolio workflow mapper slice moves workflow launch cue constructi
 status labels, empty-book setup sequencing, and supported-cue action ordering into
 `portfolio_workflow.py`, reducing `portfolio_service.py` from 2,438 to 2,076 lines while
 preserving the 49-line longest-function baseline.
+The current portfolio workflow contract slice moves readiness and workflow response models into
+`portfolio_workflow.py`, keeps the legacy `app.contracts.portfolio` import surface intact, and
+reduces `portfolio.py` from 2,226 to 1,974 lines while preserving OpenAPI contract tests.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | Current workflow mapper branch was created from clean `main` after PR #358; final remote/local cleanup remains a post-merge gate |
-| Unit/contract coverage | Healthy | 1,031 unit/contract tests passed in current branch `make check`; focused workflow mapper and portfolio service tests passed with 46 tests on this branch |
+| Branch hygiene | Healthy | Current workflow contract branch was created from clean `main` after PR #359; final remote/local cleanup remains a post-merge gate |
+| Unit/contract coverage | Healthy | 1,032 unit/contract tests passed in current branch `make check`; focused workflow contract, source-readiness, workflow mapper, and portfolio OpenAPI contract tests passed with 23 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
-| Total coverage | Healthy | 1,238 coverage tests passed in current branch `make ci`; total coverage is 94.00%, above the 84% floor |
+| Total coverage | Healthy | 1,239 coverage tests passed in current branch `make ci`; total coverage is 94.01%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper slices reduce `portfolio_service.py` to 2,076 measured lines and `performance_workspace_service.py` to 1,607 measured lines; large contracts and several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper slices reduce `portfolio_service.py` to 2,076 measured lines, `portfolio.py` to 1,974 measured lines, and `performance_workspace_service.py` to 1,607 measured lines; large contracts and several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -271,8 +274,8 @@ preserving the 49-line longest-function baseline.
    transaction-ledger payload loading, workspace source gathering, position-book mapping,
    transaction-ledger response mapping, transaction client-kwargs mapping, transaction page
    context defaults, workspace performance parsing, workspace rebalance parsing, source readiness
-   parsing, transaction summary mapping, and workflow cue/action mapping are now separately
-   testable.
+   parsing, transaction summary mapping, workflow cue/action mapping, and workflow/readiness
+   contracts are now separately testable.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes

--- a/src/app/contracts/portfolio.py
+++ b/src/app/contracts/portfolio.py
@@ -2,6 +2,17 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from app.contracts import portfolio_workflow as _portfolio_workflow
+
+PortfolioReadinessBucket = _portfolio_workflow.PortfolioReadinessBucket
+PortfolioReadinessIndicator = _portfolio_workflow.PortfolioReadinessIndicator
+PortfolioReadinessReason = _portfolio_workflow.PortfolioReadinessReason
+PortfolioReadinessResponse = _portfolio_workflow.PortfolioReadinessResponse
+PortfolioSupportabilitySummary = _portfolio_workflow.PortfolioSupportabilitySummary
+PortfolioWorkflowAction = _portfolio_workflow.PortfolioWorkflowAction
+PortfolioWorkflowLaunchCue = _portfolio_workflow.PortfolioWorkflowLaunchCue
+PortfolioWorkflowResponse = _portfolio_workflow.PortfolioWorkflowResponse
+
 
 class PortfolioPartialFailure(BaseModel):
     source_service: str = Field(
@@ -900,102 +911,6 @@ class PortfolioOperationalReadiness(BaseModel):
     )
 
 
-class PortfolioWorkflowLaunchCue(BaseModel):
-    key: str = Field(
-        description="Stable workflow cue key exposed to product surfaces.",
-        examples=["performance"],
-    )
-    label: str = Field(
-        description="Advisor-facing workflow cue label.",
-        examples=["Performance"],
-    )
-    href: str = Field(
-        description="Route or in-page target used to launch the workflow from the workspace shell.",
-        examples=["/performance?portfolioId=PF_1001"],
-    )
-
-
-class PortfolioReadinessIndicator(BaseModel):
-    key: str = Field(
-        description="Stable readiness indicator key used by product modules and UI affordances.",
-        examples=["holdings"],
-    )
-    label: str = Field(
-        description="Front-office label for the readiness dimension.",
-        examples=["Holdings"],
-    )
-    status: str = Field(
-        description="Gateway-normalized readiness posture for the dimension.",
-        examples=["Ready"],
-    )
-    href: str = Field(
-        description="In-page anchor or route target that helps the operator resolve the finding.",
-        examples=["#portfolio-insights"],
-    )
-
-
-class PortfolioReadinessReason(BaseModel):
-    code: str = Field(
-        description="Source-authored readiness reason code returned by lotus-core.",
-        examples=["pricing_not_published"],
-    )
-    detail: str | None = Field(
-        default=None,
-        description="Optional source-authored explanation for the readiness reason.",
-        examples=["Pricing has not yet been published for the requested business date."],
-    )
-
-
-class PortfolioReadinessBucket(BaseModel):
-    status: str = Field(
-        description="Readiness posture for the specific source-backed dimension.",
-        examples=["Pending"],
-    )
-    reasons: list[PortfolioReadinessReason] = Field(
-        default_factory=list,
-        description="Source-authored reasons explaining why the dimension is not fully ready.",
-    )
-
-
-class PortfolioSupportabilitySummary(BaseModel):
-    feature_key: str = Field(
-        default="core.observability.portfolio_supportability",
-        description="RFC-0108 feature key for the source-owned portfolio supportability signal.",
-        examples=["core.observability.portfolio_supportability"],
-    )
-    state: str = Field(
-        description="Gateway-normalized supportability state for portfolio readiness composition.",
-        examples=["ready", "degraded"],
-    )
-    reason: str = Field(
-        description="Bounded source-authored reason code for the supportability state.",
-        examples=["portfolio_supportability_ready"],
-    )
-    freshness_bucket: str = Field(
-        description=(
-            "Gateway-normalized freshness bucket for analytics UI observability. "
-            "`current` from lotus-core is exposed as `fresh` for Workbench metric vocabulary."
-        ),
-        examples=["fresh", "stale", "unknown"],
-    )
-    ready_domains: int = Field(
-        description="Count of source readiness domains currently ready.",
-        examples=[4],
-    )
-    pending_domains: int = Field(
-        description="Count of source readiness domains currently pending.",
-        examples=[0],
-    )
-    blocked_domains: int = Field(
-        description="Count of source readiness domains currently blocked.",
-        examples=[0],
-    )
-    no_activity_domains: int = Field(
-        description="Count of source readiness domains with no activity.",
-        examples=[0],
-    )
-
-
 class PortfolioExceptionSummary(BaseModel):
     key: str = Field(
         description="Stable exception key used by the workspace to group attention items.",
@@ -1056,75 +971,6 @@ class PortfolioInsight(BaseModel):
             "In-page anchor or route target that helps the advisor investigate the insight."
         ),
         examples=["#portfolio-insights"],
-    )
-
-
-class PortfolioReadinessResponse(BaseModel):
-    correlation_id: str = Field(
-        description="Opaque correlation identifier for the readiness response envelope.",
-        examples=["corr-portfolio-readiness"],
-    )
-    contract_version: str = Field(
-        default="v1",
-        description="Version of the gateway readiness response contract.",
-        examples=["v1"],
-    )
-    portfolio_id: str = Field(
-        description="Portfolio identifier whose operational readiness is being reported.",
-        examples=["PF_1001"],
-    )
-    as_of_date: str = Field(
-        description="Resolved readiness as-of date used for the source-backed evaluation.",
-        examples=["2026-03-27"],
-    )
-    holdings: PortfolioReadinessBucket | None = Field(
-        default=None,
-        description="Detailed holdings-book readiness bucket from lotus-core.",
-    )
-    pricing: PortfolioReadinessBucket | None = Field(
-        default=None,
-        description="Detailed pricing readiness bucket from lotus-core.",
-    )
-    transactions: PortfolioReadinessBucket | None = Field(
-        default=None,
-        description="Detailed transaction-book readiness bucket from lotus-core.",
-    )
-    reporting: PortfolioReadinessBucket | None = Field(
-        default=None,
-        description="Detailed reporting readiness bucket from lotus-core.",
-    )
-    blocking_reasons: list[PortfolioReadinessReason] = Field(
-        default_factory=list,
-        description="Portfolio-level blocking reasons that prevent the workspace from being ready.",
-        examples=[
-            [
-                {
-                    "code": "awaiting_pricing",
-                    "detail": "Reporting remains blocked until pricing is published.",
-                }
-            ]
-        ],
-    )
-    supportability: PortfolioSupportabilitySummary | None = Field(
-        default=None,
-        description=(
-            "Source-owned RFC-0108 portfolio supportability posture preserved from lotus-core "
-            "for Workbench freshness, degraded-state, and operational evidence."
-        ),
-    )
-    indicators: list[PortfolioReadinessIndicator] = Field(
-        default_factory=list,
-        description="Compact readiness indicators derived for the front-office workspace rails.",
-        examples=[
-            [
-                {
-                    "key": "holdings",
-                    "label": "Holdings",
-                    "status": "Ready",
-                    "href": "#portfolio-insights",
-                }
-            ]
-        ],
     )
 
 
@@ -1198,104 +1044,6 @@ class PortfolioInsightsResponse(BaseModel):
                     ),
                     "tone": "danger",
                     "href": "#portfolio-attention",
-                },
-            ]
-        ],
-    )
-
-
-class PortfolioWorkflowAction(BaseModel):
-    sequence: int = Field(
-        description="Display order for the workflow action within the prioritized action list.",
-        examples=[1],
-    )
-    title: str = Field(
-        description="Advisor-facing workflow action title.",
-        examples=["Review performance"],
-    )
-    impact: str = Field(
-        description="Short explanation of why the workflow action matters now for the portfolio.",
-        examples=[
-            "Review portfolio return, benchmark context, and contribution once the book is valued."
-        ],
-    )
-    target: str = Field(
-        description="Explicit workflow target or operating outcome that the action opens.",
-        examples=[
-            "Target: Performance workflow for this portfolio",
-            "Target: cash funding and opening balance setup",
-        ],
-    )
-    href: str = Field(
-        description="Route or in-page target used to launch the workflow action.",
-        examples=[
-            "/performance?portfolioId=PF_1001",
-            "/portfolio?portfolioId=PF_1001#portfolio-drilldown",
-        ],
-    )
-    cta_label: str = Field(
-        description="Short call-to-action label shown on the action button.",
-        examples=["Performance"],
-    )
-    recommended: bool = Field(
-        default=False,
-        description="Whether this action is the highest-priority recommended next step.",
-        examples=[True],
-    )
-
-
-class PortfolioWorkflowResponse(BaseModel):
-    correlation_id: str = Field(
-        description="Opaque correlation identifier for the workflow response envelope.",
-        examples=["corr-portfolio-workflow"],
-    )
-    contract_version: str = Field(
-        default="v1",
-        description="Version of the gateway workflow response contract.",
-        examples=["v1"],
-    )
-    portfolio_id: str = Field(
-        description="Portfolio identifier whose prioritized workflow actions are being returned.",
-        examples=["PF_1001"],
-    )
-    as_of_date: str = Field(
-        description=(
-            "Resolved as-of date used to derive workflow actions from "
-            "source-backed portfolio state."
-        ),
-        examples=["2026-03-27"],
-    )
-    actions: list[PortfolioWorkflowAction] = Field(
-        default_factory=list,
-        description=(
-            "Prioritized advisor workflow actions derived from the current "
-            "portfolio workspace state."
-        ),
-        examples=[
-            [
-                {
-                    "sequence": 1,
-                    "title": "Review performance",
-                    "impact": (
-                        "Review portfolio return, benchmark context, and contribution once "
-                        "the book is valued."
-                    ),
-                    "target": "Target: Performance workflow for this portfolio",
-                    "href": "/performance?portfolioId=PF_1001",
-                    "cta_label": "Performance",
-                    "recommended": True,
-                },
-                {
-                    "sequence": 2,
-                    "title": "Review holdings",
-                    "impact": (
-                        "Confirm funded positions, valuations, and portfolio weights before "
-                        "client review."
-                    ),
-                    "target": "Target: Holdings workflow for this portfolio",
-                    "href": "/portfolio?portfolioId=PF_1001#portfolio-drilldown",
-                    "cta_label": "Holdings",
-                    "recommended": False,
                 },
             ]
         ],

--- a/src/app/contracts/portfolio_workflow.py
+++ b/src/app/contracts/portfolio_workflow.py
@@ -1,0 +1,264 @@
+from pydantic import BaseModel, Field
+
+
+class PortfolioWorkflowLaunchCue(BaseModel):
+    key: str = Field(
+        description="Stable workflow cue key exposed to product surfaces.",
+        examples=["performance"],
+    )
+    label: str = Field(
+        description="Advisor-facing workflow cue label.",
+        examples=["Performance"],
+    )
+    href: str = Field(
+        description="Route or in-page target used to launch the workflow from the workspace shell.",
+        examples=["/performance?portfolioId=PF_1001"],
+    )
+
+
+class PortfolioReadinessIndicator(BaseModel):
+    key: str = Field(
+        description="Stable readiness indicator key used by product modules and UI affordances.",
+        examples=["holdings"],
+    )
+    label: str = Field(
+        description="Front-office label for the readiness dimension.",
+        examples=["Holdings"],
+    )
+    status: str = Field(
+        description="Gateway-normalized readiness posture for the dimension.",
+        examples=["Ready"],
+    )
+    href: str = Field(
+        description="In-page anchor or route target that helps the operator resolve the finding.",
+        examples=["#portfolio-insights"],
+    )
+
+
+class PortfolioReadinessReason(BaseModel):
+    code: str = Field(
+        description="Source-authored readiness reason code returned by lotus-core.",
+        examples=["pricing_not_published"],
+    )
+    detail: str | None = Field(
+        default=None,
+        description="Optional source-authored explanation for the readiness reason.",
+        examples=["Pricing has not yet been published for the requested business date."],
+    )
+
+
+class PortfolioReadinessBucket(BaseModel):
+    status: str = Field(
+        description="Readiness posture for the specific source-backed dimension.",
+        examples=["Pending"],
+    )
+    reasons: list[PortfolioReadinessReason] = Field(
+        default_factory=list,
+        description="Source-authored reasons explaining why the dimension is not fully ready.",
+    )
+
+
+class PortfolioSupportabilitySummary(BaseModel):
+    feature_key: str = Field(
+        default="core.observability.portfolio_supportability",
+        description="RFC-0108 feature key for the source-owned portfolio supportability signal.",
+        examples=["core.observability.portfolio_supportability"],
+    )
+    state: str = Field(
+        description="Gateway-normalized supportability state for portfolio readiness composition.",
+        examples=["ready", "degraded"],
+    )
+    reason: str = Field(
+        description="Bounded source-authored reason code for the supportability state.",
+        examples=["portfolio_supportability_ready"],
+    )
+    freshness_bucket: str = Field(
+        description=(
+            "Gateway-normalized freshness bucket for analytics UI observability. "
+            "`current` from lotus-core is exposed as `fresh` for Workbench metric vocabulary."
+        ),
+        examples=["fresh", "stale", "unknown"],
+    )
+    ready_domains: int = Field(
+        description="Count of source readiness domains currently ready.",
+        examples=[4],
+    )
+    pending_domains: int = Field(
+        description="Count of source readiness domains currently pending.",
+        examples=[0],
+    )
+    blocked_domains: int = Field(
+        description="Count of source readiness domains currently blocked.",
+        examples=[0],
+    )
+    no_activity_domains: int = Field(
+        description="Count of source readiness domains with no activity.",
+        examples=[0],
+    )
+
+
+class PortfolioReadinessResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Opaque correlation identifier for the readiness response envelope.",
+        examples=["corr-portfolio-readiness"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Version of the gateway readiness response contract.",
+        examples=["v1"],
+    )
+    portfolio_id: str = Field(
+        description="Portfolio identifier whose operational readiness is being reported.",
+        examples=["PF_1001"],
+    )
+    as_of_date: str = Field(
+        description="Resolved readiness as-of date used for the source-backed evaluation.",
+        examples=["2026-03-27"],
+    )
+    holdings: PortfolioReadinessBucket | None = Field(
+        default=None,
+        description="Detailed holdings-book readiness bucket from lotus-core.",
+    )
+    pricing: PortfolioReadinessBucket | None = Field(
+        default=None,
+        description="Detailed pricing readiness bucket from lotus-core.",
+    )
+    transactions: PortfolioReadinessBucket | None = Field(
+        default=None,
+        description="Detailed transaction-book readiness bucket from lotus-core.",
+    )
+    reporting: PortfolioReadinessBucket | None = Field(
+        default=None,
+        description="Detailed reporting readiness bucket from lotus-core.",
+    )
+    blocking_reasons: list[PortfolioReadinessReason] = Field(
+        default_factory=list,
+        description="Portfolio-level blocking reasons that prevent the workspace from being ready.",
+        examples=[
+            [
+                {
+                    "code": "awaiting_pricing",
+                    "detail": "Reporting remains blocked until pricing is published.",
+                }
+            ]
+        ],
+    )
+    supportability: PortfolioSupportabilitySummary | None = Field(
+        default=None,
+        description=(
+            "Source-owned RFC-0108 portfolio supportability posture preserved from lotus-core "
+            "for Workbench freshness, degraded-state, and operational evidence."
+        ),
+    )
+    indicators: list[PortfolioReadinessIndicator] = Field(
+        default_factory=list,
+        description="Compact readiness indicators derived for the front-office workspace rails.",
+        examples=[
+            [
+                {
+                    "key": "holdings",
+                    "label": "Holdings",
+                    "status": "Ready",
+                    "href": "#portfolio-insights",
+                }
+            ]
+        ],
+    )
+
+
+class PortfolioWorkflowAction(BaseModel):
+    sequence: int = Field(
+        description="Display order for the workflow action within the prioritized action list.",
+        examples=[1],
+    )
+    title: str = Field(
+        description="Advisor-facing workflow action title.",
+        examples=["Review performance"],
+    )
+    impact: str = Field(
+        description="Short explanation of why the workflow action matters now for the portfolio.",
+        examples=[
+            "Review portfolio return, benchmark context, and contribution once the book is valued."
+        ],
+    )
+    target: str = Field(
+        description="Explicit workflow target or operating outcome that the action opens.",
+        examples=[
+            "Target: Performance workflow for this portfolio",
+            "Target: cash funding and opening balance setup",
+        ],
+    )
+    href: str = Field(
+        description="Route or in-page target used to launch the workflow action.",
+        examples=[
+            "/performance?portfolioId=PF_1001",
+            "/portfolio?portfolioId=PF_1001#portfolio-drilldown",
+        ],
+    )
+    cta_label: str = Field(
+        description="Short call-to-action label shown on the action button.",
+        examples=["Performance"],
+    )
+    recommended: bool = Field(
+        default=False,
+        description="Whether this action is the highest-priority recommended next step.",
+        examples=[True],
+    )
+
+
+class PortfolioWorkflowResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Opaque correlation identifier for the workflow response envelope.",
+        examples=["corr-portfolio-workflow"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Version of the gateway workflow response contract.",
+        examples=["v1"],
+    )
+    portfolio_id: str = Field(
+        description="Portfolio identifier whose prioritized workflow actions are being returned.",
+        examples=["PF_1001"],
+    )
+    as_of_date: str = Field(
+        description=(
+            "Resolved as-of date used to derive workflow actions from "
+            "source-backed portfolio state."
+        ),
+        examples=["2026-03-27"],
+    )
+    actions: list[PortfolioWorkflowAction] = Field(
+        default_factory=list,
+        description=(
+            "Prioritized advisor workflow actions derived from the current "
+            "portfolio workspace state."
+        ),
+        examples=[
+            [
+                {
+                    "sequence": 1,
+                    "title": "Review performance",
+                    "impact": (
+                        "Review portfolio return, benchmark context, and contribution once "
+                        "the book is valued."
+                    ),
+                    "target": "Target: Performance workflow for this portfolio",
+                    "href": "/performance?portfolioId=PF_1001",
+                    "cta_label": "Performance",
+                    "recommended": True,
+                },
+                {
+                    "sequence": 2,
+                    "title": "Review holdings",
+                    "impact": (
+                        "Confirm funded positions, valuations, and portfolio weights before "
+                        "client review."
+                    ),
+                    "target": "Target: Holdings workflow for this portfolio",
+                    "href": "/portfolio?portfolioId=PF_1001#portfolio-drilldown",
+                    "cta_label": "Holdings",
+                    "recommended": False,
+                },
+            ]
+        ],
+    )

--- a/src/app/routers/portfolio_readiness.py
+++ b/src/app/routers/portfolio_readiness.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Query
 
-from app.contracts.portfolio import PortfolioReadinessResponse
+from app.contracts.portfolio_workflow import PortfolioReadinessResponse
 from app.middleware.correlation import correlation_id_var
 from app.services.portfolio_service_provider import portfolio_service
 

--- a/src/app/routers/portfolio_workflow.py
+++ b/src/app/routers/portfolio_workflow.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Query
 
-from app.contracts.portfolio import PortfolioWorkflowResponse
+from app.contracts.portfolio_workflow import PortfolioWorkflowResponse
 from app.middleware.correlation import correlation_id_var
 from app.services.portfolio_service_provider import portfolio_service
 

--- a/src/app/services/portfolio_source_readiness.py
+++ b/src/app/services/portfolio_source_readiness.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from app.contracts.portfolio import (
+from app.contracts.portfolio_workflow import (
     PortfolioReadinessBucket,
     PortfolioReadinessIndicator,
     PortfolioReadinessReason,

--- a/src/app/services/portfolio_workflow.py
+++ b/src/app/services/portfolio_workflow.py
@@ -4,11 +4,13 @@ from app.contracts.portfolio import (
     PortfolioAllocationView,
     PortfolioOperationalReadiness,
     PortfolioPositionView,
-    PortfolioReadinessIndicator,
     PortfolioSummary,
+    PortfolioWorkspaceResponse,
+)
+from app.contracts.portfolio_workflow import (
+    PortfolioReadinessIndicator,
     PortfolioWorkflowAction,
     PortfolioWorkflowLaunchCue,
-    PortfolioWorkspaceResponse,
 )
 
 

--- a/tests/unit/test_portfolio_workflow.py
+++ b/tests/unit/test_portfolio_workflow.py
@@ -1,4 +1,5 @@
-from app.contracts.portfolio import PortfolioSummary, PortfolioWorkflowLaunchCue
+from app.contracts.portfolio import PortfolioSummary
+from app.contracts.portfolio_workflow import PortfolioWorkflowLaunchCue
 from app.services.portfolio_workflow import (
     build_workflow_actions,
     build_workflow_cues,

--- a/tests/unit/test_portfolio_workflow_contracts.py
+++ b/tests/unit/test_portfolio_workflow_contracts.py
@@ -1,0 +1,12 @@
+from app.contracts import portfolio
+from app.contracts.portfolio_workflow import (
+    PortfolioReadinessResponse,
+    PortfolioWorkflowLaunchCue,
+    PortfolioWorkflowResponse,
+)
+
+
+def test_portfolio_workflow_contracts_remain_reexported_from_portfolio_contract() -> None:
+    assert portfolio.PortfolioReadinessResponse is PortfolioReadinessResponse
+    assert portfolio.PortfolioWorkflowLaunchCue is PortfolioWorkflowLaunchCue
+    assert portfolio.PortfolioWorkflowResponse is PortfolioWorkflowResponse

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -90,14 +90,14 @@ page loading, and portfolio book response assembly, lowering the baseline to 62 
 transaction request-context, transaction page-context, transaction client-kwargs, portfolio
 workspace response assembly, portfolio workspace performance parsing, and portfolio workspace
 rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, and
-portfolio workflow mapping extractions. The largest-file hotspot has moved to the portfolio
-contract module at 2,226 lines.
+portfolio workflow mapping extractions. `portfolio.py` is now measured at 1,974 lines after
+workflow/readiness contract extraction.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
 extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
-portfolio workflow mapper branch passed with ruff, format check, monetary-float guard, mypy over
-454 source files, Workbench/OpenAPI contract smoke, and 1,031 unit/contract tests. Local
-`make ci` passed with 207 integration tests, 1,238 coverage tests, 94.00 percent total coverage,
+portfolio workflow contract branch passed with ruff, format check, monetary-float guard, mypy over
+455 source files, Workbench/OpenAPI contract smoke, and 1,032 unit/contract tests. Local
+`make ci` passed with 207 integration tests, 1,239 coverage tests, 94.01 percent total coverage,
 and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette exception.
 GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were
-green before PR #358 merged. The current portfolio workflow mapper branch adds focused workflow
-mapper and portfolio service evidence with 46 passing unit tests.
+green before PR #359 merged. The current portfolio workflow contract branch adds focused contract
+compatibility and portfolio OpenAPI evidence with 23 passing tests.


### PR DESCRIPTION
## Summary
- Extract portfolio readiness/workflow DTOs into `src/app/contracts/portfolio_workflow.py`.
- Preserve the legacy `app.contracts.portfolio` import surface through explicit compatibility re-exports.
- Update direct readiness/workflow consumers to use the focused contract module and add a compatibility test.
- Refresh quality/wiki evidence for the measured contract reduction (`portfolio.py` 2,226 -> 1,974 lines; largest source file is now `portfolio_service.py` at 2,076 lines).

## Validation
- Focused: `python -m ruff check ...`, `python -m mypy ...`, and 23 workflow contract/source-readiness/OpenAPI contract tests passed.
- `python -m pytest tests/unit/test_gateway_wiki_overview.py tests/unit/test_enterprise_readiness.py -q`: 18 passed.
- `git diff --check`: passed.
- `make check`: ruff, format, monetary-float guard, mypy over 455 source files, Workbench/OpenAPI contract smoke, and 1,032 unit/contract tests passed.
- `make ci`: 207 integration tests passed; 1,239 coverage tests passed with 94.01% total coverage; `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception.

## Wiki
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reports expected pre-merge drift in `Validation-and-CI.md` because this branch updates the repo-authored wiki source. Publish after merge and verify check-only returns DiffCount 0.