### PR TITLE
Extract portfolio income activity contracts

### DIFF
--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-06-12T16:21:59Z",
+  "generated_at": "2026-06-12T16:43:52Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:162:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -340,118 +340,118 @@
       "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:176:invested_market_value_base: float = Field(",
+      "finding": "src/app/contracts/portfolio.py:183:invested_market_value_base: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:180:cash_market_value_base: float = Field(",
+      "finding": "src/app/contracts/portfolio.py:187:cash_market_value_base: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:184:cash_weight_pct: float = Field(",
+      "finding": "src/app/contracts/portfolio.py:191:cash_weight_pct: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:216:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:223:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:221:weight_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:228:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:237:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:244:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:242:weight_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:249:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:313:cost_basis_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:320:cost_basis_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:318:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:325:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:323:weight_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:330:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:373:market_price: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:380:market_price: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:378:cost_basis_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:385:cost_basis_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:383:cost_basis_local: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:390:cost_basis_local: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:388:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:395:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:393:market_value_local: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:400:market_value_local: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:410:weight_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:417:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:475:portfolio_currency_amount: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:488:return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:480:reporting_currency_amount: float = Field(",
+      "finding": "src/app/contracts/portfolio_activity_income.py:10:reporting_currency_amount: float = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-12-09"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:656:return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio_activity_income.py:5:portfolio_currency_amount: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-14"
+      "review_by": "2026-12-09"
     },
     {
       "finding": "src/app/contracts/portfolio_performance_snapshot.py:102:portfolio_return_pct: float | None = Field(",
@@ -802,25 +802,25 @@
       "review_by": "2026-12-02"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1643:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/portfolio_service.py:1645:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1770:market_value_base=float(",
+      "finding": "src/app/services/portfolio_service.py:1772:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1773:weight_pct=float(",
+      "finding": "src/app/services/portfolio_service.py:1775:weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1774:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
+      "finding": "src/app/services/portfolio_service.py:1776:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -180,6 +180,11 @@ and performance snapshot response models into focused contract modules, keeps
 `app.contracts.portfolio` as the compatibility import surface, refreshes the governed monetary
 float allowlist for the moved percentage fields, and reduces `portfolio.py` from 1,717 to 1,632
 measured lines while preserving OpenAPI schema names and the 49-line longest-function baseline.
+The current portfolio income/activity contract slice moves money summary, income summary, and
+activity summary response models into `portfolio_activity_income.py`, keeps
+`app.contracts.portfolio` as the compatibility import surface, refreshes the governed monetary
+float allowlist for the moved money fields, and reduces `portfolio.py` from 1,632 to 1,464
+measured lines while preserving OpenAPI schema names and the 49-line longest-function baseline.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -187,27 +192,27 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,331 |
-| Python source files under `src/app` | 458 |
-| Python test files under `tests` | 172 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,335 |
+| Python source files under `src/app` | 459 |
+| Python test files under `tests` | 173 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current portfolio performance snapshot contract branch shows
-1,331 files under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 458 Python source
-files under `src/app`; and 172 Python test files under `tests`.
+Working-tree verification for the current portfolio income/activity contract branch shows 1,335
+files under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 459 Python source files
+under `src/app`; and 173 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 2,076 | `src/app/services/portfolio_service.py` |
+| 1 | 2,078 | `src/app/services/portfolio_service.py` |
 | 2 | 2,043 | `src/app/contracts/risk_workspace.py` |
 | 3 | 1,840 | `src/app/contracts/reporting.py` |
 | 4 | 1,704 | `src/app/services/performance_workspace_service.py` |
-| 5 | 1,632 | `src/app/contracts/portfolio.py` |
-| 6 | 1,607 | `src/app/services/advisor_brief_service.py` |
-| 7 | 1,606 | `src/app/contracts/performance_workspace.py` |
+| 5 | 1,607 | `src/app/services/advisor_brief_service.py` |
+| 6 | 1,606 | `src/app/contracts/performance_workspace.py` |
+| 7 | 1,464 | `src/app/contracts/portfolio.py` |
 | 8 | 1,362 | `src/app/clients/dpm_client.py` |
 | 9 | 1,217 | `src/app/services/dpm_command_center_service.py` |
 | 10 | 1,098 | `src/app/clients/advise_client.py` |
@@ -381,6 +386,15 @@ Most recent local evidence:
 69. Current portfolio performance snapshot contract branch: `make ci` passed with 207 integration
     tests and 1,241 combined coverage tests; total coverage is 94.01%, and `pip-audit` found no
     known vulnerabilities after the governed `PYSEC-2026-161` exception.
+70. Current portfolio income/activity contract branch: focused validation passed with ruff, mypy
+    over the touched contract/router/service modules, monetary-float guard, diff whitespace checks,
+    and 17 income/activity summary, insight, and portfolio OpenAPI contract tests.
+71. Current portfolio income/activity contract branch: `make check` passed with ruff, format
+    check, monetary-float guard, mypy over 459 source files, Workbench/OpenAPI contract smoke, and
+    1,035 unit/contract tests.
+72. Current portfolio income/activity contract branch: `make ci` passed with 207 integration tests
+    and 1,242 combined coverage tests; total coverage is 94.02%, and `pip-audit` found no known
+    vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,36 +5,36 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 458 source files, contract smoke, and 1,034 unit/contract tests; `make ci` passed with 207 integration tests, 1,241 coverage tests, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
-| Coverage | 4/5 | 94.01% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, portfolio workflow contracts, portfolio transaction contracts, and portfolio performance snapshot contracts; `portfolio_service.py` is now 2,076 measured lines and `portfolio.py` is now 1,632 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 459 source files, contract smoke, and 1,035 unit/contract tests; `make ci` passed with 207 integration tests, 1,242 coverage tests, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Coverage | 4/5 | 94.02% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
+| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, portfolio workflow contracts, portfolio transaction contracts, portfolio performance snapshot contracts, and portfolio income/activity contracts; `portfolio_service.py` is now 2,078 measured lines and `portfolio.py` is now 1,464 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in current branch `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused portfolio performance snapshot contract slice | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused portfolio income/activity contract slice | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
 Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
-versus the current portfolio performance snapshot contract branch after PRs #349, #350, #351,
-#352, #353, #354, #355, #356, #357, #358, #359, #360, and #361.
+versus the current portfolio income/activity contract branch after PRs #349, #350, #351, #352,
+#353, #354, #355, #356, #357, #358, #359, #360, #361, and #362.
 
 | Measure | Prior scorecard | Current branch | Result |
 | --- | ---: | ---: | --- |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,331 | Added focused modules, tests, and quality evidence |
-| Tracked `src/app` Python files | 447 | 458 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper and contract modules |
-| Tracked Python test files | 162 | 172 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, and performance snapshot contract tests |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,335 | Added focused modules, tests, and quality evidence |
+| Tracked `src/app` Python files | 447 | 459 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper and contract modules |
+| Tracked Python test files | 162 | 173 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, and income/activity contract tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 2,076 lines | Improved; `src/app/services/portfolio_service.py` remains the largest residual hotspot after reducing `portfolio.py` |
+| Largest source file | 2,968 lines | 2,078 lines | Improved; `src/app/services/portfolio_service.py` remains the largest residual hotspot after reducing `portfolio.py` |
 | `performance_workspace_service.py` | 1,724 lines | 1,704 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,034 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, and performance snapshot contract tests |
-| Local coverage tests | 1,203 | 1,241 | Added focused coverage while preserving total coverage |
-| Total coverage | 93.69% | 94.01% | Improved |
+| Local unit/contract tests | 996 | 1,035 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, and income/activity contract tests |
+| Local coverage tests | 1,203 | 1,242 | Added focused coverage while preserving total coverage |
+| Total coverage | 93.69% | 94.02% | Improved |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
 ## Phase Gates
@@ -59,7 +59,7 @@ Candidate thresholds:
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
 5. no new function above the current maximum of 49 lines and no unclassified largest-file growth
-   above the current 2,076-line `src/app/services/portfolio_service.py` maximum.
+   above the current 2,078-line `src/app/services/portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -261,17 +261,22 @@ and performance snapshot models into `portfolio_common.py` and
 intact, refreshes the governed monetary-float allowlist for the moved percentage fields, and
 reduces `portfolio.py` from 1,717 to 1,632 lines while preserving OpenAPI contract tests and the
 49-line longest-function baseline.
+The current portfolio income/activity contract slice moves money summary, income summary, and
+activity summary contracts into `portfolio_activity_income.py`, keeps the legacy
+`app.contracts.portfolio` import surface intact, refreshes the governed monetary-float allowlist
+for the moved money fields, and reduces `portfolio.py` from 1,632 to 1,464 lines while preserving
+OpenAPI contract tests and the 49-line longest-function baseline.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | Current performance snapshot contract branch was created from clean `main` after PR #361; final remote/local cleanup remains a post-merge gate |
-| Unit/contract coverage | Healthy | 1,034 unit/contract tests passed in current branch `make check`; focused performance snapshot, workspace projection, and portfolio OpenAPI contract tests passed with 24 tests on this branch |
+| Branch hygiene | Healthy | Current income/activity contract branch was created from clean `main` after PR #362; final remote/local cleanup remains a post-merge gate |
+| Unit/contract coverage | Healthy | 1,035 unit/contract tests passed in current branch `make check`; focused income/activity summary, insight, and portfolio OpenAPI contract tests passed with 17 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
-| Total coverage | Healthy | 1,241 coverage tests passed in current branch `make ci`; total coverage is 94.01%, above the 84% floor |
+| Total coverage | Healthy | 1,242 coverage tests passed in current branch `make ci`; total coverage is 94.02%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper/contract slices reduce `portfolio.py` to 1,632 measured lines and leave `portfolio_service.py` at 2,076 measured lines and `performance_workspace_service.py` at 1,704 measured lines; large contracts and several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper/contract slices reduce `portfolio.py` to 1,464 measured lines and leave `portfolio_service.py` at 2,078 measured lines and `performance_workspace_service.py` at 1,704 measured lines; large contracts and several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -285,8 +290,8 @@ reduces `portfolio.py` from 1,717 to 1,632 lines while preserving OpenAPI contra
    transaction-ledger response mapping, transaction client-kwargs mapping, transaction page
    context defaults, workspace performance parsing, workspace rebalance parsing, source readiness
    parsing, transaction summary mapping, workflow cue/action mapping, workflow/readiness
-   contracts, transaction ledger contracts, and performance snapshot contracts are now separately
-   testable.
+   contracts, transaction ledger contracts, performance snapshot contracts, and income/activity
+   contracts are now separately testable.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes

--- a/src/app/contracts/portfolio.py
+++ b/src/app/contracts/portfolio.py
@@ -2,11 +2,18 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from app.contracts import portfolio_activity_income as _portfolio_activity_income
 from app.contracts import portfolio_common as _portfolio_common
 from app.contracts import portfolio_performance_snapshot as _portfolio_performance_snapshot
 from app.contracts import portfolio_transactions as _portfolio_transactions
 from app.contracts import portfolio_workflow as _portfolio_workflow
 
+PortfolioActivityBucketSummary = _portfolio_activity_income.PortfolioActivityBucketSummary
+PortfolioActivitySummaryResponse = _portfolio_activity_income.PortfolioActivitySummaryResponse
+PortfolioIncomePeriodSummary = _portfolio_activity_income.PortfolioIncomePeriodSummary
+PortfolioIncomeSummaryResponse = _portfolio_activity_income.PortfolioIncomeSummaryResponse
+PortfolioIncomeTypeSummary = _portfolio_activity_income.PortfolioIncomeTypeSummary
+PortfolioMoneySummary = _portfolio_activity_income.PortfolioMoneySummary
 PortfolioPartialFailure = _portfolio_common.PortfolioPartialFailure
 PortfolioPerformanceSnapshotPoint = (
     _portfolio_performance_snapshot.PortfolioPerformanceSnapshotPoint
@@ -468,181 +475,6 @@ class PortfolioCashflowOutlook(BaseModel):
     upcoming_points: list[PortfolioCashflowPoint] = Field(
         default_factory=list,
         description="Ordered forward cashflow points spanning the returned liquidity horizon.",
-    )
-
-
-class PortfolioMoneySummary(BaseModel):
-    portfolio_currency_amount: float | None = Field(
-        default=None,
-        description="Optional amount in portfolio currency when the upstream summary provides it.",
-        examples=[26.0],
-    )
-    reporting_currency_amount: float = Field(
-        description="Amount in the resolved reporting currency for the requested summary bucket.",
-        examples=[26.0],
-    )
-    transaction_count: int = Field(
-        description="Number of transactions contributing to the summarized amount.",
-        examples=[2],
-    )
-
-
-class PortfolioIncomePeriodSummary(BaseModel):
-    gross: PortfolioMoneySummary = Field(
-        description="Gross income before withholding tax and other deductions.",
-    )
-    withholding_tax: PortfolioMoneySummary = Field(
-        description="Withholding-tax amounts applied to the summarized income.",
-    )
-    other_deductions: PortfolioMoneySummary = Field(
-        description="Other deductions applied to the summarized income.",
-    )
-    net: PortfolioMoneySummary = Field(
-        description="Net income after taxes and deductions.",
-    )
-
-
-class PortfolioIncomeTypeSummary(BaseModel):
-    income_type: str = Field(
-        description="Canonical Lotus income type represented in the summary row.",
-        examples=["DIVIDEND"],
-    )
-    requested_window: PortfolioIncomePeriodSummary = Field(
-        description="Income totals for the requested reporting window.",
-    )
-    year_to_date: PortfolioIncomePeriodSummary = Field(
-        description=(
-            "Income totals from the start of the calendar year through the window end date."
-        ),
-    )
-
-
-class PortfolioIncomeSummaryResponse(BaseModel):
-    correlation_id: str = Field(
-        description="Opaque correlation identifier for the income-summary response envelope.",
-        examples=["corr-portfolio-income-summary"],
-    )
-    contract_version: str = Field(
-        default="v1",
-        description="Version of the gateway income-summary response contract.",
-        examples=["v1"],
-    )
-    portfolio_id: str = Field(
-        description="Portfolio identifier whose income summary is being returned.",
-        examples=["PF_1001"],
-    )
-    reporting_currency: str = Field(
-        description="Resolved reporting currency used for all summary amounts.",
-        examples=["USD"],
-    )
-    window_start_date: str = Field(
-        description="Inclusive start date for the requested reporting window.",
-        examples=["2026-03-01"],
-    )
-    window_end_date: str = Field(
-        description="Inclusive end date for the requested reporting window.",
-        examples=["2026-03-27"],
-    )
-    totals_requested_window: PortfolioIncomePeriodSummary = Field(
-        description="Portfolio-level income totals for the requested reporting window.",
-    )
-    totals_year_to_date: PortfolioIncomePeriodSummary = Field(
-        description="Portfolio-level income totals from year start through the window end date.",
-    )
-    income_types: list[PortfolioIncomeTypeSummary] = Field(
-        default_factory=list,
-        description="Breakdown of income totals by canonical income type.",
-        examples=[
-            [
-                {
-                    "income_type": "DIVIDEND",
-                    "requested_window": {
-                        "gross": {"reporting_currency_amount": 42.0, "transaction_count": 2},
-                        "withholding_tax": {
-                            "reporting_currency_amount": 6.0,
-                            "transaction_count": 2,
-                        },
-                        "other_deductions": {
-                            "reporting_currency_amount": 0.0,
-                            "transaction_count": 2,
-                        },
-                        "net": {"reporting_currency_amount": 36.0, "transaction_count": 2},
-                    },
-                    "year_to_date": {
-                        "gross": {"reporting_currency_amount": 42.0, "transaction_count": 2},
-                        "withholding_tax": {
-                            "reporting_currency_amount": 6.0,
-                            "transaction_count": 2,
-                        },
-                        "other_deductions": {
-                            "reporting_currency_amount": 0.0,
-                            "transaction_count": 2,
-                        },
-                        "net": {"reporting_currency_amount": 36.0, "transaction_count": 2},
-                    },
-                }
-            ]
-        ],
-    )
-
-
-class PortfolioActivityBucketSummary(BaseModel):
-    bucket: str = Field(
-        description="Canonical activity bucket represented in the summary row.",
-        examples=["INFLOWS"],
-    )
-    requested_window: PortfolioMoneySummary = Field(
-        description="Activity totals for the requested reporting window.",
-    )
-    year_to_date: PortfolioMoneySummary = Field(
-        description="Activity totals from year start through the window end date.",
-    )
-
-
-class PortfolioActivitySummaryResponse(BaseModel):
-    correlation_id: str = Field(
-        description="Opaque correlation identifier for the activity-summary response envelope.",
-        examples=["corr-portfolio-activity-summary"],
-    )
-    contract_version: str = Field(
-        default="v1",
-        description="Version of the gateway activity-summary response contract.",
-        examples=["v1"],
-    )
-    portfolio_id: str = Field(
-        description="Portfolio identifier whose activity summary is being returned.",
-        examples=["PF_1001"],
-    )
-    reporting_currency: str = Field(
-        description="Resolved reporting currency used for all activity summary amounts.",
-        examples=["USD"],
-    )
-    window_start_date: str = Field(
-        description="Inclusive start date for the requested activity window.",
-        examples=["2026-03-01"],
-    )
-    window_end_date: str = Field(
-        description="Inclusive end date for the requested activity window.",
-        examples=["2026-03-27"],
-    )
-    buckets: list[PortfolioActivityBucketSummary] = Field(
-        default_factory=list,
-        description="Portfolio flow buckets for the requested window and year-to-date.",
-        examples=[
-            [
-                {
-                    "bucket": "INFLOWS",
-                    "requested_window": {
-                        "reporting_currency_amount": 100.0,
-                        "transaction_count": 1,
-                    },
-                    "year_to_date": {
-                        "reporting_currency_amount": 150.0,
-                        "transaction_count": 2,
-                    },
-                }
-            ]
-        ],
     )
 
 

--- a/src/app/contracts/portfolio_activity_income.py
+++ b/src/app/contracts/portfolio_activity_income.py
@@ -1,0 +1,176 @@
+from pydantic import BaseModel, Field
+
+
+class PortfolioMoneySummary(BaseModel):
+    portfolio_currency_amount: float | None = Field(
+        default=None,
+        description="Optional amount in portfolio currency when the upstream summary provides it.",
+        examples=[26.0],
+    )
+    reporting_currency_amount: float = Field(
+        description="Amount in the resolved reporting currency for the requested summary bucket.",
+        examples=[26.0],
+    )
+    transaction_count: int = Field(
+        description="Number of transactions contributing to the summarized amount.",
+        examples=[2],
+    )
+
+
+class PortfolioIncomePeriodSummary(BaseModel):
+    gross: PortfolioMoneySummary = Field(
+        description="Gross income before withholding tax and other deductions.",
+    )
+    withholding_tax: PortfolioMoneySummary = Field(
+        description="Withholding-tax amounts applied to the summarized income.",
+    )
+    other_deductions: PortfolioMoneySummary = Field(
+        description="Other deductions applied to the summarized income.",
+    )
+    net: PortfolioMoneySummary = Field(
+        description="Net income after taxes and deductions.",
+    )
+
+
+class PortfolioIncomeTypeSummary(BaseModel):
+    income_type: str = Field(
+        description="Canonical Lotus income type represented in the summary row.",
+        examples=["DIVIDEND"],
+    )
+    requested_window: PortfolioIncomePeriodSummary = Field(
+        description="Income totals for the requested reporting window.",
+    )
+    year_to_date: PortfolioIncomePeriodSummary = Field(
+        description=(
+            "Income totals from the start of the calendar year through the window end date."
+        ),
+    )
+
+
+class PortfolioIncomeSummaryResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Opaque correlation identifier for the income-summary response envelope.",
+        examples=["corr-portfolio-income-summary"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Version of the gateway income-summary response contract.",
+        examples=["v1"],
+    )
+    portfolio_id: str = Field(
+        description="Portfolio identifier whose income summary is being returned.",
+        examples=["PF_1001"],
+    )
+    reporting_currency: str = Field(
+        description="Resolved reporting currency used for all summary amounts.",
+        examples=["USD"],
+    )
+    window_start_date: str = Field(
+        description="Inclusive start date for the requested reporting window.",
+        examples=["2026-03-01"],
+    )
+    window_end_date: str = Field(
+        description="Inclusive end date for the requested reporting window.",
+        examples=["2026-03-27"],
+    )
+    totals_requested_window: PortfolioIncomePeriodSummary = Field(
+        description="Portfolio-level income totals for the requested reporting window.",
+    )
+    totals_year_to_date: PortfolioIncomePeriodSummary = Field(
+        description="Portfolio-level income totals from year start through the window end date.",
+    )
+    income_types: list[PortfolioIncomeTypeSummary] = Field(
+        default_factory=list,
+        description="Breakdown of income totals by canonical income type.",
+        examples=[
+            [
+                {
+                    "income_type": "DIVIDEND",
+                    "requested_window": {
+                        "gross": {"reporting_currency_amount": 42.0, "transaction_count": 2},
+                        "withholding_tax": {
+                            "reporting_currency_amount": 6.0,
+                            "transaction_count": 2,
+                        },
+                        "other_deductions": {
+                            "reporting_currency_amount": 0.0,
+                            "transaction_count": 2,
+                        },
+                        "net": {"reporting_currency_amount": 36.0, "transaction_count": 2},
+                    },
+                    "year_to_date": {
+                        "gross": {"reporting_currency_amount": 42.0, "transaction_count": 2},
+                        "withholding_tax": {
+                            "reporting_currency_amount": 6.0,
+                            "transaction_count": 2,
+                        },
+                        "other_deductions": {
+                            "reporting_currency_amount": 0.0,
+                            "transaction_count": 2,
+                        },
+                        "net": {"reporting_currency_amount": 36.0, "transaction_count": 2},
+                    },
+                }
+            ]
+        ],
+    )
+
+
+class PortfolioActivityBucketSummary(BaseModel):
+    bucket: str = Field(
+        description="Canonical activity bucket represented in the summary row.",
+        examples=["INFLOWS"],
+    )
+    requested_window: PortfolioMoneySummary = Field(
+        description="Activity totals for the requested reporting window.",
+    )
+    year_to_date: PortfolioMoneySummary = Field(
+        description="Activity totals from year start through the window end date.",
+    )
+
+
+class PortfolioActivitySummaryResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Opaque correlation identifier for the activity-summary response envelope.",
+        examples=["corr-portfolio-activity-summary"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Version of the gateway activity-summary response contract.",
+        examples=["v1"],
+    )
+    portfolio_id: str = Field(
+        description="Portfolio identifier whose activity summary is being returned.",
+        examples=["PF_1001"],
+    )
+    reporting_currency: str = Field(
+        description="Resolved reporting currency used for all activity summary amounts.",
+        examples=["USD"],
+    )
+    window_start_date: str = Field(
+        description="Inclusive start date for the requested activity window.",
+        examples=["2026-03-01"],
+    )
+    window_end_date: str = Field(
+        description="Inclusive end date for the requested activity window.",
+        examples=["2026-03-27"],
+    )
+    buckets: list[PortfolioActivityBucketSummary] = Field(
+        default_factory=list,
+        description="Portfolio flow buckets for the requested window and year-to-date.",
+        examples=[
+            [
+                {
+                    "bucket": "INFLOWS",
+                    "requested_window": {
+                        "reporting_currency_amount": 100.0,
+                        "transaction_count": 1,
+                    },
+                    "year_to_date": {
+                        "reporting_currency_amount": 150.0,
+                        "transaction_count": 2,
+                    },
+                }
+            ]
+        ],
+    )

--- a/src/app/routers/portfolio_activity.py
+++ b/src/app/routers/portfolio_activity.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Query
 
-from app.contracts.portfolio import PortfolioActivitySummaryResponse
+from app.contracts.portfolio_activity_income import PortfolioActivitySummaryResponse
 from app.middleware.correlation import correlation_id_var
 from app.services.portfolio_service_provider import portfolio_service
 

--- a/src/app/routers/portfolio_income_summary.py
+++ b/src/app/routers/portfolio_income_summary.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Query
 
-from app.contracts.portfolio import PortfolioIncomeSummaryResponse
+from app.contracts.portfolio_activity_income import PortfolioIncomeSummaryResponse
 from app.middleware.correlation import correlation_id_var
 from app.services.portfolio_service_provider import portfolio_service
 

--- a/src/app/services/portfolio_insights.py
+++ b/src/app/services/portfolio_insights.py
@@ -1,10 +1,10 @@
 from app.contracts.portfolio import (
-    PortfolioActivitySummaryResponse,
     PortfolioInsight,
     PortfolioPositionView,
     PortfolioSummary,
     PortfolioTopPosition,
 )
+from app.contracts.portfolio_activity_income import PortfolioActivitySummaryResponse
 
 
 def build_portfolio_insights(

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -7,7 +7,6 @@ from fastapi import HTTPException, status
 
 from app.config import settings
 from app.contracts.portfolio import (
-    PortfolioActivitySummaryResponse,
     PortfolioAllocationBucket,
     PortfolioAllocationLookThroughCapability,
     PortfolioAllocationResponse,
@@ -20,7 +19,6 @@ from app.contracts.portfolio import (
     PortfolioCatalogResponse,
     PortfolioExceptionSummary,
     PortfolioIdentity,
-    PortfolioIncomeSummaryResponse,
     PortfolioInsight,
     PortfolioInsightsResponse,
     PortfolioLiquidityResponse,
@@ -40,6 +38,10 @@ from app.contracts.portfolio import (
     PortfolioWorkflowResponse,
     PortfolioWorkspaceControlCapabilities,
     PortfolioWorkspaceResponse,
+)
+from app.contracts.portfolio_activity_income import (
+    PortfolioActivitySummaryResponse,
+    PortfolioIncomeSummaryResponse,
 )
 from app.contracts.portfolio_transactions import PortfolioTransactionLedgerResponse
 from app.precision_policy import (

--- a/src/app/services/portfolio_transaction_summary.py
+++ b/src/app/services/portfolio_transaction_summary.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any
 
-from app.contracts.portfolio import (
+from app.contracts.portfolio_activity_income import (
     PortfolioActivityBucketSummary,
     PortfolioActivitySummaryResponse,
     PortfolioIncomePeriodSummary,

--- a/tests/unit/test_portfolio_activity_income_contracts.py
+++ b/tests/unit/test_portfolio_activity_income_contracts.py
@@ -1,0 +1,18 @@
+from app.contracts import portfolio
+from app.contracts.portfolio_activity_income import (
+    PortfolioActivityBucketSummary,
+    PortfolioActivitySummaryResponse,
+    PortfolioIncomePeriodSummary,
+    PortfolioIncomeSummaryResponse,
+    PortfolioIncomeTypeSummary,
+    PortfolioMoneySummary,
+)
+
+
+def test_portfolio_activity_income_contracts_remain_reexported() -> None:
+    assert portfolio.PortfolioActivityBucketSummary is PortfolioActivityBucketSummary
+    assert portfolio.PortfolioActivitySummaryResponse is PortfolioActivitySummaryResponse
+    assert portfolio.PortfolioIncomePeriodSummary is PortfolioIncomePeriodSummary
+    assert portfolio.PortfolioIncomeSummaryResponse is PortfolioIncomeSummaryResponse
+    assert portfolio.PortfolioIncomeTypeSummary is PortfolioIncomeTypeSummary
+    assert portfolio.PortfolioMoneySummary is PortfolioMoneySummary

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -86,19 +86,19 @@ and rebalance supportability failure-recording splits then lowered the baseline 
 74 lines. The 50-commit enterprise-hardening branch then split shared analytics async polling,
 workspace-summary payload assembly, portfolio transaction-summary context loading, transaction
 page loading, and portfolio book response assembly, lowering the baseline to 62 lines.
-`portfolio_service.py` is now measured at 2,076 lines after portfolio liquidity loading,
+`portfolio_service.py` is now measured at 2,078 lines after portfolio liquidity loading,
 transaction request-context, transaction page-context, transaction client-kwargs, portfolio
 workspace response assembly, portfolio workspace performance parsing, and portfolio workspace
 rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, and
-portfolio workflow mapping extractions. `portfolio.py` is now measured at 1,632 lines after
-workflow/readiness, transaction-ledger, and performance snapshot contract extraction.
+portfolio workflow mapping extractions. `portfolio.py` is now measured at 1,464 lines after
+workflow/readiness, transaction-ledger, performance snapshot, and income/activity contract
+extractions.
 `performance_workspace_service.py` is now measured at 1,704 lines after response assembly
 extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
-portfolio performance snapshot contract branch passed with ruff, format check, monetary-float
-guard, mypy over 458 source files, Workbench/OpenAPI contract smoke, and 1,034 unit/contract
-tests. Local `make ci` passed with 207 integration tests, 1,241 coverage tests, 94.01 percent
-total coverage, and `pip-audit` reporting no known vulnerabilities after the governed
-FastAPI/Starlette exception. GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build,
-and Docker parity checks were green before PR #361 merged. The current portfolio performance
-snapshot contract branch adds focused snapshot contract compatibility and portfolio OpenAPI
-evidence with 24 passing tests.
+portfolio income/activity contract branch passed with ruff, format check, monetary-float guard,
+mypy over 459 source files, Workbench/OpenAPI contract smoke, and 1,035 unit/contract tests. Local
+`make ci` passed with 207 integration tests, 1,242 coverage tests, 94.02 percent total coverage,
+and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette exception.
+GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were
+green before PR #362 merged. The current portfolio income/activity contract branch adds focused
+income/activity contract compatibility and portfolio OpenAPI evidence with 17 passing tests.


### PR DESCRIPTION
## Summary
- Extract portfolio money, income-summary, and activity-summary response contracts into focused portfolio_activity_income module.
- Preserve app.contracts.portfolio compatibility re-exports and OpenAPI schema names.
- Rewire direct routers/services to the focused contract module and add compatibility coverage.
- Refresh governed monetary-float allowlist and quality/wiki evidence for the moved money fields.

## Validation
- Focused: ruff, mypy, monetary-float guard, git diff --check, and 17 income/activity summary, insight, and portfolio OpenAPI contract tests.
- make check: ruff, format check, monetary-float guard 159/159, mypy over 459 source files, Workbench/OpenAPI contract smoke, 1,035 unit/contract tests.
- make ci: 207 integration tests, 1,242 coverage tests, 94.02% total coverage, pip-audit no known vulnerabilities after governed PYSEC-2026-161 exception.
- Wiki check-only: expected pre-merge drift in Validation-and-CI.md because repo-authored wiki evidence changed; publish after merge.