### PR TITLE
Extract portfolio performance snapshot contracts

### DIFF
--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-06-12T15:57:24Z",
+  "generated_at": "2026-06-12T16:21:59Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:162:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -340,154 +340,154 @@
       "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:1643:portfolio_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:1650:benchmark_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:1658:excess_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:1734:portfolio_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:1739:benchmark_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:1746:excess_return_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-27"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:179:invested_market_value_base: float = Field(",
+      "finding": "src/app/contracts/portfolio.py:176:invested_market_value_base: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:183:cash_market_value_base: float = Field(",
+      "finding": "src/app/contracts/portfolio.py:180:cash_market_value_base: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:187:cash_weight_pct: float = Field(",
+      "finding": "src/app/contracts/portfolio.py:184:cash_weight_pct: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:219:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:216:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:224:weight_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:221:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:240:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:237:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:245:weight_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:242:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:316:cost_basis_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:313:cost_basis_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:321:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:318:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:326:weight_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:323:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:376:market_price: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:373:market_price: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:381:cost_basis_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:378:cost_basis_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:386:cost_basis_local: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:383:cost_basis_local: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:391:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:388:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:396:market_value_local: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:393:market_value_local: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:413:weight_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:410:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:478:portfolio_currency_amount: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:475:portfolio_currency_amount: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:483:reporting_currency_amount: float = Field(",
+      "finding": "src/app/contracts/portfolio.py:480:reporting_currency_amount: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:659:return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:656:return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_performance_snapshot.py:102:portfolio_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_performance_snapshot.py:107:benchmark_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_performance_snapshot.py:114:excess_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_performance_snapshot.py:11:portfolio_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_performance_snapshot.py:18:benchmark_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_performance_snapshot.py:26:excess_return_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
     },
     {
       "finding": "src/app/contracts/portfolio_transactions.py:39:price: float | None = Field(",

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,6 +1,6 @@
 # Quality Baseline Report
 
-Date: 2026-06-12
+Date: 2026-06-13
 Repository: `lotus-gateway`  
 Baseline phase: report-only
 
@@ -175,6 +175,11 @@ The current portfolio transaction contract slice moves transaction row and ledge
 contracts into `portfolio_transactions.py`, keeps `app.contracts.portfolio` as the compatibility
 import surface, and reduces `portfolio.py` from 1,885 to 1,717 measured lines while preserving
 OpenAPI schema names and the 49-line longest-function baseline.
+The current portfolio performance snapshot contract slice moves the shared partial-failure DTO
+and performance snapshot response models into focused contract modules, keeps
+`app.contracts.portfolio` as the compatibility import surface, refreshes the governed monetary
+float allowlist for the moved percentage fields, and reduces `portfolio.py` from 1,717 to 1,632
+measured lines while preserving OpenAPI schema names and the 49-line longest-function baseline.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -182,30 +187,30 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,325 |
-| Python source files under `src/app` | 456 |
-| Python test files under `tests` | 171 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,331 |
+| Python source files under `src/app` | 458 |
+| Python test files under `tests` | 172 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current portfolio transaction contract branch shows 1,325 files
-under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 456 Python source files under
-`src/app`; and 171 Python test files under `tests`.
+Working-tree verification for the current portfolio performance snapshot contract branch shows
+1,331 files under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 458 Python source
+files under `src/app`; and 172 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 1,967 | `src/app/services/portfolio_service.py` |
-| 2 | 1,940 | `src/app/contracts/risk_workspace.py` |
-| 3 | 1,731 | `src/app/contracts/reporting.py` |
-| 4 | 1,717 | `src/app/contracts/portfolio.py` |
-| 5 | 1,607 | `src/app/services/performance_workspace_service.py` |
-| 6 | 1,539 | `src/app/contracts/performance_workspace.py` |
-| 7 | 1,452 | `src/app/services/advisor_brief_service.py` |
-| 8 | 1,258 | `src/app/clients/dpm_client.py` |
-| 9 | 1,137 | `src/app/services/dpm_command_center_service.py` |
-| 10 | 1,012 | `src/app/clients/advise_client.py` |
+| 1 | 2,076 | `src/app/services/portfolio_service.py` |
+| 2 | 2,043 | `src/app/contracts/risk_workspace.py` |
+| 3 | 1,840 | `src/app/contracts/reporting.py` |
+| 4 | 1,704 | `src/app/services/performance_workspace_service.py` |
+| 5 | 1,632 | `src/app/contracts/portfolio.py` |
+| 6 | 1,607 | `src/app/services/advisor_brief_service.py` |
+| 7 | 1,606 | `src/app/contracts/performance_workspace.py` |
+| 8 | 1,362 | `src/app/clients/dpm_client.py` |
+| 9 | 1,217 | `src/app/services/dpm_command_center_service.py` |
+| 10 | 1,098 | `src/app/clients/advise_client.py` |
 
 ## Largest Functions
 
@@ -367,6 +372,15 @@ Most recent local evidence:
 66. Current portfolio transaction contract branch: `make ci` passed with 207 integration tests and
     1,240 combined coverage tests; total coverage is 94.01%, and `pip-audit` found no known
     vulnerabilities after the governed `PYSEC-2026-161` exception.
+67. Current portfolio performance snapshot contract branch: focused validation passed with ruff,
+    mypy over the touched contract/router/service modules, monetary-float guard, diff whitespace
+    checks, and 24 performance snapshot/workspace/OpenAPI contract tests.
+68. Current portfolio performance snapshot contract branch: `make check` passed with ruff, format
+    check, monetary-float guard, mypy over 458 source files, Workbench/OpenAPI contract smoke, and
+    1,034 unit/contract tests.
+69. Current portfolio performance snapshot contract branch: `make ci` passed with 207 integration
+    tests and 1,241 combined coverage tests; total coverage is 94.01%, and `pip-audit` found no
+    known vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,39 +1,39 @@
 # Quality Scorecard
 
-Date: 2026-06-12
+Date: 2026-06-13
 Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 456 source files, contract smoke, and 1,033 unit/contract tests; `make ci` passed with 207 integration tests, 1,240 coverage tests, Docker-equivalent GitHub gates, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 458 source files, contract smoke, and 1,034 unit/contract tests; `make ci` passed with 207 integration tests, 1,241 coverage tests, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 94.01% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, portfolio workflow contracts, and portfolio transaction contracts; `portfolio_service.py` is now 1,967 measured lines and `portfolio.py` is now 1,717 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, portfolio workflow contracts, portfolio transaction contracts, and portfolio performance snapshot contracts; `portfolio_service.py` is now 2,076 measured lines and `portfolio.py` is now 1,632 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in current branch `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused portfolio transaction contract slice | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused portfolio performance snapshot contract slice | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
 Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
-versus the current portfolio transaction contract branch after PRs #349, #350, #351, #352, #353,
-#354, #355, #356, #357, #358, #359, and #360.
+versus the current portfolio performance snapshot contract branch after PRs #349, #350, #351,
+#352, #353, #354, #355, #356, #357, #358, #359, #360, and #361.
 
 | Measure | Prior scorecard | Current branch | Result |
 | --- | ---: | ---: | --- |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,325 | Added focused modules, tests, and quality evidence |
-| Tracked `src/app` Python files | 447 | 456 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper and contract modules |
-| Tracked Python test files | 162 | 171 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, and transaction contract tests |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,331 | Added focused modules, tests, and quality evidence |
+| Tracked `src/app` Python files | 447 | 458 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper and contract modules |
+| Tracked Python test files | 162 | 172 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, and performance snapshot contract tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 1,967 lines | Improved; `src/app/services/portfolio_service.py` remains the largest residual hotspot after reducing `portfolio.py` |
-| `performance_workspace_service.py` | 1,724 lines | 1,607 lines | Improved through response assembly extraction |
+| Largest source file | 2,968 lines | 2,076 lines | Improved; `src/app/services/portfolio_service.py` remains the largest residual hotspot after reducing `portfolio.py` |
+| `performance_workspace_service.py` | 1,724 lines | 1,704 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,033 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, and transaction contract tests |
-| Local coverage tests | 1,203 | 1,240 | Added focused coverage while preserving total coverage |
+| Local unit/contract tests | 996 | 1,034 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, and performance snapshot contract tests |
+| Local coverage tests | 1,203 | 1,241 | Added focused coverage while preserving total coverage |
 | Total coverage | 93.69% | 94.01% | Improved |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
@@ -59,7 +59,7 @@ Candidate thresholds:
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
 5. no new function above the current maximum of 49 lines and no unclassified largest-file growth
-   above the current 1,967-line `src/app/services/portfolio_service.py` maximum.
+   above the current 2,076-line `src/app/services/portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,6 +1,6 @@
 # Refactor Health Report
 
-Date: 2026-06-12
+Date: 2026-06-13
 Phase: baseline/report-only
 
 ## Current Direction
@@ -255,17 +255,23 @@ The current portfolio transaction contract slice moves transaction row and ledge
 into `portfolio_transactions.py`, keeps the legacy `app.contracts.portfolio` import surface
 intact, refreshes the governed monetary-float allowlist for the moved response float fields, and
 reduces `portfolio.py` from 1,885 to 1,717 lines while preserving OpenAPI contract tests.
+The current portfolio performance snapshot contract slice moves the shared partial-failure model
+and performance snapshot models into `portfolio_common.py` and
+`portfolio_performance_snapshot.py`, keeps the legacy `app.contracts.portfolio` import surface
+intact, refreshes the governed monetary-float allowlist for the moved percentage fields, and
+reduces `portfolio.py` from 1,717 to 1,632 lines while preserving OpenAPI contract tests and the
+49-line longest-function baseline.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | Current transaction contract branch was created from clean `main` after PR #360; final remote/local cleanup remains a post-merge gate |
-| Unit/contract coverage | Healthy | 1,033 unit/contract tests passed in current branch `make check`; focused transaction contract, transaction ledger, and portfolio OpenAPI contract tests passed with 17 tests on this branch |
+| Branch hygiene | Healthy | Current performance snapshot contract branch was created from clean `main` after PR #361; final remote/local cleanup remains a post-merge gate |
+| Unit/contract coverage | Healthy | 1,034 unit/contract tests passed in current branch `make check`; focused performance snapshot, workspace projection, and portfolio OpenAPI contract tests passed with 24 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
-| Total coverage | Healthy | 1,240 coverage tests passed in current branch `make ci`; total coverage is 94.01%, above the 84% floor |
+| Total coverage | Healthy | 1,241 coverage tests passed in current branch `make ci`; total coverage is 94.01%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper/contract slices reduce `portfolio_service.py` to 1,967 measured lines, `portfolio.py` to 1,717 measured lines, and `performance_workspace_service.py` to 1,607 measured lines; large contracts and several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper/contract slices reduce `portfolio.py` to 1,632 measured lines and leave `portfolio_service.py` at 2,076 measured lines and `performance_workspace_service.py` at 1,704 measured lines; large contracts and several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -279,7 +285,8 @@ reduces `portfolio.py` from 1,885 to 1,717 lines while preserving OpenAPI contra
    transaction-ledger response mapping, transaction client-kwargs mapping, transaction page
    context defaults, workspace performance parsing, workspace rebalance parsing, source readiness
    parsing, transaction summary mapping, workflow cue/action mapping, workflow/readiness
-   contracts, and transaction ledger contracts are now separately testable.
+   contracts, transaction ledger contracts, and performance snapshot contracts are now separately
+   testable.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes

--- a/src/app/contracts/portfolio.py
+++ b/src/app/contracts/portfolio.py
@@ -2,9 +2,21 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from app.contracts import portfolio_common as _portfolio_common
+from app.contracts import portfolio_performance_snapshot as _portfolio_performance_snapshot
 from app.contracts import portfolio_transactions as _portfolio_transactions
 from app.contracts import portfolio_workflow as _portfolio_workflow
 
+PortfolioPartialFailure = _portfolio_common.PortfolioPartialFailure
+PortfolioPerformanceSnapshotPoint = (
+    _portfolio_performance_snapshot.PortfolioPerformanceSnapshotPoint
+)
+PortfolioPerformanceSnapshotResponse = (
+    _portfolio_performance_snapshot.PortfolioPerformanceSnapshotResponse
+)
+PortfolioPerformanceSnapshotUnavailable = (
+    _portfolio_performance_snapshot.PortfolioPerformanceSnapshotUnavailable
+)
 PortfolioTransactionLedgerResponse = _portfolio_transactions.PortfolioTransactionLedgerResponse
 PortfolioTransactionView = _portfolio_transactions.PortfolioTransactionView
 PortfolioReadinessBucket = _portfolio_workflow.PortfolioReadinessBucket
@@ -15,21 +27,6 @@ PortfolioSupportabilitySummary = _portfolio_workflow.PortfolioSupportabilitySumm
 PortfolioWorkflowAction = _portfolio_workflow.PortfolioWorkflowAction
 PortfolioWorkflowLaunchCue = _portfolio_workflow.PortfolioWorkflowLaunchCue
 PortfolioWorkflowResponse = _portfolio_workflow.PortfolioWorkflowResponse
-
-
-class PortfolioPartialFailure(BaseModel):
-    source_service: str = Field(
-        description="Source service that produced the degraded optional response section.",
-        examples=["lotus-core"],
-    )
-    error_code: str = Field(
-        description="Gateway warning or failure code associated with the degraded section.",
-        examples=["PORTFOLIO_CASHFLOW_UNAVAILABLE"],
-    )
-    detail: str = Field(
-        description="Human-readable detail describing the degraded upstream section.",
-        examples=["cashflow temporarily unavailable"],
-    )
 
 
 class PortfolioCatalogItem(BaseModel):
@@ -1629,173 +1626,6 @@ class PortfolioBookResponse(BaseModel):
                     "market_value_base": 400.0,
                     "market_value_local": 400.0,
                     "weight_pct": 40.0,
-                }
-            ]
-        ],
-    )
-
-
-class PortfolioPerformanceSnapshotPoint(BaseModel):
-    as_of_date: str = Field(
-        description="Observation end date represented by the compact performance sparkline point.",
-        examples=["2026-03-27"],
-    )
-    portfolio_return_pct: float | None = Field(
-        default=None,
-        description=(
-            "Cumulative portfolio return percentage through the sparkline observation date."
-        ),
-        examples=[15.1],
-    )
-    benchmark_return_pct: float | None = Field(
-        default=None,
-        description=(
-            "Cumulative benchmark return percentage through the sparkline observation date when "
-            "benchmark context is available."
-        ),
-        examples=[14.72],
-    )
-    excess_return_pct: float | None = Field(
-        default=None,
-        description=(
-            "Cumulative excess return percentage versus benchmark through the sparkline "
-            "observation date."
-        ),
-        examples=[0.38],
-    )
-
-
-class PortfolioPerformanceSnapshotUnavailable(BaseModel):
-    title: str = Field(
-        description="Advisor-facing unavailable-state title for the performance snapshot module.",
-        examples=["Performance data unavailable"],
-    )
-    detail: str = Field(
-        description="Short explanation of why the performance snapshot cannot yet be calculated.",
-        examples=[
-            "Performance snapshot requires valuation history, cashflow history, and a selected "
-            "reporting period."
-        ],
-    )
-    requirements: list[str] = Field(
-        default_factory=list,
-        description="Named prerequisites that remain missing before the snapshot becomes usable.",
-        examples=[["valuation history", "cashflow history", "selected reporting period"]],
-    )
-
-
-class PortfolioPerformanceSnapshotResponse(BaseModel):
-    correlation_id: str = Field(
-        description="Opaque correlation identifier for the performance snapshot response envelope.",
-        examples=["corr-portfolio-performance-snapshot"],
-    )
-    contract_version: str = Field(
-        default="v1",
-        description="Version of the gateway performance snapshot response contract.",
-        examples=["v1"],
-    )
-    portfolio_id: str = Field(
-        description=(
-            "Portfolio identifier whose lightweight performance snapshot is being returned."
-        ),
-        examples=["PF_1001"],
-    )
-    as_of_date: str = Field(
-        description="Resolved as-of date used for the snapshot response.",
-        examples=["2026-03-27"],
-    )
-    report_start_date: str | None = Field(
-        default=None,
-        description=(
-            "Source-authored inclusive start date of the reporting window represented by the "
-            "snapshot when available."
-        ),
-        examples=["2026-01-01"],
-    )
-    report_end_date: str | None = Field(
-        default=None,
-        description=(
-            "Source-authored inclusive end date of the reporting window represented by the "
-            "snapshot when available."
-        ),
-        examples=["2026-03-27"],
-    )
-    period: str = Field(
-        description=(
-            "Resolved reporting horizon represented by the snapshot, such as YTD or EXPLICIT."
-        ),
-        examples=["YTD"],
-    )
-    benchmark_code: str | None = Field(
-        default=None,
-        description="Resolved benchmark code used for the comparison values when available.",
-        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
-    )
-    portfolio_return_pct: float | None = Field(
-        default=None,
-        description="Portfolio return percentage for the resolved reporting horizon.",
-        examples=[15.1],
-    )
-    benchmark_return_pct: float | None = Field(
-        default=None,
-        description=(
-            "Benchmark return percentage for the resolved reporting horizon when available."
-        ),
-        examples=[14.72],
-    )
-    excess_return_pct: float | None = Field(
-        default=None,
-        description="Excess return percentage versus benchmark for the resolved reporting horizon.",
-        examples=[0.38],
-    )
-    sparkline: list[PortfolioPerformanceSnapshotPoint] = Field(
-        default_factory=list,
-        description="Compact cumulative return observations suitable for a small trend sparkline.",
-        examples=[
-            [
-                {
-                    "as_of_date": "2026-01-31",
-                    "portfolio_return_pct": 2.0,
-                    "benchmark_return_pct": 1.8,
-                    "excess_return_pct": 0.2,
-                }
-            ]
-        ],
-    )
-    unavailable: PortfolioPerformanceSnapshotUnavailable | None = Field(
-        default=None,
-        description=(
-            "Explicit unavailable-state metadata when performance cannot yet be calculated."
-        ),
-        examples=[
-            {
-                "title": "Performance data unavailable",
-                "detail": (
-                    "Performance snapshot requires valuation history, cashflow history, and a "
-                    "selected reporting period."
-                ),
-                "requirements": [
-                    "valuation history",
-                    "cashflow history",
-                    "selected reporting period",
-                ],
-            }
-        ],
-    )
-    warnings: list[str] = Field(
-        default_factory=list,
-        description="Gateway warning codes describing degraded but still usable snapshot output.",
-        examples=[["PERFORMANCE_SNAPSHOT_UNAVAILABLE"]],
-    )
-    partial_failures: list[PortfolioPartialFailure] = Field(
-        default_factory=list,
-        description="Upstream source failures preserved when optional snapshot inputs are missing.",
-        examples=[
-            [
-                {
-                    "source_service": "lotus-performance",
-                    "error_code": "PERFORMANCE_SNAPSHOT_UNAVAILABLE",
-                    "detail": "performance summary temporarily unavailable",
                 }
             ]
         ],

--- a/src/app/contracts/portfolio_common.py
+++ b/src/app/contracts/portfolio_common.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, Field
+
+
+class PortfolioPartialFailure(BaseModel):
+    source_service: str = Field(
+        description="Source service that produced the degraded optional response section.",
+        examples=["lotus-core"],
+    )
+    error_code: str = Field(
+        description="Gateway warning or failure code associated with the degraded section.",
+        examples=["PORTFOLIO_CASHFLOW_UNAVAILABLE"],
+    )
+    detail: str = Field(
+        description="Human-readable detail describing the degraded upstream section.",
+        examples=["cashflow temporarily unavailable"],
+    )

--- a/src/app/contracts/portfolio_performance_snapshot.py
+++ b/src/app/contracts/portfolio_performance_snapshot.py
@@ -1,0 +1,170 @@
+from pydantic import BaseModel, Field
+
+from app.contracts.portfolio_common import PortfolioPartialFailure
+
+
+class PortfolioPerformanceSnapshotPoint(BaseModel):
+    as_of_date: str = Field(
+        description="Observation end date represented by the compact performance sparkline point.",
+        examples=["2026-03-27"],
+    )
+    portfolio_return_pct: float | None = Field(
+        default=None,
+        description=(
+            "Cumulative portfolio return percentage through the sparkline observation date."
+        ),
+        examples=[15.1],
+    )
+    benchmark_return_pct: float | None = Field(
+        default=None,
+        description=(
+            "Cumulative benchmark return percentage through the sparkline observation date when "
+            "benchmark context is available."
+        ),
+        examples=[14.72],
+    )
+    excess_return_pct: float | None = Field(
+        default=None,
+        description=(
+            "Cumulative excess return percentage versus benchmark through the sparkline "
+            "observation date."
+        ),
+        examples=[0.38],
+    )
+
+
+class PortfolioPerformanceSnapshotUnavailable(BaseModel):
+    title: str = Field(
+        description="Advisor-facing unavailable-state title for the performance snapshot module.",
+        examples=["Performance data unavailable"],
+    )
+    detail: str = Field(
+        description="Short explanation of why the performance snapshot cannot yet be calculated.",
+        examples=[
+            "Performance snapshot requires valuation history, cashflow history, and a selected "
+            "reporting period."
+        ],
+    )
+    requirements: list[str] = Field(
+        default_factory=list,
+        description="Named prerequisites that remain missing before the snapshot becomes usable.",
+        examples=[["valuation history", "cashflow history", "selected reporting period"]],
+    )
+
+
+class PortfolioPerformanceSnapshotResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Opaque correlation identifier for the performance snapshot response envelope.",
+        examples=["corr-portfolio-performance-snapshot"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Version of the gateway performance snapshot response contract.",
+        examples=["v1"],
+    )
+    portfolio_id: str = Field(
+        description=(
+            "Portfolio identifier whose lightweight performance snapshot is being returned."
+        ),
+        examples=["PF_1001"],
+    )
+    as_of_date: str = Field(
+        description="Resolved as-of date used for the snapshot response.",
+        examples=["2026-03-27"],
+    )
+    report_start_date: str | None = Field(
+        default=None,
+        description=(
+            "Source-authored inclusive start date of the reporting window represented by the "
+            "snapshot when available."
+        ),
+        examples=["2026-01-01"],
+    )
+    report_end_date: str | None = Field(
+        default=None,
+        description=(
+            "Source-authored inclusive end date of the reporting window represented by the "
+            "snapshot when available."
+        ),
+        examples=["2026-03-27"],
+    )
+    period: str = Field(
+        description=(
+            "Resolved reporting horizon represented by the snapshot, such as YTD or EXPLICIT."
+        ),
+        examples=["YTD"],
+    )
+    benchmark_code: str | None = Field(
+        default=None,
+        description="Resolved benchmark code used for the comparison values when available.",
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
+    )
+    portfolio_return_pct: float | None = Field(
+        default=None,
+        description="Portfolio return percentage for the resolved reporting horizon.",
+        examples=[15.1],
+    )
+    benchmark_return_pct: float | None = Field(
+        default=None,
+        description=(
+            "Benchmark return percentage for the resolved reporting horizon when available."
+        ),
+        examples=[14.72],
+    )
+    excess_return_pct: float | None = Field(
+        default=None,
+        description="Excess return percentage versus benchmark for the resolved reporting horizon.",
+        examples=[0.38],
+    )
+    sparkline: list[PortfolioPerformanceSnapshotPoint] = Field(
+        default_factory=list,
+        description="Compact cumulative return observations suitable for a small trend sparkline.",
+        examples=[
+            [
+                {
+                    "as_of_date": "2026-01-31",
+                    "portfolio_return_pct": 2.0,
+                    "benchmark_return_pct": 1.8,
+                    "excess_return_pct": 0.2,
+                }
+            ]
+        ],
+    )
+    unavailable: PortfolioPerformanceSnapshotUnavailable | None = Field(
+        default=None,
+        description=(
+            "Explicit unavailable-state metadata when performance cannot yet be calculated."
+        ),
+        examples=[
+            {
+                "title": "Performance data unavailable",
+                "detail": (
+                    "Performance snapshot requires valuation history, cashflow history, and a "
+                    "selected reporting period."
+                ),
+                "requirements": [
+                    "valuation history",
+                    "cashflow history",
+                    "selected reporting period",
+                ],
+            }
+        ],
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Gateway warning codes describing degraded but still usable snapshot output.",
+        examples=[["PERFORMANCE_SNAPSHOT_UNAVAILABLE"]],
+    )
+    partial_failures: list[PortfolioPartialFailure] = Field(
+        default_factory=list,
+        description="Upstream source failures preserved when optional snapshot inputs are missing.",
+        examples=[
+            [
+                {
+                    "source_service": "lotus-performance",
+                    "error_code": "PERFORMANCE_SNAPSHOT_UNAVAILABLE",
+                    "detail": "performance summary temporarily unavailable",
+                }
+            ]
+        ],
+    )

--- a/src/app/routers/portfolio_performance.py
+++ b/src/app/routers/portfolio_performance.py
@@ -3,7 +3,9 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
 
-from app.contracts.portfolio import PortfolioPerformanceSnapshotResponse
+from app.contracts.portfolio_performance_snapshot import (
+    PortfolioPerformanceSnapshotResponse,
+)
 from app.middleware.correlation import correlation_id_var
 from app.services.portfolio_service_provider import portfolio_performance_workspace_service
 

--- a/src/app/services/performance_workspace_projection.py
+++ b/src/app/services/performance_workspace_projection.py
@@ -8,8 +8,8 @@ from app.contracts.performance_workspace import (
     PerformanceWorkspaceResponse,
     PerformanceWorkspaceSummaryResponse,
 )
-from app.contracts.portfolio import (
-    PortfolioPartialFailure,
+from app.contracts.portfolio_common import PortfolioPartialFailure
+from app.contracts.portfolio_performance_snapshot import (
     PortfolioPerformanceSnapshotPoint,
     PortfolioPerformanceSnapshotResponse,
     PortfolioPerformanceSnapshotUnavailable,

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -21,7 +21,7 @@ from app.contracts.performance_workspace import (
     PerformanceWorkspaceResponse,
     PerformanceWorkspaceSummaryResponse,
 )
-from app.contracts.portfolio import (
+from app.contracts.portfolio_performance_snapshot import (
     PortfolioPerformanceSnapshotResponse,
 )
 from app.contracts.workbench import WorkbenchOverviewResponse, WorkbenchPartialFailure

--- a/src/app/services/portfolio_exception_summaries.py
+++ b/src/app/services/portfolio_exception_summaries.py
@@ -1,9 +1,7 @@
 from dataclasses import dataclass
 
-from app.contracts.portfolio import (
-    PortfolioExceptionSummary,
-    PortfolioPartialFailure,
-)
+from app.contracts.portfolio import PortfolioExceptionSummary
+from app.contracts.portfolio_common import PortfolioPartialFailure
 
 
 @dataclass(frozen=True)

--- a/src/app/services/portfolio_workspace_rebalance.py
+++ b/src/app/services/portfolio_workspace_rebalance.py
@@ -1,10 +1,10 @@
 from typing import Any
 
 from app.contracts.portfolio import (
-    PortfolioPartialFailure,
     PortfolioRebalanceSummary,
     PortfolioRebalanceSupportabilitySummary,
 )
+from app.contracts.portfolio_common import PortfolioPartialFailure
 
 REBALANCE_SUPPORTABILITY_UNAVAILABLE = "PORTFOLIO_REBALANCE_SUPPORTABILITY_UNAVAILABLE"
 

--- a/src/app/services/portfolio_workspace_response.py
+++ b/src/app/services/portfolio_workspace_response.py
@@ -6,7 +6,6 @@ from app.contracts.portfolio import (
     PortfolioCashflowOutlook,
     PortfolioIdentity,
     PortfolioOperationalReadiness,
-    PortfolioPartialFailure,
     PortfolioPerformanceSummary,
     PortfolioProfile,
     PortfolioRebalanceSummary,
@@ -16,6 +15,7 @@ from app.contracts.portfolio import (
     PortfolioWorkspaceControlCapabilities,
     PortfolioWorkspaceResponse,
 )
+from app.contracts.portfolio_common import PortfolioPartialFailure
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_portfolio_performance_snapshot_contracts.py
+++ b/tests/unit/test_portfolio_performance_snapshot_contracts.py
@@ -1,0 +1,16 @@
+from app.contracts import portfolio
+from app.contracts.portfolio_common import PortfolioPartialFailure
+from app.contracts.portfolio_performance_snapshot import (
+    PortfolioPerformanceSnapshotPoint,
+    PortfolioPerformanceSnapshotResponse,
+    PortfolioPerformanceSnapshotUnavailable,
+)
+
+
+def test_portfolio_performance_snapshot_contracts_remain_reexported() -> None:
+    assert portfolio.PortfolioPartialFailure is PortfolioPartialFailure
+    assert portfolio.PortfolioPerformanceSnapshotPoint is PortfolioPerformanceSnapshotPoint
+    assert portfolio.PortfolioPerformanceSnapshotResponse is (PortfolioPerformanceSnapshotResponse)
+    assert portfolio.PortfolioPerformanceSnapshotUnavailable is (
+        PortfolioPerformanceSnapshotUnavailable
+    )

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -86,18 +86,19 @@ and rebalance supportability failure-recording splits then lowered the baseline 
 74 lines. The 50-commit enterprise-hardening branch then split shared analytics async polling,
 workspace-summary payload assembly, portfolio transaction-summary context loading, transaction
 page loading, and portfolio book response assembly, lowering the baseline to 62 lines.
-`portfolio_service.py` is now measured at 1,967 lines after portfolio liquidity loading,
+`portfolio_service.py` is now measured at 2,076 lines after portfolio liquidity loading,
 transaction request-context, transaction page-context, transaction client-kwargs, portfolio
 workspace response assembly, portfolio workspace performance parsing, and portfolio workspace
 rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, and
-portfolio workflow mapping extractions. `portfolio.py` is now measured at 1,717 lines after
-workflow/readiness and transaction-ledger contract extraction.
-`performance_workspace_service.py` is now measured at 1,607 lines after response assembly
+portfolio workflow mapping extractions. `portfolio.py` is now measured at 1,632 lines after
+workflow/readiness, transaction-ledger, and performance snapshot contract extraction.
+`performance_workspace_service.py` is now measured at 1,704 lines after response assembly
 extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
-portfolio transaction contract branch passed with ruff, format check, monetary-float guard, mypy
-over 456 source files, Workbench/OpenAPI contract smoke, and 1,033 unit/contract tests. Local
-`make ci` passed with 207 integration tests, 1,240 coverage tests, 94.01 percent total coverage,
-and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette exception.
-GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were
-green before PR #360 merged. The current portfolio transaction contract branch adds focused
-transaction contract compatibility and portfolio OpenAPI evidence with 17 passing tests.
+portfolio performance snapshot contract branch passed with ruff, format check, monetary-float
+guard, mypy over 458 source files, Workbench/OpenAPI contract smoke, and 1,034 unit/contract
+tests. Local `make ci` passed with 207 integration tests, 1,241 coverage tests, 94.01 percent
+total coverage, and `pip-audit` reporting no known vulnerabilities after the governed
+FastAPI/Starlette exception. GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build,
+and Docker parity checks were green before PR #361 merged. The current portfolio performance
+snapshot contract branch adds focused snapshot contract compatibility and portfolio OpenAPI
+evidence with 24 passing tests.


### PR DESCRIPTION
## Summary
- Extract shared portfolio partial-failure and performance snapshot contracts into focused modules while preserving app.contracts.portfolio compatibility re-exports.
- Rewire direct performance snapshot consumers to the focused contract modules and add a re-export compatibility test.
- Refresh governed monetary-float allowlist and quality/wiki evidence for the moved percentage fields and measured contract-size reduction.

## Validation
- Focused: ruff, mypy, monetary-float guard, git diff --check, and 24 performance snapshot/workspace/OpenAPI contract tests.
- make check: ruff, format check, monetary-float guard 159/159, mypy over 458 source files, Workbench/OpenAPI contract smoke, 1,034 unit/contract tests.
- make ci: 207 integration tests, 1,241 coverage tests, 94.01% total coverage, pip-audit no known vulnerabilities after governed PYSEC-2026-161 exception.
- Wiki check-only: expected pre-merge drift in Validation-and-CI.md because repo-authored wiki evidence changed; publish after merge.