### PR TITLE
Extract portfolio transaction contracts

### DIFF
--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-06-12T14:51:29Z",
+  "generated_at": "2026-06-12T15:57:24Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:162:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -340,172 +340,172 @@
       "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:165:invested_market_value_base: float = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:169:cash_market_value_base: float = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:173:cash_weight_pct: float = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:205:market_value_base: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:2067:portfolio_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:1643:portfolio_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:2074:benchmark_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:1650:benchmark_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:2082:excess_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:1658:excess_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:210:weight_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:2158:portfolio_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:1734:portfolio_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:2163:benchmark_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:1739:benchmark_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:2170:excess_return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:1746:excess_return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:226:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:179:invested_market_value_base: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:231:weight_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:183:cash_market_value_base: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:302:cost_basis_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:187:cash_weight_pct: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:307:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:219:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:312:weight_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:224:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:362:market_price: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:240:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:367:cost_basis_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:245:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:372:cost_basis_local: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:316:cost_basis_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:377:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:321:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:382:market_value_local: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:326:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:399:weight_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:376:market_price: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:446:price: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:381:cost_basis_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:451:gross_amount: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:386:cost_basis_local: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:461:net_cost_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:391:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:575:portfolio_currency_amount: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:396:market_value_local: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:580:reporting_currency_amount: float = Field(",
