### PR TITLE
Extract reporting batch contracts

### DIFF
--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -196,6 +196,11 @@ The current risk drawdown contract slice moves drawdown payload models into
 surface, refreshes the governed monetary float allowlist for the moved drawdown-at-risk fields,
 and reduces `risk_workspace.py` from 2,043 to 1,734 measured lines while preserving OpenAPI schema
 names and the 49-line longest-function baseline.
+The current reporting batch contract slice moves batch, worker-run, scheduler, and shared
+reporting error-example contracts into `reporting_batches.py` and `reporting_errors.py`, keeps
+`app.contracts.reporting` as the compatibility import surface, and reduces `reporting.py` from
+1,840 to 1,184 measured lines while preserving OpenAPI schema names and the 49-line
+longest-function baseline.
 It is intended to make quality debt visible before introducing stricter CI gates. Findings are not
 yet enforced unless they are already covered by existing repo-native gates.
 
@@ -203,28 +208,28 @@ yet enforced unless they are already covered by existing repo-native gates.
 
 | Measure | Current value |
 | --- | ---: |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,345 |
-| Python source files under `src/app` | 462 |
-| Python test files under `tests` | 175 |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,351 |
+| Python source files under `src/app` | 464 |
+| Python test files under `tests` | 176 |
 | OpenAPI paths | 233 |
 | OpenAPI operations | 247 |
 
-Working-tree verification for the current risk drawdown contract branch shows 1,345 files under
-`src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 462 Python source files under `src/app`;
-and 175 Python test files under `tests`.
+Working-tree verification for the current reporting batch contract branch shows 1,351 files under
+`src`, `tests`, `docs`, `wiki`, `.github`, and `scripts`; 464 Python source files under `src/app`;
+and 176 Python test files under `tests`.
 
 ## Largest Source Files
 
 | Rank | Lines | File |
 | ---: | ---: | --- |
 | 1 | 2,079 | `src/app/services/portfolio_service.py` |
-| 2 | 1,840 | `src/app/contracts/reporting.py` |
-| 3 | 1,734 | `src/app/contracts/risk_workspace.py` |
-| 4 | 1,704 | `src/app/services/performance_workspace_service.py` |
-| 5 | 1,607 | `src/app/services/advisor_brief_service.py` |
-| 6 | 1,606 | `src/app/contracts/performance_workspace.py` |
-| 7 | 1,362 | `src/app/clients/dpm_client.py` |
-| 8 | 1,217 | `src/app/services/dpm_command_center_service.py` |
+| 2 | 1,734 | `src/app/contracts/risk_workspace.py` |
+| 3 | 1,704 | `src/app/services/performance_workspace_service.py` |
+| 4 | 1,607 | `src/app/services/advisor_brief_service.py` |
+| 5 | 1,606 | `src/app/contracts/performance_workspace.py` |
+| 6 | 1,362 | `src/app/clients/dpm_client.py` |
+| 7 | 1,217 | `src/app/services/dpm_command_center_service.py` |
+| 8 | 1,184 | `src/app/contracts/reporting.py` |
 | 9 | 1,098 | `src/app/clients/advise_client.py` |
 | 10 | 1,093 | `src/app/services/dpm_wave_service.py` |
 
@@ -415,6 +420,9 @@ Most recent local evidence:
 75. Current risk drawdown contract branch: `make ci` passed with 207 integration tests and 1,248
     combined coverage tests; total coverage is 94.03%, and `pip-audit` found no known
     vulnerabilities after the governed `PYSEC-2026-161` exception.
+76. Current reporting batch contract branch: focused validation passed with ruff, format check,
+    monetary-float guard, mypy over the touched contract/router/service modules, and 40 reporting
+    batch, contract, and integration tests.
 
 ## Tooling Availability Baseline
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -423,6 +423,12 @@ Most recent local evidence:
 76. Current reporting batch contract branch: focused validation passed with ruff, format check,
     monetary-float guard, mypy over the touched contract/router/service modules, and 40 reporting
     batch, contract, and integration tests.
+77. Current reporting batch contract branch: `make check` passed with ruff, format check,
+    monetary-float guard, mypy over 464 source files, Workbench/OpenAPI contract smoke, and 1,044
+    unit/contract tests.
+78. Current reporting batch contract branch: `make ci` passed with 207 integration tests and 1,251
+    combined coverage tests; total coverage is 94.03%, and `pip-audit` found no known
+    vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,7 +5,7 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Latest merged branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 462 source files, contract smoke, and 1,041 unit/contract tests; `make ci` passed with 207 integration tests, 1,248 coverage tests, and dependency audit; current branch focused checks passed with ruff, format check, monetary-float guard, mypy, and 40 reporting tests | Keep Docker parity blocking in PR Merge Gate |
+| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 464 source files, contract smoke, and 1,044 unit/contract tests; `make ci` passed with 207 integration tests, 1,251 coverage tests, and dependency audit; focused checks passed with 40 reporting tests | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 94.03% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
 | Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, portfolio workflow contracts, portfolio transaction contracts, portfolio performance snapshot contracts, portfolio income/activity contracts, portfolio holdings/book contracts, risk drawdown contracts, and reporting batch contracts; `portfolio_service.py` is now 2,079 measured lines, `portfolio.py` is now 954 measured lines, `risk_workspace.py` is now 1,734 measured lines, and `reporting.py` is now 1,184 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
@@ -32,9 +32,9 @@ versus the current reporting batch contract branch after PRs #349, #350, #351, #
 | Largest source file | 2,968 lines | 2,079 lines | Improved; `src/app/services/portfolio_service.py` remains the largest residual hotspot after reducing `portfolio.py`, `risk_workspace.py`, and `reporting.py` |
 | `performance_workspace_service.py` | 1,724 lines | 1,704 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,039 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, income/activity contract, and holdings contract tests |
-| Local coverage tests | 1,203 | 1,246 | Added focused coverage while preserving total coverage |
-| Total coverage | 93.69% | 94.02% | Improved |
+| Local unit/contract tests | 996 | 1,044 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, income/activity contract, holdings contract, risk drawdown contract, and reporting batch contract tests |
+| Local coverage tests | 1,203 | 1,251 | Added focused coverage while preserving total coverage |
+| Total coverage | 93.69% | 94.03% | Improved |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
 ## Phase Gates

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,31 +5,31 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 462 source files, contract smoke, and 1,041 unit/contract tests; `make ci` passed with 207 integration tests, 1,248 coverage tests, and dependency audit; focused checks passed with 31 risk workspace tests | Keep Docker parity blocking in PR Merge Gate |
+| Build and test reliability | 5/5 | Latest merged branch evidence includes `make check` with ruff, format, monetary-float guard, mypy over 462 source files, contract smoke, and 1,041 unit/contract tests; `make ci` passed with 207 integration tests, 1,248 coverage tests, and dependency audit; current branch focused checks passed with ruff, format check, monetary-float guard, mypy, and 40 reporting tests | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 94.03% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, portfolio workflow contracts, portfolio transaction contracts, portfolio performance snapshot contracts, portfolio income/activity contracts, portfolio holdings/book contracts, and risk drawdown contracts; `portfolio_service.py` is now 2,079 measured lines, `portfolio.py` is now 954 measured lines, and `risk_workspace.py` is now 1,734 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, portfolio workflow contracts, portfolio transaction contracts, portfolio performance snapshot contracts, portfolio income/activity contracts, portfolio holdings/book contracts, risk drawdown contracts, and reporting batch contracts; `portfolio_service.py` is now 2,079 measured lines, `portfolio.py` is now 954 measured lines, `risk_workspace.py` is now 1,734 measured lines, and `reporting.py` is now 1,184 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
 | Security | 4/5 | `pip-audit` passed in current branch `make ci` with the governed FastAPI/Starlette exception; no known vulnerabilities found | Triage bandit and sensitive-data handling checks |
-| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused risk drawdown contract slice | Keep wiki synced and add diagrams over time |
+| Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused reporting batch contract slice | Keep wiki synced and add diagrams over time |
 | Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
 Comparison point: the prior scorecard state after the portfolio liquidity payload-loader slice
-versus the current risk drawdown contract branch after PRs #349, #350, #351, #352, #353, #354,
-#355, #356, #357, #358, #359, #360, #361, #362, #363, and #364.
+versus the current reporting batch contract branch after PRs #349, #350, #351, #352, #353, #354,
+#355, #356, #357, #358, #359, #360, #361, #362, #363, #364, and #365.
 
 | Measure | Prior scorecard | Current branch | Result |
 | --- | ---: | ---: | --- |
-| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,345 | Added focused modules, tests, and quality evidence |
-| Tracked `src/app` Python files | 447 | 462 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper and contract modules plus risk drawdown contracts |
-| Tracked Python test files | 162 | 175 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, income/activity contract, holdings contract, and risk drawdown contract tests |
+| Counted files under `src`, `tests`, `docs`, `wiki`, `.github`, `scripts` | 1,265 | 1,351 | Added focused modules, tests, and quality evidence |
+| Tracked `src/app` Python files | 447 | 464 | Added focused portfolio/performance response helpers and workspace/readiness/transaction summary/workflow mapper and contract modules plus risk drawdown and reporting batch contracts |
+| Tracked Python test files | 162 | 176 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, income/activity contract, holdings contract, risk drawdown contract, and reporting batch contract tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 2,079 lines | Improved; `src/app/services/portfolio_service.py` remains the largest residual hotspot after reducing `portfolio.py` and `risk_workspace.py` |
+| Largest source file | 2,968 lines | 2,079 lines | Improved; `src/app/services/portfolio_service.py` remains the largest residual hotspot after reducing `portfolio.py`, `risk_workspace.py`, and `reporting.py` |
 | `performance_workspace_service.py` | 1,724 lines | 1,704 lines | Improved through response assembly extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
 | Local unit/contract tests | 996 | 1,039 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, income/activity contract, and holdings contract tests |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -277,17 +277,22 @@ The current risk drawdown contract slice moves drawdown payload contracts into
 intact, refreshes the governed monetary-float allowlist for the moved drawdown-at-risk fields, and
 reduces `risk_workspace.py` from 2,043 to 1,734 lines while preserving risk workspace contract
 tests and the 49-line longest-function baseline.
+The current reporting batch contract slice moves batch, worker-run, scheduler, and shared
+reporting error-example contracts into `reporting_batches.py` and `reporting_errors.py`, keeps the
+legacy `app.contracts.reporting` import surface intact, and reduces `reporting.py` from 1,840 to
+1,184 lines while preserving reporting contract/router tests and the 49-line longest-function
+baseline.
 
 ## Health Signals
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | Current risk drawdown contract branch was created from clean `main` after PR #364; final remote/local cleanup remains a post-merge gate |
-| Unit/contract coverage | Healthy | 1,041 unit/contract tests passed in current branch `make check`; focused risk drawdown contract and risk workspace service tests passed with 31 tests on this branch |
+| Branch hygiene | Healthy | Current reporting batch contract branch was created from clean `main` after PR #365; final remote/local cleanup remains a post-merge gate |
+| Unit/contract coverage | Healthy | 1,041 unit/contract tests passed in the latest merged branch `make check`; focused reporting batch, contract, and integration tests passed with 40 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
 | Total coverage | Healthy | 1,248 coverage tests passed in current branch `make ci`; total coverage is 94.03%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
-| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper/contract slices reduce `portfolio.py` to 954 measured lines and `risk_workspace.py` to 1,734 measured lines, leaving `portfolio_service.py` at 2,079 measured lines and `performance_workspace_service.py` at 1,704 measured lines; large contracts and several service files remain above 1,000 lines |
+| Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper/contract slices reduce `portfolio.py` to 954 measured lines, `risk_workspace.py` to 1,734 measured lines, and `reporting.py` to 1,184 measured lines, leaving `portfolio_service.py` at 2,079 measured lines and `performance_workspace_service.py` at 1,704 measured lines; large contracts and several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
 | Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -288,9 +288,9 @@ baseline.
 | Area | Current posture | Evidence |
 | --- | --- | --- |
 | Branch hygiene | Healthy | Current reporting batch contract branch was created from clean `main` after PR #365; final remote/local cleanup remains a post-merge gate |
-| Unit/contract coverage | Healthy | 1,041 unit/contract tests passed in the latest merged branch `make check`; focused reporting batch, contract, and integration tests passed with 40 tests on this branch |
+| Unit/contract coverage | Healthy | 1,044 unit/contract tests passed in current branch `make check`; focused reporting batch, contract, and integration tests passed with 40 tests on this branch |
 | Integration coverage | Healthy | 207 integration tests passed in current branch `make ci` |
-| Total coverage | Healthy | 1,248 coverage tests passed in current branch `make ci`; total coverage is 94.03%, above the 84% floor |
+| Total coverage | Healthy | 1,251 coverage tests passed in current branch `make ci`; total coverage is 94.03%, above the 84% floor |
 | Security audit | Governed | `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception |
 | Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper/contract slices reduce `portfolio.py` to 954 measured lines, `risk_workspace.py` to 1,734 measured lines, and `reporting.py` to 1,184 measured lines, leaving `portfolio_service.py` at 2,079 measured lines and `performance_workspace_service.py` at 1,704 measured lines; large contracts and several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |

