### PR TITLE
Enforce refactor quality thresholds in CI

### DIFF
--- a/.github/workflows/feature-lane.yml
+++ b/.github/workflows/feature-lane.yml
@@ -37,7 +37,7 @@ jobs:
         run: python -m pip check
       - name: Security Audit
         run: make security-audit
-      - name: Lint
+      - name: Lint and Refactor Quality Thresholds
         run: make lint
       - name: Typecheck
         run: make typecheck

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -36,7 +36,7 @@ jobs:
         run: python -m pip check
       - name: Security Audit
         run: make security-audit
-      - name: Lint
+      - name: Lint and Refactor Quality Thresholds
         run: make lint
       - name: Typecheck
         run: make typecheck
@@ -65,7 +65,7 @@ jobs:
 
   coverage:
     name: PR Merge Gate / Coverage Gate
-    needs: [integration]
+    needs: [lint-typecheck-unit]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
 
   docker-build:
     name: PR Merge Gate / Validate Docker Build
-    needs: [coverage]
+    needs: [integration, coverage]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
 
   ci-local-docker:
     name: PR Merge Gate / CI Local Docker Parity
-    needs: [coverage]
+    needs: [integration, coverage]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck monetary-float-guard openapi-gate migration-smoke migration-apply test test-unit test-integration test-coverage test-e2e test-e2e-live security-audit check ci ci-local ci-local-docker ci-local-docker-down run run-canonical clean docker-up docker-down e2e-up e2e-down
+.PHONY: install lint typecheck monetary-float-guard refactor-quality-thresholds openapi-gate migration-smoke migration-apply test test-unit test-integration test-coverage test-e2e test-e2e-live security-audit check ci ci-local ci-local-docker ci-local-docker-down run run-canonical clean docker-up docker-down e2e-up e2e-down
 
 install:
 	python -m pip install -e ".[dev]"
@@ -7,9 +7,13 @@ lint:
 	python -m ruff check .
 	python -m ruff format --check .
 	$(MAKE) monetary-float-guard
+	$(MAKE) refactor-quality-thresholds
 
 monetary-float-guard:
 	python scripts/check_monetary_float_usage.py
+
+refactor-quality-thresholds:
+	python scripts/check_refactor_quality_thresholds.py
 
 typecheck:
 	python -m mypy src

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -509,6 +509,16 @@ Most recent local evidence:
 90. Current performance evidence-view builder branch: `make ci` passed with 207 integration tests
     and 1,270 combined coverage tests; total coverage is 94.05%, and `pip-audit` found no known
     vulnerabilities after the governed `PYSEC-2026-161` exception.
+91. Current quality-baseline enforcement branch promotes the remediated file/function-size
+    baseline into `make lint` through `scripts/check_refactor_quality_thresholds.py`.
+92. `python scripts/check_refactor_quality_thresholds.py` passed with
+    `max_source_file_lines=2100` and `max_function_lines=49`.
+93. Current quality-baseline enforcement branch: `make check` passed with ruff, format check,
+    monetary-float guard, refactor threshold gate, mypy over 471 source files, Workbench/OpenAPI
+    contract smoke, and 1,066 unit/contract tests.
+94. Current quality-baseline enforcement branch: `make ci` passed with 207 integration tests and
+    1,273 combined coverage tests; total coverage is 94.05%, and `pip-audit` found no known
+    vulnerabilities after the governed `PYSEC-2026-161` exception.
 
 ## Tooling Availability Baseline
 
@@ -521,12 +531,15 @@ Baseline workflow installs Python and Node quality tooling explicitly.
 
 Report-only complexity tools are being introduced now. Current manual size evidence already shows
 large-file and long-function hotspots in service, contract, and client code.
-The first enforcement candidates should be:
+The remediated size baselines are now partially enforced through `make lint`:
 
-1. no new service file above the current largest-file baseline,
-2. no new function above the current longest-function baseline of 49 lines,
-3. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
-4. no new architecture import-linter violations after contracts are reviewed.
+1. no Python source file under `src/app` above 2,100 physical lines,
+2. no function or async function above the current longest-function baseline of 49 lines.
+
+The remaining enforcement candidates should be:
+
+1. no regression in average cyclomatic complexity after `radon` baselines are collected in CI,
+2. no new architecture import-linter violations after contracts are reviewed.
 
 ## Dead Code Gaps
 

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -1,6 +1,6 @@
 # CI Quality Gates
 
