### PR TITLE
docs: improve gateway demo and wiki guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Experience API and composition boundary for Lotus product clients, primarily
 `lotus-workbench`.
 
+`lotus-gateway` is the place where product-facing API contracts are composed, stabilized, and made
+safe for front-office use. It is not a portfolio book, performance engine, risk engine, advisory
+workflow system, reporting engine, archive, or AI authority.
+
 Repository-local engineering context:
 [REPOSITORY-ENGINEERING-CONTEXT.md](REPOSITORY-ENGINEERING-CONTEXT.md)
 
@@ -34,6 +38,43 @@ It is responsible for:
 
 It does not own portfolio domain truth, analytics methodology, reporting methodology, advisory
 workflow truth, management workflow truth, or AI output truth. Those remain upstream.
+
+## Current Implementation-Backed Story
+
+For demos, onboarding, and buyer-facing technical review, describe the current Gateway posture this
+way:
+
+1. Gateway is the governed API boundary consumed by Workbench.
+2. Gateway preserves upstream authority and supportability rather than recomputing domain truth.
+3. Gateway has implementation-backed route families for foundation/workbench, platform
+   capabilities, domain-product discovery, portfolio, performance/risk workbench reads, proposals,
+   advisory policy, advisor cockpit, bank-demo proof, DPM command center, reporting, report
+   batches, archive metadata/download, and analytics diagnostics.
+4. Gateway exposes bounded degraded, partial, unavailable, and permission-blocked states where the
+   UI and operators need them.
+5. Gateway does not by itself certify full product demo readiness. Populated Workbench proof,
+   screenshots, and end-to-end demo claims still require the governed Workbench canonical runtime
+   and platform QA evidence.
+
+Use [docs/demo/README.md](docs/demo/README.md) and [wiki/Supported-Features.md](wiki/Supported-Features.md)
+as the claim-controlled demo entrypoints.
+
+## Audience Guide
+
+- Business, demo, and client-facing reviewers:
+  start with [wiki/Supported-Features.md](wiki/Supported-Features.md),
+  [wiki/Overview.md](wiki/Overview.md), and [docs/demo/README.md](docs/demo/README.md).
+- Engineers changing routes or contracts:
+  start with this README, [REPOSITORY-ENGINEERING-CONTEXT.md](REPOSITORY-ENGINEERING-CONTEXT.md),
+  [wiki/API-Surface.md](wiki/API-Surface.md), and
+  [docs/standards/RFC-0082-upstream-contract-family-map.md](docs/standards/RFC-0082-upstream-contract-family-map.md).
+- Operators and support teams:
+  start with [wiki/Operations-Runbook.md](wiki/Operations-Runbook.md),
+  [wiki/Troubleshooting.md](wiki/Troubleshooting.md), and [docs/operations-runbook.md](docs/operations-runbook.md).
+- Security, governance, and procurement reviewers:
+  start with [wiki/Security-and-Governance.md](wiki/Security-and-Governance.md),
+  [quality/quality_scorecard.md](quality/quality_scorecard.md), and
+  [docs/security.md](docs/security.md).
 
 ## Ownership And Boundaries
 
@@ -417,12 +458,16 @@ Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 
 ## Documentation Map
 
+- claim-controlled demo pack:
+  [docs/demo/README.md](docs/demo/README.md)
+- current implementation-backed feature matrix:
+  [wiki/Supported-Features.md](wiki/Supported-Features.md)
+- copy-paste API examples:
+  [wiki/API-Surface.md](wiki/API-Surface.md)
 - architecture direction:
   [docs/documentation/experience-api-foundation-blueprint.md](docs/documentation/experience-api-foundation-blueprint.md)
 - upstream integration governance:
   [docs/standards/RFC-0082-upstream-contract-family-map.md](docs/standards/RFC-0082-upstream-contract-family-map.md)
-- demo material:
-  [docs/demo/README.md](docs/demo/README.md)
 - RFC inventory:
   [docs/rfcs/README.md](docs/rfcs/README.md)
 - wiki home:

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,11 +1,29 @@
 # Advisor Experience API Demo Pack
 
+This pack helps presenters and engineers demonstrate the Gateway experience API without
+overclaiming ownership or product readiness.
+
 ## Goal
 
 Run deterministic lotus-gateway demos for:
 
 1. the split benchmark-aware performance workstation contracts, and
 2. proposal creation plus approval-chain actions.