+      "finding": "src/app/contracts/portfolio.py:413:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:756:return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:478:portfolio_currency_amount: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:483:reporting_currency_amount: float = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-14"
+    },
+    {
+      "finding": "src/app/contracts/portfolio.py:659:return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-10-14"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_transactions.py:39:price: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_transactions.py:44:gross_amount: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_transactions.py:54:net_cost_base: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
     },
     {
       "finding": "src/app/contracts/risk_workspace.py:1094:metric_values: dict[str, float | None] = Field(",
@@ -802,25 +802,25 @@
       "review_by": "2026-12-02"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1736:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/portfolio_service.py:1643:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1863:market_value_base=float(",
+      "finding": "src/app/services/portfolio_service.py:1770:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1866:weight_pct=float(",
+      "finding": "src/app/services/portfolio_service.py:1773:weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1867:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
+      "finding": "src/app/services/portfolio_service.py:1774:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -171,6 +171,10 @@ The current portfolio workflow contract slice moves readiness and workflow respo
 `portfolio_workflow.py`, keeps `app.contracts.portfolio` as the compatibility import surface, and
 reduces `portfolio.py` from 2,226 to 1,974 measured lines while preserving OpenAPI schema names and
 the 49-line longest-function baseline.
+The current portfolio transaction contract slice moves transaction row and ledger response
+contracts into `portfolio_transactions.py`, keeps `app.contracts.portfolio` as the compatibility
+import surface, and reduces `portfolio.py` from 1,885 to 1,717 measured lines while preserving
+OpenAPI schema names and the 49-line longest-function baseline.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -178,30 +182,30 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,321 |
-| Python source files under `src/app` | 455 |
-| Python test files under `tests` | 170 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,325 |
+| Python source files under `src/app` | 456 |
+| Python test files under `tests` | 171 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current portfolio workflow contract branch shows 1,321 files
-under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 455 Python source files under
-`src/app`; and 170 Python test files under `tests`.
+Working-tree verification for the current portfolio transaction contract branch shows 1,325 files
+under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 456 Python source files under
+`src/app`; and 171 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 2,076 | `src/app/services/portfolio_service.py` |
-| 2 | 2,043 | `src/app/contracts/risk_workspace.py` |
-| 3 | 1,974 | `src/app/contracts/portfolio.py` |
-| 4 | 1,840 | `src/app/contracts/reporting.py` |
-| 5 | 1,704 | `src/app/services/performance_workspace_service.py` |
-| 6 | 1,607 | `src/app/services/advisor_brief_service.py` |
-| 7 | 1,606 | `src/app/contracts/performance_workspace.py` |
-| 8 | 1,362 | `src/app/clients/dpm_client.py` |
-| 9 | 1,217 | `src/app/services/dpm_command_center_service.py` |
-| 10 | 1,098 | `src/app/clients/advise_client.py` |
+| 1 | 1,967 | `src/app/services/portfolio_service.py` |
+| 2 | 1,940 | `src/app/contracts/risk_workspace.py` |
+| 3 | 1,731 | `src/app/contracts/reporting.py` |
+| 4 | 1,717 | `src/app/contracts/portfolio.py` |
+| 5 | 1,607 | `src/app/services/performance_workspace_service.py` |
+| 6 | 1,539 | `src/app/contracts/performance_workspace.py` |
+| 7 | 1,452 | `src/app/services/advisor_brief_service.py` |
+| 8 | 1,258 | `src/app/clients/dpm_client.py` |
+| 9 | 1,137 | `src/app/services/dpm_command_center_service.py` |
+| 10 | 1,012 | `src/app/clients/advise_client.py` |
 
 ## Largest Functions
 
@@ -353,6 +357,15 @@ Most recent local evidence:
     unit/contract tests.
 63. Current portfolio workflow contract branch: `make ci` passed with 207 integration tests and
     1,239 combined coverage tests; total coverage is 94.01%, and `pip-audit` found no known
+    vulnerabilities after the governed `PYSEC-2026-161` exception.
+64. Current portfolio transaction contract branch: focused validation passed with ruff, mypy over
+    the touched contract/router/service modules, and 17 transaction contract/ledger/OpenAPI
+    contract tests.
+65. Current portfolio transaction contract branch: `make check` passed with ruff, format check,
+    monetary-float guard, mypy over 456 source files, Workbench/OpenAPI contract smoke, and 1,033
+    unit/contract tests.
+66. Current portfolio transaction contract branch: `make ci` passed with 207 integration tests and
+    1,240 combined coverage tests; total coverage is 94.01%, and `pip-audit` found no known
     vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,35 +5,35 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 455 source files, contract smoke, and 1,032 unit/contract tests; `make ci` passed with 207 integration tests, 1,239 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 456 source files, contract smoke, and 1,033 unit/contract tests; `make ci` passed with 207 integration tests, 1,240 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 94.01% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, and portfolio workflow contracts; `portfolio_service.py` is now 2,076 measured lines and `portfolio.py` is now 1,974 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, portfolio workflow contracts, and portfolio transaction contracts; `portfolio_service.py` is now 1,967 measured lines and `portfolio.py` is now 1,717 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in current branch `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused portfolio workflow contract slice | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused portfolio transaction contract slice | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
 Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
-versus the current portfolio workflow contract branch after PRs #349, #350, #351, #352, #353,
-#354, #355, #356, #357, #358, and #359.
+versus the current portfolio transaction contract branch after PRs #349, #350, #351, #352, #353,
+#354, #355, #356, #357, #358, #359, and #360.
 
 | Measure | Prior scorecard | Current branch | Result |
 | --- | ---: | ---: | --- |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,321 | Added focused modules, tests, and quality evidence |
-| Tracked `src/app` Python files | 447 | 455 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper and contract modules |
-| Tracked Python test files | 162 | 170 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, and workflow contract tests |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,325 | Added focused modules, tests, and quality evidence |
+| Tracked `src/app` Python files | 447 | 456 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper and contract modules |
+| Tracked Python test files | 162 | 171 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, and transaction contract tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 2,076 lines | Improved; `src/app/services/portfolio_service.py` is again the largest residual hotspot after reducing `portfolio.py` |
+| Largest source file | 2,968 lines | 1,967 lines | Improved; `src/app/services/portfolio_service.py` remains the largest residual hotspot after reducing `portfolio.py` |
 | `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,032 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, and workflow contract tests |
-| Local coverage tests | 1,203 | 1,239 | Added focused coverage while preserving total coverage |
+| Local unit/contract tests | 996 | 1,033 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, and transaction contract tests |
+| Local coverage tests | 1,203 | 1,240 | Added focused coverage while preserving total coverage |
 | Total coverage | 93.69% | 94.01% | Improved |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
@@ -59,7 +59,7 @@ Candidate thresholds:
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
 5. no new function above the current maximum of 49 lines and no unclassified largest-file growth
-   above the current 2,076-line `src/app/services/portfolio_service.py` maximum.
+   above the current 1,967-line `src/app/services/portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -251,17 +251,21 @@ preserving the 49-line longest-function baseline.
 The current portfolio workflow contract slice moves readiness and workflow response models into
 `portfolio_workflow.py`, keeps the legacy `app.contracts.portfolio` import surface intact, and
 reduces `portfolio.py` from 2,226 to 1,974 lines while preserving OpenAPI contract tests.
+The current portfolio transaction contract slice moves transaction row and ledger response models
+into `portfolio_transactions.py`, keeps the legacy `app.contracts.portfolio` import surface
+intact, refreshes the governed monetary-float allowlist for the moved response float fields, and
+reduces `portfolio.py` from 1,885 to 1,717 lines while preserving OpenAPI contract tests.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | Current workflow contract branch was created from clean `main` after PR #359; final remote/local cleanup remains a post-merge gate |
-| Unit/contract coverage | Healthy | 1,032 unit/contract tests passed in current branch `make check`; focused workflow contract, source-readiness, workflow mapper, and portfolio OpenAPI contract tests passed with 23 tests on this branch |
+| Branch hygiene | Healthy | Current transaction contract branch was created from clean `main` after PR #360; final remote/local cleanup remains a post-merge gate |
+| Unit/contract coverage | Healthy | 1,033 unit/contract tests passed in current branch `make check`; focused transaction contract, transaction ledger, and portfolio OpenAPI contract tests passed with 17 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
-| Total coverage | Healthy | 1,239 coverage tests passed in current branch `make ci`; total coverage is 94.01%, above the 84% floor |
+| Total coverage | Healthy | 1,240 coverage tests passed in current branch `make ci`; total coverage is 94.01%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper slices reduce `portfolio_service.py` to 2,076 measured lines, `portfolio.py` to 1,974 measured lines, and `performance_workspace_service.py` to 1,607 measured lines; large contracts and several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper/contract slices reduce `portfolio_service.py` to 1,967 measured lines, `portfolio.py` to 1,717 measured lines, and `performance_workspace_service.py` to 1,607 measured lines; large contracts and several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -274,8 +278,8 @@ reduces `portfolio.py` from 2,226 to 1,974 lines while preserving OpenAPI contra
    transaction-ledger payload loading, workspace source gathering, position-book mapping,
    transaction-ledger response mapping, transaction client-kwargs mapping, transaction page
    context defaults, workspace performance parsing, workspace rebalance parsing, source readiness
-   parsing, transaction summary mapping, workflow cue/action mapping, and workflow/readiness
-   contracts are now separately testable.
+   parsing, transaction summary mapping, workflow cue/action mapping, workflow/readiness
+   contracts, and transaction ledger contracts are now separately testable.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes

--- a/src/app/contracts/portfolio.py
+++ b/src/app/contracts/portfolio.py
@@ -2,8 +2,11 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from app.contracts import portfolio_transactions as _portfolio_transactions
 from app.contracts import portfolio_workflow as _portfolio_workflow
 
+PortfolioTransactionLedgerResponse = _portfolio_transactions.PortfolioTransactionLedgerResponse
+PortfolioTransactionView = _portfolio_transactions.PortfolioTransactionView
 PortfolioReadinessBucket = _portfolio_workflow.PortfolioReadinessBucket
 PortfolioReadinessIndicator = _portfolio_workflow.PortfolioReadinessIndicator
 PortfolioReadinessReason = _portfolio_workflow.PortfolioReadinessReason
@@ -416,117 +419,6 @@ class PortfolioPositionView(BaseModel):
         default=None,
         description="Optional upstream reprocessing or valuation status for the position row.",
         examples=["READY"],
-    )
-
-
-class PortfolioTransactionView(BaseModel):
-    transaction_id: str = Field(
-        description="Identifier of the transaction row.",
-        examples=["TX_1"],
-    )
-    transaction_date: str = Field(
-        description="Booked transaction date or timestamp for the ledger row.",
-        examples=["2026-03-27T09:30:00Z"],
-    )
-    settlement_date: str | None = Field(
-        default=None,
-        description="Optional settlement date for the transaction row.",
-        examples=["2026-03-29"],
-    )
-    transaction_type: str = Field(
-        description="Canonical transaction type returned by the source ledger.",
-        examples=["BUY"],
-    )
-    component_type: str | None = Field(
-        default=None,
-        description="Optional component type for linked or multi-row economic events.",
-        examples=["FX_CONTRACT_OPEN"],
-    )
-    security_id: str = Field(
-        description="Security identifier associated with the transaction row.",
-        examples=["EQ_1"],
-    )
-    instrument_id: str = Field(
-        description="Instrument identifier associated with the transaction row.",
-        examples=["INST_EQ_1"],
-    )
-    quantity: float = Field(
-        description="Transaction quantity for the ledger row.",
-        examples=[10.0],
-    )
-    price: float | None = Field(
-        default=None,
-        description="Booked transaction price when available.",
-        examples=[70.0],
-    )
-    gross_amount: float | None = Field(
-        default=None,
-        description="Gross transaction amount when available.",
-        examples=[700.0],
-    )
-    currency: str | None = Field(
-        default=None,
-        description="Currency associated with the transaction row when available.",
-        examples=["USD"],
-    )
-    net_cost_base: float | None = Field(
-        default=None,
-        description="Net cost expressed in portfolio base currency when available.",
-        examples=[700.0],
-    )
-    realized_gain_loss_base: float | None = Field(
-        default=None,
-        description="Realized gain or loss expressed in portfolio base currency when available.",
-        examples=[15.0],
-    )
-    settlement_status: str | None = Field(
-        default=None,
-        description="Optional settlement status for the transaction row.",
-        examples=["SETTLED"],
-    )
-    source_system: str | None = Field(
-        default=None,
-        description="Optional upstream source system associated with the transaction row.",
-        examples=["lotus-core"],
-    )
-    cash_entry_mode: str | None = Field(
-        default=None,
-        description="Optional cash-entry mode associated with the transaction row.",
-        examples=["BOOKED"],
-    )
-    economic_event_id: str | None = Field(
-        default=None,
-        description="Optional economic event identifier linking related transaction rows.",
-        examples=["EVT-2026-0001"],
-    )
-    linked_transaction_group_id: str | None = Field(
-        default=None,
-        description="Optional linked transaction group identifier for multi-row events.",
-        examples=["LTG-2026-0001"],
-    )
-    fx_contract_id: str | None = Field(
-        default=None,
-        description="Optional FX contract identifier associated with the transaction row.",
-        examples=["FXC-2026-0001"],
-    )
-    swap_event_id: str | None = Field(
-        default=None,
-        description="Optional FX swap event identifier associated with the transaction row.",
-        examples=["FXSWAP-2026-0001"],
-    )
-    near_leg_group_id: str | None = Field(
-        default=None,
-        description=(
-            "Optional FX swap near-leg group identifier associated with the transaction row."
-        ),
-        examples=["FXSWAP-2026-0001-NEAR"],
-    )
-    far_leg_group_id: str | None = Field(
-        default=None,
-        description=(
-            "Optional FX swap far-leg group identifier associated with the transaction row."
-        ),
-        examples=["FXSWAP-2026-0001-FAR"],
     )
 
 
@@ -1737,70 +1629,6 @@ class PortfolioBookResponse(BaseModel):
                     "market_value_base": 400.0,
                     "market_value_local": 400.0,
                     "weight_pct": 40.0,
-                }
-            ]
-        ],
-    )
-
-
-class PortfolioTransactionLedgerResponse(BaseModel):
-    correlation_id: str = Field(
-        description="Opaque correlation identifier for the transaction-ledger response envelope.",
-        examples=["corr-portfolio-transactions"],
-    )
-    contract_version: str = Field(
-        default="v1",
-        description="Version of the gateway transaction-ledger response contract.",
-        examples=["v1"],
-    )
-    portfolio_id: str = Field(
-        description="Portfolio identifier whose transaction ledger is being returned.",
-        examples=["PF_1001"],
-    )
-    as_of_date: str | None = Field(
-        default=None,
-        description=(
-            "Resolved as-of date used for booked transaction state when "
-            "provided by source or caller."
-        ),
-        examples=["2026-03-27"],
-    )
-    include_projected: bool = Field(
-        description="Whether future-dated projected transactions are included in the result set.",
-        examples=[False],
-    )
-    total: int = Field(
-        description="Total number of matching transactions before paging is applied.",
-        examples=[125],
-    )
-    skip: int = Field(
-        description="Number of matching rows skipped before the current page.",
-        examples=[0],
-    )
-    limit: int = Field(
-        description="Maximum number of matching rows requested for the current page.",
-        examples=[50],
-    )
-    transactions: list[PortfolioTransactionView] = Field(
-        default_factory=list,
-        description="Transaction rows returned for the current filter and paging window.",
-        examples=[
-            [
-                {
-                    "transaction_id": "TX_1",
-                    "transaction_date": "2026-03-27T00:00:00Z",
-                    "settlement_date": "2026-03-31",
-                    "transaction_type": "BUY",
-                    "component_type": "FX_CONTRACT_OPEN",
-                    "security_id": "EQ_1",
-                    "instrument_id": "INST_EQ_1",
-                    "quantity": 1.0,
-                    "currency": "USD",
-                    "linked_transaction_group_id": "LTG-2026-0001",
-                    "fx_contract_id": "FXC-2026-0001",
-                    "swap_event_id": "FXSWAP-2026-0001",
-                    "near_leg_group_id": "FXSWAP-2026-0001-NEAR",
-                    "far_leg_group_id": "FXSWAP-2026-0001-FAR",
                 }
             ]
         ],

--- a/src/app/contracts/portfolio_transactions.py
+++ b/src/app/contracts/portfolio_transactions.py
@@ -1,0 +1,176 @@
+from pydantic import BaseModel, Field
+
+
+class PortfolioTransactionView(BaseModel):
+    transaction_id: str = Field(
+        description="Identifier of the transaction row.",
+        examples=["TX_1"],
+    )
+    transaction_date: str = Field(
+        description="Booked transaction date or timestamp for the ledger row.",
+        examples=["2026-03-27T09:30:00Z"],
+    )
+    settlement_date: str | None = Field(
+        default=None,
+        description="Optional settlement date for the transaction row.",
+        examples=["2026-03-29"],
+    )
+    transaction_type: str = Field(
+        description="Canonical transaction type returned by the source ledger.",
+        examples=["BUY"],
+    )
+    component_type: str | None = Field(
+        default=None,
+        description="Optional component type for linked or multi-row economic events.",
+        examples=["FX_CONTRACT_OPEN"],
+    )
+    security_id: str = Field(
+        description="Security identifier associated with the transaction row.",
+        examples=["EQ_1"],
+    )
+    instrument_id: str = Field(
+        description="Instrument identifier associated with the transaction row.",
+        examples=["INST_EQ_1"],
+    )
+    quantity: float = Field(
+        description="Transaction quantity for the ledger row.",
+        examples=[10.0],
+    )
+    price: float | None = Field(
+        default=None,
+        description="Booked transaction price when available.",
+        examples=[70.0],
+    )
+    gross_amount: float | None = Field(
+        default=None,
+        description="Gross transaction amount when available.",
+        examples=[700.0],
+    )
+    currency: str | None = Field(
+        default=None,
+        description="Currency associated with the transaction row when available.",
+        examples=["USD"],
+    )
+    net_cost_base: float | None = Field(
+        default=None,
+        description="Net cost expressed in portfolio base currency when available.",
+        examples=[700.0],
+    )
+    realized_gain_loss_base: float | None = Field(
+        default=None,
+        description="Realized gain or loss expressed in portfolio base currency when available.",
+        examples=[15.0],
+    )
+    settlement_status: str | None = Field(
+        default=None,
+        description="Optional settlement status for the transaction row.",
+        examples=["SETTLED"],
+    )
+    source_system: str | None = Field(
+        default=None,
+        description="Optional upstream source system associated with the transaction row.",
+        examples=["lotus-core"],
+    )
+    cash_entry_mode: str | None = Field(
+        default=None,
+        description="Optional cash-entry mode associated with the transaction row.",
+        examples=["BOOKED"],
+    )
+    economic_event_id: str | None = Field(
+        default=None,
+        description="Optional economic event identifier linking related transaction rows.",
+        examples=["EVT-2026-0001"],
+    )
+    linked_transaction_group_id: str | None = Field(
+        default=None,
+        description="Optional linked transaction group identifier for multi-row events.",
+        examples=["LTG-2026-0001"],
+    )
+    fx_contract_id: str | None = Field(
+        default=None,
+        description="Optional FX contract identifier associated with the transaction row.",
+        examples=["FXC-2026-0001"],
+    )
+    swap_event_id: str | None = Field(
+        default=None,
+        description="Optional FX swap event identifier associated with the transaction row.",
+        examples=["FXSWAP-2026-0001"],
+    )
+    near_leg_group_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional FX swap near-leg group identifier associated with the transaction row."
+        ),
+        examples=["FXSWAP-2026-0001-NEAR"],
+    )
+    far_leg_group_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional FX swap far-leg group identifier associated with the transaction row."
+        ),
+        examples=["FXSWAP-2026-0001-FAR"],
+    )
+
+
+class PortfolioTransactionLedgerResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Opaque correlation identifier for the transaction-ledger response envelope.",
+        examples=["corr-portfolio-transactions"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Version of the gateway transaction-ledger response contract.",
+        examples=["v1"],
+    )
+    portfolio_id: str = Field(
+        description="Portfolio identifier whose transaction ledger is being returned.",
+        examples=["PF_1001"],
+    )
+    as_of_date: str | None = Field(
+        default=None,
+        description=(
+            "Resolved as-of date used for booked transaction state when "
+            "provided by source or caller."
+        ),
+        examples=["2026-03-27"],
+    )
+    include_projected: bool = Field(
+        description="Whether future-dated projected transactions are included in the result set.",
+        examples=[False],
+    )
+    total: int = Field(
+        description="Total number of matching transactions before paging is applied.",
+        examples=[125],
+    )
+    skip: int = Field(
+        description="Number of matching rows skipped before the current page.",
+        examples=[0],
+    )
+    limit: int = Field(
+        description="Maximum number of matching rows requested for the current page.",
+        examples=[50],
+    )
+    transactions: list[PortfolioTransactionView] = Field(
+        default_factory=list,
+        description="Transaction rows returned for the current filter and paging window.",
+        examples=[
+            [
+                {
+                    "transaction_id": "TX_1",
+                    "transaction_date": "2026-03-27T00:00:00Z",
+                    "settlement_date": "2026-03-31",
+                    "transaction_type": "BUY",
+                    "component_type": "FX_CONTRACT_OPEN",
+                    "security_id": "EQ_1",
+                    "instrument_id": "INST_EQ_1",
+                    "quantity": 1.0,
+                    "currency": "USD",
+                    "linked_transaction_group_id": "LTG-2026-0001",
+                    "fx_contract_id": "FXC-2026-0001",
+                    "swap_event_id": "FXSWAP-2026-0001",
+                    "near_leg_group_id": "FXSWAP-2026-0001-NEAR",
+                    "far_leg_group_id": "FXSWAP-2026-0001-FAR",
+                }
+            ]
+        ],
+    )

--- a/src/app/routers/portfolio_transactions.py
+++ b/src/app/routers/portfolio_transactions.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from fastapi import APIRouter, Query
 
-from app.contracts.portfolio import PortfolioTransactionLedgerResponse
+from app.contracts.portfolio_transactions import PortfolioTransactionLedgerResponse
 from app.middleware.correlation import correlation_id_var
 from app.services.portfolio_service_provider import portfolio_service
 

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -37,11 +37,11 @@ from app.contracts.portfolio import (
     PortfolioReportingReadiness,
     PortfolioSummary,
     PortfolioTopPosition,
-    PortfolioTransactionLedgerResponse,
     PortfolioWorkflowResponse,
     PortfolioWorkspaceControlCapabilities,
     PortfolioWorkspaceResponse,
 )
+from app.contracts.portfolio_transactions import PortfolioTransactionLedgerResponse
 from app.precision_policy import (
     quantize_money,
     quantize_performance,

--- a/src/app/services/portfolio_transaction_ledger.py
+++ b/src/app/services/portfolio_transaction_ledger.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any
 
-from app.contracts.portfolio import (
+from app.contracts.portfolio_transactions import (
     PortfolioTransactionLedgerResponse,
     PortfolioTransactionView,
 )

--- a/tests/unit/test_portfolio_transaction_contracts.py
+++ b/tests/unit/test_portfolio_transaction_contracts.py
@@ -1,0 +1,10 @@
+from app.contracts import portfolio
+from app.contracts.portfolio_transactions import (
+    PortfolioTransactionLedgerResponse,
+    PortfolioTransactionView,
+)
+
+
+def test_portfolio_transaction_contracts_remain_reexported_from_portfolio_contract() -> None:
+    assert portfolio.PortfolioTransactionLedgerResponse is PortfolioTransactionLedgerResponse
+    assert portfolio.PortfolioTransactionView is PortfolioTransactionView

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -86,18 +86,18 @@ and rebalance supportability failure-recording splits then lowered the baseline 
 74 lines. The 50-commit enterprise-hardening branch then split shared analytics async polling,
 workspace-summary payload assembly, portfolio transaction-summary context loading, transaction
 page loading, and portfolio book response assembly, lowering the baseline to 62 lines.
-`portfolio_service.py` is now measured at 2,076 lines after portfolio liquidity loading,
+`portfolio_service.py` is now measured at 1,967 lines after portfolio liquidity loading,
 transaction request-context, transaction page-context, transaction client-kwargs, portfolio
 workspace response assembly, portfolio workspace performance parsing, and portfolio workspace
 rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, and
-portfolio workflow mapping extractions. `portfolio.py` is now measured at 1,974 lines after
-workflow/readiness contract extraction.
+portfolio workflow mapping extractions. `portfolio.py` is now measured at 1,717 lines after
+workflow/readiness and transaction-ledger contract extraction.
 `performance_workspace_service.py` is now measured at 1,607 lines after response assembly
 extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
-portfolio workflow contract branch passed with ruff, format check, monetary-float guard, mypy over
-455 source files, Workbench/OpenAPI contract smoke, and 1,032 unit/contract tests. Local
-`make ci` passed with 207 integration tests, 1,239 coverage tests, 94.01 percent total coverage,
+portfolio transaction contract branch passed with ruff, format check, monetary-float guard, mypy
+over 456 source files, Workbench/OpenAPI contract smoke, and 1,033 unit/contract tests. Local
+`make ci` passed with 207 integration tests, 1,240 coverage tests, 94.01 percent total coverage,
 and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette exception.
 GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were
-green before PR #359 merged. The current portfolio workflow contract branch adds focused contract
-compatibility and portfolio OpenAPI evidence with 23 passing tests.
+green before PR #360 merged. The current portfolio transaction contract branch adds focused
+transaction contract compatibility and portfolio OpenAPI evidence with 17 passing tests.


### PR DESCRIPTION
## Summary
- Extract portfolio transaction row and ledger response DTOs into `src/app/contracts/portfolio_transactions.py`.
- Preserve the legacy `app.contracts.portfolio` import surface through explicit compatibility re-exports.
- Update direct transaction-ledger consumers to use the focused contract module and add compatibility coverage.
- Refresh the governed monetary-float allowlist for moved quantized response float fields.
- Refresh quality/wiki evidence for the measured contract reduction (`portfolio.py` 1,885 -> 1,717 lines; largest source file remains `portfolio_service.py` at 1,967 lines).

## Validation
- Focused: `python -m ruff check ...`, `python -m mypy ...`, and 17 transaction contract/ledger/OpenAPI contract tests passed.
- `python -m pytest tests/unit/test_gateway_wiki_overview.py tests/unit/test_enterprise_readiness.py -q`: 18 passed.
- `git diff --check`: passed.
- `make check`: ruff, format, monetary-float guard, mypy over 456 source files, Workbench/OpenAPI contract smoke, and 1,033 unit/contract tests passed.
- `make ci`: 207 integration tests passed; 1,240 coverage tests passed with 94.01% total coverage; `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception.

## Wiki
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reports expected pre-merge drift in `Validation-and-CI.md` because this branch updates the repo-authored wiki source. Publish after merge and verify check-only returns DiffCount 0.