-Date: 2026-06-04  
+Date: 2026-06-13  
 Mode: progressive enforcement
 
 This file records the governed CI measurement posture for the gateway hardening program. It is the
@@ -13,15 +13,21 @@ The current local and PR-grade blocking gates are:
 
 1. `ruff` lint and format checks,
 2. monetary-float governance,
-3. `mypy` over `src`,
-4. Workbench OpenAPI contract smoke, operation-governance contract checks, and global tag-catalog
+3. refactor quality thresholds blocking new growth above the current largest-file and
+   longest-function baselines,
+4. `mypy` over `src`,
+5. Workbench OpenAPI contract smoke, operation-governance contract checks, and global tag-catalog
    coverage,
-5. migration contract smoke,
-6. unit and contract tests,
-7. integration tests,
-8. coverage with an 84% floor,
-9. `pip-audit` with the governed temporary `PYSEC-2026-161` exception,
-10. Docker build and local Docker parity in the PR Merge Gate.
+6. migration contract smoke,
+7. unit and contract tests,
+8. integration tests,
+9. coverage with an 84% floor,
+10. `pip-audit` with the governed temporary `PYSEC-2026-161` exception,
+11. Docker build and local Docker parity in the PR Merge Gate.
+
+The PR Merge Gate now runs integration tests and the coverage gate in parallel after the
+lint/typecheck/unit job. Docker build and Docker parity remain downstream of both jobs so the
+merge barrier still requires all PR-grade proof.
 
 ## Report-Only Gates
 
@@ -48,11 +54,20 @@ Report-only quality checks should remain advisory until findings are classified:
 
 Most recent local PR-grade evidence:
 
-1. `make check`: 969 unit/contract tests passed.
-2. `make ci`: 207 integration tests passed.
-3. `make ci`: 1,176 coverage tests passed.
-4. Total coverage: 93.36%, above the 84% floor.
-5. `pip-audit`: no known vulnerabilities after the governed `PYSEC-2026-161` exception.
+1. Current branch adds `scripts/check_refactor_quality_thresholds.py` as a blocking lint-stage
+   gate.
+2. Current enforced source-file threshold: no Python source file under `src/app` above 2,100
+   physical lines.
+3. Current enforced function threshold: no Python function or async function above the remediated
+   49-line AST span baseline.
+4. `python scripts/check_refactor_quality_thresholds.py`: passed with
+   `max_source_file_lines=2100` and `max_function_lines=49`.
+5. Feature Lane and PR Merge Gate step names now call out `Lint and Refactor Quality Thresholds`
+   so the promoted gate is visible in GitHub logs.
+6. Current branch `make check` passed with 1,066 unit/contract tests.
+7. Current branch `make ci` passed with 207 integration tests and 1,273 coverage tests; total
+   coverage was 94.05%, and `pip-audit` found no known vulnerabilities after the governed
+   `PYSEC-2026-161` exception.
 
 ## Next Tightening Candidates
 
@@ -60,5 +75,5 @@ Most recent local PR-grade evidence:
 2. Refresh the Spectral warning artifact from the GitHub quality-baseline workflow and decide
    whether explicit operation IDs should replace generated IDs.
 3. Promote import-linter contracts after false positives are classified.
-4. Add no-new-file/function-above-baseline checks for refactor slices.
+4. Tighten the enforced source-file threshold downward as the remaining largest services are split.
 5. Add static no-sensitive-observability checks for logs, metrics labels, and diagnostics fields.

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -5,16 +5,16 @@ Mode: feature-branch evidence refresh
 
 | Dimension | Score | Current status | Next action |
 | --- | ---: | --- | --- |