+
+## Demo-Safe Positioning
+
+Use this concise talk track:
+
+1. `lotus-gateway` is the governed Workbench-facing API boundary.
+2. It composes product-ready payloads while preserving upstream source authority.
+3. It exposes supportability, partial-readiness, degraded, unavailable, and permission-blocked
+   states instead of hiding upstream posture.
+4. It can certify deterministic Gateway route behavior through `make demo-certification`.
+5. Full populated Workbench demo readiness, screenshots, and buyer-facing evidence packs require
+   the canonical Workbench runtime and platform QA evidence after the Gateway route checks pass.
+
+Do not claim that Gateway alone owns portfolio source data, performance/risk calculations,
+advisory policy truth, DPM workflow state, report rendering, archive retention, or AI model output.
 
 ## Prerequisites
 
@@ -43,6 +61,18 @@ through real Gateway FastAPI routes and asserts canonical product figures for
 
 Do not treat this command as full live front-office certification. Full populated Workbench proof
 still uses the governed `lotus-workbench` canonical runtime and platform QA evidence.
+
+## Evidence To Keep
+
+For a demo rehearsal or PR evidence package, keep:
+
+1. the `make demo-certification` command output,
+2. `output/demo-certification/gateway-demo-certification.json`,
+3. any local or GitHub `make check` / `make ci` evidence used for the slice,
+4. Workbench canonical runtime evidence when the demo includes UI screenshots or populated panels.
+
+Do not paste raw client, account, holding, prompt, model-output, document, entitlement, trace, or
+correlation payloads into demo notes.
 
 ## Performance Contract Demo
 

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -44,7 +44,7 @@ Docker parity is required because gateway is a live integration boundary.
 
 ## Quality Baseline
 
-The report-only quality workflow installs optional quality tooling and runs:
+The Quality Baseline workflow installs optional quality tooling and runs:
 
 1. ruff,
 2. mypy,
@@ -58,7 +58,25 @@ The report-only quality workflow installs optional quality tooling and runs:
 10. interrogate,
 11. spectral.
 
-The workflow is intentionally `continue-on-error` during baseline classification.
+It is no longer purely report-only. It blocks the promoted no-regression checks for refactor
+thresholds, workflow action-runtime governance, agent quality evidence, and required artifact
+presence, while keeping broader advisory tools report-only until false positives, thresholds,
+exception policy, and lane placement are clear.
+
+Demo certification evidence is also generated from the repo-native command:
+
+```powershell
+make demo-certification
+```
+
+The command writes:
+
+```text
+output/demo-certification/gateway-demo-certification.json
+```
+
+Use it as Gateway API evidence only. Full populated Workbench proof still requires the governed
+Workbench canonical runtime and platform QA evidence.
 
 ## Incident Notes
 

--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -1,8 +1,10 @@
 # Architecture Rules
 
 This document records the baseline architecture rules for the `lotus-gateway` enterprise
-hardening program. The first implementation phase is report-only; later phases should fail only
-new regressions, then enforce agreed thresholds.
+hardening program. The program now uses progressive enforcement: classified refactor thresholds,
+workflow governance, and agent quality evidence are blocking no-regression gates, while broader
+architecture and quality signals remain report-only until findings, thresholds, exceptions, and CI
+lane placement are governed.
 
 ## Layering
 
@@ -600,7 +602,8 @@ surface and Lotus Core transaction request behavior. The current longest functio
 ## Progressive Enforcement
 
 1. Phase 1: report-only quality baseline.
-2. Phase 2: fail only new architecture regressions.
-3. Phase 3: enforce thresholds for largest modules, function length, complexity, and import rules.
+2. Phase 2: fail only classified no-new-regression signals.
+3. Phase 3: enforce thresholds for largest modules, function length, complexity, and import rules
+   after the signal is deterministic and low-noise.
 4. Phase 4: enterprise-readiness gate requiring architecture, API, security, observability, and
    docs scorecard targets to pass.

--- a/wiki/Development-Workflow.md
+++ b/wiki/Development-Workflow.md
@@ -5,6 +5,8 @@
 - branch from `main`
 - keep one branch per RFC or documentation slice
 - use PR-first delivery
+- keep commits small and scoped to one real improvement area
+- preserve behavior unless a change is intentional, tested, and documented
 
 ## Repo-native commands
 