--- a/src/app/contracts/reporting.py
+++ b/src/app/contracts/reporting.py
@@ -1,7 +1,103 @@
-from datetime import date, datetime
+from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+from app.contracts.reporting_batches import (
+    BATCH_CONTROL_RESPONSE_EXAMPLE,
+    BATCH_CREATE_REQUEST_EXAMPLE,
+    BATCH_HANDLE_RESPONSE_EXAMPLE,
+    BATCH_RECOVERY_RESPONSE_EXAMPLE,
+    BATCH_SCHEDULE_LIST_RESPONSE_EXAMPLE,
+    BATCH_SCHEDULER_RUN_REQUEST_EXAMPLE,
+    BATCH_SCHEDULER_RUN_RESPONSE_EXAMPLE,
+    BATCH_STATUS_RESPONSE_EXAMPLE,
+    BATCH_WORKER_RUN_REQUEST_EXAMPLE,
+    BATCH_WORKER_RUN_RESPONSE_EXAMPLE,
+    BatchControlResponse,
+    BatchCreateRequest,
+    BatchDispatchPolicy,
+    BatchHandleResponse,
+    BatchItemStatus,
+    BatchItemStatusResponse,
+    BatchRecoveryResponse,
+    BatchRuntimeLoad,
+    BatchScheduleListResponse,
+    BatchSchedulerMaterializationResponse,
+    BatchSchedulerRunRequest,
+    BatchSchedulerRunResponse,
+    BatchScheduleSummaryResponse,
+    BatchStatus,
+    BatchStatusResponse,
+    BatchWorkerItemExecutionResponse,
+    BatchWorkerRunRequest,
+    BatchWorkerRunResponse,
+    PortfolioBatchCandidate,
+    RenderSupportabilitySummary,
+    ReportingEvidenceSurfaceSupportability,
+)
+from app.contracts.reporting_errors import (
+    REPORT_BATCH_ERROR_EXAMPLES,
+    REPORT_JOB_ERROR_EXAMPLES,
+)
+
+__all__ = [
+    "BATCH_CONTROL_RESPONSE_EXAMPLE",
+    "BATCH_CREATE_REQUEST_EXAMPLE",
+    "BATCH_HANDLE_RESPONSE_EXAMPLE",
+    "BATCH_RECOVERY_RESPONSE_EXAMPLE",
+    "BATCH_SCHEDULER_RUN_REQUEST_EXAMPLE",
+    "BATCH_SCHEDULER_RUN_RESPONSE_EXAMPLE",
+    "BATCH_SCHEDULE_LIST_RESPONSE_EXAMPLE",
+    "BATCH_STATUS_RESPONSE_EXAMPLE",
+    "BATCH_WORKER_RUN_REQUEST_EXAMPLE",
+    "BATCH_WORKER_RUN_RESPONSE_EXAMPLE",
+    "BatchControlResponse",
+    "BatchCreateRequest",
+    "BatchDispatchPolicy",
+    "BatchHandleResponse",
+    "BatchItemStatus",
+    "BatchItemStatusResponse",
+    "BatchRecoveryResponse",
+    "BatchRuntimeLoad",
+    "BatchScheduleListResponse",
+    "BatchScheduleSummaryResponse",
+    "BatchSchedulerMaterializationResponse",
+    "BatchSchedulerRunRequest",
+    "BatchSchedulerRunResponse",
+    "BatchStatus",
+    "BatchStatusResponse",
+    "BatchWorkerItemExecutionResponse",
+    "BatchWorkerRunRequest",
+    "BatchWorkerRunResponse",
+    "PortfolioBatchCandidate",
+    "REPORT_BATCH_ERROR_EXAMPLES",
+    "REPORT_JOB_ERROR_EXAMPLES",
+    "REPORT_JOB_LINEAGE_RESPONSE_EXAMPLE",
+    "REPORT_JOB_LIST_FILTERS_EXAMPLE",
+    "REPORT_JOB_LIST_RESPONSE_EXAMPLE",
+    "REPORT_JOB_SNAPSHOT_RESPONSE_EXAMPLE",
+    "REPORT_JOB_UPSTREAM_CALL_RESPONSE_EXAMPLE",
+    "RenderSupportabilitySummary",
+    "ReportInputSnapshotRecord",
+    "ReportJobErrorDetail",
+    "ReportJobErrorResponse",
+    "ReportJobHandleResponse",
+    "ReportJobListFilters",
+    "ReportJobListItem",
+    "ReportJobListResponse",
+    "ReportJobStatusEventsResponse",
+    "ReportJobStatusResponse",
+    "ReportSnapshotLineageResponse",
+    "ReportStatusEvent",
+    "ReportUpstreamCallRecord",
+    "ReportingEvidenceSurfaceSupportability",
+    "ReportingPortfolioRequest",
+    "ReportingReviewResponse",
+    "ReportingSnapshotResponse",
+    "ReportingSummaryResponse",
+    "SnapshotPosture",
+]
 
 REPORT_JOB_LIST_FILTERS_EXAMPLE: dict[str, Any] = {
     "tenantId": "tenant-sg",
@@ -98,58 +194,6 @@ REPORT_JOB_UPSTREAM_CALL_RESPONSE_EXAMPLE: dict[str, Any] = {
 REPORT_JOB_LINEAGE_RESPONSE_EXAMPLE: dict[str, Any] = {
     "snapshot": REPORT_JOB_SNAPSHOT_RESPONSE_EXAMPLE,
     "upstreamCalls": [REPORT_JOB_UPSTREAM_CALL_RESPONSE_EXAMPLE],
-}
-
-REPORT_JOB_ERROR_EXAMPLES: dict[str, dict[str, Any]] = {
-    "missing_idempotency_key": {
-        "detail": {
-            "code": "missing_idempotency_key",
-            "message": "Idempotency-Key is required.",
-        }
-    },
-    "missing_caller_context": {
-        "detail": {
-            "code": "missing_caller_context",
-            "message": "Required caller context headers are missing.",
-            "missing_headers": ["X-Actor-Id", "X-Tenant-Id", "X-Region"],
-        }
-    },
-    "report_job_not_found": {
-        "detail": {
-            "code": "report_job_not_found",
-            "message": "Report job was not found.",
-        }
-    },
-    "report_snapshot_not_found": {
-        "detail": {
-            "code": "report_snapshot_not_found",
-            "message": "Report snapshot was not found.",
-        }
-    },
-    "idempotency_conflict": {
-        "detail": {
-            "code": "idempotency_conflict",
-            "message": "Idempotency-Key was reused with a different report request.",
-        }
-    },
-    "report_job_cannot_be_cancelled": {
-        "detail": {
-            "code": "report_job_cannot_be_cancelled",
-            "message": "Report job can no longer be cancelled.",
-        }
-    },
-    "report_job_upstream_unavailable": {
-        "detail": {
-            "code": "report_job_upstream_unavailable",
-            "message": "Report job service is unavailable.",
-        }
-    },
-    "invalid_report_job_filters": {
-        "detail": {
-            "code": "invalid_report_job_filters",
-            "message": "At least one supported job-search filter is required.",
-        }
-    },
 }
 
 
@@ -1138,703 +1182,3 @@ class ReportSnapshotLineageResponse(BaseModel):
     )
 
     model_config = {"populate_by_name": True}
-
-
-BatchStatus = Literal[
-    "materialized",
-    "running",
-    "paused",
-    "cancelled",
-    "completed",
-    "completed_with_failures",
-    "failed",
-]
-BatchItemStatus = Literal[
-    "materialized",
-    "leased",
-    "waiting_on_report_job",
-    "succeeded",
-    "failed_retryable",
-    "failed_terminal",
-    "cancelled",
-    "recovery_pending",
-]
-
-BATCH_CREATE_REQUEST_EXAMPLE: dict[str, Any] = {
-    "selector_mode": "explicit_portfolio_list",
-    "portfolio_ids": ["PB_SG_GLOBAL_BAL_001"],
-    "source_candidates": [
-        {
-            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-            "tenant_id": "tenant-sg",
-            "region": "APAC",
-            "active": True,
-            "selected": True,
-            "source_system": "lotus-core",
-            "source_object": "PortfolioScope",
-        }
-    ],
-    "as_of_date": "2026-04-22",
-    "requested_output_formats": ["pdf"],
-    "reporting_currency": "USD",
-    "options": {"sections": ["OVERVIEW", "PERFORMANCE"]},
-    "max_batch_size": 250,
-}
-
-BATCH_HANDLE_RESPONSE_EXAMPLE: dict[str, Any] = {
-    "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
-    "status": "materialized",
-    "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
-    "idempotency_key": "batch-portfolio-review-2026-04-22",
-    "item_count": 1,
-    "supportability": {
-        "feature_key": "report.observability.evidence_surface_supportability",
-        "state": "ready",
-        "reason": "evidence_surface_ready",
-        "freshness_bucket": "current",
-        "evidence_feature_count": 14,
-        "ready_evidence_feature_count": 14,
-        "degraded_evidence_feature_count": 0,
-        "workflow_count": 4,
-        "ready_workflow_count": 4,
-    },
-}
-
-BATCH_STATUS_RESPONSE_EXAMPLE: dict[str, Any] = {
-    **BATCH_HANDLE_RESPONSE_EXAMPLE,
-    "selector_mode": "explicit_portfolio_list",
-    "tenant_id": "tenant-sg",
-    "region": "APAC",
-    "materialized_portfolio_ids": ["PB_SG_GLOBAL_BAL_001"],
-    "as_of_date": "2026-04-22",
-    "requested_output_formats": ["pdf"],
-    "reporting_currency": "USD",
-    "status_counts": {"materialized": 1},
-    "items": [
-        {
-            "batch_item_id": "rbci_1a3b5c7d9e0f4a12a45f7a8d00bd129c",
-            "item_position": 1,
-            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-            "status": "materialized",
-            "report_job_id": None,
-            "attempt_count": 0,
-            "retry_eligible": False,
-            "next_retry_at": None,
-            "last_error_category": None,
-            "last_error_summary": None,
-            "created_at": "2026-04-22T09:00:00Z",
-            "started_at": None,
-            "completed_at": None,
-            "cancelled_at": None,
-        }
-    ],
-    "created_at": "2026-04-22T09:00:00Z",
-    "updated_at": "2026-04-22T09:00:00Z",
-    "started_at": None,
-    "completed_at": None,
-    "cancelled_at": None,
-    "failed_at": None,
-    "correlation_id": "corr-batch-1",
-    "trace_id": "trace-batch-1",
-}
-
-BATCH_CONTROL_RESPONSE_EXAMPLE: dict[str, Any] = {
-    "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
-    "status": "paused",
-    "affected_count": 1,
-    "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
-}
-
-BATCH_RECOVERY_RESPONSE_EXAMPLE: dict[str, Any] = {
-    "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
-    "status": "running",
-    "recovered_count": 1,
-    "recovery_pending_item_ids": ["rbci_1a3b5c7d9e0f4a12a45f7a8d00bd129c"],
-    "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
-}
-
-BATCH_WORKER_RUN_REQUEST_EXAMPLE: dict[str, Any] = {
-    "worker_id": "lotus-report-batch-worker-1",
-    "recover_expired_leases": True,
-    "dispatch_policy": {
-        "max_active_batches": 1,
-        "max_active_items": 5,
-        "max_active_upstream_jobs": 3,
-        "max_active_render_jobs": 2,
-        "max_active_archive_jobs": 2,
-        "lease_seconds": 300,
-    },
-    "runtime_load": {
-        "active_batches": 0,
-        "active_items": 0,
-        "active_upstream_jobs": 0,
-        "active_render_jobs": 0,
-        "active_archive_jobs": 0,
-    },
-}
-
-BATCH_WORKER_RUN_RESPONSE_EXAMPLE: dict[str, Any] = {
-    "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
-    "status": "completed",
-    "batch_status_before": "materialized",
-    "batch_status_after": "completed",
-    "recovered_count": 0,
-    "leased_count": 1,
-    "dispatched_count": 1,
-    "executed_count": 1,
-    "report_job_ids": ["rjob_83ca965c50334c40a17d2b8cc94873a5"],
-    "back_pressure_reasons": [],
-    "skipped_reason": None,
-    "execution_results": [
-        {
-            "batch_item_id": "rbci_1a3b5c7d9e0f4a12a45f7a8d00bd129c",
-            "report_job_id": "rjob_83ca965c50334c40a17d2b8cc94873a5",
-            "item_status": "succeeded",
-            "report_job_status": "archived",
-            "failure_category": None,
-            "retry_eligible": False,
-        }
-    ],
-    "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
-    "supportability": BATCH_HANDLE_RESPONSE_EXAMPLE["supportability"],
-}
-
-BATCH_SCHEDULE_LIST_RESPONSE_EXAMPLE: dict[str, Any] = {
-    "scheduler_id": "lotus-report-batch-scheduler-1",
-    "interval_seconds": 60.0,
-    "tenant_id": "tenant-sg",
-    "region": "APAC",
-    "booking_center_code": "SG",
-    "schedule_count": 1,
-    "enabled_schedule_count": 1,
-    "schedules": [
-        {
-            "schedule_id": "monthly-sg-global-bal",
-            "enabled": True,
-            "selector_mode": "explicit_portfolio_list",
-            "frequency": "monthly",
-            "as_of_date": "2026-04-22",
-            "portfolio_count": 1,
-            "manifest_entry_count": 0,
-            "requested_output_formats": ["pdf"],
-            "reporting_currency": "USD",
-            "max_batch_size": 250,
-            "template_id": "portfolio-review",
-            "template_version": "v1",
-            "render_package_version": "portfolio-review.v1",
-            "manifest_source": None,
-            "manifest_version": None,
-            "manifest_hash": None,
-            "option_keys": ["sections"],
-        }
-    ],
-}
-
-BATCH_SCHEDULER_RUN_REQUEST_EXAMPLE: dict[str, Any] = {"pass_sequence": 1}
-
-BATCH_SCHEDULER_RUN_RESPONSE_EXAMPLE: dict[str, Any] = {
-    "scheduler_id": "lotus-report-batch-scheduler-1",
-    "attempted_count": 1,
-    "materialized_count": 1,
-    "skipped_schedule_ids": [],
-    "materialized": [
-        {
-            "schedule_id": "monthly-sg-global-bal",
-            "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
-            "idempotency_key": "scheduled-batch-2f6d1a8f2ef24f019e7d7f37507f352c",
-            "item_count": 1,
-            "status": "materialized",
-        }
-    ],
-    "correlation_id": "corr-batch-scheduler-1-abc123def456",
-    "trace_id": "trace1234567890abcdef1234567890ab",
-}
-
-REPORT_BATCH_ERROR_EXAMPLES: dict[str, dict[str, Any]] = {
-    "missing_idempotency_key": REPORT_JOB_ERROR_EXAMPLES["missing_idempotency_key"],
-    "missing_caller_context": REPORT_JOB_ERROR_EXAMPLES["missing_caller_context"],
-    "idempotency_conflict": {
-        "detail": {
-            "code": "idempotency_conflict",
-            "message": "Idempotency-Key was reused with a different batch request.",
-        }
-    },
-    "invalid_batch_selector": {
-        "detail": {
-            "code": "invalid_batch_selector",
-            "message": "Batch selector could not be materialized from eligible portfolios.",
-        }
-    },
-    "report_batch_not_found": {
-        "detail": {
-            "code": "report_batch_not_found",
-            "message": "Report batch was not found.",
-        }
-    },
-    "batch_worker_run_failed": {
-        "detail": {
-            "code": "batch_worker_run_failed",
-            "message": "Report batch run could not be completed.",
-        }
-    },
-    "batch_scheduler_run_failed": {
-        "detail": {
-            "code": "batch_scheduler_run_failed",
-            "message": "Report batch scheduler pass could not be completed.",
-        }
-    },
-    "report_batch_upstream_unavailable": {
-        "detail": {
-            "code": "report_batch_upstream_unavailable",
-            "message": "Report batch service is unavailable.",
-        }
-    },
-}
-
-
-class PortfolioBatchCandidate(BaseModel):
-    portfolio_id: str = Field(
-        ...,
-        description="Portfolio identifier from lotus-core portfolio scope.",
-        examples=["PB_SG_GLOBAL_BAL_001"],
-    )
-    tenant_id: str = Field(
-        ..., description="Tenant that owns the portfolio.", examples=["tenant-sg"]
-    )
-    region: str = Field(..., description="Region that owns the portfolio.", examples=["APAC"])
-    active: bool = Field(..., description="Whether the portfolio is active.", examples=[True])
-    selected: bool = Field(
-        False,
-        description="Whether selected-subset materialization includes this portfolio.",
-        examples=[True],
-    )
-    source_system: str = Field(
-        "lotus-core",
-        description="Authoritative source system for the portfolio candidate.",
-        examples=["lotus-core"],
-    )
-    source_object: str = Field(
-        "PortfolioScope",
-        description="Authoritative source object or API contract for the candidate.",
-        examples=["PortfolioScope"],
-    )
-
-
-class BatchCreateRequest(BaseModel):
-    selector_mode: str = Field(
-        ...,
-        description="Portfolio selector mode used to materialize batch items.",
-        examples=["explicit_portfolio_list"],
-    )
-    portfolio_ids: list[str] = Field(
-        default_factory=list,
-        description="Requested portfolio identifiers for explicit-list selection.",
-        examples=[["PB_SG_GLOBAL_BAL_001"]],
-    )
-    source_candidates: list[PortfolioBatchCandidate] = Field(
-        default_factory=list,
-        description="Portfolio candidates resolved from lotus-core before materialization.",
-    )
-    as_of_date: date = Field(
-        ...,
-        description="Business as-of date for all materialized batch items.",
-        examples=["2026-04-22"],
-    )
-    requested_output_formats: list[str] = Field(
-        default_factory=lambda: ["pdf"],
-        description="Requested output formats for each report job.",
-        examples=[["pdf"]],
-    )
-    reporting_currency: str | None = Field(
-        default=None,
-        description="Reporting currency passed into each report job.",
-        examples=["USD"],
-    )
-    options: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Report options that affect every materialized batch item.",
-        examples=[{"sections": ["OVERVIEW", "PERFORMANCE"]}],
-    )
-    max_batch_size: int = Field(
-        250,
-        ge=1,
-        le=1000,
-        description="Maximum number of materialized items allowed for this request.",
-        examples=[250],
-    )
-
-
-class ReportingEvidenceSurfaceSupportability(BaseModel):
-    feature_key: str = Field(
-        "report.observability.evidence_surface_supportability",
-        description="RFC-0108 feature key for lotus-report evidence-surface supportability.",
-    )
-    state: str = Field(
-        ...,
-        description="Bounded supportability state published by lotus-report.",
-        examples=["ready"],
-    )
-    reason: str = Field(
-        ...,
-        description="Bounded reason code explaining the evidence-surface posture.",
-        examples=["evidence_surface_ready"],
-    )
-    freshness_bucket: str = Field(
-        ...,
-        description="Bounded freshness bucket for evidence-surface supportability.",
-        examples=["current"],
-    )
-    evidence_feature_count: int = Field(
-        0,
-        ge=0,
-        description="Number of evidence-surface feature keys reviewed by lotus-report.",
-    )
-    ready_evidence_feature_count: int = Field(
-        0,
-        ge=0,
-        description="Number of evidence-surface feature keys currently ready.",
-    )
-    degraded_evidence_feature_count: int = Field(
-        0,
-        ge=0,
-        description="Number of evidence-surface feature keys currently degraded.",
-    )
-    workflow_count: int = Field(
-        0,
-        ge=0,
-        description="Number of report workflows included in the supportability posture.",
-    )
-    ready_workflow_count: int = Field(
-        0,
-        ge=0,
-        description="Number of report workflows currently ready.",
-    )
-
-
-class RenderSupportabilitySummary(BaseModel):
-    feature_key: str = Field(
-        "render.observability.render_supportability",
-        description="RFC-0108 feature key for lotus-render supportability posture.",
-    )
-    state: str = Field(
-        ...,
-        description="Bounded render supportability state published by lotus-render.",
-        examples=["ready"],
-    )
-    reason: str = Field(
-        ...,
-        description="Bounded reason code explaining render supportability posture.",
-        examples=["render_supportability_ready"],
-    )
-    freshness_bucket: str = Field(
-        ...,
-        description="Bounded freshness bucket for render supportability.",
-        examples=["current"],
-    )
-    deterministic_output_supported: bool = Field(
-        False,
-        description="Whether deterministic render proof is supported by the source service.",
-    )
-    render_store_ready: bool = Field(
-        False,
-        description="Whether the source render store is ready.",
-    )
-    template_registry_ready: bool = Field(
-        False,
-        description="Whether the source template registry is ready.",
-    )
-    default_output_format: str | None = Field(
-        default=None,
-        description="Default output format reported by lotus-render.",
-        examples=["pdf"],
-    )
-    supported_output_formats: list[str] = Field(
-        default_factory=list,
-        description="Output formats reported as supported by lotus-render.",
-        examples=[["pdf"]],
-    )
-
-
-class BatchHandleResponse(BaseModel):
-    batch_id: str = Field(..., description="Opaque durable batch identifier.")
-    status: BatchStatus = Field(..., description="Current product-safe batch status.")
-    status_url: str = Field(
-        ...,
-        description="Gateway-relative URL for product-safe batch status retrieval.",
-    )
-    idempotency_key: str = Field(
-        ...,
-        description="Caller-supplied idempotency key associated with this batch request.",
-    )
-    item_count: int = Field(..., ge=0, description="Number of materialized portfolio items.")
-    supportability: ReportingEvidenceSurfaceSupportability | None = Field(
-        default=None,
-        description=(
-            "lotus-report evidence-surface supportability posture captured from "
-            "GET /integration/capabilities for Workbench reporting operator reads."
-        ),
-    )
-    render_supportability: RenderSupportabilitySummary | None = Field(
-        default=None,
-        description=(
-            "lotus-render supportability posture captured from GET /metadata for "
-            "Workbench reporting operator reads."
-        ),
-    )
-
-
-class BatchItemStatusResponse(BaseModel):
-    batch_item_id: str = Field(..., description="Opaque durable batch item identifier.")
-    item_position: int = Field(..., ge=1, description="Deterministic item ordering.")
-    portfolio_id: str = Field(..., description="Portfolio represented by this batch item.")
-    status: BatchItemStatus = Field(..., description="Current product-safe item status.")
-    report_job_id: str | None = Field(
-        default=None,
-        description="Linked report job identifier after dispatch.",
-    )
-    attempt_count: int = Field(0, ge=0, description="Number of recorded attempts.")
-    retry_eligible: bool = Field(False, description="Whether bounded retry is currently allowed.")
-    next_retry_at: datetime | None = Field(default=None, description="Earliest retry timestamp.")
-    last_error_category: str | None = Field(
-        default=None,
-        description="Support-safe failure category for the latest item failure.",
-    )
-    last_error_summary: str | None = Field(
-        default=None,
-        description="Support-safe summary for the latest item failure.",
-    )
-    created_at: datetime = Field(..., description="UTC timestamp when the item was materialized.")
-    started_at: datetime | None = Field(default=None, description="UTC item start timestamp.")
-    completed_at: datetime | None = Field(
-        default=None, description="UTC item completion timestamp."
-    )
-    cancelled_at: datetime | None = Field(
-        default=None, description="UTC item cancellation timestamp."
-    )
-
-
-class BatchStatusResponse(BaseModel):
-    batch_id: str = Field(..., description="Opaque durable batch identifier.")
-    selector_mode: str = Field(..., description="Portfolio selector mode used.")
-    tenant_id: str = Field(..., description="Tenant ownership boundary for the batch.")
-    region: str = Field(..., description="Regional ownership boundary for the batch.")
-    materialized_portfolio_ids: list[str] = Field(
-        ...,
-        description="Portfolio identifiers materialized into durable batch items.",
-    )
-    as_of_date: date = Field(..., description="Business as-of date applied to all items.")
-    requested_output_formats: list[str] = Field(..., description="Requested output formats.")
-    reporting_currency: str | None = Field(
-        default=None, description="Requested reporting currency."
-    )
-    status: BatchStatus = Field(..., description="Current product-safe batch status.")
-    item_count: int = Field(..., ge=0, description="Number of materialized items.")
-    status_counts: dict[str, int] = Field(..., description="Counts by current item status.")
-    items: list[BatchItemStatusResponse] = Field(..., description="Ordered item status details.")
-    created_at: datetime = Field(..., description="UTC timestamp when the batch was materialized.")
-    updated_at: datetime | None = Field(default=None, description="UTC latest update timestamp.")
-    started_at: datetime | None = Field(default=None, description="UTC batch start timestamp.")
-    completed_at: datetime | None = Field(
-        default=None, description="UTC batch completion timestamp."
-    )
-    cancelled_at: datetime | None = Field(
-        default=None, description="UTC batch cancellation timestamp."
-    )
-    failed_at: datetime | None = Field(default=None, description="UTC batch failure timestamp.")
-    correlation_id: str = Field(..., description="Correlation identifier captured at creation.")
-    trace_id: str = Field(..., description="Distributed trace identifier captured at creation.")
-    supportability: ReportingEvidenceSurfaceSupportability | None = Field(
-        default=None,
-        description=(
-            "lotus-report evidence-surface supportability posture captured from "
-            "GET /integration/capabilities for Workbench reporting operator reads."
-        ),
-    )
-    render_supportability: RenderSupportabilitySummary | None = Field(
-        default=None,
-        description=(
-            "lotus-render supportability posture captured from GET /metadata for "
-            "Workbench reporting operator reads."
-        ),
-    )
-
-
-class BatchControlResponse(BaseModel):
-    batch_id: str = Field(..., description="Opaque durable batch identifier.")
-    status: BatchStatus = Field(..., description="Batch status after the control operation.")
-    affected_count: int = Field(..., ge=0, description="Number of affected records.")
-    status_url: str = Field(..., description="Gateway-relative URL for batch status retrieval.")
-
-
-class BatchRecoveryResponse(BaseModel):
-    batch_id: str = Field(..., description="Opaque durable batch identifier.")
-    status: BatchStatus = Field(..., description="Batch status after expired-lease recovery.")
-    recovered_count: int = Field(..., ge=0, description="Number of recovered expired leases.")
-    recovery_pending_item_ids: list[str] = Field(
-        default_factory=list,
-        description="Batch items moved to recovery-pending posture.",
-    )
-    status_url: str = Field(..., description="Gateway-relative URL for batch status retrieval.")
-
-
-class BatchRuntimeLoad(BaseModel):
-    active_batches: int = Field(0, ge=0, description="Currently active durable batches.")
-    active_items: int = Field(0, ge=0, description="Currently active batch items.")
-    active_upstream_jobs: int = Field(0, ge=0, description="Active upstream data jobs.")
-    active_render_jobs: int = Field(0, ge=0, description="Active render jobs.")
-    active_archive_jobs: int = Field(0, ge=0, description="Active archive jobs.")
-
-
-class BatchDispatchPolicy(BaseModel):
-    max_active_batches: int = Field(1, ge=1, description="Maximum active batches allowed.")
-    max_active_items: int = Field(5, ge=1, description="Maximum items leased by one run.")
-    max_active_upstream_jobs: int = Field(3, ge=1, description="Upstream work limit.")
-    max_active_render_jobs: int = Field(2, ge=1, description="Render work limit.")
-    max_active_archive_jobs: int = Field(2, ge=1, description="Archive work limit.")
-    lease_seconds: int = Field(300, ge=1, description="Lease duration for item dispatch.")
-
-
-class BatchWorkerRunRequest(BaseModel):
-    worker_id: str = Field(
-        ...,
-        min_length=1,
-        description="Stable operator or service worker identifier recorded on leased items.",
-        examples=["lotus-report-batch-worker-1"],
-    )
-    recover_expired_leases: bool = Field(
-        True,
-        description="Whether expired unjobbed item leases are recovered before dispatch.",
-    )
-    runtime_load: BatchRuntimeLoad | None = Field(
-        default=None,
-        description="Optional caller-supplied work snapshot for back-pressure decisions.",
-    )
-    dispatch_policy: BatchDispatchPolicy | None = Field(
-        default=None,
-        description="Optional explicit dispatch policy for this bounded operator run.",
-    )
-
-
-class BatchWorkerItemExecutionResponse(BaseModel):
-    batch_item_id: str = Field(..., description="Batch item advanced by this run.")
-    report_job_id: str = Field(..., description="Report job linked to the batch item.")
-    item_status: BatchItemStatus = Field(..., description="Batch item status after execution.")
-    report_job_status: str = Field(..., description="Report job status observed after execution.")
-    failure_category: str | None = Field(default=None, description="Product-safe failure category.")
-    retry_eligible: bool = Field(False, description="Whether bounded retry remains available.")
-
-
-class BatchWorkerRunResponse(BaseModel):
-    batch_id: str = Field(..., description="Opaque durable batch identifier processed.")
-    status: BatchStatus = Field(..., description="Batch status after the bounded run.")
-    batch_status_before: BatchStatus = Field(..., description="Batch status before the run.")
-    batch_status_after: BatchStatus = Field(..., description="Batch status after the run.")
-    recovered_count: int = Field(..., ge=0, description="Expired leases recovered before dispatch.")
-    leased_count: int = Field(..., ge=0, description="Eligible items leased during dispatch.")
-    dispatched_count: int = Field(..., ge=0, description="Report jobs created or reused.")
-    executed_count: int = Field(..., ge=0, description="Waiting items advanced through execution.")
-    report_job_ids: list[str] = Field(
-        default_factory=list,
-        description="Report job identifiers linked during this bounded run.",
-    )
-    back_pressure_reasons: list[str] = Field(
-        default_factory=list,
-        description="Product-safe reasons dispatch was skipped or limited.",
-    )
-    skipped_reason: str | None = Field(default=None, description="Reason the batch was not run.")
-    execution_results: list[BatchWorkerItemExecutionResponse] = Field(
-        default_factory=list,
-        description="Per-item execution outcomes.",
-    )
-    status_url: str = Field(..., description="Gateway-relative URL for batch status retrieval.")
-    supportability: ReportingEvidenceSurfaceSupportability | None = Field(
-        default=None,
-        description=(
-            "lotus-report evidence-surface supportability posture captured from "
-            "GET /integration/capabilities for Workbench reporting operator reads."
-        ),
-    )
-    render_supportability: RenderSupportabilitySummary | None = Field(
-        default=None,
-        description=(
-            "lotus-render supportability posture captured from GET /metadata for "
-            "Workbench reporting operator reads."
-        ),
-    )
-
-
-class BatchScheduleSummaryResponse(BaseModel):
-    schedule_id: str = Field(..., description="Governed schedule identifier.")
-    enabled: bool = Field(..., description="Whether the configured schedule is enabled.")
-    selector_mode: str = Field(..., description="Configured selector mode.")
-    frequency: str = Field(..., description="Configured production cycle frequency.")
-    as_of_date: date = Field(..., description="Business as-of date used by this schedule.")
-    portfolio_count: int = Field(..., ge=0, description="Configured explicit portfolio count.")
-    manifest_entry_count: int = Field(
-        ..., ge=0, description="Configured inline manifest entry count."
-    )
-    requested_output_formats: list[str] = Field(
-        ..., description="Requested output formats for materialized batch items."
-    )
-    reporting_currency: str | None = Field(default=None, description="Reporting currency.")
-    max_batch_size: int = Field(..., ge=1, description="Maximum materialized item count.")
-    template_id: str = Field(..., description="Report template identifier.")
-    template_version: str = Field(..., description="Report template version.")
-    render_package_version: str = Field(..., description="Render package contract version.")
-    manifest_source: str | None = Field(default=None, description="Inline manifest source.")
-    manifest_version: str | None = Field(default=None, description="Inline manifest version.")
-    manifest_hash: str | None = Field(default=None, description="Stable inline manifest hash.")
-    option_keys: list[str] = Field(
-        default_factory=list,
-        description="Sorted configured option keys without exposing option values.",
-    )
-
-
-class BatchScheduleListResponse(BaseModel):
-    scheduler_id: str = Field(..., description="Stable scheduler identity.")
-    interval_seconds: float = Field(..., ge=0, description="Configured scheduler interval.")
-    tenant_id: str = Field(..., description="Tenant context used by configured schedules.")
-    region: str = Field(..., description="Region context used by configured schedules.")
-    booking_center_code: str | None = Field(
-        default=None, description="Optional booking-center context."
-    )
-    schedule_count: int = Field(..., ge=0, description="Total configured schedule count.")
-    enabled_schedule_count: int = Field(..., ge=0, description="Enabled configured schedule count.")
-    schedules: list[BatchScheduleSummaryResponse] = Field(
-        ..., description="Configured report batch schedules."
-    )
-
-
-class BatchSchedulerRunRequest(BaseModel):
-    pass_sequence: int = Field(
-        1,
-        ge=1,
-        description="Deterministic scheduler pass sequence for correlation and idempotency proof.",
-        examples=[1],
-    )
-
-
-class BatchSchedulerMaterializationResponse(BaseModel):
-    schedule_id: str = Field(..., description="Schedule that produced or reused this batch.")
-    batch_id: str = Field(..., description="Durable report batch identifier.")
-    idempotency_key: str = Field(..., description="Deterministic scheduled idempotency key.")
-    item_count: int = Field(..., ge=0, description="Materialized batch item count.")
-    status: str = Field(..., description="Batch status after materialization or reuse.")
-
-
-class BatchSchedulerRunResponse(BaseModel):
-    scheduler_id: str = Field(..., description="Stable scheduler identity.")
-    attempted_count: int = Field(..., ge=0, description="Enabled schedule count attempted.")
-    materialized_count: int = Field(
-        ..., ge=0, description="Batches materialized or idempotently reused."
-    )
-    skipped_schedule_ids: list[str] = Field(
-        default_factory=list,
-        description="Enabled schedule ids skipped because no eligible candidates were resolved.",
-    )
-    materialized: list[BatchSchedulerMaterializationResponse] = Field(
-        default_factory=list,
-        description="Durable batch materialization results.",
-    )
-    correlation_id: str = Field(..., description="Scheduler correlation id used for this pass.")
-    trace_id: str = Field(..., description="Scheduler trace id used for this pass.")

