### PR TITLE
Mount domain product artifacts in Gateway compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,14 @@ services:
       - REPORTING_AGGREGATION_BASE_URL=${REPORTING_AGGREGATION_BASE_URL:-http://host.docker.internal:8300}
       - RENDER_SERVICE_BASE_URL=${RENDER_SERVICE_BASE_URL:-http://host.docker.internal:8310}
       - ARCHIVE_SERVICE_BASE_URL=${ARCHIVE_SERVICE_BASE_URL:-http://host.docker.internal:8150}
+      - DOMAIN_PRODUCT_CATALOG_PATH=${DOMAIN_PRODUCT_CATALOG_PATH:-/lotus-platform/generated/domain-product-catalog.json}
+      - DOMAIN_PRODUCT_DEPENDENCY_GRAPH_PATH=${DOMAIN_PRODUCT_DEPENDENCY_GRAPH_PATH:-/lotus-platform/generated/domain-product-dependency-graph.json}
+      - DOMAIN_PRODUCT_LIVE_TRUST_CERTIFICATION_PATH=${DOMAIN_PRODUCT_LIVE_TRUST_CERTIFICATION_PATH:-/lotus-platform/output/trust-certification/domain-product-live-trust-certification.json}
       - UPSTREAM_TIMEOUT_SECONDS=${UPSTREAM_TIMEOUT_SECONDS:-30}
       - CONTRACT_VERSION=${CONTRACT_VERSION:-v1}
+    volumes:
+      - ../lotus-platform/generated:/lotus-platform/generated:ro
+      - ../lotus-platform/output/trust-certification:/lotus-platform/output/trust-certification:ro
     healthcheck:
       test:
         [

--- a/tests/unit/test_docker_compose_runtime_config.py
+++ b/tests/unit/test_docker_compose_runtime_config.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+def test_gateway_compose_mounts_domain_product_artifacts_read_only() -> None:
+    compose_text = Path("docker-compose.yml").read_text(encoding="utf-8")
+
+    assert (
+        "DOMAIN_PRODUCT_CATALOG_PATH=${DOMAIN_PRODUCT_CATALOG_PATH:-"
+        "/lotus-platform/generated/domain-product-catalog.json}"
+    ) in compose_text
+    assert (
+        "DOMAIN_PRODUCT_DEPENDENCY_GRAPH_PATH=${DOMAIN_PRODUCT_DEPENDENCY_GRAPH_PATH:-"
+        "/lotus-platform/generated/domain-product-dependency-graph.json}"
+    ) in compose_text
+    assert (
+        "DOMAIN_PRODUCT_LIVE_TRUST_CERTIFICATION_PATH=${"
+        "DOMAIN_PRODUCT_LIVE_TRUST_CERTIFICATION_PATH:-"
+        "/lotus-platform/output/trust-certification/"
+        "domain-product-live-trust-certification.json}"
+    ) in compose_text
+    assert "../lotus-platform/generated:/lotus-platform/generated:ro" in compose_text
+    assert (
+        "../lotus-platform/output/trust-certification:/lotus-platform/output/trust-certification:ro"
+    ) in compose_text

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -32,10 +32,11 @@ before debugging gateway contracts.
 Domain-product discovery depends on platform-generated artifacts under the sibling
 `lotus-platform/generated/` directory by default. Live trust certification depends on
 `lotus-platform/output/trust-certification/domain-product-live-trust-certification.json` by
-default and returns an explicit unavailable posture until that artifact exists. Use
-`DOMAIN_PRODUCT_CATALOG_PATH`, `DOMAIN_PRODUCT_DEPENDENCY_GRAPH_PATH`, and
-`DOMAIN_PRODUCT_LIVE_TRUST_CERTIFICATION_PATH` when a runtime image mounts those artifacts
-elsewhere.
+default and returns an explicit unavailable posture until that artifact exists. The Docker Compose
+runtime mounts these platform artifact directories read-only at `/lotus-platform/generated` and
+`/lotus-platform/output/trust-certification`. Use `DOMAIN_PRODUCT_CATALOG_PATH`,
+`DOMAIN_PRODUCT_DEPENDENCY_GRAPH_PATH`, and `DOMAIN_PRODUCT_LIVE_TRUST_CERTIFICATION_PATH` when a
+runtime image mounts those artifacts elsewhere.
 
 ## First docs to read
 


### PR DESCRIPTION
## Summary
- mount platform domain-product generated artifacts and live trust certification output into Docker-backed Gateway read-only
- set explicit Gateway artifact paths for Docker runtime publication
- document the compose mount behavior in the repo wiki source
- add a regression test for the compose artifact wiring

## Validation
- python -m pytest tests/unit/test_docker_compose_runtime_config.py tests/unit/test_config_defaults.py tests/unit/test_domain_product_catalog_service_factory.py tests/integration/test_domain_products_router.py tests/integration/test_source_products_router.py
- make check
- make ci
- docker compose up -d --build lotus-gateway
- npm run live:validate from lotus-workbench after Gateway rebuild: 95 API checks, 0 non-OK, 25/25 panels ready, 9/9 RFC36-43 features validated
- npm run live:evidence from lotus-workbench after Gateway rebuild: 13 API captures, 0 non-200, 4 metric captures, 0 non-200, 14 log artifacts, 5 screenshots
- direct data-mesh live probes through gateway.dev.lotus: catalog 70 products, graph 81 nodes / 245 edges, detail PortfolioStateSnapshot v1, trust certification 17/17 certified