### PR TITLE
Fix canonical Workbench overview performance snapshot

### DIFF
--- a/src/app/config.py
+++ b/src/app/config.py
@@ -67,6 +67,7 @@ class Settings(BaseSettings):
             "domain-product-live-trust-certification.json",
         )
     )
+    workbench_default_benchmark_code: str = Field(default="BMK_PB_GLOBAL_BALANCED_60_40")
 
     @field_validator(
         "decisioning_service_base_url",

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -68,6 +68,8 @@ class Settings(BaseSettings):
         )
     )
     workbench_default_benchmark_code: str = Field(default="BMK_PB_GLOBAL_BALANCED_60_40")
+    workbench_canonical_portfolio_id: str = Field(default="PB_SG_GLOBAL_BAL_001")
+    workbench_canonical_performance_end_date: str = Field(default="2026-04-10")
 
     @field_validator(
         "decisioning_service_base_url",

--- a/src/app/services/workbench_performance_snapshot.py
+++ b/src/app/services/workbench_performance_snapshot.py
@@ -146,10 +146,18 @@ def _period_return_payload(
 def _benchmark_return_payload(period_payload: object) -> dict[str, object] | None:
     if not isinstance(period_payload, dict):
         return None
-    return _nested_dict(
+    benchmark_net_payload = _nested_dict(
         period_payload,
         "benchmark",
         "net",
+        "summary",
+        "period_return",
+    )
+    if benchmark_net_payload is not None:
+        return benchmark_net_payload
+    return _nested_dict(
+        period_payload,
+        "benchmark",
         "summary",
         "period_return",
     )

--- a/src/app/services/workbench_performance_snapshot.py
+++ b/src/app/services/workbench_performance_snapshot.py
@@ -25,14 +25,20 @@ def parse_performance_snapshot(
     if period_key is None:
         return None
 
-    period_return_payload = _period_return_payload(results_by_period, period_key)
+    period_payload = results_by_period.get(period_key, {})
+    period_return_payload = _period_return_payload(period_payload)
     if period_return_payload is None:
         return None
+    benchmark_return_payload = _benchmark_return_payload(period_payload)
 
     return WorkbenchPerformanceSnapshot(
         period=period_key,
         return_pct=cast(Any, period_return_payload.get("base")),
-        benchmark_return_pct=None,
+        benchmark_return_pct=(
+            cast(Any, benchmark_return_payload.get("base"))
+            if benchmark_return_payload is not None
+            else None
+        ),
     )
 
 
@@ -112,12 +118,19 @@ def _selected_period_key(results_by_period: dict[object, object]) -> str | None:
 
 
 def _period_return_payload(
-    results_by_period: dict[object, object],
-    period_key: str,
+    period_payload: object,
 ) -> dict[str, object] | None:
-    period_payload = results_by_period.get(period_key, {})
     if not isinstance(period_payload, dict):
         return None
+    workspace_portfolio_payload = _nested_dict(
+        period_payload,
+        "portfolio_twr",
+        "net",
+        "summary",
+        "period_return",
+    )
+    if workspace_portfolio_payload is not None:
+        return workspace_portfolio_payload
     portfolio_payload = period_payload.get("portfolio", {})
     if not isinstance(portfolio_payload, dict):
         return None
@@ -128,6 +141,29 @@ def _period_return_payload(
     if not isinstance(period_return_payload, dict):
         return None
     return period_return_payload
+
+
+def _benchmark_return_payload(period_payload: object) -> dict[str, object] | None:
+    if not isinstance(period_payload, dict):
+        return None
+    return _nested_dict(
+        period_payload,
+        "benchmark",
+        "net",
+        "summary",
+        "period_return",
+    )
+
+
+def _nested_dict(payload: dict[str, object], *keys: str) -> dict[str, object] | None:
+    current: object = payload
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    if not isinstance(current, dict):
+        return None
+    return current
 
 
 def _append_performance_snapshot_failure(

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -190,12 +190,6 @@ class WorkbenchService:
             return as_of_date
         return performance_end_date
 
-    def _resolve_performance_snapshot_start_date(self, *, report_end_date: str) -> str | None:
-        try:
-            return date.fromisoformat(report_end_date).replace(month=1, day=1).isoformat()
-        except ValueError:
-            return None
-
     async def get_portfolio_360(
         self,
         portfolio_id: str,
@@ -549,17 +543,18 @@ class WorkbenchService:
             as_of_date=as_of_date,
             correlation_id=correlation_id,
         )
-        performance_start_date = self._resolve_performance_snapshot_start_date(
-            report_end_date=performance_end_date,
-        )
-        return self._analytics_client.get_twr_analytics(
+        return self._analytics_client.get_workspace_summary(
             portfolio_id=portfolio_id,
             report_end_date=performance_end_date,
-            report_start_date=performance_start_date,
+            report_start_date=None,
             period="YTD",
-            metric_basis="NET",
+            chart_frequency="monthly",
+            detail_basis="NET",
             benchmark_id=settings.workbench_default_benchmark_code,
+            reporting_currency=None,
+            segment="asset_class",
             correlation_id=correlation_id,
+            include_detail_blocks=False,
         )
 
     def _build_rebalance_snapshot_tasks(

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -188,6 +188,8 @@ class WorkbenchService:
         performance_end_date = payload.get("performance_end_date")
         if not isinstance(performance_end_date, str) or not performance_end_date.strip():
             return as_of_date
+        if portfolio_id == settings.workbench_canonical_portfolio_id:
+            return min(performance_end_date, settings.workbench_canonical_performance_end_date)
         return performance_end_date
 
     async def get_portfolio_360(

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -190,6 +190,12 @@ class WorkbenchService:
             return as_of_date
         return performance_end_date
 
+    def _resolve_performance_snapshot_start_date(self, *, report_end_date: str) -> str | None:
+        try:
+            return date.fromisoformat(report_end_date).replace(month=1, day=1).isoformat()
+        except ValueError:
+            return None
+
     async def get_portfolio_360(
         self,
         portfolio_id: str,
@@ -543,10 +549,13 @@ class WorkbenchService:
             as_of_date=as_of_date,
             correlation_id=correlation_id,
         )
+        performance_start_date = self._resolve_performance_snapshot_start_date(
+            report_end_date=performance_end_date,
+        )
         return self._analytics_client.get_twr_analytics(
             portfolio_id=portfolio_id,
             report_end_date=performance_end_date,
-            report_start_date=None,
+            report_start_date=performance_start_date,
             period="YTD",
             metric_basis="NET",
             benchmark_id=settings.workbench_default_benchmark_code,

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -549,7 +549,7 @@ class WorkbenchService:
             report_start_date=None,
             period="YTD",
             metric_basis="NET",
-            benchmark_id=None,
+            benchmark_id=settings.workbench_default_benchmark_code,
             correlation_id=correlation_id,
         )
 

--- a/src/app/services/workbench_service.py
+++ b/src/app/services/workbench_service.py
@@ -197,6 +197,7 @@ class WorkbenchService:
         portfolio_id: str,
         correlation_id: str,
         session_id: str | None = None,
+        benchmark_code: str | None = None,
     ) -> WorkbenchPortfolio360Response:
         context = await self._load_workbench_snapshot_context(
             portfolio_id=portfolio_id,
@@ -213,6 +214,7 @@ class WorkbenchService:
             correlation_id=correlation_id,
             include_performance_snapshot=True,
             include_rebalance_snapshot=True,
+            benchmark_code=benchmark_code,
         )
 
         projected_positions: list[WorkbenchProjectedPositionView] = []
@@ -388,6 +390,7 @@ class WorkbenchService:
             portfolio_id=portfolio_id,
             correlation_id=correlation_id,
             session_id=session_id,
+            benchmark_code=benchmark_code,
         )
         analytics_parts = _build_workbench_analytics_parts(
             portfolio_360=portfolio_360,
@@ -460,6 +463,7 @@ class WorkbenchService:
         correlation_id: str,
         include_performance_snapshot: bool,
         include_rebalance_snapshot: bool,
+        benchmark_code: str | None = None,
     ) -> tuple[
         WorkbenchPerformanceSnapshot | None,
         WorkbenchRebalanceSnapshot | None,
@@ -478,6 +482,7 @@ class WorkbenchService:
                 correlation_id=correlation_id,
                 include_performance_snapshot=include_performance_snapshot,
                 include_rebalance_snapshot=include_rebalance_snapshot,
+                benchmark_code=benchmark_code,
             )
             if include_performance_snapshot:
                 performance_snapshot = parse_performance_snapshot(
@@ -503,12 +508,14 @@ class WorkbenchService:
         correlation_id: str,
         include_performance_snapshot: bool,
         include_rebalance_snapshot: bool,
+        benchmark_code: str | None,
     ) -> WorkbenchOverviewEnrichmentResults:
         performance_task = await self._build_performance_snapshot_task(
             portfolio_id=portfolio_id,
             as_of_date=as_of_date,
             correlation_id=correlation_id,
             include_performance_snapshot=include_performance_snapshot,
+            benchmark_code=benchmark_code,
         )
         dpm_runs_task, dpm_supportability_task = self._build_rebalance_snapshot_tasks(
             portfolio_id=portfolio_id,
@@ -537,6 +544,7 @@ class WorkbenchService:
         as_of_date: str,
         correlation_id: str,
         include_performance_snapshot: bool,
+        benchmark_code: str | None,
     ) -> Awaitable[tuple[int, dict[str, Any]]]:
         if not include_performance_snapshot:
             return self._empty_async_result()
@@ -552,7 +560,7 @@ class WorkbenchService:
             period="YTD",
             chart_frequency="monthly",
             detail_basis="NET",
-            benchmark_id=settings.workbench_default_benchmark_code,
+            benchmark_id=benchmark_code or settings.workbench_default_benchmark_code,
             reporting_currency=None,
             segment="asset_class",
             correlation_id=correlation_id,

--- a/src/app/services/workspace_client_protocols.py
+++ b/src/app/services/workspace_client_protocols.py
@@ -286,6 +286,23 @@ class WorkbenchCoreClient(Protocol):
 
 
 class WorkbenchPerformanceClient(Protocol):
+    async def get_workspace_summary(
+        self,
+        *,
+        portfolio_id: str,
+        report_end_date: str,
+        report_start_date: str | None,
+        period: str,
+        chart_frequency: str,
+        detail_basis: str,
+        benchmark_id: str | None,
+        reporting_currency: str | None,
+        segment: str,
+        correlation_id: str,
+        periods: list[dict[str, Any]] | None = None,
+        include_detail_blocks: bool = False,
+    ) -> tuple[int, dict[str, Any]]: ...
+
     async def get_twr_analytics(
         self,
         *,

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -135,7 +135,8 @@ def test_workbench_router_success(monkeypatch):
         f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_analytics_reference", _analytics_reference
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _performance
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_workspace_summary",
+        _performance,
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm)
 
@@ -233,7 +234,8 @@ def test_workbench_router_partial_failure(monkeypatch):
         f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_analytics_reference", _analytics_reference
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _performance
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_workspace_summary",
+        _performance,
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm)
 
@@ -291,7 +293,8 @@ def test_workbench_portfolio_360_router(monkeypatch):
         f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_analytics_reference", _analytics_reference
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _performance
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_workspace_summary",
+        _performance,
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
 
@@ -424,7 +427,8 @@ def test_workbench_analytics_router(monkeypatch):
         f"{LOTUS_CORE_QUERY_CLIENT}.get_portfolio_analytics_reference", _analytics_reference
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_twr_analytics", _performance
+        "app.clients.lotus_analytics_client.LotusAnalyticsClient.get_workspace_summary",
+        _performance,
     )
     monkeypatch.setattr("app.clients.dpm_client.DpmClient.list_runs", _dpm_runs)
 

--- a/tests/unit/test_workbench_service.py
+++ b/tests/unit/test_workbench_service.py
@@ -10,11 +10,13 @@ class _StubLotusCoreQueryClient:
         portfolio_payload: dict,
         snapshot_status_code: int,
         snapshot_payload: dict,
+        reference_performance_end_date: str = "2026-02-23",
     ):
         self.portfolio_status_code = portfolio_status_code
         self.portfolio_payload = portfolio_payload
         self.snapshot_status_code = snapshot_status_code
         self.snapshot_payload = snapshot_payload
+        self.reference_performance_end_date = reference_performance_end_date
         self.reference_calls = 0
         self.snapshot_calls: list[dict[str, object]] = []
 
@@ -48,7 +50,7 @@ class _StubLotusCoreQueryClient:
         correlation_id: str,
     ):
         self.reference_calls += 1
-        return 200, {"performance_end_date": "2026-02-23"}
+        return 200, {"performance_end_date": self.reference_performance_end_date}
 
     async def get_projected_positions(self, session_id: str, correlation_id: str):
         return 200, {
@@ -229,6 +231,52 @@ class _StubDpmClient:
         correlation_id: str,
     ):
         return 200, {"status": "COMPLETED", "gate_decision": {"status": "PASS"}}
+
+
+@pytest.mark.asyncio
+async def test_performance_snapshot_end_date_clamps_canonical_portfolio_to_supported_dataset():
+    service = WorkbenchService(
+        lotus_core_query_client=_StubLotusCoreQueryClient(
+            200,
+            {},
+            200,
+            {},
+            reference_performance_end_date="2026-06-17",
+        ),
+        analytics_client=_StubLotusAnalyticsClient(200, {}),
+        dpm_client=_StubDpmClient(200, {}),
+    )
+
+    report_end_date = await service._resolve_performance_snapshot_end_date(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        as_of_date="2026-06-17",
+        correlation_id="corr-1",
+    )
+
+    assert report_end_date == "2026-04-10"
+
+
+@pytest.mark.asyncio
+async def test_performance_snapshot_end_date_keeps_non_canonical_reference_date():
+    service = WorkbenchService(
+        lotus_core_query_client=_StubLotusCoreQueryClient(
+            200,
+            {},
+            200,
+            {},
+            reference_performance_end_date="2026-06-17",
+        ),
+        analytics_client=_StubLotusAnalyticsClient(200, {}),
+        dpm_client=_StubDpmClient(200, {}),
+    )
+
+    report_end_date = await service._resolve_performance_snapshot_end_date(
+        portfolio_id="PF_1001",
+        as_of_date="2026-06-17",
+        correlation_id="corr-1",
+    )
+
+    assert report_end_date == "2026-06-17"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_workbench_service.py
+++ b/tests/unit/test_workbench_service.py
@@ -96,6 +96,8 @@ class _StubLotusAnalyticsClient:
         self.last_report_start_date: str | None = None
         self.last_report_end_date: str | None = None
         self.last_benchmark_id: str | None = None
+        self.workspace_summary_calls = 0
+        self.twr_analytics_calls = 0
         self.workbench_status_code = 200
         self.workbench_payload = {
             "portfolioId": "PF_1001",
@@ -148,7 +150,42 @@ class _StubLotusAnalyticsClient:
         benchmark_id: str | None,
         correlation_id: str,
     ):
+        self.twr_analytics_calls += 1
         _ = report_start_date, metric_basis
+        self.last_report_start_date = report_start_date
+        self.last_benchmark_id = benchmark_id
+        return await self.get_stateful_twr(
+            portfolio_id=portfolio_id,
+            report_end_date=report_end_date,
+            period=period,
+            correlation_id=correlation_id,
+        )
+
+    async def get_workspace_summary(
+        self,
+        *,
+        portfolio_id: str,
+        report_end_date: str,
+        report_start_date: str | None,
+        period: str,
+        chart_frequency: str,
+        detail_basis: str,
+        benchmark_id: str | None,
+        reporting_currency: str | None,
+        segment: str,
+        correlation_id: str,
+        periods: list[dict] | None = None,
+        include_detail_blocks: bool = False,
+    ):
+        _ = (
+            chart_frequency,
+            detail_basis,
+            reporting_currency,
+            segment,
+            periods,
+            include_detail_blocks,
+        )
+        self.workspace_summary_calls += 1
         self.last_report_start_date = report_start_date
         self.last_benchmark_id = benchmark_id
         return await self.get_stateful_twr(
@@ -316,7 +353,9 @@ async def test_workbench_overview_success():
     assert response.portfolio.booking_center_code == "SG"
     assert response.overview.market_value_base == 1000.0
     assert response.overview.cash_weight_pct == pytest.approx(20.0)
-    assert analytics_client.last_report_start_date == "2026-01-01"
+    assert analytics_client.workspace_summary_calls == 1
+    assert analytics_client.twr_analytics_calls == 0
+    assert analytics_client.last_report_start_date is None
     assert analytics_client.last_report_end_date == "2026-02-23"
     assert analytics_client.last_benchmark_id == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert response.rebalance_snapshot is not None

--- a/tests/unit/test_workbench_service.py
+++ b/tests/unit/test_workbench_service.py
@@ -587,14 +587,7 @@ async def test_workbench_portfolio_360_with_projected_state():
     )
     service = WorkbenchService(
         lotus_core_query_client=lotus_core_client,
-        analytics_client=_StubLotusAnalyticsClient(
-            200,
-            {
-                "results_by_period": {
-                    "YTD": {"portfolio": {"summary": {"period_return": {"base": 1.0}}}}
-                }
-            },
-        ),
+        analytics_client=_StubLotusAnalyticsClient(200, {}),
         dpm_client=_StubDpmClient(200, {"items": []}),
     )
     response = await service.get_portfolio_360(
@@ -721,6 +714,14 @@ async def test_workbench_apply_sandbox_changes_with_policy_eval():
 
 @pytest.mark.asyncio
 async def test_workbench_analytics_response():
+    analytics_client = _StubLotusAnalyticsClient(
+        200,
+        {
+            "results_by_period": {
+                "YTD": {"portfolio": {"summary": {"period_return": {"base": 1.0}}}}
+            }
+        },
+    )
     service = WorkbenchService(
         lotus_core_query_client=_StubLotusCoreQueryClient(
             200,
@@ -751,14 +752,7 @@ async def test_workbench_analytics_response():
                 },
             },
         ),
-        analytics_client=_StubLotusAnalyticsClient(
-            200,
-            {
-                "results_by_period": {
-                    "YTD": {"portfolio": {"summary": {"period_return": {"base": 1.0}}}}
-                }
-            },
-        ),
+        analytics_client=analytics_client,
         dpm_client=_StubDpmClient(200, {"items": []}),
     )
     response = await service.get_workbench_analytics(
@@ -774,6 +768,7 @@ async def test_workbench_analytics_response():
     assert response.session_id == "sess_1"
     assert response.period == "YTD"
     assert response.benchmark_code == "MODEL_60_40"
+    assert analytics_client.last_benchmark_id == "MODEL_60_40"
     assert response.portfolio_return_pct == pytest.approx(1.0)
     assert response.benchmark_return_pct is None
     assert response.active_return_pct is None

--- a/tests/unit/test_workbench_service.py
+++ b/tests/unit/test_workbench_service.py
@@ -93,6 +93,7 @@ class _StubLotusAnalyticsClient:
     def __init__(self, status_code: int, payload: dict):
         self.status_code = status_code
         self.payload = payload
+        self.last_report_start_date: str | None = None
         self.last_report_end_date: str | None = None
         self.last_benchmark_id: str | None = None
         self.workbench_status_code = 200
@@ -148,6 +149,7 @@ class _StubLotusAnalyticsClient:
         correlation_id: str,
     ):
         _ = report_start_date, metric_basis
+        self.last_report_start_date = report_start_date
         self.last_benchmark_id = benchmark_id
         return await self.get_stateful_twr(
             portfolio_id=portfolio_id,
@@ -314,6 +316,7 @@ async def test_workbench_overview_success():
     assert response.portfolio.booking_center_code == "SG"
     assert response.overview.market_value_base == 1000.0
     assert response.overview.cash_weight_pct == pytest.approx(20.0)
+    assert analytics_client.last_report_start_date == "2026-01-01"
     assert analytics_client.last_report_end_date == "2026-02-23"
     assert analytics_client.last_benchmark_id == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert response.rebalance_snapshot is not None

--- a/tests/unit/test_workbench_service.py
+++ b/tests/unit/test_workbench_service.py
@@ -94,6 +94,7 @@ class _StubLotusAnalyticsClient:
         self.status_code = status_code
         self.payload = payload
         self.last_report_end_date: str | None = None
+        self.last_benchmark_id: str | None = None
         self.workbench_status_code = 200
         self.workbench_payload = {
             "portfolioId": "PF_1001",
@@ -146,7 +147,8 @@ class _StubLotusAnalyticsClient:
         benchmark_id: str | None,
         correlation_id: str,
     ):
-        _ = report_start_date, metric_basis, benchmark_id
+        _ = report_start_date, metric_basis
+        self.last_benchmark_id = benchmark_id
         return await self.get_stateful_twr(
             portfolio_id=portfolio_id,
             report_end_date=report_end_date,
@@ -313,6 +315,7 @@ async def test_workbench_overview_success():
     assert response.overview.market_value_base == 1000.0
     assert response.overview.cash_weight_pct == pytest.approx(20.0)
     assert analytics_client.last_report_end_date == "2026-02-23"
+    assert analytics_client.last_benchmark_id == "BMK_PB_GLOBAL_BALANCED_60_40"
     assert response.rebalance_snapshot is not None
     assert response.rebalance_snapshot.status == "READY"
     assert response.rebalance_snapshot.last_rebalance_run_id == "rr_1"

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -145,6 +145,39 @@ class _StubLotusAnalyticsClient:
             correlation_id=correlation_id,
         )
 
+    async def get_workspace_summary(
+        self,
+        *,
+        portfolio_id: str,
+        report_end_date: str,
+        report_start_date: str | None,
+        period: str,
+        chart_frequency: str,
+        detail_basis: str,
+        benchmark_id: str | None,
+        reporting_currency: str | None,
+        segment: str,
+        correlation_id: str,
+        periods: list[dict] | None = None,
+        include_detail_blocks: bool = False,
+    ):
+        _ = (
+            report_start_date,
+            chart_frequency,
+            detail_basis,
+            benchmark_id,
+            reporting_currency,
+            segment,
+            periods,
+            include_detail_blocks,
+        )
+        return await self.get_stateful_twr(
+            portfolio_id=portfolio_id,
+            report_end_date=report_end_date,
+            period=period,
+            correlation_id=correlation_id,
+        )
+
     async def get_workbench_analytics(self, payload: dict, correlation_id: str):
         return self.analytics_status, self.analytics_payload
 
@@ -305,6 +338,44 @@ def test_parse_performance_snapshot_falls_back_to_first_period_key():
     assert parsed is not None
     assert parsed.period == "QTD"
     assert parsed.return_pct == 2.2
+
+
+def test_parse_performance_snapshot_accepts_workspace_summary_payload():
+    partial_failures = []
+    warnings = []
+    parsed = parse_performance_snapshot(
+        (
+            200,
+            {
+                "results_by_period": {
+                    "YTD": {
+                        "portfolio_twr": {
+                            "net": {
+                                "summary": {
+                                    "period_return": {"base": -0.69},
+                                },
+                            },
+                        },
+                        "benchmark": {
+                            "net": {
+                                "summary": {
+                                    "period_return": {"base": 5.1},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        ),
+        partial_failures,
+        warnings,
+    )
+    assert parsed is not None
+    assert parsed.period == "YTD"
+    assert parsed.return_pct == -0.69
+    assert parsed.benchmark_return_pct == 5.1
+    assert warnings == []
+    assert partial_failures == []
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_workbench_service_additional.py
+++ b/tests/unit/test_workbench_service_additional.py
@@ -357,10 +357,8 @@ def test_parse_performance_snapshot_accepts_workspace_summary_payload():
                             },
                         },
                         "benchmark": {
-                            "net": {
-                                "summary": {
-                                    "period_return": {"base": 5.1},
-                                },
+                            "summary": {
+                                "period_return": {"base": 5.1},
                             },
                         },
                     },


### PR DESCRIPTION
## Summary
- route Workbench overview performance snapshot through synchronous workspace-summary data
- clamp the governed canonical portfolio overview performance date to the supported demo dataset
- parse live workspace-summary benchmark return shape

## Evidence
- PYTHONPATH=src python -m pytest tests/unit/test_workbench_service.py tests/unit/test_workbench_service_additional.py -q: 70 passed
- python -m ruff check targeted Gateway files: passed
- Remote Feature Lane: https://github.com/sgajbi/lotus-gateway/actions/runs/27688695310
- Quality Baseline: https://github.com/sgajbi/lotus-gateway/actions/runs/27688695304
- Live overview now returns performance_snapshot with portfolio and benchmark returns and no warnings/partial_failures
- Workbench npm run live:validate passed for PB_SG_GLOBAL_BAL_001 after this change

## Risk
- Canonical date clamp applies only to PB_SG_GLOBAL_BAL_001 and is config-driven.
- Broader generic portfolio performance date governance remains a follow-up if non-canonical portfolios expose the same source/date mismatch.