### PR TITLE
Harden performance evidence artifact handling

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -39,7 +39,7 @@ jobs:
         run: python -m pip check
       - name: Security Audit
         run: make security-audit
-      - name: Lint
+      - name: Lint and Refactor Quality Thresholds
         run: make lint
       - name: Typecheck
         run: make typecheck
@@ -68,7 +68,7 @@ jobs:
 
   coverage:
     name: Main Releasability / Coverage Gate
-    needs: [integration]
+    needs: [lint-typecheck-unit]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -93,7 +93,7 @@ jobs:
 
   docker-build:
     name: Main Releasability / Validate Docker Build
-    needs: [coverage]
+    needs: [integration, coverage]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -102,7 +102,7 @@ jobs:
 
   ci-local-docker:
     name: Main Releasability / CI Local Docker Parity
-    needs: [coverage]
+    needs: [integration, coverage]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/src/app/services/performance_workspace_evidence.py
+++ b/src/app/services/performance_workspace_evidence.py
@@ -5,6 +5,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, TypeAlias
 
+from fastapi import HTTPException
+
 from app.contracts.performance_evidence import (
     PerformanceCalculationEvidenceView,
     PerformanceEvidenceArtifactView,
@@ -97,6 +99,35 @@ def build_evidence_requested_items(
         for role, calculation_id in calculations
         if calculation_id is not None
     ]
+
+
+async def fetch_performance_evidence_artifact(
+    *,
+    analytics_client: PerformanceWorkspaceAnalyticsClient,
+    calculation_id: str,
+    artifact_name: str,
+    correlation_id: str,
+) -> tuple[bytes, str | None]:
+    status_code, content, content_type = await analytics_client.get_lineage_artifact(
+        calculation_id=calculation_id,
+        artifact_name=artifact_name,
+        correlation_id=correlation_id,
+    )
+    if status_code >= 400:
+        raise HTTPException(
+            status_code=status_code,
+            detail=performance_evidence_artifact_failure_detail(content),
+        )
+    return content, content_type
+
+
+def performance_evidence_artifact_failure_detail(content: bytes) -> str:
+    if not content:
+        return "Performance evidence artifact is unavailable."
+    try:
+        return content.decode("utf-8")
+    except UnicodeDecodeError:
+        return "Performance evidence artifact retrieval failed."
 
 
 async def fetch_evidence_view_state(

--- a/src/app/services/performance_workspace_service.py
+++ b/src/app/services/performance_workspace_service.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any, TypeAlias, cast
 
-from fastapi import HTTPException
-
 from app.config import settings
 from app.contracts.performance_attribution import (
     AttributionSummaryView,
@@ -61,6 +59,7 @@ from app.services.performance_workspace_evidence import (
     EvidenceViewRequestContext,
     extract_calculation_id_from_result,
     fetch_evidence_view_state,
+    fetch_performance_evidence_artifact,
     resolve_evidence_view_response,
 )
 from app.services.performance_workspace_horizon import (
@@ -1367,23 +1366,12 @@ class PerformanceWorkspaceService:
         artifact_name: str,
         correlation_id: str,
     ) -> tuple[bytes, str | None]:
-        status_code, content, content_type = await self._analytics_client.get_lineage_artifact(
+        return await fetch_performance_evidence_artifact(
+            analytics_client=self._analytics_client,
             calculation_id=calculation_id,
             artifact_name=artifact_name,
             correlation_id=correlation_id,
         )
-        if status_code >= 400:
-            detail = "Performance evidence artifact is unavailable."
-            if content:
-                try:
-                    detail = content.decode("utf-8")
-                except UnicodeDecodeError:
-                    detail = "Performance evidence artifact retrieval failed."
-            raise HTTPException(
-                status_code=status_code,
-                detail=detail,
-            )
-        return content, content_type
 
     async def _build_evidence_view(
         self,

--- a/tests/unit/test_performance_workspace_evidence.py
+++ b/tests/unit/test_performance_workspace_evidence.py
@@ -1,4 +1,5 @@
 import pytest
+from fastapi import HTTPException
 
 from app.contracts import performance_workspace
 from app.contracts.performance_evidence import (
@@ -18,9 +19,11 @@ from app.services.performance_workspace_evidence import (
     execution_lineage_stage_complete,
     extract_calculation_id_from_result,
     fetch_calculation_evidence,
+    fetch_performance_evidence_artifact,
     gateway_evidence_artifact_url,
     lineage_is_complete,
     lineage_is_transient,
+    performance_evidence_artifact_failure_detail,
     refresh_execution_after_lineage_completion,
     resolve_evidence_reason,
     resolve_evidence_state,
@@ -66,11 +69,78 @@ class _EvidenceAnalyticsClient:
         return self.lineage_results.pop(0)
 
 
+class _ArtifactAnalyticsClient:
+    def __init__(self, result: tuple[int, bytes, str | None]) -> None:
+        self.result = result
+        self.artifact_calls: list[dict[str, str]] = []
+
+    async def get_lineage_artifact(
+        self, *, calculation_id: str, artifact_name: str, correlation_id: str
+    ) -> tuple[int, bytes, str | None]:
+        self.artifact_calls.append(
+            {
+                "calculation_id": calculation_id,
+                "artifact_name": artifact_name,
+                "correlation_id": correlation_id,
+            }
+        )
+        return self.result
+
+
 def test_extract_calculation_id_from_result_returns_stable_string_id():
     assert extract_calculation_id_from_result((200, {"calculation_id": 42})) == "42"
     assert extract_calculation_id_from_result((200, {})) is None
     assert extract_calculation_id_from_result(ValueError("boom")) is None
     assert extract_calculation_id_from_result(None) is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_performance_evidence_artifact_returns_bytes_and_content_type() -> None:
+    client = _ArtifactAnalyticsClient((200, b"{}", "application/json"))
+
+    content, content_type = await fetch_performance_evidence_artifact(
+        analytics_client=client,
+        calculation_id="calc-1",
+        artifact_name="request.json",
+        correlation_id="corr-1",
+    )
+
+    assert content == b"{}"
+    assert content_type == "application/json"
+    assert client.artifact_calls == [
+        {
+            "calculation_id": "calc-1",
+            "artifact_name": "request.json",
+            "correlation_id": "corr-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_performance_evidence_artifact_raises_upstream_text_detail() -> None:
+    client = _ArtifactAnalyticsClient((404, b"artifact not found", "text/plain"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fetch_performance_evidence_artifact(
+            analytics_client=client,
+            calculation_id="calc-1",
+            artifact_name="request.json",
+            correlation_id="corr-1",
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "artifact not found"
+
+
+def test_performance_evidence_artifact_failure_detail_uses_safe_fallbacks() -> None:
+    assert (
+        performance_evidence_artifact_failure_detail(b"")
+        == "Performance evidence artifact is unavailable."
+    )
+    assert (
+        performance_evidence_artifact_failure_detail(b"\xff\xfe\xfd")
+        == "Performance evidence artifact retrieval failed."
+    )
 
 
 def test_build_source_supportability_deduplicates_upstream_posture():

--- a/tests/unit/test_workflow_action_runtime.py
+++ b/tests/unit/test_workflow_action_runtime.py
@@ -182,9 +182,9 @@ def test_gateway_workflows_match_platform_action_runtime_baseline() -> None:
 
 
 def test_main_releasability_runs_coverage_in_parallel_with_integration() -> None:
-    workflow = (
-        REPO_ROOT / ".github" / "workflows" / "main-releasability.yml"
-    ).read_text(encoding="utf-8")
+    workflow = (REPO_ROOT / ".github" / "workflows" / "main-releasability.yml").read_text(
+        encoding="utf-8"
+    )
 
     assert (
         "      - name: Lint and Refactor Quality Thresholds\n        run: make lint"

--- a/tests/unit/test_workflow_action_runtime.py
+++ b/tests/unit/test_workflow_action_runtime.py
@@ -179,3 +179,29 @@ def test_gateway_workflows_match_platform_action_runtime_baseline() -> None:
     }
     assert find_workflow_action_runtime_violations([REPO_ROOT / ".github" / "workflows"]) == ()
     assert find_workflow_node24_opt_in_violations([REPO_ROOT / ".github" / "workflows"]) == ()
+
+
+def test_main_releasability_runs_coverage_in_parallel_with_integration() -> None:
+    workflow = (
+        REPO_ROOT / ".github" / "workflows" / "main-releasability.yml"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        "      - name: Lint and Refactor Quality Thresholds\n        run: make lint"
+    ) in workflow
+    assert (
+        "  integration:\n    name: Main Releasability / Integration Tests\n"
+        "    needs: [lint-typecheck-unit]"
+    ) in workflow
+    assert (
+        "  coverage:\n    name: Main Releasability / Coverage Gate\n"
+        "    needs: [lint-typecheck-unit]"
+    ) in workflow
+    assert (
+        "  docker-build:\n    name: Main Releasability / Validate Docker Build\n"
+        "    needs: [integration, coverage]"
+    ) in workflow
+    assert (
+        "  ci-local-docker:\n    name: Main Releasability / CI Local Docker Parity\n"
+        "    needs: [integration, coverage]"
+    ) in workflow


### PR DESCRIPTION
## Summary
- Move performance evidence artifact download and safe upstream error detail handling into the evidence helper module.
- Add focused evidence artifact unit coverage for success, upstream text errors, and fallback error details.
- Align Main Releasability coverage scheduling with the PR gate by running coverage in parallel with integration after lint/typecheck/unit, while keeping Docker checks dependent on both.
- Add workflow topology coverage so the CI parallelism and refactor-threshold label stay governed.

## Validation
- python -m pytest tests/unit/test_performance_workspace_evidence.py tests/unit/test_performance_workspace_service.py
- python -m pytest tests/unit/test_workflow_action_runtime.py tests/unit/test_quality_baseline_artifacts.py
- python scripts/check_workflow_action_runtime.py
- make check
- make ci

## Wiki
- No wiki change. This slice changes service internals, tests, and CI workflow scheduling only; no durable operator-facing wiki truth changed.