### PR TITLE
Fix capability contract evidence drift

### DIFF
--- a/CODEBASE-REVIEW-LEDGER.md
+++ b/CODEBASE-REVIEW-LEDGER.md
@@ -2,7 +2,42 @@
 
 Date: 2026-06-21
 Repository: `lotus-gateway`
-Branch: `feature/gateway-dpm-proof-pack-service-boundary`
+Branch: `fix/gateway-issue-129-report-capability-query-params`
+
+## Capability Contract Issue Triage
+
+- Scope: GitHub issue triage for open Gateway integration-contract findings affecting platform
+  capability composition, reporting capabilities, proposal upstream ownership, and foundation
+  cash totals.
+- Existing owner pattern: Gateway owns the BFF composition contract and public camelCase
+  `/api/v1/platform/capabilities` API; source services own their direct integration capability
+  contracts. Gateway must call source-owned capability endpoints with source-owned query
+  vocabulary while preserving the public BFF shape for Workbench consumers.
+- Change: updated `ReportingClient.get_capabilities()` and direct e2e source-service healthchecks
+  to use canonical `consumer_system` and `tenant_id` query parameters; refreshed Manage and Report
+  platform-capability fixtures from retired `pas_ref` terminology to current `portfolio_id`
+  input-mode terminology.
+- Measured signal: stale camelCase direct source-service capability calls are removed from
+  `ReportingClient` and `docker-compose.e2e.yml`; Manage and Report capability fixtures now
+  preserve current downstream vocabulary while Core, Performance, and Risk legacy compatibility
+  coverage remains explicit.
+- Tests: `python -m pytest tests/unit/test_upstream_clients.py
+  tests/unit/test_platform_capabilities_service.py
+  tests/integration/test_platform_capabilities_router.py tests/e2e/test_workflow_journeys.py
+  tests/contract/test_platform_capabilities_contract.py -q` passed with 209 tests;
+  `python -m pytest tests/unit/test_foundation_service.py tests/integration/test_foundation_router.py
+  tests/contract/test_foundation_contract.py -q` passed with 23 tests; `python -m ruff check` on
+  touched Python files and `python -m mypy src\app\clients\reporting_client.py` passed.
+- Issue disposition evidence: #129 is valid and fixed in this slice; #130 and #131 are valid
+  fixture-drift issues fixed in this slice; #128, #132, and #134 are resolved in current code with
+  existing tests and search evidence; #182 remains open until current canonical QA proves whether a
+  Gateway-owned or downstream-owned defect still exists.
+- Integration review: no current downstream issue is warranted for the fixed capability contract
+  drift because Gateway now sends the source-owned vocabulary and preserves downstream
+  `portfolio_id` capability terminology; open downstream issues should be created only from fresh
+  failing integration evidence.
+- Follow-up: after merge, close resolved issues with the PR/test evidence and leave #182 open or
+  file a downstream issue only if current canonical QA reproduces a non-Gateway defect.
 
 ## DPM Proof-Pack Supportability Mapping Extraction
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -86,7 +86,7 @@ services:
           "CMD",
           "python",
           "-c",
-          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default', timeout=5)"
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/integration/capabilities?consumer_system=lotus-gateway&tenant_id=default', timeout=5)"
         ]
       interval: 20s
       timeout: 5s
@@ -136,7 +136,7 @@ services:
           "CMD",
           "python",
           "-c",
-          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8001/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default', timeout=5)"
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8001/integration/capabilities?consumer_system=lotus-gateway&tenant_id=default', timeout=5)"
         ]
       interval: 20s
       timeout: 5s
@@ -190,7 +190,7 @@ services:
           "CMD",
           "python",
           "-c",
-          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default', timeout=5)"
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/integration/capabilities?consumer_system=lotus-gateway&tenant_id=default', timeout=5)"
         ]
       interval: 20s
       timeout: 5s
@@ -219,7 +219,7 @@ services:
           "CMD",
           "python",
           "-c",