-| Build and test reliability | 5/5 | Current performance evidence-view builder branch `make check` passed with ruff, format check, monetary-float guard, mypy over 471 source files, Workbench/OpenAPI contract smoke, and 1,063 unit/contract tests; `make ci` passed with 207 integration tests, 1,270 coverage tests, 94.05% total coverage, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
+| Build and test reliability | 5/5 | Current quality-baseline enforcement branch adds a blocking lint-stage refactor threshold gate; `make check` passed with ruff, format check, monetary-float guard, the refactor threshold gate, mypy over 471 source files, Workbench/OpenAPI contract smoke, and 1,066 unit/contract tests; `make ci` passed with 207 integration tests, 1,273 coverage tests, 94.05% total coverage, and dependency audit | Keep Docker parity blocking in PR Merge Gate |
 | Coverage | 4/5 | 94.05% total coverage, above the 84% floor | Add targeted middleware/security/error tests |
-| Modularity | 4/5 | Current branch state preserves the 49-line longest-function baseline; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, portfolio workflow contracts, portfolio transaction contracts, portfolio performance snapshot contracts, portfolio income/activity contracts, portfolio holdings/book contracts, risk drawdown contracts, reporting batch contracts, reporting query contracts, risk concentration contracts, risk rolling contracts, risk attribution contracts, performance contribution contracts, performance attribution contracts, performance evidence contracts, and performance evidence-view orchestration; `portfolio_service.py` is now 1,970 measured lines, `performance_workspace_service.py` is now 1,413 measured lines, `performance_workspace.py` is now 903 measured lines, `portfolio.py` is now 911 measured lines, `risk_workspace.py` is now 678 measured lines, and `reporting.py` is now 532 measured lines | Continue extraction slices and reduce remaining largest-file pressure |
+| Modularity | 4/5 | Current branch state blocks regressions above the 49-line longest-function baseline and the current 2,100-line source-file ceiling; recent slices extracted transaction request context, transaction page-context defaults, transaction client-kwargs mapping, performance workspace response assembly, portfolio workspace response assembly, portfolio workspace performance parsing, portfolio workspace rebalance parsing, portfolio source-readiness parsing, portfolio transaction summary mapping, portfolio workflow mapping, portfolio workflow contracts, portfolio transaction contracts, portfolio performance snapshot contracts, portfolio income/activity contracts, portfolio holdings/book contracts, risk drawdown contracts, reporting batch contracts, reporting query contracts, risk concentration contracts, risk rolling contracts, risk attribution contracts, performance contribution contracts, performance attribution contracts, performance evidence contracts, and performance evidence-view orchestration; `portfolio_service.py` remains the largest residual hotspot | Continue extraction slices and tighten the source-file ceiling downward |
 | Architecture boundaries | 3/5 | Blocking AST tests exist; import-linter is report-only | Classify and enforce no-new-regression |
 | API governance | 4/5 | 233 OpenAPI paths and 247 operations; missing summary, description, operation ID, tags, and documented 4xx/5xx response counts are all 0; Spectral remains report-only | Triage Spectral warnings and decide explicit operation ID policy |
 | Error consistency | 2/5 | ProblemDetails exists for unhandled exceptions; route/upstream error normalization remains a meaningful hardening candidate | Normalize route/upstream errors |
 | Observability | 3/5 | Health/readiness/metrics/correlation/audit are present; RFC-0108 fan-out and selected analytics audit posture remain implementation-backed | Enforce structured log and metric label rules |
-| Security | 4/5 | Current performance evidence-view builder branch `pip-audit` passed with the governed FastAPI/Starlette exception; monetary-float guard passed without allowlist churn | Triage bandit and sensitive-data handling checks |
+| Security | 4/5 | Current quality-baseline enforcement branch `pip-audit` passed with the governed FastAPI/Starlette exception; monetary-float guard passed without allowlist churn | Triage bandit and sensitive-data handling checks |
 | Documentation | 4/5 | Baseline, scorecard, health report, and wiki validation evidence are refreshed to current branch metrics after the current focused performance attribution contract slice | Keep wiki synced and add diagrams over time |
-| Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture describe the report-only quality lane | Add incident playbooks and SLO checks |
+| Operations readiness | 3/5 | Existing CI/runbook docs and wiki validation posture now distinguish report-only quality baselines from the blocking refactor threshold gate | Add incident playbooks and SLO checks |
 
 ## Before/After Evidence
 