--- a/src/app/contracts/reporting_batches.py
+++ b/src/app/contracts/reporting_batches.py
@@ -1,0 +1,662 @@
+from datetime import date, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+BatchStatus = Literal[
+    "materialized",
+    "running",
+    "paused",
+    "cancelled",
+    "completed",
+    "completed_with_failures",
+    "failed",
+]
+BatchItemStatus = Literal[
+    "materialized",
+    "leased",
+    "waiting_on_report_job",
+    "succeeded",
+    "failed_retryable",
+    "failed_terminal",
+    "cancelled",
+    "recovery_pending",
+]
+
+BATCH_CREATE_REQUEST_EXAMPLE: dict[str, Any] = {
+    "selector_mode": "explicit_portfolio_list",
+    "portfolio_ids": ["PB_SG_GLOBAL_BAL_001"],
+    "source_candidates": [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "tenant_id": "tenant-sg",
+            "region": "APAC",
+            "active": True,
+            "selected": True,
+            "source_system": "lotus-core",
+            "source_object": "PortfolioScope",
+        }
+    ],
+    "as_of_date": "2026-04-22",
+    "requested_output_formats": ["pdf"],
+    "reporting_currency": "USD",
+    "options": {"sections": ["OVERVIEW", "PERFORMANCE"]},
+    "max_batch_size": 250,
+}
+
+BATCH_HANDLE_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+    "status": "materialized",
+    "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+    "idempotency_key": "batch-portfolio-review-2026-04-22",
+    "item_count": 1,
+    "supportability": {
+        "feature_key": "report.observability.evidence_surface_supportability",
+        "state": "ready",
+        "reason": "evidence_surface_ready",
+        "freshness_bucket": "current",
+        "evidence_feature_count": 14,
+        "ready_evidence_feature_count": 14,
+        "degraded_evidence_feature_count": 0,
+        "workflow_count": 4,
+        "ready_workflow_count": 4,
+    },
+}
+
+BATCH_STATUS_RESPONSE_EXAMPLE: dict[str, Any] = {
+    **BATCH_HANDLE_RESPONSE_EXAMPLE,
+    "selector_mode": "explicit_portfolio_list",
+    "tenant_id": "tenant-sg",
+    "region": "APAC",
+    "materialized_portfolio_ids": ["PB_SG_GLOBAL_BAL_001"],
+    "as_of_date": "2026-04-22",
+    "requested_output_formats": ["pdf"],
+    "reporting_currency": "USD",
+    "status_counts": {"materialized": 1},
+    "items": [
+        {
+            "batch_item_id": "rbci_1a3b5c7d9e0f4a12a45f7a8d00bd129c",
+            "item_position": 1,
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "status": "materialized",
+            "report_job_id": None,
+            "attempt_count": 0,
+            "retry_eligible": False,
+            "next_retry_at": None,
+            "last_error_category": None,
+            "last_error_summary": None,
+            "created_at": "2026-04-22T09:00:00Z",
+            "started_at": None,
+            "completed_at": None,
+            "cancelled_at": None,
+        }
+    ],
+    "created_at": "2026-04-22T09:00:00Z",
+    "updated_at": "2026-04-22T09:00:00Z",
+    "started_at": None,
+    "completed_at": None,
+    "cancelled_at": None,
+    "failed_at": None,
+    "correlation_id": "corr-batch-1",
+    "trace_id": "trace-batch-1",
+}
+
+BATCH_CONTROL_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+    "status": "paused",
+    "affected_count": 1,
+    "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+}
+
+BATCH_RECOVERY_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+    "status": "running",
+    "recovered_count": 1,
+    "recovery_pending_item_ids": ["rbci_1a3b5c7d9e0f4a12a45f7a8d00bd129c"],
+    "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+}
+
+BATCH_WORKER_RUN_REQUEST_EXAMPLE: dict[str, Any] = {
+    "worker_id": "lotus-report-batch-worker-1",
+    "recover_expired_leases": True,
+    "dispatch_policy": {
+        "max_active_batches": 1,
+        "max_active_items": 5,
+        "max_active_upstream_jobs": 3,
+        "max_active_render_jobs": 2,
+        "max_active_archive_jobs": 2,
+        "lease_seconds": 300,
+    },
+    "runtime_load": {
+        "active_batches": 0,
+        "active_items": 0,
+        "active_upstream_jobs": 0,
+        "active_render_jobs": 0,
+        "active_archive_jobs": 0,
+    },
+}
+
+BATCH_WORKER_RUN_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+    "status": "completed",
+    "batch_status_before": "materialized",
+    "batch_status_after": "completed",
+    "recovered_count": 0,
+    "leased_count": 1,
+    "dispatched_count": 1,
+    "executed_count": 1,
+    "report_job_ids": ["rjob_83ca965c50334c40a17d2b8cc94873a5"],
+    "back_pressure_reasons": [],
+    "skipped_reason": None,
+    "execution_results": [
+        {
+            "batch_item_id": "rbci_1a3b5c7d9e0f4a12a45f7a8d00bd129c",
+            "report_job_id": "rjob_83ca965c50334c40a17d2b8cc94873a5",
+            "item_status": "succeeded",
+            "report_job_status": "archived",
+            "failure_category": None,
+            "retry_eligible": False,
+        }
+    ],
+    "status_url": "/api/v1/report-batches/rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+    "supportability": BATCH_HANDLE_RESPONSE_EXAMPLE["supportability"],
+}
+
+BATCH_SCHEDULE_LIST_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "scheduler_id": "lotus-report-batch-scheduler-1",
+    "interval_seconds": 60.0,
+    "tenant_id": "tenant-sg",
+    "region": "APAC",
+    "booking_center_code": "SG",
+    "schedule_count": 1,
+    "enabled_schedule_count": 1,
+    "schedules": [
+        {
+            "schedule_id": "monthly-sg-global-bal",
+            "enabled": True,
+            "selector_mode": "explicit_portfolio_list",
+            "frequency": "monthly",
+            "as_of_date": "2026-04-22",
+            "portfolio_count": 1,
+            "manifest_entry_count": 0,
+            "requested_output_formats": ["pdf"],
+            "reporting_currency": "USD",
+            "max_batch_size": 250,
+            "template_id": "portfolio-review",
+            "template_version": "v1",
+            "render_package_version": "portfolio-review.v1",
+            "manifest_source": None,
+            "manifest_version": None,
+            "manifest_hash": None,
+            "option_keys": ["sections"],
+        }
+    ],
+}
+
+BATCH_SCHEDULER_RUN_REQUEST_EXAMPLE: dict[str, Any] = {"pass_sequence": 1}
+
+BATCH_SCHEDULER_RUN_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "scheduler_id": "lotus-report-batch-scheduler-1",
+    "attempted_count": 1,
+    "materialized_count": 1,
+    "skipped_schedule_ids": [],
+    "materialized": [
+        {
+            "schedule_id": "monthly-sg-global-bal",
+            "batch_id": "rbch_2f6d1a8f2ef24f019e7d7f37507f352c",
+            "idempotency_key": "scheduled-batch-2f6d1a8f2ef24f019e7d7f37507f352c",
+            "item_count": 1,
+            "status": "materialized",
+        }
+    ],
+    "correlation_id": "corr-batch-scheduler-1-abc123def456",
+    "trace_id": "trace1234567890abcdef1234567890ab",
+}
+
+
+class PortfolioBatchCandidate(BaseModel):
+    portfolio_id: str = Field(
+        ...,
+        description="Portfolio identifier from lotus-core portfolio scope.",
+        examples=["PB_SG_GLOBAL_BAL_001"],
+    )
+    tenant_id: str = Field(
+        ..., description="Tenant that owns the portfolio.", examples=["tenant-sg"]
+    )
+    region: str = Field(..., description="Region that owns the portfolio.", examples=["APAC"])
+    active: bool = Field(..., description="Whether the portfolio is active.", examples=[True])
+    selected: bool = Field(
+        False,
+        description="Whether selected-subset materialization includes this portfolio.",
+        examples=[True],
+    )
+    source_system: str = Field(
+        "lotus-core",
+        description="Authoritative source system for the portfolio candidate.",
+        examples=["lotus-core"],
+    )
+    source_object: str = Field(
+        "PortfolioScope",
+        description="Authoritative source object or API contract for the candidate.",
+        examples=["PortfolioScope"],
+    )
+
+
+class BatchCreateRequest(BaseModel):
+    selector_mode: str = Field(
+        ...,
+        description="Portfolio selector mode used to materialize batch items.",
+        examples=["explicit_portfolio_list"],
+    )
+    portfolio_ids: list[str] = Field(
+        default_factory=list,
+        description="Requested portfolio identifiers for explicit-list selection.",
+        examples=[["PB_SG_GLOBAL_BAL_001"]],
+    )
+    source_candidates: list[PortfolioBatchCandidate] = Field(
+        default_factory=list,
+        description="Portfolio candidates resolved from lotus-core before materialization.",
+    )
+    as_of_date: date = Field(
+        ...,
+        description="Business as-of date for all materialized batch items.",
+        examples=["2026-04-22"],
+    )
+    requested_output_formats: list[str] = Field(
+        default_factory=lambda: ["pdf"],
+        description="Requested output formats for each report job.",
+        examples=[["pdf"]],
+    )
+    reporting_currency: str | None = Field(
+        default=None,
+        description="Reporting currency passed into each report job.",
+        examples=["USD"],
+    )
+    options: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Report options that affect every materialized batch item.",
+        examples=[{"sections": ["OVERVIEW", "PERFORMANCE"]}],
+    )
+    max_batch_size: int = Field(
+        250,
+        ge=1,
+        le=1000,
+        description="Maximum number of materialized items allowed for this request.",
+        examples=[250],
+    )
+
+
+class ReportingEvidenceSurfaceSupportability(BaseModel):
+    feature_key: str = Field(
+        "report.observability.evidence_surface_supportability",
+        description="RFC-0108 feature key for lotus-report evidence-surface supportability.",
+    )
+    state: str = Field(
+        ...,
+        description="Bounded supportability state published by lotus-report.",
+        examples=["ready"],
+    )
+    reason: str = Field(
+        ...,
+        description="Bounded reason code explaining the evidence-surface posture.",
+        examples=["evidence_surface_ready"],
+    )
+    freshness_bucket: str = Field(
+        ...,
+        description="Bounded freshness bucket for evidence-surface supportability.",
+        examples=["current"],
+    )
+    evidence_feature_count: int = Field(
+        0,
+        ge=0,
+        description="Number of evidence-surface feature keys reviewed by lotus-report.",
+    )
+    ready_evidence_feature_count: int = Field(
+        0,
+        ge=0,
+        description="Number of evidence-surface feature keys currently ready.",
+    )
+    degraded_evidence_feature_count: int = Field(
+        0,
+        ge=0,
+        description="Number of evidence-surface feature keys currently degraded.",
+    )
+    workflow_count: int = Field(
+        0,
+        ge=0,
+        description="Number of report workflows included in the supportability posture.",
+    )
+    ready_workflow_count: int = Field(
+        0,
+        ge=0,
+        description="Number of report workflows currently ready.",
+    )
+
+
+class RenderSupportabilitySummary(BaseModel):
+    feature_key: str = Field(
+        "render.observability.render_supportability",
+        description="RFC-0108 feature key for lotus-render supportability posture.",
+    )
+    state: str = Field(
+        ...,
+        description="Bounded render supportability state published by lotus-render.",
+        examples=["ready"],
+    )
+    reason: str = Field(
+        ...,
+        description="Bounded reason code explaining render supportability posture.",
+        examples=["render_supportability_ready"],
+    )
+    freshness_bucket: str = Field(
+        ...,
+        description="Bounded freshness bucket for render supportability.",
+        examples=["current"],
+    )
+    deterministic_output_supported: bool = Field(
+        False,
+        description="Whether deterministic render proof is supported by the source service.",
+    )
+    render_store_ready: bool = Field(
+        False,
+        description="Whether the source render store is ready.",
+    )
+    template_registry_ready: bool = Field(
+        False,
+        description="Whether the source template registry is ready.",
+    )
+    default_output_format: str | None = Field(
+        default=None,
+        description="Default output format reported by lotus-render.",
+        examples=["pdf"],
+    )
+    supported_output_formats: list[str] = Field(
+        default_factory=list,
+        description="Output formats reported as supported by lotus-render.",
+        examples=[["pdf"]],
+    )
+
+
+class BatchHandleResponse(BaseModel):
+    batch_id: str = Field(..., description="Opaque durable batch identifier.")
+    status: BatchStatus = Field(..., description="Current product-safe batch status.")
+    status_url: str = Field(
+        ...,
+        description="Gateway-relative URL for product-safe batch status retrieval.",
+    )
+    idempotency_key: str = Field(
+        ...,
+        description="Caller-supplied idempotency key associated with this batch request.",
+    )
+    item_count: int = Field(..., ge=0, description="Number of materialized portfolio items.")
+    supportability: ReportingEvidenceSurfaceSupportability | None = Field(
+        default=None,
+        description=(
+            "lotus-report evidence-surface supportability posture captured from "
+            "GET /integration/capabilities for Workbench reporting operator reads."
+        ),
+    )
+    render_supportability: RenderSupportabilitySummary | None = Field(
+        default=None,
+        description=(
+            "lotus-render supportability posture captured from GET /metadata for "
+            "Workbench reporting operator reads."
+        ),
+    )
+
+
+class BatchItemStatusResponse(BaseModel):
+    batch_item_id: str = Field(..., description="Opaque durable batch item identifier.")
+    item_position: int = Field(..., ge=1, description="Deterministic item ordering.")
+    portfolio_id: str = Field(..., description="Portfolio represented by this batch item.")
+    status: BatchItemStatus = Field(..., description="Current product-safe item status.")
+    report_job_id: str | None = Field(
+        default=None,
+        description="Linked report job identifier after dispatch.",
+    )
+    attempt_count: int = Field(0, ge=0, description="Number of recorded attempts.")
+    retry_eligible: bool = Field(False, description="Whether bounded retry is currently allowed.")
+    next_retry_at: datetime | None = Field(default=None, description="Earliest retry timestamp.")
+    last_error_category: str | None = Field(
+        default=None,
+        description="Support-safe failure category for the latest item failure.",
+    )
+    last_error_summary: str | None = Field(
+        default=None,
+        description="Support-safe summary for the latest item failure.",
+    )
+    created_at: datetime = Field(..., description="UTC timestamp when the item was materialized.")
+    started_at: datetime | None = Field(default=None, description="UTC item start timestamp.")
+    completed_at: datetime | None = Field(
+        default=None, description="UTC item completion timestamp."
+    )
+    cancelled_at: datetime | None = Field(
+        default=None, description="UTC item cancellation timestamp."
+    )
+
+
+class BatchStatusResponse(BaseModel):
+    batch_id: str = Field(..., description="Opaque durable batch identifier.")
+    selector_mode: str = Field(..., description="Portfolio selector mode used.")
+    tenant_id: str = Field(..., description="Tenant ownership boundary for the batch.")
+    region: str = Field(..., description="Regional ownership boundary for the batch.")
+    materialized_portfolio_ids: list[str] = Field(
+        ...,
+        description="Portfolio identifiers materialized into durable batch items.",
+    )
+    as_of_date: date = Field(..., description="Business as-of date applied to all items.")
+    requested_output_formats: list[str] = Field(..., description="Requested output formats.")
+    reporting_currency: str | None = Field(
+        default=None, description="Requested reporting currency."
+    )
+    status: BatchStatus = Field(..., description="Current product-safe batch status.")
+    item_count: int = Field(..., ge=0, description="Number of materialized items.")
+    status_counts: dict[str, int] = Field(..., description="Counts by current item status.")
+    items: list[BatchItemStatusResponse] = Field(..., description="Ordered item status details.")
+    created_at: datetime = Field(..., description="UTC timestamp when the batch was materialized.")
+    updated_at: datetime | None = Field(default=None, description="UTC latest update timestamp.")
+    started_at: datetime | None = Field(default=None, description="UTC batch start timestamp.")
+    completed_at: datetime | None = Field(
+        default=None, description="UTC batch completion timestamp."
+    )
+    cancelled_at: datetime | None = Field(
+        default=None, description="UTC batch cancellation timestamp."
+    )
+    failed_at: datetime | None = Field(default=None, description="UTC batch failure timestamp.")
+    correlation_id: str = Field(..., description="Correlation identifier captured at creation.")
+    trace_id: str = Field(..., description="Distributed trace identifier captured at creation.")
+    supportability: ReportingEvidenceSurfaceSupportability | None = Field(
+        default=None,
+        description=(
+            "lotus-report evidence-surface supportability posture captured from "
+            "GET /integration/capabilities for Workbench reporting operator reads."
+        ),
+    )
+    render_supportability: RenderSupportabilitySummary | None = Field(
+        default=None,
+        description=(
+            "lotus-render supportability posture captured from GET /metadata for "
+            "Workbench reporting operator reads."
+        ),
+    )
+
+
+class BatchControlResponse(BaseModel):
+    batch_id: str = Field(..., description="Opaque durable batch identifier.")
+    status: BatchStatus = Field(..., description="Batch status after the control operation.")
+    affected_count: int = Field(..., ge=0, description="Number of affected records.")
+    status_url: str = Field(..., description="Gateway-relative URL for batch status retrieval.")
+
+
+class BatchRecoveryResponse(BaseModel):
+    batch_id: str = Field(..., description="Opaque durable batch identifier.")
+    status: BatchStatus = Field(..., description="Batch status after expired-lease recovery.")
+    recovered_count: int = Field(..., ge=0, description="Number of recovered expired leases.")
+    recovery_pending_item_ids: list[str] = Field(
+        default_factory=list,
+        description="Batch items moved to recovery-pending posture.",
+    )
+    status_url: str = Field(..., description="Gateway-relative URL for batch status retrieval.")
+
+
+class BatchRuntimeLoad(BaseModel):
+    active_batches: int = Field(0, ge=0, description="Currently active durable batches.")
+    active_items: int = Field(0, ge=0, description="Currently active batch items.")
+    active_upstream_jobs: int = Field(0, ge=0, description="Active upstream data jobs.")
+    active_render_jobs: int = Field(0, ge=0, description="Active render jobs.")
+    active_archive_jobs: int = Field(0, ge=0, description="Active archive jobs.")
+
+
+class BatchDispatchPolicy(BaseModel):
+    max_active_batches: int = Field(1, ge=1, description="Maximum active batches allowed.")
+    max_active_items: int = Field(5, ge=1, description="Maximum items leased by one run.")
+    max_active_upstream_jobs: int = Field(3, ge=1, description="Upstream work limit.")
+    max_active_render_jobs: int = Field(2, ge=1, description="Render work limit.")
+    max_active_archive_jobs: int = Field(2, ge=1, description="Archive work limit.")
+    lease_seconds: int = Field(300, ge=1, description="Lease duration for item dispatch.")
+
+
+class BatchWorkerRunRequest(BaseModel):
+    worker_id: str = Field(
+        ...,
+        min_length=1,
+        description="Stable operator or service worker identifier recorded on leased items.",
+        examples=["lotus-report-batch-worker-1"],
+    )
+    recover_expired_leases: bool = Field(
+        True,
+        description="Whether expired unjobbed item leases are recovered before dispatch.",
+    )
+    runtime_load: BatchRuntimeLoad | None = Field(
+        default=None,
+        description="Optional caller-supplied work snapshot for back-pressure decisions.",
+    )
+    dispatch_policy: BatchDispatchPolicy | None = Field(
+        default=None,
+        description="Optional explicit dispatch policy for this bounded operator run.",
+    )
+
+
+class BatchWorkerItemExecutionResponse(BaseModel):
+    batch_item_id: str = Field(..., description="Batch item advanced by this run.")
+    report_job_id: str = Field(..., description="Report job linked to the batch item.")
+    item_status: BatchItemStatus = Field(..., description="Batch item status after execution.")
+    report_job_status: str = Field(..., description="Report job status observed after execution.")
+    failure_category: str | None = Field(default=None, description="Product-safe failure category.")
+    retry_eligible: bool = Field(False, description="Whether bounded retry remains available.")
+
+
+class BatchWorkerRunResponse(BaseModel):
+    batch_id: str = Field(..., description="Opaque durable batch identifier processed.")
+    status: BatchStatus = Field(..., description="Batch status after the bounded run.")
+    batch_status_before: BatchStatus = Field(..., description="Batch status before the run.")
+    batch_status_after: BatchStatus = Field(..., description="Batch status after the run.")
+    recovered_count: int = Field(..., ge=0, description="Expired leases recovered before dispatch.")
+    leased_count: int = Field(..., ge=0, description="Eligible items leased during dispatch.")
+    dispatched_count: int = Field(..., ge=0, description="Report jobs created or reused.")
+    executed_count: int = Field(..., ge=0, description="Waiting items advanced through execution.")
+    report_job_ids: list[str] = Field(
+        default_factory=list,
+        description="Report job identifiers linked during this bounded run.",
+    )
+    back_pressure_reasons: list[str] = Field(
+        default_factory=list,
+        description="Product-safe reasons dispatch was skipped or limited.",
+    )
+    skipped_reason: str | None = Field(default=None, description="Reason the batch was not run.")
+    execution_results: list[BatchWorkerItemExecutionResponse] = Field(
+        default_factory=list,
+        description="Per-item execution outcomes.",
+    )
+    status_url: str = Field(..., description="Gateway-relative URL for batch status retrieval.")
+    supportability: ReportingEvidenceSurfaceSupportability | None = Field(
+        default=None,
+        description=(
+            "lotus-report evidence-surface supportability posture captured from "
+            "GET /integration/capabilities for Workbench reporting operator reads."
+        ),
+    )
+    render_supportability: RenderSupportabilitySummary | None = Field(
+        default=None,
+        description=(
+            "lotus-render supportability posture captured from GET /metadata for "
+            "Workbench reporting operator reads."
+        ),
+    )
+
+
+class BatchScheduleSummaryResponse(BaseModel):
+    schedule_id: str = Field(..., description="Governed schedule identifier.")
+    enabled: bool = Field(..., description="Whether the configured schedule is enabled.")
+    selector_mode: str = Field(..., description="Configured selector mode.")
+    frequency: str = Field(..., description="Configured production cycle frequency.")
+    as_of_date: date = Field(..., description="Business as-of date used by this schedule.")
+    portfolio_count: int = Field(..., ge=0, description="Configured explicit portfolio count.")
+    manifest_entry_count: int = Field(
+        ..., ge=0, description="Configured inline manifest entry count."
+    )
+    requested_output_formats: list[str] = Field(
+        ..., description="Requested output formats for materialized batch items."
+    )
+    reporting_currency: str | None = Field(default=None, description="Reporting currency.")
+    max_batch_size: int = Field(..., ge=1, description="Maximum materialized item count.")
+    template_id: str = Field(..., description="Report template identifier.")
+    template_version: str = Field(..., description="Report template version.")
+    render_package_version: str = Field(..., description="Render package contract version.")
+    manifest_source: str | None = Field(default=None, description="Inline manifest source.")
+    manifest_version: str | None = Field(default=None, description="Inline manifest version.")
+    manifest_hash: str | None = Field(default=None, description="Stable inline manifest hash.")
+    option_keys: list[str] = Field(
+        default_factory=list,
+        description="Sorted configured option keys without exposing option values.",
+    )
+
+
+class BatchScheduleListResponse(BaseModel):
+    scheduler_id: str = Field(..., description="Stable scheduler identity.")
+    interval_seconds: float = Field(..., ge=0, description="Configured scheduler interval.")
+    tenant_id: str = Field(..., description="Tenant context used by configured schedules.")
+    region: str = Field(..., description="Region context used by configured schedules.")
+    booking_center_code: str | None = Field(
+        default=None, description="Optional booking-center context."
+    )
+    schedule_count: int = Field(..., ge=0, description="Total configured schedule count.")
+    enabled_schedule_count: int = Field(..., ge=0, description="Enabled configured schedule count.")
+    schedules: list[BatchScheduleSummaryResponse] = Field(
+        ..., description="Configured report batch schedules."
+    )
+
+
+class BatchSchedulerRunRequest(BaseModel):
+    pass_sequence: int = Field(
+        1,
+        ge=1,
+        description="Deterministic scheduler pass sequence for correlation and idempotency proof.",
+        examples=[1],
+    )
+
+
+class BatchSchedulerMaterializationResponse(BaseModel):
+    schedule_id: str = Field(..., description="Schedule that produced or reused this batch.")
+    batch_id: str = Field(..., description="Durable report batch identifier.")
+    idempotency_key: str = Field(..., description="Deterministic scheduled idempotency key.")
+    item_count: int = Field(..., ge=0, description="Materialized batch item count.")
+    status: str = Field(..., description="Batch status after materialization or reuse.")
+
+
+class BatchSchedulerRunResponse(BaseModel):
+    scheduler_id: str = Field(..., description="Stable scheduler identity.")
+    attempted_count: int = Field(..., ge=0, description="Enabled schedule count attempted.")
+    materialized_count: int = Field(
+        ..., ge=0, description="Batches materialized or idempotently reused."
+    )
+    skipped_schedule_ids: list[str] = Field(
+        default_factory=list,
+        description="Enabled schedule ids skipped because no eligible candidates were resolved.",
+    )
+    materialized: list[BatchSchedulerMaterializationResponse] = Field(
+        default_factory=list,
+        description="Durable batch materialization results.",
+    )
+    correlation_id: str = Field(..., description="Scheduler correlation id used for this pass.")
+    trace_id: str = Field(..., description="Scheduler trace id used for this pass.")

