### PR TITLE
Extract portfolio holdings contracts

### DIFF
--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-06-12T16:43:52Z",
+  "generated_at": "2026-06-12T17:12:49Z",
   "allowlist": [
     {
       "finding": "scripts/check_monetary_float_usage.py:162:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
@@ -340,103 +340,7 @@
       "review_by": "2026-11-06"
     },
     {
-      "finding": "src/app/contracts/portfolio.py:183:invested_market_value_base: float = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:187:cash_market_value_base: float = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:191:cash_weight_pct: float = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:223:market_value_base: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:228:weight_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:244:market_value_base: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:249:weight_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:320:cost_basis_base: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:325:market_value_base: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:330:weight_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:380:market_price: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:385:cost_basis_base: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:390:cost_basis_local: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:395:market_value_base: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:400:market_value_local: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:417:weight_pct: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-14"
-    },
-    {
-      "finding": "src/app/contracts/portfolio.py:488:return_pct: float | None = Field(",
+      "finding": "src/app/contracts/portfolio.py:227:return_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-14"
@@ -449,6 +353,102 @@
     },
     {
       "finding": "src/app/contracts/portfolio_activity_income.py:5:portfolio_currency_amount: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_core.py:34:invested_market_value_base: float = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_core.py:38:cash_market_value_base: float = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_core.py:42:cash_weight_pct: float = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:121:cost_basis_base: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:126:market_value_base: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:131:weight_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:181:market_price: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:186:cost_basis_base: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:191:cost_basis_local: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:196:market_value_base: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:201:market_value_local: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:218:weight_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:24:market_value_base: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:29:weight_pct: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:45:market_value_base: float | None = Field(",
+      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "owner": "platform-governance",
+      "review_by": "2026-12-09"
+    },
+    {
+      "finding": "src/app/contracts/portfolio_holdings.py:50:weight_pct: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-12-09"
@@ -766,61 +766,61 @@
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_position_book.py:110:return float(quantize_performance(float(raw or 0) * 100))",
+      "finding": "src/app/services/portfolio_position_book.py:107:return float(quantize_performance(float(raw or 0) * 100))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-12-02"
     },
     {
-      "finding": "src/app/services/portfolio_position_book.py:139:cash_total += float(quantize_money(market_value or 0))",
+      "finding": "src/app/services/portfolio_position_book.py:136:cash_total += float(quantize_money(market_value or 0))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-12-02"
     },
     {
-      "finding": "src/app/services/portfolio_position_book.py:141:return float(quantize_money(cash_total)), cash_count",
+      "finding": "src/app/services/portfolio_position_book.py:138:return float(quantize_money(cash_total)), cash_count",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-12-02"
     },
     {
-      "finding": "src/app/services/portfolio_position_book.py:30:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/portfolio_position_book.py:27:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-12-02"
     },
     {
-      "finding": "src/app/services/portfolio_position_book.py:88:return float(quantize_price(raw_quote))",
+      "finding": "src/app/services/portfolio_position_book.py:85:return float(quantize_price(raw_quote))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-12-02"
     },
     {
-      "finding": "src/app/services/portfolio_position_book.py:94:return float(quantize_money(raw))",
+      "finding": "src/app/services/portfolio_position_book.py:91:return float(quantize_money(raw))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-12-02"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1645:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
+      "finding": "src/app/services/portfolio_service.py:1646:invested_market_value_base=float(quantize_money(total_aum - cash_total)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1772:market_value_base=float(",
+      "finding": "src/app/services/portfolio_service.py:1773:market_value_base=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1775:weight_pct=float(",
+      "finding": "src/app/services/portfolio_service.py:1776:weight_pct=float(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"
     },
     {
-      "finding": "src/app/services/portfolio_service.py:1776:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
+      "finding": "src/app/services/portfolio_service.py:1777:quantize_performance(float(bucket.get(\"weight\", 0)) * 100)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-11-19"

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -185,6 +185,12 @@ activity summary response models into `portfolio_activity_income.py`, keeps
 `app.contracts.portfolio` as the compatibility import surface, refreshes the governed monetary
 float allowlist for the moved money fields, and reduces `portfolio.py` from 1,632 to 1,464
 measured lines while preserving OpenAPI schema names and the 49-line longest-function baseline.
+The current portfolio holdings contract slice moves shared portfolio identity/summary models into
+`portfolio_core.py` and holdings/book response models into `portfolio_holdings.py`, keeps
+`app.contracts.portfolio` as the compatibility import surface, refreshes the governed monetary
+float allowlist for the moved position and allocation fields, and reduces `portfolio.py` from
+1,464 to 954 measured lines while preserving OpenAPI schema names and the 49-line
+longest-function baseline.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -192,30 +198,30 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,335 |
-| Python source files under `src/app` | 459 |
-| Python test files under `tests` | 173 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,341 |
+| Python source files under `src/app` | 461 |
+| Python test files under `tests` | 174 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current portfolio income/activity contract branch shows 1,335
-files under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 459 Python source files
-under `src/app`; and 173 Python test files under `tests`.
+Working-tree verification for the current portfolio holdings contract branch shows 1,341 files
+under `src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 461 Python source files under
+`src/app`; and 174 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
-| 1 | 2,078 | `src/app/services/portfolio_service.py` |
+| 1 | 2,079 | `src/app/services/portfolio_service.py` |
 | 2 | 2,043 | `src/app/contracts/risk_workspace.py` |
 | 3 | 1,840 | `src/app/contracts/reporting.py` |
 | 4 | 1,704 | `src/app/services/performance_workspace_service.py` |
 | 5 | 1,607 | `src/app/services/advisor_brief_service.py` |
 | 6 | 1,606 | `src/app/contracts/performance_workspace.py` |
-| 7 | 1,464 | `src/app/contracts/portfolio.py` |
-| 8 | 1,362 | `src/app/clients/dpm_client.py` |
-| 9 | 1,217 | `src/app/services/dpm_command_center_service.py` |
-| 10 | 1,098 | `src/app/clients/advise_client.py` |
+| 7 | 1,362 | `src/app/clients/dpm_client.py` |
+| 8 | 1,217 | `src/app/services/dpm_command_center_service.py` |
+| 9 | 1,098 | `src/app/clients/advise_client.py` |
+| 10 | 1,093 | `src/app/services/dpm_wave_service.py` |
 
 ## Largest Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,35 +5,35 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 459 source files, contract smoke, and 1,035 unit/contract tests; `make ci` passed with 207 integration tests, 1,242 coverage tests, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 461 source files, contract smoke, and 1,039 unit/contract tests; `make ci` passed with 207 integration tests, 1,246 coverage tests, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 94.02% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, portfolio workflow contracts, portfolio transaction contracts, portfolio performance snapshot contracts, and portfolio income/activity contracts; `portfolio_service.py` is now 2,078 measured lines and `portfolio.py` is now 1,464 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, portfolio workflow contracts, portfolio transaction contracts, portfolio performance snapshot contracts, portfolio income/activity contracts, and portfolio holdings/book contracts; `portfolio_service.py` is now 2,079 measured lines and `portfolio.py` is now 954 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in current branch `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused portfolio income/activity contract slice | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused portfolio holdings contract slice | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
 Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
-versus the current portfolio income/activity contract branch after PRs #349, #350, #351, #352,
-#353, #354, #355, #356, #357, #358, #359, #360, #361, and #362.
+versus the current portfolio holdings contract branch after PRs #349, #350, #351, #352, #353,
+#354, #355, #356, #357, #358, #359, #360, #361, #362, and #363.
 
 | Measure | Prior scorecard | Current branch | Result |
 | --- | ---: | ---: | --- |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,335 | Added focused modules, tests, and quality evidence |
-| Tracked `src/app` Python files | 447 | 459 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper and contract modules |
-| Tracked Python test files | 162 | 173 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, and income/activity contract tests |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,341 | Added focused modules, tests, and quality evidence |
+| Tracked `src/app` Python files | 447 | 461 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper and contract modules |
+| Tracked Python test files | 162 | 174 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, income/activity contract, and holdings contract tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 2,078 lines | Improved; `src/app/services/portfolio_service.py` remains the largest residual hotspot after reducing `portfolio.py` |
+| Largest source file | 2,968 lines | 2,079 lines | Improved; `src/app/services/portfolio_service.py` remains the largest residual hotspot after reducing `portfolio.py` |
 | `performance_workspace_service.py` | 1,724 lines | 1,704 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,035 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, and income/activity contract tests |
-| Local coverage tests | 1,203 | 1,242 | Added focused coverage while preserving total coverage |
+| Local unit/contract tests | 996 | 1,039 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, income/activity contract, and holdings contract tests |
+| Local coverage tests | 1,203 | 1,246 | Added focused coverage while preserving total coverage |
 | Total coverage | 93.69% | 94.02% | Improved |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
@@ -59,7 +59,7 @@ Candidate thresholds:
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
 5. no new function above the current maximum of 49 lines and no unclassified largest-file growth
-   above the current 2,078-line `src/app/services/portfolio_service.py` maximum.
+   above the current 2,079-line `src/app/services/portfolio_service.py` maximum.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -266,17 +266,23 @@ activity summary contracts into `portfolio_activity_income.py`, keeps the legacy
 `app.contracts.portfolio` import surface intact, refreshes the governed monetary-float allowlist
 for the moved money fields, and reduces `portfolio.py` from 1,632 to 1,464 lines while preserving
 OpenAPI contract tests and the 49-line longest-function baseline.
+The current portfolio holdings contract slice moves shared identity/summary contracts into
+`portfolio_core.py` and cash, allocation, position, and combined book contracts into
+`portfolio_holdings.py`, keeps the legacy `app.contracts.portfolio` import surface intact,
+refreshes the governed monetary-float allowlist for the moved holdings fields, and reduces
+`portfolio.py` from 1,464 to 954 lines while preserving OpenAPI contract tests and the 49-line
+longest-function baseline.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | Current income/activity contract branch was created from clean `main` after PR #362; final remote/local cleanup remains a post-merge gate |
-| Unit/contract coverage | Healthy | 1,035 unit/contract tests passed in current branch `make check`; focused income/activity summary, insight, and portfolio OpenAPI contract tests passed with 17 tests on this branch |
+| Branch hygiene | Healthy | Current holdings contract branch was created from clean `main` after PR #363; final remote/local cleanup remains a post-merge gate |
+| Unit/contract coverage | Healthy | 1,039 unit/contract tests passed in current branch `make check`; focused holdings, portfolio OpenAPI, insight, workflow, and workspace tests passed with 24 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
-| Total coverage | Healthy | 1,242 coverage tests passed in current branch `make ci`; total coverage is 94.02%, above the 84% floor |
+| Total coverage | Healthy | 1,246 coverage tests passed in current branch `make ci`; total coverage is 94.02%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper/contract slices reduce `portfolio.py` to 1,464 measured lines and leave `portfolio_service.py` at 2,078 measured lines and `performance_workspace_service.py` at 1,704 measured lines; large contracts and several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper/contract slices reduce `portfolio.py` to 954 measured lines and leave `portfolio_service.py` at 2,079 measured lines and `performance_workspace_service.py` at 1,704 measured lines; large contracts and several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
@@ -290,8 +296,8 @@ OpenAPI contract tests and the 49-line longest-function baseline.
    transaction-ledger response mapping, transaction client-kwargs mapping, transaction page
    context defaults, workspace performance parsing, workspace rebalance parsing, source readiness
    parsing, transaction summary mapping, workflow cue/action mapping, workflow/readiness
-   contracts, transaction ledger contracts, performance snapshot contracts, and income/activity
-   contracts are now separately testable.
+   contracts, transaction ledger contracts, performance snapshot contracts, income/activity
+   contracts, and holdings/book contracts are now separately testable.
 2. Continue splitting `risk_workspace_service.py` around remaining orchestration helpers only when
    behavior-preserving seams are obvious; the risk response boundaries are now separately testable.
 3. Continue splitting platform capability normalization or orchestration helpers if future changes

--- a/src/app/contracts/portfolio.py
+++ b/src/app/contracts/portfolio.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel, Field
 
 from app.contracts import portfolio_activity_income as _portfolio_activity_income
 from app.contracts import portfolio_common as _portfolio_common
+from app.contracts import portfolio_core as _portfolio_core
+from app.contracts import portfolio_holdings as _portfolio_holdings
 from app.contracts import portfolio_performance_snapshot as _portfolio_performance_snapshot
 from app.contracts import portfolio_transactions as _portfolio_transactions
 from app.contracts import portfolio_workflow as _portfolio_workflow
@@ -14,6 +16,15 @@ PortfolioIncomePeriodSummary = _portfolio_activity_income.PortfolioIncomePeriodS
 PortfolioIncomeSummaryResponse = _portfolio_activity_income.PortfolioIncomeSummaryResponse
 PortfolioIncomeTypeSummary = _portfolio_activity_income.PortfolioIncomeTypeSummary
 PortfolioMoneySummary = _portfolio_activity_income.PortfolioMoneySummary
+PortfolioAllocationBucket = _portfolio_holdings.PortfolioAllocationBucket
+PortfolioAllocationLookThroughCapability = (
+    _portfolio_holdings.PortfolioAllocationLookThroughCapability
+)
+PortfolioAllocationResponse = _portfolio_holdings.PortfolioAllocationResponse
+PortfolioAllocationView = _portfolio_holdings.PortfolioAllocationView
+PortfolioBookResponse = _portfolio_holdings.PortfolioBookResponse
+PortfolioCashBalance = _portfolio_holdings.PortfolioCashBalance
+PortfolioIdentity = _portfolio_core.PortfolioIdentity
 PortfolioPartialFailure = _portfolio_common.PortfolioPartialFailure
 PortfolioPerformanceSnapshotPoint = (
     _portfolio_performance_snapshot.PortfolioPerformanceSnapshotPoint
@@ -26,11 +37,15 @@ PortfolioPerformanceSnapshotUnavailable = (
 )
 PortfolioTransactionLedgerResponse = _portfolio_transactions.PortfolioTransactionLedgerResponse
 PortfolioTransactionView = _portfolio_transactions.PortfolioTransactionView
+PortfolioPositionBookResponse = _portfolio_holdings.PortfolioPositionBookResponse
+PortfolioPositionView = _portfolio_holdings.PortfolioPositionView
 PortfolioReadinessBucket = _portfolio_workflow.PortfolioReadinessBucket
 PortfolioReadinessIndicator = _portfolio_workflow.PortfolioReadinessIndicator
 PortfolioReadinessReason = _portfolio_workflow.PortfolioReadinessReason
 PortfolioReadinessResponse = _portfolio_workflow.PortfolioReadinessResponse
+PortfolioSummary = _portfolio_core.PortfolioSummary
 PortfolioSupportabilitySummary = _portfolio_workflow.PortfolioSupportabilitySummary
+PortfolioTopPosition = _portfolio_holdings.PortfolioTopPosition
 PortfolioWorkflowAction = _portfolio_workflow.PortfolioWorkflowAction
 PortfolioWorkflowLaunchCue = _portfolio_workflow.PortfolioWorkflowLaunchCue
 PortfolioWorkflowResponse = _portfolio_workflow.PortfolioWorkflowResponse
@@ -100,31 +115,6 @@ class PortfolioCatalogResponse(BaseModel):
     )
 
 
-class PortfolioIdentity(BaseModel):
-    portfolio_id: str = Field(
-        description="Canonical Lotus portfolio identifier.",
-        examples=["PF_1001"],
-    )
-    display_name: str = Field(
-        description="Advisor-facing portfolio display label.",
-        examples=["PF_1001"],
-    )
-    client_id: str | None = Field(
-        default=None,
-        description="Optional client or CIF identifier associated with the portfolio.",
-        examples=["CIF_1"],
-    )
-    base_currency: str = Field(
-        description="Base currency assigned to the portfolio.",
-        examples=["USD"],
-    )
-    booking_center_code: str | None = Field(
-        default=None,
-        description="Optional booking-center code for the portfolio record.",
-        examples=["SGPB"],
-    )
-
-
 class PortfolioProfile(BaseModel):
     status: str | None = Field(
         default=None,
@@ -172,257 +162,6 @@ class PortfolioProfile(BaseModel):
         default=None,
         description="Optional portfolio close date in YYYY-MM-DD format.",
         examples=["2026-03-31"],
-    )
-
-
-class PortfolioSummary(BaseModel):
-    assets_under_management_base: float = Field(
-        description="Total assets under management for the portfolio, expressed in base currency.",
-        examples=[1000.0],
-    )
-    invested_market_value_base: float = Field(
-        description="Invested market value excluding cash, expressed in base currency.",
-        examples=[900.0],
-    )
-    cash_market_value_base: float = Field(
-        description="Total cash market value, expressed in base currency.",
-        examples=[100.0],
-    )
-    cash_weight_pct: float = Field(
-        description="Cash weight as a percentage of total assets under management.",
-        examples=[10.0],
-    )
-    position_count: int = Field(
-        description="Count of position rows included in the resolved portfolio snapshot.",
-        examples=[3],
-    )
-    cash_balance_count: int = Field(
-        description="Count of cash balance rows included in the resolved portfolio snapshot.",
-        examples=[1],
-    )
-
-
-class PortfolioCashBalance(BaseModel):
-    security_id: str = Field(
-        description="Identifier of the cash balance or cash account row.",
-        examples=["CASH_USD"],
-    )
-    instrument_name: str = Field(
-        description="Advisor-facing label for the cash balance row.",
-        examples=["USD Cash"],
-    )
-    currency: str | None = Field(
-        default=None,
-        description="Currency of the cash account or balance row.",
-        examples=["USD"],
-    )
-    quantity: float = Field(
-        description="Cash quantity or balance in account currency units.",
-        examples=[100.0],
-    )
-    market_value_base: float | None = Field(
-        default=None,
-        description="Cash market value expressed in portfolio base currency.",
-        examples=[100.0],
-    )
-    weight_pct: float | None = Field(
-        default=None,
-        description="Cash weight as a percentage of portfolio assets under management.",
-        examples=[10.0],
-    )
-
-
-class PortfolioAllocationBucket(BaseModel):
-    bucket: str = Field(
-        description="Bucket label within the requested allocation dimension.",
-        examples=["Equity"],
-    )
-    position_count: int = Field(
-        description="Count of positions contributing to the allocation bucket.",
-        examples=[1],
-    )
-    market_value_base: float | None = Field(
-        default=None,
-        description="Bucket market value expressed in portfolio base currency.",
-        examples=[700.0],
-    )
-    weight_pct: float | None = Field(
-        default=None,
-        description="Bucket weight as a percentage of portfolio assets under management.",
-        examples=[70.0],
-    )
-
-
-class PortfolioAllocationView(BaseModel):
-    dimension: str = Field(
-        description="Allocation dimension represented by the current view.",
-        examples=["asset_class"],
-    )
-    buckets: list[PortfolioAllocationBucket] = Field(
-        default_factory=list,
-        description="Allocation buckets returned for the requested dimension.",
-        examples=[
-            [
-                {
-                    "bucket": "Asia",
-                    "position_count": 3,
-                    "market_value_base": 420000.0,
-                    "weight_pct": 42.0,
-                }
-            ]
-        ],
-    )
-
-
-class PortfolioAllocationLookThroughCapability(BaseModel):
-    requested_mode: str = Field(
-        description="Look-through mode requested by the consumer for the allocation query.",
-        examples=["full"],
-    )
-    effective_mode: str = Field(
-        description="Look-through mode actually applied by the upstream allocation service.",
-        examples=["direct_only"],
-    )
-    applied: bool = Field(
-        description="Whether the requested look-through expansion was applied in the response.",
-        examples=[False],
-    )
-
-
-class PortfolioTopPosition(BaseModel):
-    security_id: str = Field(
-        description="Identifier of the ranked top holding.",
-        examples=["EQ_1"],
-    )
-    instrument_name: str = Field(
-        description="Advisor-facing instrument name for the ranked holding.",
-        examples=["Equity 1"],
-    )
-    asset_class: str | None = Field(
-        default=None,
-        description="Asset class assigned to the ranked holding when available.",
-        examples=["Equity"],
-    )
-    isin: str | None = Field(
-        default=None,
-        description="Optional ISIN associated with the ranked holding.",
-        examples=["US1234567890"],
-    )
-    currency: str | None = Field(
-        default=None,
-        description="Trading or instrument currency of the ranked holding.",
-        examples=["USD"],
-    )
-    quantity: float = Field(
-        description="Held quantity of the ranked position.",
-        examples=[10.0],
-    )
-    cost_basis_base: float | None = Field(
-        default=None,
-        description="Cost basis expressed in portfolio base currency.",
-        examples=[500.0],
-    )
-    market_value_base: float | None = Field(
-        default=None,
-        description="Market value expressed in portfolio base currency.",
-        examples=[700.0],
-    )
-    weight_pct: float | None = Field(
-        default=None,
-        description="Position weight as a percentage of portfolio assets under management.",
-        examples=[70.0],
-    )
-
-
-class PortfolioPositionView(BaseModel):
-    security_id: str = Field(
-        description="Identifier of the position row.",
-        examples=["EQ_1"],
-    )
-    instrument_name: str = Field(
-        description="Advisor-facing instrument name for the position row.",
-        examples=["Equity 1"],
-    )
-    asset_class: str | None = Field(
-        default=None,
-        description="Asset class assigned to the position when available.",
-        examples=["Equity"],
-    )
-    isin: str | None = Field(
-        default=None,
-        description="Optional ISIN associated with the position.",
-        examples=["US1234567890"],
-    )
-    currency: str | None = Field(
-        default=None,
-        description="Trading or instrument currency of the position.",
-        examples=["USD"],
-    )
-    sector: str | None = Field(
-        default=None,
-        description="Optional sector classification for the position.",
-        examples=["Technology"],
-    )
-    country_of_risk: str | None = Field(
-        default=None,
-        description="Optional country-of-risk classification for the position.",
-        examples=["US"],
-    )
-    held_since_date: str | None = Field(
-        default=None,
-        description="Optional holding start date in YYYY-MM-DD format.",
-        examples=["2025-12-31"],
-    )
-    quantity: float = Field(
-        description="Held quantity of the position.",
-        examples=[10.0],
-    )
-    market_price: float | None = Field(
-        default=None,
-        description="Current market price of the position when valuation is available.",
-        examples=[70.0],
-    )
-    cost_basis_base: float | None = Field(
-        default=None,
-        description="Cost basis expressed in portfolio base currency.",
-        examples=[500.0],
-    )
-    cost_basis_local: float | None = Field(
-        default=None,
-        description="Cost basis expressed in local or instrument currency when available.",
-        examples=[500.0],
-    )
-    market_value_base: float | None = Field(
-        default=None,
-        description="Market value expressed in portfolio base currency.",
-        examples=[700.0],
-    )
-    market_value_local: float | None = Field(
-        default=None,
-        description="Market value expressed in local or instrument currency when available.",
-        examples=[700.0],
-    )
-    unrealized_gain_loss_base: float | None = Field(
-        default=None,
-        description="Unrealized gain or loss expressed in portfolio base currency.",
-        examples=[200.0],
-    )
-    unrealized_gain_loss_local: float | None = Field(
-        default=None,
-        description=(
-            "Unrealized gain or loss expressed in local or instrument currency when available."
-        ),
-        examples=[200.0],
-    )
-    weight_pct: float | None = Field(
-        default=None,
-        description="Position weight as a percentage of portfolio assets under management.",
-        examples=[70.0],
-    )
-    reprocessing_status: str | None = Field(
-        default=None,
-        description="Optional upstream reprocessing or valuation status for the position row.",
-        examples=["READY"],
     )
 
 
@@ -1209,255 +948,6 @@ class PortfolioProjectedCashflowResponse(BaseModel):
                     "source_service": "lotus-core",
                     "error_code": "PORTFOLIO_PROJECTED_CASHFLOW_UNAVAILABLE",
                     "detail": "projected cashflow unavailable",
-                }
-            ]
-        ],
-    )
-
-
-class PortfolioAllocationResponse(BaseModel):
-    correlation_id: str = Field(
-        description="Opaque correlation identifier for the allocation response envelope.",
-        examples=["corr-portfolio-allocation"],
-    )
-    contract_version: str = Field(
-        default="v1",
-        description="Version of the gateway allocation response contract.",
-        examples=["v1"],
-    )
-    portfolio_id: str = Field(
-        description="Portfolio identifier whose allocation views are being returned.",
-        examples=["PF_1001"],
-    )
-    as_of_date: str = Field(
-        description="Resolved as-of date used for the allocation query inputs.",
-        examples=["2026-03-27"],
-    )
-    reporting_currency: str | None = Field(
-        default=None,
-        description=(
-            "Reporting currency used for the allocation response when restatement is applied."
-        ),
-        examples=["USD"],
-    )
-    look_through: PortfolioAllocationLookThroughCapability | None = Field(
-        default=None,
-        description=(
-            "Look-through capability and effective mode returned by the "
-            "upstream allocation service."
-        ),
-        examples=[
-            {
-                "requested_mode": "full",
-                "effective_mode": "direct_only",
-                "applied": False,
-            }
-        ],
-    )
-    summary: PortfolioSummary = Field(
-        description="Source-backed summary values used to frame the allocation response.",
-        examples=[
-            {
-                "assets_under_management_base": 1000.0,
-                "invested_market_value_base": 900.0,
-                "cash_market_value_base": 100.0,
-                "cash_weight_pct": 10.0,
-                "position_count": 3,
-                "cash_balance_count": 1,
-            }
-        ],
-    )
-    views: list[PortfolioAllocationView] = Field(
-        default_factory=list,
-        description="Allocation views returned for the supported reporting dimensions.",
-        examples=[
-            [
-                {
-                    "dimension": "region",
-                    "buckets": [
-                        {
-                            "bucket": "Asia",
-                            "position_count": 1,
-                            "market_value_base": 700.0,
-                            "weight_pct": 70.0,
-                        }
-                    ],
-                }
-            ]
-        ],
-    )
-
-
-class PortfolioPositionBookResponse(BaseModel):
-    correlation_id: str = Field(
-        description="Opaque correlation identifier for the position-book response envelope.",
-        examples=["corr-portfolio-positions"],
-    )
-    contract_version: str = Field(
-        default="v1",
-        description="Version of the gateway position-book response contract.",
-        examples=["v1"],
-    )
-    portfolio_id: str = Field(
-        description="Portfolio identifier whose position book is being returned.",
-        examples=["PF_1001"],
-    )
-    as_of_date: str = Field(
-        description="Resolved as-of date used for the position-book request.",
-        examples=["2026-03-27"],
-    )
-    summary: PortfolioSummary = Field(
-        description="Source-backed summary values used to frame the positions response.",
-    )
-    top_positions: list[PortfolioTopPosition] = Field(
-        default_factory=list,
-        description="Ranked top holdings derived from the returned position rows.",
-        examples=[
-            [
-                {
-                    "security_id": "EQ_1",
-                    "instrument_name": "Equity 1",
-                    "asset_class": "Equity",
-                    "isin": "US1234567890",
-                    "currency": "USD",
-                    "quantity": 10.0,
-                    "cost_basis_base": 320.0,
-                    "market_value_base": 400.0,
-                    "weight_pct": 40.0,
-                }
-            ]
-        ],
-    )
-    positions: list[PortfolioPositionView] = Field(
-        default_factory=list,
-        description="Detailed position rows for the requested portfolio book.",
-        examples=[
-            [
-                {
-                    "security_id": "EQ_1",
-                    "instrument_name": "Equity 1",
-                    "asset_class": "Equity",
-                    "isin": "US1234567890",
-                    "currency": "USD",
-                    "sector": "Technology",
-                    "country_of_risk": "United States",
-                    "held_since_date": "2025-12-31",
-                    "quantity": 10.0,
-                    "market_price": 40.0,
-                    "cost_basis_base": 320.0,
-                    "cost_basis_local": 320.0,
-                    "market_value_base": 400.0,
-                    "market_value_local": 400.0,
-                    "unrealized_gain_loss_base": 80.0,
-                    "unrealized_gain_loss_local": 80.0,
-                    "weight_pct": 40.0,
-                    "reprocessing_status": "READY",
-                }
-            ]
-        ],
-    )
-
-
-class PortfolioBookResponse(BaseModel):
-    correlation_id: str = Field(
-        description=(
-            "Opaque correlation identifier for the combined portfolio-book response envelope."
-        ),
-        examples=["corr-portfolio-book"],
-    )
-    contract_version: str = Field(
-        default="v1",
-        description="Version of the gateway combined portfolio-book response contract.",
-        examples=["v1"],
-    )
-    as_of_date: str = Field(
-        description="Resolved as-of date used for the combined portfolio book sections.",
-        examples=["2026-03-27"],
-    )
-    portfolio: PortfolioIdentity = Field(
-        description="Portfolio identity metadata for the combined book view.",
-        examples=[{"portfolio_id": "PF_1001", "display_name": "PF_1001", "base_currency": "USD"}],
-    )
-    summary: PortfolioSummary = Field(
-        description="Source-backed summary values for the current portfolio book.",
-        examples=[
-            {
-                "assets_under_management_base": 1000.0,
-                "invested_market_value_base": 900.0,
-                "cash_market_value_base": 100.0,
-                "cash_weight_pct": 10.0,
-                "position_count": 1,
-                "cash_balance_count": 1,
-            }
-        ],
-    )
-    cash_balances: list[PortfolioCashBalance] = Field(
-        default_factory=list,
-        description="Cash inventory included in the current portfolio book view.",
-        examples=[
-            [
-                {
-                    "security_id": "CASH_USD",
-                    "instrument_name": "USD Cash",
-                    "currency": "USD",
-                    "quantity": 100.0,
-                    "market_value_base": 100.0,
-                    "weight_pct": 10.0,
-                }
-            ]
-        ],
-    )
-    allocation_views: list[PortfolioAllocationView] = Field(
-        default_factory=list,
-        description="Allocation views included with the portfolio book response.",
-        examples=[
-            [
-                {
-                    "dimension": "asset_class",
-                    "buckets": [
-                        {
-                            "bucket": "Equity",
-                            "position_count": 1,
-                            "market_value_base": 900.0,
-                            "weight_pct": 90.0,
-                        }
-                    ],
-                }
-            ]
-        ],
-    )
-    top_positions: list[PortfolioTopPosition] = Field(
-        default_factory=list,
-        description="Ranked top holdings for the current book.",
-        examples=[
-            [
-                {
-                    "security_id": "EQ_1",
-                    "instrument_name": "Equity 1",
-                    "asset_class": "Equity",
-                    "currency": "USD",
-                    "quantity": 10.0,
-                    "cost_basis_base": 500.0,
-                    "market_value_base": 900.0,
-                    "weight_pct": 90.0,
-                }
-            ]
-        ],
-    )
-    positions: list[PortfolioPositionView] = Field(
-        default_factory=list,
-        description="Detailed position rows included in the current portfolio book.",
-        examples=[
-            [
-                {
-                    "security_id": "EQ_1",
-                    "instrument_name": "Equity 1",
-                    "asset_class": "Equity",
-                    "currency": "USD",
-                    "quantity": 10.0,
-                    "market_value_base": 400.0,
-                    "market_value_local": 400.0,
-                    "weight_pct": 40.0,
                 }
             ]
         ],

--- a/src/app/contracts/portfolio_core.py
+++ b/src/app/contracts/portfolio_core.py
@@ -1,0 +1,53 @@
+from pydantic import BaseModel, Field
+
+
+class PortfolioIdentity(BaseModel):
+    portfolio_id: str = Field(
+        description="Canonical Lotus portfolio identifier.",
+        examples=["PF_1001"],
+    )
+    display_name: str = Field(
+        description="Advisor-facing portfolio display label.",
+        examples=["PF_1001"],
+    )
+    client_id: str | None = Field(
+        default=None,
+        description="Optional client or CIF identifier associated with the portfolio.",
+        examples=["CIF_1"],
+    )
+    base_currency: str = Field(
+        description="Base currency assigned to the portfolio.",
+        examples=["USD"],
+    )
+    booking_center_code: str | None = Field(
+        default=None,
+        description="Optional booking-center code for the portfolio record.",
+        examples=["SGPB"],
+    )
+
+
+class PortfolioSummary(BaseModel):
+    assets_under_management_base: float = Field(
+        description="Total assets under management for the portfolio, expressed in base currency.",
+        examples=[1000.0],
+    )
+    invested_market_value_base: float = Field(
+        description="Invested market value excluding cash, expressed in base currency.",
+        examples=[900.0],
+    )
+    cash_market_value_base: float = Field(
+        description="Total cash market value, expressed in base currency.",
+        examples=[100.0],
+    )
+    cash_weight_pct: float = Field(
+        description="Cash weight as a percentage of total assets under management.",
+        examples=[10.0],
+    )
+    position_count: int = Field(
+        description="Count of position rows included in the resolved portfolio snapshot.",
+        examples=[3],
+    )
+    cash_balance_count: int = Field(
+        description="Count of cash balance rows included in the resolved portfolio snapshot.",
+        examples=[1],
+    )

--- a/src/app/contracts/portfolio_holdings.py
+++ b/src/app/contracts/portfolio_holdings.py
@@ -1,0 +1,476 @@
+from pydantic import BaseModel, Field
+
+from app.contracts.portfolio_core import PortfolioIdentity, PortfolioSummary
+
+
+class PortfolioCashBalance(BaseModel):
+    security_id: str = Field(
+        description="Identifier of the cash balance or cash account row.",
+        examples=["CASH_USD"],
+    )
+    instrument_name: str = Field(
+        description="Advisor-facing label for the cash balance row.",
+        examples=["USD Cash"],
+    )
+    currency: str | None = Field(
+        default=None,
+        description="Currency of the cash account or balance row.",
+        examples=["USD"],
+    )
+    quantity: float = Field(
+        description="Cash quantity or balance in account currency units.",
+        examples=[100.0],
+    )
+    market_value_base: float | None = Field(
+        default=None,
+        description="Cash market value expressed in portfolio base currency.",
+        examples=[100.0],
+    )
+    weight_pct: float | None = Field(
+        default=None,
+        description="Cash weight as a percentage of portfolio assets under management.",
+        examples=[10.0],
+    )
+
+
+class PortfolioAllocationBucket(BaseModel):
+    bucket: str = Field(
+        description="Bucket label within the requested allocation dimension.",
+        examples=["Equity"],
+    )
+    position_count: int = Field(
+        description="Count of positions contributing to the allocation bucket.",
+        examples=[1],
+    )
+    market_value_base: float | None = Field(
+        default=None,
+        description="Bucket market value expressed in portfolio base currency.",
+        examples=[700.0],
+    )
+    weight_pct: float | None = Field(
+        default=None,
+        description="Bucket weight as a percentage of portfolio assets under management.",
+        examples=[70.0],
+    )
+
+
+class PortfolioAllocationView(BaseModel):
+    dimension: str = Field(
+        description="Allocation dimension represented by the current view.",
+        examples=["asset_class"],
+    )
+    buckets: list[PortfolioAllocationBucket] = Field(
+        default_factory=list,
+        description="Allocation buckets returned for the requested dimension.",
+        examples=[
+            [
+                {
+                    "bucket": "Asia",
+                    "position_count": 3,
+                    "market_value_base": 420000.0,
+                    "weight_pct": 42.0,
+                }
+            ]
+        ],
+    )
+
+
+class PortfolioAllocationLookThroughCapability(BaseModel):
+    requested_mode: str = Field(
+        description="Look-through mode requested by the consumer for the allocation query.",
+        examples=["full"],
+    )
+    effective_mode: str = Field(
+        description="Look-through mode actually applied by the upstream allocation service.",
+        examples=["direct_only"],
+    )
+    applied: bool = Field(
+        description="Whether the requested look-through expansion was applied in the response.",
+        examples=[False],
+    )
+
+
+class PortfolioTopPosition(BaseModel):
+    security_id: str = Field(
+        description="Identifier of the ranked top holding.",
+        examples=["EQ_1"],
+    )
+    instrument_name: str = Field(
+        description="Advisor-facing instrument name for the ranked holding.",
+        examples=["Equity 1"],
+    )
+    asset_class: str | None = Field(
+        default=None,
+        description="Asset class assigned to the ranked holding when available.",
+        examples=["Equity"],
+    )
+    isin: str | None = Field(
+        default=None,
+        description="Optional ISIN associated with the ranked holding.",
+        examples=["US1234567890"],
+    )
+    currency: str | None = Field(
+        default=None,
+        description="Trading or instrument currency of the ranked holding.",
+        examples=["USD"],
+    )
+    quantity: float = Field(
+        description="Held quantity of the ranked position.",
+        examples=[10.0],
+    )
+    cost_basis_base: float | None = Field(
+        default=None,
+        description="Cost basis expressed in portfolio base currency.",
+        examples=[500.0],
+    )
+    market_value_base: float | None = Field(
+        default=None,
+        description="Market value expressed in portfolio base currency.",
+        examples=[700.0],
+    )
+    weight_pct: float | None = Field(
+        default=None,
+        description="Position weight as a percentage of portfolio assets under management.",
+        examples=[70.0],
+    )
+
+
+class PortfolioPositionView(BaseModel):
+    security_id: str = Field(
+        description="Identifier of the position row.",
+        examples=["EQ_1"],
+    )
+    instrument_name: str = Field(
+        description="Advisor-facing instrument name for the position row.",
+        examples=["Equity 1"],
+    )
+    asset_class: str | None = Field(
+        default=None,
+        description="Asset class assigned to the position when available.",
+        examples=["Equity"],
+    )
+    isin: str | None = Field(
+        default=None,
+        description="Optional ISIN associated with the position.",
+        examples=["US1234567890"],
+    )
+    currency: str | None = Field(
+        default=None,
+        description="Trading or instrument currency of the position.",
+        examples=["USD"],
+    )
+    sector: str | None = Field(
+        default=None,
+        description="Optional sector classification for the position.",
+        examples=["Technology"],
+    )
+    country_of_risk: str | None = Field(
+        default=None,
+        description="Optional country-of-risk classification for the position.",
+        examples=["US"],
+    )
+    held_since_date: str | None = Field(
+        default=None,
+        description="Optional holding start date in YYYY-MM-DD format.",
+        examples=["2025-12-31"],
+    )
+    quantity: float = Field(
+        description="Held quantity of the position.",
+        examples=[10.0],
+    )
+    market_price: float | None = Field(
+        default=None,
+        description="Current market price of the position when valuation is available.",
+        examples=[70.0],
+    )
+    cost_basis_base: float | None = Field(
+        default=None,
+        description="Cost basis expressed in portfolio base currency.",
+        examples=[500.0],
+    )
+    cost_basis_local: float | None = Field(
+        default=None,
+        description="Cost basis expressed in local or instrument currency when available.",
+        examples=[500.0],
+    )
+    market_value_base: float | None = Field(
+        default=None,
+        description="Market value expressed in portfolio base currency.",
+        examples=[700.0],
+    )
+    market_value_local: float | None = Field(
+        default=None,
+        description="Market value expressed in local or instrument currency when available.",
+        examples=[700.0],
+    )
+    unrealized_gain_loss_base: float | None = Field(
+        default=None,
+        description="Unrealized gain or loss expressed in portfolio base currency.",
+        examples=[200.0],
+    )
+    unrealized_gain_loss_local: float | None = Field(
+        default=None,
+        description=(
+            "Unrealized gain or loss expressed in local or instrument currency when available."
+        ),
+        examples=[200.0],
+    )
+    weight_pct: float | None = Field(
+        default=None,
+        description="Position weight as a percentage of portfolio assets under management.",
+        examples=[70.0],
+    )
+    reprocessing_status: str | None = Field(
+        default=None,
+        description="Optional upstream reprocessing or valuation status for the position row.",
+        examples=["READY"],
+    )
+
+
+class PortfolioAllocationResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Opaque correlation identifier for the allocation response envelope.",
+        examples=["corr-portfolio-allocation"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Version of the gateway allocation response contract.",
+        examples=["v1"],
+    )
+    portfolio_id: str = Field(
+        description="Portfolio identifier whose allocation views are being returned.",
+        examples=["PF_1001"],
+    )
+    as_of_date: str = Field(
+        description="Resolved as-of date used for the allocation query inputs.",
+        examples=["2026-03-27"],
+    )
+    reporting_currency: str | None = Field(
+        default=None,
+        description=(
+            "Reporting currency used for the allocation response when restatement is applied."
+        ),
+        examples=["USD"],
+    )
+    look_through: PortfolioAllocationLookThroughCapability | None = Field(
+        default=None,
+        description=(
+            "Look-through capability and effective mode returned by the "
+            "upstream allocation service."
+        ),
+        examples=[
+            {
+                "requested_mode": "full",
+                "effective_mode": "direct_only",
+                "applied": False,
+            }
+        ],
+    )
+    summary: PortfolioSummary = Field(
+        description="Source-backed summary values used to frame the allocation response.",
+        examples=[
+            {
+                "assets_under_management_base": 1000.0,
+                "invested_market_value_base": 900.0,
+                "cash_market_value_base": 100.0,
+                "cash_weight_pct": 10.0,
+                "position_count": 3,
+                "cash_balance_count": 1,
+            }
+        ],
+    )
+    views: list[PortfolioAllocationView] = Field(
+        default_factory=list,
+        description="Allocation views returned for the supported reporting dimensions.",
+        examples=[
+            [
+                {
+                    "dimension": "region",
+                    "buckets": [
+                        {
+                            "bucket": "Asia",
+                            "position_count": 1,
+                            "market_value_base": 700.0,
+                            "weight_pct": 70.0,
+                        }
+                    ],
+                }
+            ]
+        ],
+    )
+
+
+class PortfolioPositionBookResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Opaque correlation identifier for the position-book response envelope.",
+        examples=["corr-portfolio-positions"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Version of the gateway position-book response contract.",
+        examples=["v1"],
+    )
+    portfolio_id: str = Field(
+        description="Portfolio identifier whose position book is being returned.",
+        examples=["PF_1001"],
+    )
+    as_of_date: str = Field(
+        description="Resolved as-of date used for the position-book request.",
+        examples=["2026-03-27"],
+    )
+    summary: PortfolioSummary = Field(
+        description="Source-backed summary values used to frame the positions response.",
+    )
+    top_positions: list[PortfolioTopPosition] = Field(
+        default_factory=list,
+        description="Ranked top holdings derived from the returned position rows.",
+        examples=[
+            [
+                {
+                    "security_id": "EQ_1",
+                    "instrument_name": "Equity 1",
+                    "asset_class": "Equity",
+                    "isin": "US1234567890",
+                    "currency": "USD",
+                    "quantity": 10.0,
+                    "cost_basis_base": 320.0,
+                    "market_value_base": 400.0,
+                    "weight_pct": 40.0,
+                }
+            ]
+        ],
+    )
+    positions: list[PortfolioPositionView] = Field(
+        default_factory=list,
+        description="Detailed position rows for the requested portfolio book.",
+        examples=[
+            [
+                {
+                    "security_id": "EQ_1",
+                    "instrument_name": "Equity 1",
+                    "asset_class": "Equity",
+                    "isin": "US1234567890",
+                    "currency": "USD",
+                    "sector": "Technology",
+                    "country_of_risk": "United States",
+                    "held_since_date": "2025-12-31",
+                    "quantity": 10.0,
+                    "market_price": 40.0,
+                    "cost_basis_base": 320.0,
+                    "cost_basis_local": 320.0,
+                    "market_value_base": 400.0,
+                    "market_value_local": 400.0,
+                    "unrealized_gain_loss_base": 80.0,
+                    "unrealized_gain_loss_local": 80.0,
+                    "weight_pct": 40.0,
+                    "reprocessing_status": "READY",
+                }
+            ]
+        ],
+    )
+
+
+class PortfolioBookResponse(BaseModel):
+    correlation_id: str = Field(
+        description=(
+            "Opaque correlation identifier for the combined portfolio-book response envelope."
+        ),
+        examples=["corr-portfolio-book"],
+    )
+    contract_version: str = Field(
+        default="v1",
+        description="Version of the gateway combined portfolio-book response contract.",
+        examples=["v1"],
+    )
+    as_of_date: str = Field(
+        description="Resolved as-of date used for the combined portfolio book sections.",
+        examples=["2026-03-27"],
+    )
+    portfolio: PortfolioIdentity = Field(
+        description="Portfolio identity metadata for the combined book view.",
+        examples=[{"portfolio_id": "PF_1001", "display_name": "PF_1001", "base_currency": "USD"}],
+    )
+    summary: PortfolioSummary = Field(
+        description="Source-backed summary values for the current portfolio book.",
+        examples=[
+            {
+                "assets_under_management_base": 1000.0,
+                "invested_market_value_base": 900.0,
+                "cash_market_value_base": 100.0,
+                "cash_weight_pct": 10.0,
+                "position_count": 1,
+                "cash_balance_count": 1,
+            }
+        ],
+    )
+    cash_balances: list[PortfolioCashBalance] = Field(
+        default_factory=list,
+        description="Cash inventory included in the current portfolio book view.",
+        examples=[
+            [
+                {
+                    "security_id": "CASH_USD",
+                    "instrument_name": "USD Cash",
+                    "currency": "USD",
+                    "quantity": 100.0,
+                    "market_value_base": 100.0,
+                    "weight_pct": 10.0,
+                }
+            ]
+        ],
+    )
+    allocation_views: list[PortfolioAllocationView] = Field(
+        default_factory=list,
+        description="Allocation views included with the portfolio book response.",
+        examples=[
+            [
+                {
+                    "dimension": "asset_class",
+                    "buckets": [
+                        {
+                            "bucket": "Equity",
+                            "position_count": 1,
+                            "market_value_base": 900.0,
+                            "weight_pct": 90.0,
+                        }
+                    ],
+                }
+            ]
+        ],
+    )
+    top_positions: list[PortfolioTopPosition] = Field(
+        default_factory=list,
+        description="Ranked top holdings for the current book.",
+        examples=[
+            [
+                {
+                    "security_id": "EQ_1",
+                    "instrument_name": "Equity 1",
+                    "asset_class": "Equity",
+                    "currency": "USD",
+                    "quantity": 10.0,
+                    "cost_basis_base": 500.0,
+                    "market_value_base": 900.0,
+                    "weight_pct": 90.0,
+                }
+            ]
+        ],
+    )
+    positions: list[PortfolioPositionView] = Field(
+        default_factory=list,
+        description="Detailed position rows included in the current portfolio book.",
+        examples=[
+            [
+                {
+                    "security_id": "EQ_1",
+                    "instrument_name": "Equity 1",
+                    "asset_class": "Equity",
+                    "currency": "USD",
+                    "quantity": 10.0,
+                    "market_value_base": 400.0,
+                    "market_value_local": 400.0,
+                    "weight_pct": 40.0,
+                }
+            ]
+        ],
+    )

--- a/src/app/routers/portfolio_allocations.py
+++ b/src/app/routers/portfolio_allocations.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Query
 
-from app.contracts.portfolio import PortfolioAllocationResponse
+from app.contracts.portfolio_holdings import PortfolioAllocationResponse
 from app.middleware.correlation import correlation_id_var
 from app.services.portfolio_service_provider import portfolio_service
 

--- a/src/app/routers/portfolio_book.py
+++ b/src/app/routers/portfolio_book.py
@@ -1,8 +1,6 @@
 from fastapi import APIRouter, Query
 
-from app.contracts.portfolio import (
-    PortfolioBookResponse,
-)
+from app.contracts.portfolio_holdings import PortfolioBookResponse
 from app.middleware.correlation import correlation_id_var
 from app.services.portfolio_service_provider import portfolio_service
 

--- a/src/app/routers/portfolio_positions.py
+++ b/src/app/routers/portfolio_positions.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Query
 
-from app.contracts.portfolio import PortfolioPositionBookResponse
+from app.contracts.portfolio_holdings import PortfolioPositionBookResponse
 from app.middleware.correlation import correlation_id_var
 from app.services.portfolio_service_provider import portfolio_service
 

--- a/src/app/services/portfolio_insights.py
+++ b/src/app/services/portfolio_insights.py
@@ -1,10 +1,9 @@
 from app.contracts.portfolio import (
     PortfolioInsight,
-    PortfolioPositionView,
-    PortfolioSummary,
-    PortfolioTopPosition,
 )
 from app.contracts.portfolio_activity_income import PortfolioActivitySummaryResponse
+from app.contracts.portfolio_core import PortfolioSummary
+from app.contracts.portfolio_holdings import PortfolioPositionView, PortfolioTopPosition
 
 
 def build_portfolio_insights(

--- a/src/app/services/portfolio_position_book.py
+++ b/src/app/services/portfolio_position_book.py
@@ -1,10 +1,7 @@
 from typing import Any
 
-from app.contracts.portfolio import (
-    PortfolioPositionView,
-    PortfolioSummary,
-    PortfolioTopPosition,
-)
+from app.contracts.portfolio_core import PortfolioSummary
+from app.contracts.portfolio_holdings import PortfolioPositionView, PortfolioTopPosition
 from app.precision_policy import (
     quantize_money,
     quantize_performance,

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -7,34 +7,23 @@ from fastapi import HTTPException, status
 
 from app.config import settings
 from app.contracts.portfolio import (
-    PortfolioAllocationBucket,
-    PortfolioAllocationLookThroughCapability,
-    PortfolioAllocationResponse,
-    PortfolioAllocationView,
-    PortfolioBookResponse,
-    PortfolioCashBalance,
     PortfolioCashflowOutlook,
     PortfolioCashflowPoint,
     PortfolioCatalogItem,
     PortfolioCatalogResponse,
     PortfolioExceptionSummary,
-    PortfolioIdentity,
     PortfolioInsight,
     PortfolioInsightsResponse,
     PortfolioLiquidityResponse,
     PortfolioOperationalReadiness,
     PortfolioPartialFailure,
     PortfolioPerformanceSummary,
-    PortfolioPositionBookResponse,
-    PortfolioPositionView,
     PortfolioProfile,
     PortfolioProjectedCashflowResponse,
     PortfolioReadinessResponse,
     PortfolioRebalanceSummary,
     PortfolioRebalanceSupportabilitySummary,
     PortfolioReportingReadiness,
-    PortfolioSummary,
-    PortfolioTopPosition,
     PortfolioWorkflowResponse,
     PortfolioWorkspaceControlCapabilities,
     PortfolioWorkspaceResponse,
@@ -42,6 +31,18 @@ from app.contracts.portfolio import (
 from app.contracts.portfolio_activity_income import (
     PortfolioActivitySummaryResponse,
     PortfolioIncomeSummaryResponse,
+)
+from app.contracts.portfolio_core import PortfolioIdentity, PortfolioSummary
+from app.contracts.portfolio_holdings import (
+    PortfolioAllocationBucket,
+    PortfolioAllocationLookThroughCapability,
+    PortfolioAllocationResponse,
+    PortfolioAllocationView,
+    PortfolioBookResponse,
+    PortfolioCashBalance,
+    PortfolioPositionBookResponse,
+    PortfolioPositionView,
+    PortfolioTopPosition,
 )
 from app.contracts.portfolio_transactions import PortfolioTransactionLedgerResponse
 from app.precision_policy import (

--- a/src/app/services/portfolio_workflow.py
+++ b/src/app/services/portfolio_workflow.py
@@ -1,12 +1,11 @@
 from dataclasses import dataclass
 
 from app.contracts.portfolio import (
-    PortfolioAllocationView,
     PortfolioOperationalReadiness,
-    PortfolioPositionView,
-    PortfolioSummary,
     PortfolioWorkspaceResponse,
 )
+from app.contracts.portfolio_core import PortfolioSummary
+from app.contracts.portfolio_holdings import PortfolioAllocationView, PortfolioPositionView
 from app.contracts.portfolio_workflow import (
     PortfolioReadinessIndicator,
     PortfolioWorkflowAction,

--- a/src/app/services/portfolio_workspace_controls.py
+++ b/src/app/services/portfolio_workspace_controls.py
@@ -1,13 +1,13 @@
 from typing import Literal
 
 from app.contracts.portfolio import (
-    PortfolioIdentity,
     PortfolioProfile,
     PortfolioWorkspaceControlCapabilities,
     PortfolioWorkspaceHistoricalSnapshotCapability,
     PortfolioWorkspaceModuleCapability,
     PortfolioWorkspaceReportingCurrencyCapability,
 )
+from app.contracts.portfolio_core import PortfolioIdentity
 
 ModuleCapabilityState = Literal["supported", "partial", "unsupported"]
 ModuleCapabilitySpec = tuple[str, ModuleCapabilityState, str]

--- a/src/app/services/portfolio_workspace_response.py
+++ b/src/app/services/portfolio_workspace_response.py
@@ -4,18 +4,17 @@ from dataclasses import dataclass
 
 from app.contracts.portfolio import (
     PortfolioCashflowOutlook,
-    PortfolioIdentity,
     PortfolioOperationalReadiness,
     PortfolioPerformanceSummary,
     PortfolioProfile,
     PortfolioRebalanceSummary,
     PortfolioReportingReadiness,
-    PortfolioSummary,
     PortfolioWorkflowLaunchCue,
     PortfolioWorkspaceControlCapabilities,
     PortfolioWorkspaceResponse,
 )
 from app.contracts.portfolio_common import PortfolioPartialFailure
+from app.contracts.portfolio_core import PortfolioIdentity, PortfolioSummary
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_portfolio_holdings_contracts.py
+++ b/tests/unit/test_portfolio_holdings_contracts.py
@@ -1,0 +1,124 @@
+from app.contracts import portfolio
+from app.contracts.portfolio_core import PortfolioIdentity, PortfolioSummary
+from app.contracts.portfolio_holdings import (
+    PortfolioAllocationBucket,
+    PortfolioAllocationResponse,
+    PortfolioAllocationView,
+    PortfolioBookResponse,
+    PortfolioCashBalance,
+    PortfolioPositionBookResponse,
+    PortfolioPositionView,
+    PortfolioTopPosition,
+)
+
+
+def test_portfolio_core_contracts_remain_compatibility_reexports() -> None:
+    assert portfolio.PortfolioIdentity is PortfolioIdentity
+    assert portfolio.PortfolioSummary is PortfolioSummary
+
+
+def test_portfolio_holdings_contracts_remain_compatibility_reexports() -> None:
+    assert portfolio.PortfolioAllocationBucket is PortfolioAllocationBucket
+    assert portfolio.PortfolioAllocationResponse is PortfolioAllocationResponse
+    assert portfolio.PortfolioAllocationView is PortfolioAllocationView
+    assert portfolio.PortfolioBookResponse is PortfolioBookResponse
+    assert portfolio.PortfolioCashBalance is PortfolioCashBalance
+    assert portfolio.PortfolioPositionBookResponse is PortfolioPositionBookResponse
+    assert portfolio.PortfolioPositionView is PortfolioPositionView
+    assert portfolio.PortfolioTopPosition is PortfolioTopPosition
+
+
+def test_portfolio_book_contract_accepts_extracted_core_and_holdings_models() -> None:
+    summary = PortfolioSummary(
+        assets_under_management_base=1000.0,
+        invested_market_value_base=900.0,
+        cash_market_value_base=100.0,
+        cash_weight_pct=10.0,
+        position_count=1,
+        cash_balance_count=1,
+    )
+
+    response = PortfolioBookResponse(
+        correlation_id="corr-book",
+        as_of_date="2026-03-27",
+        portfolio=PortfolioIdentity(
+            portfolio_id="PF_1001",
+            display_name="PF_1001",
+            client_id="CIF_1",
+            base_currency="USD",
+            booking_center_code="SGPB",
+        ),
+        summary=summary,
+        cash_balances=[
+            PortfolioCashBalance(
+                security_id="CASH_USD",
+                instrument_name="USD Cash",
+                currency="USD",
+                quantity=100.0,
+                market_value_base=100.0,
+                weight_pct=10.0,
+            )
+        ],
+        allocation_views=[
+            PortfolioAllocationView(
+                dimension="asset_class",
+                buckets=[
+                    PortfolioAllocationBucket(
+                        bucket="Equity",
+                        position_count=1,
+                        market_value_base=900.0,
+                        weight_pct=90.0,
+                    )
+                ],
+            )
+        ],
+        top_positions=[
+            PortfolioTopPosition(
+                security_id="EQ_1",
+                instrument_name="Equity 1",
+                asset_class="Equity",
+                quantity=10.0,
+                market_value_base=900.0,
+                weight_pct=90.0,
+            )
+        ],
+        positions=[
+            PortfolioPositionView(
+                security_id="EQ_1",
+                instrument_name="Equity 1",
+                asset_class="Equity",
+                quantity=10.0,
+                market_value_base=900.0,
+                weight_pct=90.0,
+            )
+        ],
+    )
+
+    assert response.summary is summary
+    assert response.model_dump()["portfolio"]["portfolio_id"] == "PF_1001"
+
+
+def test_portfolio_position_book_contract_uses_extracted_holdings_models() -> None:
+    response = PortfolioPositionBookResponse(
+        correlation_id="corr-positions",
+        portfolio_id="PF_1001",
+        as_of_date="2026-03-27",
+        summary=PortfolioSummary(
+            assets_under_management_base=1000.0,
+            invested_market_value_base=900.0,
+            cash_market_value_base=100.0,
+            cash_weight_pct=10.0,
+            position_count=1,
+            cash_balance_count=1,
+        ),
+        positions=[
+            PortfolioPositionView(
+                security_id="EQ_1",
+                instrument_name="Equity 1",
+                quantity=10.0,
+            )
+        ],
+    )
+
+    assert response.contract_version == "v1"
+    assert response.positions[0].security_id == "EQ_1"

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -86,19 +86,19 @@ and rebalance supportability failure-recording splits then lowered the baseline 
 74 lines. The 50-commit enterprise-hardening branch then split shared analytics async polling,
 workspace-summary payload assembly, portfolio transaction-summary context loading, transaction
 page loading, and portfolio book response assembly, lowering the baseline to 62 lines.
-`portfolio_service.py` is now measured at 2,078 lines after portfolio liquidity loading,
+`portfolio_service.py` is now measured at 2,079 lines after portfolio liquidity loading,
 transaction request-context, transaction page-context, transaction client-kwargs, portfolio
 workspace response assembly, portfolio workspace performance parsing, and portfolio workspace
 rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, and
 portfolio workflow mapping extractions. `portfolio.py` is now measured at 1,464 lines after
 workflow/readiness, transaction-ledger, performance snapshot, and income/activity contract
-extractions.
+extractions, and 954 lines after the holdings/book contract extraction.
 `performance_workspace_service.py` is now measured at 1,704 lines after response assembly
 extraction. The current longest-function baseline is 49 lines. Local `make check` for the current
-portfolio income/activity contract branch passed with ruff, format check, monetary-float guard,
-mypy over 459 source files, Workbench/OpenAPI contract smoke, and 1,035 unit/contract tests. Local
-`make ci` passed with 207 integration tests, 1,242 coverage tests, 94.02 percent total coverage,
+portfolio holdings contract branch passed with ruff, format check, monetary-float guard, mypy over
+461 source files, Workbench/OpenAPI contract smoke, and 1,039 unit/contract tests. Local `make ci`
+passed with 207 integration tests, 1,246 coverage tests, 94.02 percent total coverage,
 and `pip-audit` reporting no known vulnerabilities after the governed FastAPI/Starlette exception.
 GitHub Feature Lane, PR Merge Gate, Quality Baseline, Docker build, and Docker parity checks were
-green before PR #362 merged. The current portfolio income/activity contract branch adds focused
-income/activity contract compatibility and portfolio OpenAPI evidence with 17 passing tests.
+green before PR #363 merged. The current portfolio holdings contract branch adds focused holdings
+contract compatibility and portfolio OpenAPI evidence with 24 passing focused tests.


### PR DESCRIPTION
## Summary
- Extract shared portfolio identity/summary contracts into `portfolio_core.py` and portfolio cash/allocation/position/book contracts into `portfolio_holdings.py`.
- Keep `app.contracts.portfolio` compatibility re-exports intact while updating internal holdings/book consumers to import the narrower modules directly.
- Refresh the governed monetary-float allowlist for moved baseline float fields and update quality/wiki evidence with current measurements.

## Measured improvement
- `src/app/contracts/portfolio.py`: 1,464 lines -> 954 lines.
- Longest-function baseline preserved at 49 lines.
- Largest source file remains `src/app/services/portfolio_service.py` at 2,079 lines.
- Counted files: 1,341 under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts`; 461 `src/app` Python files; 174 Python test files.

## Validation
- Focused: `python -m ruff check` on touched files: passed.
- Focused: `python -m ruff format --check` on touched files: passed.
- Focused: `python -m mypy` on 12 touched source files: passed.
- Focused: `python scripts/check_monetary_float_usage.py`: passed, Findings=159, allowlisted=159.
- Focused: `python -m pytest tests/unit/test_portfolio_holdings_contracts.py tests/contract/test_portfolio_contract.py tests/unit/test_portfolio_insights.py tests/unit/test_portfolio_workflow.py tests/unit/test_portfolio_workspace_controls.py tests/unit/test_portfolio_workspace_response.py`: 24 passed.
- `make check`: passed; ruff, format, monetary-float guard, mypy over 461 source files, Workbench contract smoke, 1,039 unit/contract tests.
- `make ci`: passed; migration smoke, 207 integration tests, 1,246 coverage tests, total coverage 94.02%, `pip-audit` no known vulnerabilities after governed `PYSEC-2026-161` exception.

## Governance
- Repo profile: Experience API.
- Stranded truth: `git branch -r --no-merged origin/main` lists only this active branch.
- Wiki source changed intentionally: `wiki/Validation-and-CI.md` records current validation evidence. `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway` reports expected drift for `Validation-and-CI.md`; publish after merge.
- No behavior change intended; OpenAPI schema names and legacy import surface are preserved.