@@ -18,6 +20,8 @@
   PR-grade local proof
 - `make ci-local-docker`
   docker parity check
+- `make demo-certification`
+  deterministic Gateway demo-certification evidence; report-only until promoted by governance
 
 ## Documentation workflow
 
@@ -25,3 +29,21 @@
 - keep `wiki/` as the authored wiki source
 - keep route-family detail and request examples in the wiki, not in the README
 - keep deep architecture and RFC detail in `docs/`
+- update [REPOSITORY-ENGINEERING-CONTEXT.md](../REPOSITORY-ENGINEERING-CONTEXT.md) when route
+  ownership, startup commands, CI posture, or integration boundaries change
+- update [docs/demo/README.md](../docs/demo/README.md) when demo-safe claims or certification
+  evidence change
+- run the repo wiki check before merge when wiki source changes:
+
+```powershell
+..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway
+```
+
+## Engineering guardrails
+
+1. Workbench should consume Gateway, not raw upstream services.
+2. Gateway may compose, reshape, and annotate responses, but domain authority stays upstream.
+3. Request-shape differences must be documented in [API Surface](API-Surface) with examples.
+4. New route families need contract or integration tests before they become supported claims.
+5. Do not add metric labels, logs, or evidence fields that expose portfolio, client, document,
+   prompt, response, trace, or correlation payloads.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,5 +1,15 @@
 # Getting Started
 
+This page is for a new engineer, operator, or demo-prep reviewer who needs a working Gateway
+process and a few high-signal probes.
+
+## Prerequisites
+
+1. Python dependencies available for the repo.
+2. `make` available in the shell.
+3. Optional platform ingress when using `http://gateway.dev.lotus`.
+4. Sibling `lotus-platform` generated artifacts when testing domain-product discovery.
+
 ## Install
 
 ```bash
@@ -16,6 +26,9 @@ Canonical identities:
 
 - cross-app and product validation: `http://gateway.dev.lotus`
 - direct process debugging: `http://127.0.0.1:8111`
+
+`make run-canonical` uses `uvicorn app.main:app --reload --app-dir src --host 0.0.0.0 --port 8111`.
+The `--app-dir src` flag is part of the supported startup contract.
 
 ## First checks
 
@@ -38,9 +51,27 @@ runtime mounts these platform artifact directories read-only at `/lotus-platform
 `DOMAIN_PRODUCT_DEPENDENCY_GRAPH_PATH`, and `DOMAIN_PRODUCT_LIVE_TRUST_CERTIFICATION_PATH` when a
 runtime image mounts those artifacts elsewhere.
 
+## Demo readiness smoke
+
+Run the deterministic app-level Gateway certification before using Gateway claims in a demo:
+
+```bash
+make demo-certification
+```
+
+The command writes:
+
+```text
+output/demo-certification/gateway-demo-certification.json
+```
+
+This is Gateway API evidence only. UI screenshots and populated Workbench demo claims still need
+the governed Workbench runtime and platform QA evidence.
+
 ## First docs to read
 
 - [README.md](../README.md)
 - [REPOSITORY-ENGINEERING-CONTEXT.md](../REPOSITORY-ENGINEERING-CONTEXT.md)
+- [docs/demo/README.md](../docs/demo/README.md)
 - [docs/documentation/experience-api-foundation-blueprint.md](../docs/documentation/experience-api-foundation-blueprint.md)
 - [docs/standards/RFC-0082-upstream-contract-family-map.md](../docs/standards/RFC-0082-upstream-contract-family-map.md)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -2,10 +2,16 @@
 
 `lotus-gateway` is the Lotus experience API and product-facing composition boundary.
 
+It is the API contract that `lotus-workbench` should consume for product surfaces. It composes
+domain-service responses into product-safe payloads, but it does not become the authority for
+portfolio, performance, risk, advisory, DPM, reporting, archive, or AI truth.
+
 ## Start here
 
 - Repo entrypoint: [README.md](../README.md)
 - Repo context: [REPOSITORY-ENGINEERING-CONTEXT.md](../REPOSITORY-ENGINEERING-CONTEXT.md)
+- Demo pack and claim control:
+  [docs/demo/README.md](../docs/demo/README.md)
 - Experience-API blueprint:
   [docs/documentation/experience-api-foundation-blueprint.md](../docs/documentation/experience-api-foundation-blueprint.md)
 - Upstream contract-family map:
@@ -23,6 +29,19 @@
   bank-demo proof, reporting, portfolio, and intake/lookups
 - still replacing thin pass-through patterns with cleaner experience-API contracts
 
+## Audience paths
+
+- Business and demo reviewers:
+  [Overview](Overview), [Supported Features](Supported-Features), [API Surface](API-Surface), and
+  [Roadmap](Roadmap)
+- Operators and support:
+  [Getting Started](Getting-Started), [Operations Runbook](Operations-Runbook),
+  [Troubleshooting](Troubleshooting), and [Integrations](Integrations)
+- Engineers and agents:
+  [Architecture](Architecture), [Development Workflow](Development-Workflow),
+  [Validation and CI](Validation-and-CI), [RFC Index](RFC-Index), and
+  [Security and Governance](Security-and-Governance)
+
 ## Most important commands
 
 - `make install`
@@ -30,6 +49,7 @@
 - `make ci`
 - `make ci-local-docker`
 - `make run-canonical`
+- `make demo-certification`
 
 ## Navigation
 

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -1,11 +1,16 @@
 # Operations Runbook
 
+This page summarizes everyday operational checks. Use
+[docs/operations-runbook.md](../docs/operations-runbook.md) for the root runbook and
+[Troubleshooting](Troubleshooting) for failure triage.
+
 ## Important operational checks
 
 - confirm canonical gateway identity is `gateway.dev.lotus` before product validation
 - if Windows startup looks healthy but routes fail, verify `--app-dir src`
 - treat partial-failure and supportability signals as contract data, not as noise to suppress
 - use repo-native gates before inventing custom checks
+- preserve support references and bounded degraded reasons when escalating incidents
 - use [docs/operations-runbook.md](../docs/operations-runbook.md),
   [docs/observability.md](../docs/observability.md), and
   [docs/security.md](../docs/security.md) as the consolidated root-doc entry points for
@@ -92,6 +97,15 @@ curl "http://127.0.0.1:8111/api/v1/analytics-ui/diagnostics/gdiag-risk-summary-p
   -H "X-Region: APAC" \
   -H "X-Role: support-operator"
 ```