@@ -30,11 +30,11 @@ versus the current performance evidence-view builder branch after PRs #349, #350
 | Tracked Python test files | 162 | 182 | Added focused request-context, response-assembly, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, income/activity contract, holdings contract, risk drawdown contract, reporting batch contract, reporting query contract, risk concentration contract, risk rolling contract, risk attribution contract, performance contribution contract, and performance attribution contract tests |
 | Longest function | 49 lines | 49 lines | Preserved |
 | Top function hotspot count at 49 lines | 2 | 2 | Preserved |
-| Largest source file | 2,968 lines | 1,970 lines | Improved; `src/app/services/portfolio_service.py` remains the largest residual hotspot after reducing `performance_workspace.py` to 903 lines, `portfolio.py` to 911 lines, `risk_workspace.py` to 678 lines, and `reporting.py` to 532 lines |
+| Largest source file | 2,968 lines | 2,079 physical lines | Improved and now protected by the 2,100-line blocking threshold; `src/app/services/portfolio_service.py` remains the largest residual hotspot after reducing `performance_workspace.py` to 903 measured lines, `portfolio.py` to 911 measured lines, `risk_workspace.py` to 678 measured lines, and `reporting.py` to 532 measured lines |
 | `performance_workspace.py` | 1,539 lines | 903 lines | Improved through performance contribution, attribution, and evidence contract extraction |
 | OpenAPI operations with missing summary/description/tags/errors | 0 | 0 | Preserved |
-| Local unit/contract tests | 996 | 1,063 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, income/activity contract, holdings contract, risk drawdown contract, reporting batch contract, reporting query contract, risk concentration contract, risk rolling contract, risk attribution contract, performance contribution contract, performance attribution contract, performance evidence compatibility tests, and performance evidence-view builder tests |
-| Local coverage tests | 1,203 | 1,270 | Added focused coverage while preserving total coverage |
+| Local unit/contract tests | 996 | 1,066 | Added focused response/request boundary, workspace parser, source-readiness parser, transaction summary mapper, workflow mapper, workflow contract, transaction contract, performance snapshot contract, income/activity contract, holdings contract, risk drawdown contract, reporting batch contract, reporting query contract, risk concentration contract, risk rolling contract, risk attribution contract, performance contribution contract, performance attribution contract, performance evidence compatibility tests, performance evidence-view builder tests, and refactor threshold gate tests |
+| Local coverage tests | 1,203 | 1,273 | Added focused coverage while preserving total coverage |
 | Total coverage | 93.69% | 94.05% | Improved |
 | Dependency audit | governed pass | governed pass, no known vulnerabilities after the `PYSEC-2026-161` exception | Preserved |
 
@@ -49,7 +49,7 @@ Required evidence:
 1. baseline reports exist under `quality/`,
 2. architecture and API governance rules are documented,
 3. report-only CI workflow exists,
-4. existing Feature Lane and PR Merge Gate remain unchanged.
+4. existing Feature Lane and PR Merge Gate remain stable except for promoted no-regression checks.
 
 ### Phase 2: Fail Only New Regressions
 
@@ -59,8 +59,8 @@ Candidate thresholds:
 2. no new forbidden imports,
 3. no new high-confidence dead-code findings,
 4. no new high-severity bandit findings,
-5. no new function above the current maximum of 49 lines and no unclassified largest-file growth
-   above the current 2,079-line `src/app/services/portfolio_service.py` maximum.
+5. no new function above the current maximum of 49 lines and no Python source file above the
+   current 2,100-line blocking ceiling.
 
 ### Phase 3: Enforce Agreed Thresholds
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -333,14 +333,14 @@ baseline.
 
 | Area | Current posture | Evidence |
 | --- | --- | --- |