--- a/src/app/contracts/reporting_errors.py
+++ b/src/app/contracts/reporting_errors.py
@@ -1,0 +1,94 @@
+from typing import Any
+
+REPORT_JOB_ERROR_EXAMPLES: dict[str, dict[str, Any]] = {
+    "missing_idempotency_key": {
+        "detail": {
+            "code": "missing_idempotency_key",
+            "message": "Idempotency-Key is required.",
+        }
+    },
+    "missing_caller_context": {
+        "detail": {
+            "code": "missing_caller_context",
+            "message": "Required caller context headers are missing.",
+            "missing_headers": ["X-Actor-Id", "X-Tenant-Id", "X-Region"],
+        }
+    },
+    "report_job_not_found": {
+        "detail": {
+            "code": "report_job_not_found",
+            "message": "Report job was not found.",
+        }
+    },
+    "report_snapshot_not_found": {
+        "detail": {
+            "code": "report_snapshot_not_found",
+            "message": "Report snapshot was not found.",
+        }
+    },
+    "idempotency_conflict": {
+        "detail": {
+            "code": "idempotency_conflict",
+            "message": "Idempotency-Key was reused with a different report request.",
+        }
+    },
+    "report_job_cannot_be_cancelled": {
+        "detail": {
+            "code": "report_job_cannot_be_cancelled",
+            "message": "Report job can no longer be cancelled.",
+        }
+    },
+    "report_job_upstream_unavailable": {
+        "detail": {
+            "code": "report_job_upstream_unavailable",
+            "message": "Report job service is unavailable.",
+        }
+    },
+    "invalid_report_job_filters": {
+        "detail": {
+            "code": "invalid_report_job_filters",
+            "message": "At least one supported job-search filter is required.",
+        }
+    },
+}
+
+REPORT_BATCH_ERROR_EXAMPLES: dict[str, dict[str, Any]] = {
+    "missing_idempotency_key": REPORT_JOB_ERROR_EXAMPLES["missing_idempotency_key"],
+    "missing_caller_context": REPORT_JOB_ERROR_EXAMPLES["missing_caller_context"],
+    "idempotency_conflict": {
+        "detail": {
+            "code": "idempotency_conflict",
+            "message": "Idempotency-Key was reused with a different batch request.",
+        }
+    },
+    "invalid_batch_selector": {
+        "detail": {
+            "code": "invalid_batch_selector",
+            "message": "Batch selector could not be materialized from eligible portfolios.",
+        }
+    },
+    "report_batch_not_found": {
+        "detail": {
+            "code": "report_batch_not_found",
+            "message": "Report batch was not found.",
+        }
+    },
+    "batch_worker_run_failed": {
+        "detail": {
+            "code": "batch_worker_run_failed",
+            "message": "Report batch run could not be completed.",
+        }
+    },
+    "batch_scheduler_run_failed": {
+        "detail": {
+            "code": "batch_scheduler_run_failed",
+            "message": "Report batch scheduler pass could not be completed.",
+        }
+    },
+    "report_batch_upstream_unavailable": {
+        "detail": {
+            "code": "report_batch_upstream_unavailable",
+            "message": "Report batch service is unavailable.",
+        }
+    },
+}