+
+## Demo certification probe
+
+```powershell
+make demo-certification
+```
+
+Use the generated `output/demo-certification/gateway-demo-certification.json` as Gateway API
+evidence. It is not a replacement for populated Workbench browser proof.
 
 ## Key references
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -4,12 +4,18 @@
 
 - active experience API for `lotus-workbench`
 - foundation, workbench, reporting, proposal, and platform capability contracts are live
+- domain-product discovery, archive retrieval, analytics diagnostics, bank-demo proof, advisor
+  cockpit, advisory policy, DPM command-center, report job, and report batch route families are
+  active where listed in [Supported Features](Supported-Features) and [API Surface](API-Surface)
 
 ## Intentional limitations
 
 - some thin pass-through and transitional route shapes still exist
 - parameter conventions are not fully uniform across all route families
 - gateway is not the authority for upstream domain methodology
+- full populated Workbench demo readiness is not claimed by Gateway alone
+- route existence does not imply a client-ready business claim unless the route is documented,
+  tested, and supported by owning upstream evidence
 
 ## Next priorities
 
@@ -46,3 +52,18 @@
    compensation, conduct-enforcement, approval, client-contact, OMS, or execution decisions.
 3. preserve RFC-0082 boundary discipline as integrations evolve
 4. keep request-convention and runtime guidance explicit for operators and future agents
+5. continue promoting deterministic, low-noise evidence into blocking CI only after the quality
+   baseline and governance policy prove the signal is stable
+6. keep README, wiki, demo docs, context, and quality scorecards synchronized whenever route
+   support, startup, CI, or integration truth changes
+
+## Demo roadmap
+
+1. Gateway API certification:
+   implementation-backed through `make demo-certification` with deterministic synthetic upstream
+   fixtures.
+2. Populated Workbench proof:
+   owned by the governed Workbench canonical runtime and platform QA evidence.
+3. Client-facing evidence pack:
+   only claim after API, UI, calculation, security, observability, and screenshot evidence are all
+   current and reviewed.

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -1,5 +1,9 @@
 # Security and Governance
 
+Gateway is a high-sensitivity boundary because it sits between Workbench and domain-authoritative
+services. Security posture must be expressed through implemented controls, tests, CI gates, and
+operator evidence rather than broad readiness claims.
+
 ## Current governance
 
 - RFC-0007