-          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8300/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default', timeout=5)"
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8300/integration/capabilities?consumer_system=lotus-gateway&tenant_id=default', timeout=5)"
         ]
       interval: 20s
       timeout: 5s

--- a/src/app/clients/reporting_client.py
+++ b/src/app/clients/reporting_client.py
@@ -47,7 +47,7 @@ class ReportingClient:
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/integration/capabilities"
-        params = {"consumerSystem": consumer_system, "tenantId": tenant_id}
+        params = {"consumer_system": consumer_system, "tenant_id": tenant_id}
         headers = build_upstream_headers(correlation_id)
         return await self._request(
             operation="report.integration.capabilities",

--- a/tests/e2e/test_workflow_journeys.py
+++ b/tests/e2e/test_workflow_journeys.py
@@ -33,7 +33,7 @@ def test_e2e_platform_capability_aggregation_and_health(monkeypatch) -> None:
             "policyVersion": "lotus-manage-default-v1",
             "features": [{"key": "dpm.proposals.lifecycle", "enabled": True}],
             "workflows": [{"workflow_key": "proposal_lifecycle", "enabled": True}],
-            "supportedInputModes": ["pas_ref", "inline_bundle"],
+            "supportedInputModes": ["portfolio_id", "inline_bundle"],
         }
 
     async def _ras(*args, **kwargs):
@@ -43,7 +43,7 @@ def test_e2e_platform_capability_aggregation_and_health(monkeypatch) -> None:
             "policyVersion": "lotus-report-default-v1",
             "features": [{"key": "ras.reporting.portfolio_summary", "enabled": True}],
             "workflows": [{"workflow_key": "portfolio_reporting", "enabled": True}],
-            "supportedInputModes": ["pas_ref"],
+            "supportedInputModes": ["portfolio_id"],
         }
 
     async def _pas_policy(*args, **kwargs):
@@ -314,7 +314,7 @@ def test_e2e_platform_capabilities_partial_failure_when_one_upstream_fails(
             "policyVersion": "lotus-manage-default-v1",
             "features": [{"key": "dpm.proposals.lifecycle", "enabled": True}],
             "workflows": [],
-            "supportedInputModes": ["pas_ref", "inline_bundle"],
+            "supportedInputModes": ["portfolio_id", "inline_bundle"],
         }
 
     async def _ras(*args, **kwargs):
@@ -324,7 +324,7 @@ def test_e2e_platform_capabilities_partial_failure_when_one_upstream_fails(
             "policyVersion": "lotus-report-default-v1",
             "features": [{"key": "ras.reporting.portfolio_summary", "enabled": True}],
             "workflows": [],
-            "supportedInputModes": ["pas_ref"],
+            "supportedInputModes": ["portfolio_id"],
         }
 
     async def _pas_policy(*args, **kwargs):

--- a/tests/integration/test_platform_capabilities_router.py
+++ b/tests/integration/test_platform_capabilities_router.py
@@ -49,7 +49,7 @@ def test_platform_capabilities_router_success(monkeypatch):
                 {"key": "dpm.support.run_apis", "enabled": True},
             ],
             "workflows": [{"workflow_key": "proposal_lifecycle", "enabled": True}],
-            "supportedInputModes": ["pas_ref", "inline_bundle"],
+            "supportedInputModes": ["portfolio_id", "inline_bundle"],
         }
 
     async def _ras(*args, **kwargs):
@@ -62,7 +62,7 @@ def test_platform_capabilities_router_success(monkeypatch):
                 {"key": "ras.reporting.portfolio_review", "enabled": True},
             ],
             "workflows": [{"workflow_key": "portfolio_reporting", "enabled": True}],
-            "supportedInputModes": ["pas_ref"],
+            "supportedInputModes": ["portfolio_id"],
         }
 
     async def _pas_policy(*args, **kwargs):

--- a/tests/unit/test_platform_capabilities_service.py
+++ b/tests/unit/test_platform_capabilities_service.py
@@ -166,7 +166,7 @@ async def test_platform_capabilities_all_sources_success():
             {
                 "sourceService": "lotus_manage",
                 "policyVersion": "manage-tenant-a-v2",
-                "supportedInputModes": ["pas_ref"],
+                "supportedInputModes": ["portfolio_id"],
                 "features": [{"key": "dpm.support.run_apis", "enabled": True}],
                 "workflows": [],
             },