--- a/src/app/routers/reporting_batch_cancel.py
+++ b/src/app/routers/reporting_batch_cancel.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Path
 
-from app.contracts.reporting import BatchControlResponse
+from app.contracts.reporting_batches import BatchControlResponse
 from app.routers.reporting_batch_control_common import control_report_batch
 from app.routers.reporting_context import ReportingCallerContext
 

--- a/src/app/routers/reporting_batch_control_common.py
+++ b/src/app/routers/reporting_batch_control_common.py
@@ -1,4 +1,4 @@
-from app.contracts.reporting import BatchControlResponse
+from app.contracts.reporting_batches import BatchControlResponse
 from app.middleware.correlation import correlation_id_var
 from app.services.reporting_service_provider import reporting_batch_control_service
 

--- a/src/app/routers/reporting_batch_lease_recovery.py
+++ b/src/app/routers/reporting_batch_lease_recovery.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Path
 
-from app.contracts.reporting import BATCH_RECOVERY_RESPONSE_EXAMPLE, BatchRecoveryResponse
+from app.contracts.reporting_batches import BATCH_RECOVERY_RESPONSE_EXAMPLE, BatchRecoveryResponse
 from app.middleware.correlation import correlation_id_var
 from app.routers.reporting_context import ReportingCallerContext
 from app.services.reporting_service_provider import reporting_batch_control_service