-| Branch hygiene | Healthy | Current performance evidence-view builder branch was created from clean `main` after PR #373; final remote/local cleanup remains a post-merge gate |
-| Unit/contract coverage | Healthy | Current performance evidence-view builder branch `make check` passed with ruff, format check, monetary-float guard, mypy over 471 source files, Workbench/OpenAPI contract smoke, and 1,063 unit/contract tests |
-| Integration coverage | Healthy | 207 integration tests passed in current performance evidence-view builder branch `make ci` |
-| Total coverage | Healthy | 1,270 coverage tests passed in current performance evidence-view builder branch `make ci`; total coverage is 94.05%, above the 84% floor |
-| Security audit | Governed | Current performance evidence-view builder branch `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception; monetary-float guard passed without allowlist churn |
+| Branch hygiene | Healthy | Current quality-baseline enforcement branch was created from clean `main` after PR #374; final remote/local cleanup remains a post-merge gate |
+| Unit/contract coverage | Healthy | Current quality-baseline enforcement branch `make check` passed with ruff, format check, monetary-float guard, refactor threshold gate, mypy over 471 source files, Workbench/OpenAPI contract smoke, and 1,066 unit/contract tests |
+| Integration coverage | Healthy | 207 integration tests passed in current quality-baseline enforcement branch `make ci` |
+| Total coverage | Healthy | 1,273 coverage tests passed in current quality-baseline enforcement branch `make ci`; total coverage is 94.05%, above the 84% floor |
+| Security audit | Governed | Current quality-baseline enforcement branch `pip-audit` found no known vulnerabilities after the governed `PYSEC-2026-161` exception; monetary-float guard passed without allowlist churn |
 | Modularity | Improving, incomplete | Longest-function baseline remains 49 lines; recent response/request-context/parser/mapper/contract slices reduce `performance_workspace_service.py` to 1,413 measured lines, `performance_workspace.py` to 903 measured lines, `portfolio.py` to 911 measured lines, `risk_workspace.py` to 678 measured lines, and `reporting.py` to 532 measured lines, leaving `portfolio_service.py` at 1,970 measured lines and `advisor_brief_service.py` at 1,454 measured lines; several service files remain above 1,000 lines |
 | API governance | Improving, incomplete | 233 OpenAPI paths and 247 operations have summaries, descriptions, operation IDs, tags, and documented 4xx/5xx responses; Spectral remains report-only |
-| Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is new report-only baseline |
+| Architecture rules | Improving, incomplete | AST boundary tests exist; import-linter is report-only; source-file and function-size thresholds are now blocking through `make lint` |
 | Observability | Partial | Health/readiness/metrics/correlation exist; trace/log scoring not enforced |
 
 ## Primary Refactor Backlog
@@ -374,14 +374,15 @@ baseline.
 
 ## Quality-Gate Roadmap
 
-1. Report-only workflow introduced in this slice.
-2. Report-only workflow uploads quality logs for baseline classification.
+1. Report-only workflow uploads quality logs for baseline classification.
+2. Blocking refactor threshold gate now enforces:
+   - no Python source file under `src/app` above 2,100 physical lines,
+   - no Python function or async function above the remediated 49-line AST span baseline.
 3. Then enforce no-new-regression thresholds for:
    - ruff/mypy,
    - coverage,
    - import-linter,
    - OpenAPI spectral warnings,
-   - largest-file and longest-function thresholds,
    - `pip-audit` and high-confidence `bandit` findings.
 4. Enterprise-readiness gates should require docs, API, security, observability, and architecture
    scorecard sections to be green before release promotion.

--- a/scripts/check_refactor_quality_thresholds.py
+++ b/scripts/check_refactor_quality_thresholds.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+DEFAULT_SOURCE_ROOT = Path("src/app")
+DEFAULT_MAX_SOURCE_FILE_LINES = 2100
+DEFAULT_MAX_FUNCTION_LINES = 49
+
+
+@dataclass(frozen=True)
+class FileSizeViolation:
+    path: Path
+    line_count: int
+    max_lines: int
+
+    def format(self) -> str:
+        return f"{self.path}: {self.line_count} lines exceeds max {self.max_lines}"
+
+
+@dataclass(frozen=True)
+class FunctionSizeViolation:
+    path: Path
+    line_number: int
+    function_name: str
+    line_count: int
+    max_lines: int
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line_number} {self.function_name}: "
+            f"{self.line_count} lines exceeds max {self.max_lines}"
+        )
+
+
+@dataclass(frozen=True)
+class ThresholdResult:
+    file_size_violations: tuple[FileSizeViolation, ...]
+    function_size_violations: tuple[FunctionSizeViolation, ...]
+
+    @property
+    def passed(self) -> bool:
+        return not self.file_size_violations and not self.function_size_violations
+
+
+def iter_python_files(source_roots: Sequence[Path]) -> Iterable[Path]:
+    for source_root in source_roots:
+        if source_root.is_file() and source_root.suffix == ".py":
+            yield source_root
+            continue
+        if source_root.is_dir():
+            yield from source_root.rglob("*.py")
+
+
+def check_refactor_quality_thresholds(
+    *,
+    source_roots: Sequence[Path],
+    max_source_file_lines: int,
+    max_function_lines: int,
+) -> ThresholdResult:
+    file_violations: list[FileSizeViolation] = []
+    function_violations: list[FunctionSizeViolation] = []
+
+    for path in sorted(iter_python_files(source_roots)):
+        source = path.read_text(encoding="utf-8")
+        line_count = len(source.splitlines())
+        if line_count > max_source_file_lines:
+            file_violations.append(
+                FileSizeViolation(
+                    path=path,
+                    line_count=line_count,
+                    max_lines=max_source_file_lines,
+                )
+            )
+        function_violations.extend(
+            find_function_size_violations(
+                path=path,
+                source=source,
+                max_function_lines=max_function_lines,
+            )
+        )
+
+    return ThresholdResult(
+        file_size_violations=tuple(file_violations),
+        function_size_violations=tuple(function_violations),
+    )
+
+
+def find_function_size_violations(
+    *,
+    path: Path,
+    source: str,
+    max_function_lines: int,
+) -> list[FunctionSizeViolation]:
+    tree = ast.parse(source, filename=str(path))
+    violations: list[FunctionSizeViolation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.end_lineno is None:
+            continue
+        line_count = node.end_lineno - node.lineno + 1
+        if line_count > max_function_lines:
+            violations.append(
+                FunctionSizeViolation(
+                    path=path,
+                    line_number=node.lineno,
+                    function_name=node.name,
+                    line_count=line_count,
+                    max_lines=max_function_lines,
+                )
+            )
+    return violations
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fail when refactor quality thresholds regress above the governed baseline."
+    )
+    parser.add_argument(
+        "source_roots",
+        nargs="*",
+        type=Path,
+        default=[DEFAULT_SOURCE_ROOT],
+        help="Python source roots or files to scan.",
+    )
+    parser.add_argument(
+        "--max-source-file-lines",
+        type=int,
+        default=DEFAULT_MAX_SOURCE_FILE_LINES,
+        help="Maximum allowed physical lines in any Python source file.",
+    )
+    parser.add_argument(
+        "--max-function-lines",
+        type=int,
+        default=DEFAULT_MAX_FUNCTION_LINES,
+        help="Maximum allowed AST span for any function or async function.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    result = check_refactor_quality_thresholds(
+        source_roots=args.source_roots,
+        max_source_file_lines=args.max_source_file_lines,
+        max_function_lines=args.max_function_lines,
+    )
+    if result.passed:
+        print(
+            "Refactor quality thresholds passed: "
+            f"max_source_file_lines={args.max_source_file_lines}, "
+            f"max_function_lines={args.max_function_lines}"
+        )
+        return 0
+
+    print("Refactor quality threshold violations:")
+    for violation in result.file_size_violations:
+        print(f"- {violation.format()}")
+    for violation in result.function_size_violations:
+        print(f"- {violation.format()}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_refactor_quality_thresholds.py
+++ b/tests/unit/test_refactor_quality_thresholds.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+from scripts.check_refactor_quality_thresholds import (
+    check_refactor_quality_thresholds,
+    find_function_size_violations,
+)
+
+
+def test_refactor_quality_thresholds_pass_for_small_source_file(tmp_path: Path) -> None:
+    source_file = tmp_path / "small.py"
+    source_file.write_text("def ok():\n    return 1\n", encoding="utf-8")
+
+    result = check_refactor_quality_thresholds(
+        source_roots=[tmp_path],
+        max_source_file_lines=10,
+        max_function_lines=3,
+    )
+
+    assert result.passed
+    assert result.file_size_violations == ()
+    assert result.function_size_violations == ()
+
+
+def test_refactor_quality_thresholds_reports_oversized_files(tmp_path: Path) -> None:
+    source_file = tmp_path / "large.py"
+    source_file.write_text("\n".join(["VALUE = 1"] * 4), encoding="utf-8")
+
+    result = check_refactor_quality_thresholds(
+        source_roots=[tmp_path],
+        max_source_file_lines=3,
+        max_function_lines=10,
+    )
+
+    assert not result.passed
+    assert len(result.file_size_violations) == 1
+    assert result.file_size_violations[0].path == source_file
+    assert result.file_size_violations[0].line_count == 4
+
+
+def test_refactor_quality_thresholds_reports_oversized_functions() -> None:
+    violations = find_function_size_violations(
+        path=Path("example.py"),
+        source="\n".join(
+            [
+                "async def too_large():",
+                "    value = 1",
+                "    value += 1",
+                "    return value",
+            ]
+        ),
+        max_function_lines=3,
+    )
+
+    assert len(violations) == 1
+    assert violations[0].function_name == "too_large"
+    assert violations[0].line_number == 1
+    assert violations[0].line_count == 4

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -207,3 +207,18 @@ tests. Local `make check` passed with ruff, format check, monetary-float guard, 
 source files, Workbench/OpenAPI contract smoke, and 1,063 unit/contract tests. Local `make ci`
 passed with 207 integration tests, 1,270 coverage tests, 94.05% total coverage, and no known
 vulnerabilities after the governed `PYSEC-2026-161` exception.
+PR #374 then merged the performance evidence-view builder extraction with all GitHub checks green.
+The current quality-baseline enforcement branch promotes remediated refactor thresholds into the
+blocking `make lint` path through `scripts/check_refactor_quality_thresholds.py`. The gate fails
+when any Python source file under `src/app` exceeds 2,100 physical lines or any Python function or
+async function exceeds the current 49-line AST span baseline. Focused local evidence:
+`python scripts/check_refactor_quality_thresholds.py` passed with
+`max_source_file_lines=2100` and `max_function_lines=49`. The branch also makes the promoted gate
+visible as `Lint and Refactor Quality Thresholds` in Feature Lane and PR Merge Gate logs, and lets
+PR Merge Gate integration and coverage jobs run in parallel after lint/typecheck/unit. Docker build
+and Docker parity still wait for both integration and coverage.
+Local validation for the current branch passed with `make check` covering ruff, format check,
+monetary-float guard, refactor threshold gate, mypy over 471 source files, Workbench/OpenAPI
+contract smoke, and 1,066 unit/contract tests. Local `make ci` passed with 207 integration tests,
+1,273 coverage tests, 94.05% total coverage, and no known vulnerabilities after the governed
+`PYSEC-2026-161` exception.


### PR DESCRIPTION
## Summary
- Promote remediated refactor size baselines into the blocking make lint path via scripts/check_refactor_quality_thresholds.py.
- Enforce no Python source file under src/app above 2,100 physical lines and no function/async function above the current 49-line AST span baseline.
- Add focused tests for pass, file-size violation, and function-size violation behavior.
- Make the promoted gate visible in Feature Lane and PR Merge Gate logs as Lint and Refactor Quality Thresholds.
- Let PR Merge Gate integration and coverage jobs run in parallel after lint/typecheck/unit; Docker build and Docker parity still wait for both.
- Refresh quality and wiki evidence for the new blocking gate.

## Validation
- python scripts/check_refactor_quality_thresholds.py passed.
- python -m pytest tests/unit/test_refactor_quality_thresholds.py tests/unit/test_gateway_wiki_overview.py passed: 4 tests.
- make check passed: ruff, format check, monetary-float guard, refactor threshold gate, mypy over 471 source files, Workbench/OpenAPI contract smoke, 1,066 unit/contract tests.
- make ci passed: 207 integration tests, 1,273 coverage tests, total coverage 94.05%, pip-audit no known vulnerabilities with governed PYSEC-2026-161 exception.

## Governance
- Stranded-truth check before PR: no remote branches unmerged into origin/main.
- No open PRs existed before this PR.
- Wiki source changed for validation/CI truth; pre-merge wiki check reports expected drift in Validation-and-CI.md; publish/check required after merge.
- Local workflow lint tool ctionlint is not installed; GitHub workflow-lint jobs remain the workflow syntax authority for this PR.