@@ -209,7 +209,7 @@ async def test_platform_capabilities_all_sources_success():
             {
                 "sourceService": "lotus-report",
                 "policyVersion": "ras-tenant-a-v1",
-                "supportedInputModes": ["pas_ref"],
+                "supportedInputModes": ["portfolio_id"],
                 "features": [
                     {"key": "ras.reporting.portfolio_summary", "enabled": True},
                     {"key": "ras.reporting.portfolio_review", "enabled": True},
@@ -868,7 +868,7 @@ async def test_platform_capabilities_keeps_advise_and_manage_capabilities_separa
         {
             "sourceService": "lotus_manage_split",
             "policyVersion": "manage-split-v2",
-            "supportedInputModes": ["inline_bundle", "pas_ref"],
+            "supportedInputModes": ["inline_bundle", "portfolio_id"],
             "features": [
                 {"key": "dpm.support.run_apis", "enabled": True},
             ],
@@ -919,7 +919,7 @@ async def test_platform_capabilities_keeps_advise_and_manage_capabilities_separa
     ]
     assert lotus_advise["policyVersion"] == "advise-v2"
     assert lotus_manage["policyVersion"] == "manage-split-v2"
-    assert lotus_manage["supportedInputModes"] == ["inline_bundle", "pas_ref"]
+    assert lotus_manage["supportedInputModes"] == ["inline_bundle", "portfolio_id"]
     assert lotus_manage["features"] == [{"key": "dpm.support.run_apis", "enabled": True}]
     assert lotus_manage["workflows"] == []
     assert response.data.normalized.workflow_flags["proposal_lifecycle"] is True

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -3538,8 +3538,8 @@ async def test_reporting_client_summary_and_review_routes():
     assert review_payload["portfolio_id"] == "P1"
     assert _FakeAsyncClient.calls[0]["url"] == "http://ras/integration/capabilities"
     assert _FakeAsyncClient.calls[0]["params"] == {
-        "consumerSystem": "lotus-gateway",
-        "tenantId": "default",
+        "consumer_system": "lotus-gateway",
+        "tenant_id": "default",
     }
     assert _FakeAsyncClient.calls[0]["headers"]["X-Correlation-Id"] == "corr-7"
     assert _FakeAsyncClient.calls[1]["url"] == "http://ras/reports/portfolios/P1/summary"


### PR DESCRIPTION
## Summary
- send lotus-report capability requests with canonical source-owned snake_case query params
- update direct e2e source-service capability healthchecks to use consumer_system/tenant_id
- refresh Manage and Report platform capability fixtures from pas_ref to portfolio_id and record the issue-triage evidence in CODEBASE-REVIEW-LEDGER.md

## Issue disposition
- Fixes #129
- Fixes #130
- Fixes #131
- Refs #178 because this resolves the direct source-service capability query drift, but the broader strategic DPM posture work remains open

## Validation
- python -m pytest tests/unit/test_upstream_clients.py tests/unit/test_platform_capabilities_service.py tests/integration/test_platform_capabilities_router.py tests/e2e/test_workflow_journeys.py tests/contract/test_platform_capabilities_contract.py -q
- python -m pytest tests/unit/test_foundation_service.py tests/integration/test_foundation_router.py tests/contract/test_foundation_contract.py -q
- python -m ruff check src\\app\\clients\\reporting_client.py tests\\unit\\test_upstream_clients.py tests\\unit\\test_platform_capabilities_service.py tests\\integration\\test_platform_capabilities_router.py tests\\e2e\\test_workflow_journeys.py
- python -m mypy src\\app\\clients\\reporting_client.py
- make lint
- make check

## Wiki
- No wiki source change needed: this is a client/source-contract and test-evidence alignment slice; durable engineering evidence is recorded in CODEBASE-REVIEW-LEDGER.md.