--- a/src/app/routers/reporting_batch_pause.py
+++ b/src/app/routers/reporting_batch_pause.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Path
 
-from app.contracts.reporting import BATCH_CONTROL_RESPONSE_EXAMPLE, BatchControlResponse
+from app.contracts.reporting_batches import BATCH_CONTROL_RESPONSE_EXAMPLE, BatchControlResponse
 from app.routers.reporting_batch_control_common import control_report_batch
 from app.routers.reporting_context import ReportingCallerContext
 

--- a/src/app/routers/reporting_batch_resume.py
+++ b/src/app/routers/reporting_batch_resume.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Path
 
-from app.contracts.reporting import BatchControlResponse
+from app.contracts.reporting_batches import BatchControlResponse
 from app.routers.reporting_batch_control_common import control_report_batch
 from app.routers.reporting_context import ReportingCallerContext
 

--- a/src/app/routers/reporting_batch_retry.py
+++ b/src/app/routers/reporting_batch_retry.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Path
 
-from app.contracts.reporting import BatchControlResponse
+from app.contracts.reporting_batches import BatchControlResponse
 from app.routers.reporting_batch_control_common import control_report_batch
 from app.routers.reporting_context import ReportingCallerContext
 

--- a/src/app/routers/reporting_batch_run_once.py
+++ b/src/app/routers/reporting_batch_run_once.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Body, Path
 