@@ -21,10 +25,16 @@
 
 - OpenAPI contract proof is active
 - migration smoke, monetary-float guard, and security audit remain active
+- refactor quality thresholds, workflow action-runtime governance, and agent quality evidence
+  governance are active through `make lint`
 - monetary-float approvals are matched in a line-shift tolerant way, so routine formatting changes
   do not force import-order suppressions or approval churn
 - Docker parity matters because this is a live integration boundary
 - gateway must not smuggle domain logic out of authoritative upstream services
+- archive document retrieval must remain Gateway-first and caller-context governed; Workbench
+  should not bypass Gateway to call `lotus-archive`
+- AI handoffs must use governed `lotus-ai` workflow-pack execution seams and must not expose raw
+  prompts, model output, or unsupported generated advice
 
 ## Operational discipline
 
@@ -36,3 +46,16 @@
   sent as another verb
 - keep gateway contracts product-oriented instead of accreting thin pass-through clutter
 - document endpoint-specific parameter conventions explicitly when they differ by route family
+
+## Sensitive data rules
+
+Do not put these values in metric labels, support tickets, screenshots, demo notes, or generated
+evidence unless a governed artifact explicitly allows it:
+
+1. client names or account identifiers,
+2. portfolio, holding, transaction, session, upload, or document identifiers as metric labels,
+3. request bodies, response bodies, raw prompts, model output, or raw entitlement failures,
+4. trace IDs and correlation IDs as metric labels.
+
+Use support references, bounded state/reason codes, source service, route family, status class, and
+operator guidance instead.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,5 +1,8 @@
 # Troubleshooting
 
+Use this page to decide whether a failure belongs in Gateway, an upstream domain service, platform
+runtime, or documentation.
+
 ## Common checks
 
 - if startup looks healthy but routes 404, verify `--app-dir src`
@@ -9,6 +12,12 @@
   graph paths before changing gateway contracts
 - if intake upload requests fail, verify the camelCase multipart aliases expected by gateway
 - if proposal writes fail, verify `Idempotency-Key`
+- if archived document lookup or download fails, verify caller context headers and `lotus-archive`
+  readiness before changing Gateway response contracts
+- if analytics diagnostics returns forbidden, verify `X-Actor-Id`, `X-Tenant-Id`, `X-Region`, and
+  an operator support role in `X-Role`
+- if Workbench direct upstream calls appear in evidence, treat that as an integration-boundary
+  defect; product UI should consume Gateway
 
 ## Useful commands
 
@@ -16,9 +25,19 @@
 make check
 make ci
 make ci-local-docker
+make demo-certification
 ```
+
+## Triage checklist
+
+1. Identify the route family and exact request shape.
+2. Confirm the canonical runtime used `make run-canonical` or `--app-dir src`.
+3. Capture product-safe status class, source service, degraded reason, and support reference.
+4. Check the owning upstream service before changing Gateway business semantics.
+5. For docs defects, update README/wiki/docs together with any pinned documentation tests.
 
 ## References
 
 - [docs/documentation/experience-api-foundation-blueprint.md](../docs/documentation/experience-api-foundation-blueprint.md)
 - [docs/standards/RFC-0082-upstream-contract-family-map.md](../docs/standards/RFC-0082-upstream-contract-family-map.md)
+- [docs/demo/README.md](../docs/demo/README.md)


### PR DESCRIPTION
## Summary
- Improve the Gateway README with audience-specific entrypoints and demo-safe implementation-backed positioning.
- Expand the demo pack, wiki getting-started/development/operations/security/roadmap/troubleshooting pages with claim-control, startup, evidence, and triage guidance.
- Correct stale quality-rule wording so documentation reflects progressive enforcement rather than pure report-only posture.

## Validation
- python -m pytest tests/unit/test_gateway_wiki_overview.py tests/unit/test_rfc0026_advisor_cockpit_documentation.py tests/unit/test_rfc0028_bank_demo_proof_documentation.py tests/unit/test_rfc0098_documentation.py tests/unit/test_agent_quality_evidence.py tests/unit/test_quality_baseline_artifacts.py -q
- make lint
- make check
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway reports expected drift for changed repo-authored wiki pages before publication.

## Risk
- Documentation-only change. No runtime behavior changed.
- Wiki publication is required after merge so the live GitHub wiki matches repo-authored source.