-from app.contracts.reporting import (
+from app.contracts.reporting_batches import (
     BATCH_WORKER_RUN_REQUEST_EXAMPLE,
     BATCH_WORKER_RUN_RESPONSE_EXAMPLE,
     BatchWorkerRunRequest,

--- a/src/app/routers/reporting_batch_status.py
+++ b/src/app/routers/reporting_batch_status.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Path
 
-from app.contracts.reporting import BATCH_STATUS_RESPONSE_EXAMPLE, BatchStatusResponse
+from app.contracts.reporting_batches import BATCH_STATUS_RESPONSE_EXAMPLE, BatchStatusResponse
 from app.middleware.correlation import correlation_id_var
 from app.routers.reporting_context import ReportingCallerContext
 from app.routers.reporting_errors import report_batch_error_response

--- a/src/app/routers/reporting_batches.py
+++ b/src/app/routers/reporting_batches.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Body, Header, status
 
-from app.contracts.reporting import (
+from app.contracts.reporting_batches import (
     BATCH_CREATE_REQUEST_EXAMPLE,
     BATCH_HANDLE_RESPONSE_EXAMPLE,
     BatchCreateRequest,

--- a/src/app/routers/reporting_errors.py
+++ b/src/app/routers/reporting_errors.py
@@ -1,9 +1,9 @@
 from typing import Any
 
-from app.contracts.reporting import (
+from app.contracts.reporting import ReportJobErrorResponse
+from app.contracts.reporting_errors import (
     REPORT_BATCH_ERROR_EXAMPLES,
     REPORT_JOB_ERROR_EXAMPLES,
-    ReportJobErrorResponse,
 )
 
 

--- a/src/app/routers/reporting_schedule_runs.py
+++ b/src/app/routers/reporting_schedule_runs.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Body
 
-from app.contracts.reporting import (
+from app.contracts.reporting_batches import (
     BATCH_SCHEDULER_RUN_REQUEST_EXAMPLE,
     BATCH_SCHEDULER_RUN_RESPONSE_EXAMPLE,
     BatchSchedulerRunRequest,

--- a/src/app/routers/reporting_schedules.py
+++ b/src/app/routers/reporting_schedules.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.contracts.reporting import (
+from app.contracts.reporting_batches import (
     BATCH_SCHEDULE_LIST_RESPONSE_EXAMPLE,
     BatchScheduleListResponse,
 )

--- a/src/app/services/reporting_batch_control_service.py
+++ b/src/app/services/reporting_batch_control_service.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from app.contracts.reporting import (
+from app.contracts.reporting_batches import (
     BatchControlResponse,
     BatchRecoveryResponse,
     BatchWorkerRunRequest,

--- a/src/app/services/reporting_batch_lifecycle_service.py
+++ b/src/app/services/reporting_batch_lifecycle_service.py
@@ -1,11 +1,11 @@
 from fastapi import HTTPException, status
 
-from app.contracts.reporting import (
-    REPORT_BATCH_ERROR_EXAMPLES,
+from app.contracts.reporting_batches import (
     BatchCreateRequest,
     BatchHandleResponse,
     BatchStatusResponse,
 )
+from app.contracts.reporting_errors import REPORT_BATCH_ERROR_EXAMPLES
 from app.services.reporting_client_protocols import ReportingBatchLifecycleClient
 from app.services.reporting_error_mapping import raise_report_batch_error
 from app.services.reporting_links import rewrite_report_batch_status_url

--- a/src/app/services/reporting_batch_scheduler_service.py
+++ b/src/app/services/reporting_batch_scheduler_service.py
@@ -1,4 +1,4 @@
-from app.contracts.reporting import (
+from app.contracts.reporting_batches import (
     BatchScheduleListResponse,
     BatchSchedulerRunRequest,
     BatchSchedulerRunResponse,

--- a/tests/unit/test_reporting_batch_contracts.py
+++ b/tests/unit/test_reporting_batch_contracts.py
@@ -1,0 +1,103 @@
+from app.contracts import reporting
+from app.contracts.reporting_batches import (
+    BatchControlResponse,
+    BatchCreateRequest,
+    BatchHandleResponse,
+    BatchItemStatusResponse,
+    BatchRecoveryResponse,
+    BatchScheduleListResponse,
+    BatchSchedulerRunRequest,
+    BatchSchedulerRunResponse,
+    BatchStatusResponse,
+    BatchWorkerRunRequest,
+    BatchWorkerRunResponse,
+    PortfolioBatchCandidate,
+    RenderSupportabilitySummary,
+    ReportingEvidenceSurfaceSupportability,
+)
+from app.contracts.reporting_errors import (
+    REPORT_BATCH_ERROR_EXAMPLES,
+    REPORT_JOB_ERROR_EXAMPLES,
+)
+
+
+def test_reporting_batch_contracts_remain_compatibility_reexports() -> None:
+    assert reporting.BatchControlResponse is BatchControlResponse
+    assert reporting.BatchCreateRequest is BatchCreateRequest
+    assert reporting.BatchHandleResponse is BatchHandleResponse
+    assert reporting.BatchItemStatusResponse is BatchItemStatusResponse
+    assert reporting.BatchRecoveryResponse is BatchRecoveryResponse
+    assert reporting.BatchScheduleListResponse is BatchScheduleListResponse
+    assert reporting.BatchSchedulerRunRequest is BatchSchedulerRunRequest
+    assert reporting.BatchSchedulerRunResponse is BatchSchedulerRunResponse
+    assert reporting.BatchStatusResponse is BatchStatusResponse
+    assert reporting.BatchWorkerRunRequest is BatchWorkerRunRequest
+    assert reporting.BatchWorkerRunResponse is BatchWorkerRunResponse
+    assert reporting.PortfolioBatchCandidate is PortfolioBatchCandidate
+    assert reporting.RenderSupportabilitySummary is RenderSupportabilitySummary
+    assert (
+        reporting.ReportingEvidenceSurfaceSupportability is ReportingEvidenceSurfaceSupportability
+    )
+    assert reporting.REPORT_BATCH_ERROR_EXAMPLES is REPORT_BATCH_ERROR_EXAMPLES
+    assert reporting.REPORT_JOB_ERROR_EXAMPLES is REPORT_JOB_ERROR_EXAMPLES
+
+
+def test_batch_request_accepts_extracted_candidate_contract() -> None:
+    request = BatchCreateRequest(
+        selector_mode="explicit_portfolio_list",
+        portfolio_ids=["PB_SG_GLOBAL_BAL_001"],
+        source_candidates=[
+            PortfolioBatchCandidate(
+                portfolio_id="PB_SG_GLOBAL_BAL_001",
+                tenant_id="tenant-sg",
+                region="APAC",
+                active=True,
+                selected=True,
+            )
+        ],
+        as_of_date="2026-04-22",
+        requested_output_formats=["pdf"],
+        reporting_currency="USD",
+        options={"sections": ["OVERVIEW"]},
+        max_batch_size=250,
+    )
+
+    assert request.source_candidates[0].portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert request.source_candidates[0].source_system == "lotus-core"
+
+
+def test_batch_response_accepts_extracted_supportability_contracts() -> None:
+    supportability = ReportingEvidenceSurfaceSupportability(
+        state="ready",
+        reason="evidence_surface_ready",
+        freshness_bucket="current",
+        evidence_feature_count=14,
+        ready_evidence_feature_count=14,
+        degraded_evidence_feature_count=0,
+        workflow_count=4,
+        ready_workflow_count=4,
+    )
+    render_supportability = RenderSupportabilitySummary(
+        state="ready",
+        reason="render_supportability_ready",
+        freshness_bucket="current",
+        deterministic_output_supported=True,
+        render_store_ready=True,
+        template_registry_ready=True,
+        default_output_format="pdf",
+        supported_output_formats=["pdf"],
+    )
+
+    response = BatchHandleResponse(
+        batch_id="rbch_1",
+        status="materialized",
+        status_url="/api/v1/report-batches/rbch_1",
+        idempotency_key="idem-batch-1",
+        item_count=1,
+        supportability=supportability,
+        render_supportability=render_supportability,
+    )
+
+    assert response.supportability is supportability
+    assert response.render_supportability is render_supportability
+    assert response.model_dump()["status"] == "materialized"

--- a/tests/unit/test_reporting_batch_control_service.py
+++ b/tests/unit/test_reporting_batch_control_service.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
-from app.contracts.reporting import BatchWorkerRunRequest
+from app.contracts.reporting_batches import BatchWorkerRunRequest
 from app.services.reporting_batch_control_service import ReportingBatchControlService
 
 

--- a/tests/unit/test_reporting_batch_lifecycle_service.py
+++ b/tests/unit/test_reporting_batch_lifecycle_service.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
-from app.contracts.reporting import BatchCreateRequest
+from app.contracts.reporting_batches import BatchCreateRequest
 from app.services.reporting_batch_lifecycle_service import ReportingBatchLifecycleService
 
 

--- a/tests/unit/test_reporting_batch_scheduler_service.py
+++ b/tests/unit/test_reporting_batch_scheduler_service.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
-from app.contracts.reporting import BatchSchedulerRunRequest
+from app.contracts.reporting_batches import BatchSchedulerRunRequest
 from app.services.reporting_batch_scheduler_service import ReportingBatchSchedulerService
 
 

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -116,4 +116,8 @@ reporting batch contract branch moves batch, worker-run, scheduler, and shared r
 error-example contracts into `reporting_batches.py` and `reporting_errors.py`, keeps
 `app.contracts.reporting` as the compatibility import surface, reduces `reporting.py` from 1,840
 to 1,184 measured lines, and has focused evidence from ruff, format check, mypy,
-monetary-float guard, and 40 passing reporting batch, contract, and integration tests.
+monetary-float guard, and 40 passing reporting batch, contract, and integration tests. Local
+validation passed with `make check` covering ruff, format check, monetary-float guard, mypy over
+464 source files, Workbench/OpenAPI contract smoke, and 1,044 unit/contract tests; `make ci`
+passed with 207 integration tests, 1,251 coverage tests, 94.03% total coverage, and no known
+vulnerabilities after the governed `PYSEC-2026-161` exception.

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -111,3 +111,9 @@ format check, monetary-float guard, mypy over 462 source files, Workbench/OpenAP
 and 1,041 unit/contract tests; `make ci` passed with 207 integration tests, 1,248 coverage tests,
 94.03% total coverage, and no known vulnerabilities after the governed `PYSEC-2026-161`
 exception.
+PR #365 then merged the risk drawdown contract extraction with all GitHub checks green. The current
+reporting batch contract branch moves batch, worker-run, scheduler, and shared reporting
+error-example contracts into `reporting_batches.py` and `reporting_errors.py`, keeps
+`app.contracts.reporting` as the compatibility import surface, reduces `reporting.py` from 1,840
+to 1,184 measured lines, and has focused evidence from ruff, format check, mypy,
+monetary-float guard, and 40 passing reporting batch, contract, and integration tests.


### PR DESCRIPTION
## Summary
- Extract reporting batch, worker-run, scheduler, and supportability contracts into `app.contracts.reporting_batches`
- Extract shared reporting job/batch error examples into `app.contracts.reporting_errors`
- Keep `app.contracts.reporting` as the compatibility import surface for existing API consumers
- Narrow batch-specific routers, services, and tests to the focused contract modules
- Refresh quality/wiki evidence for the measured contract split

## Measured impact
- `src/app/contracts/reporting.py`: 1,840 -> 1,184 measured lines
- Added focused modules: `reporting_batches.py` and `reporting_errors.py`
- Longest-function baseline preserved at 49 lines

## Local validation
- Focused: ruff, format check, monetary-float guard, mypy over touched contract/router/service modules, and 40 reporting batch/contract/integration tests
- `make check`: ruff, format check, monetary-float guard, mypy over 464 source files, Workbench/OpenAPI contract smoke, 1,044 unit/contract tests
- `make ci`: 207 integration tests, 1,251 coverage tests, 94.03% total coverage, `pip-audit` no known vulnerabilities after governed `PYSEC-2026-161`

## Wiki / governance
- Repo-authored wiki source changed in `wiki/Validation-and-CI.md`
- Pre-merge wiki `-CheckOnly` reports expected drift on `Validation-and-CI.md`; publish is intentionally deferred until after merge to `main`
- Stranded-truth preflight found no unmerged remote branches