### PR TITLE
Add Lotus Idea gateway read publication

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -5,8 +5,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   queue-auto-merge:
@@ -19,13 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Enable auto-merge queue (merge commit)
+      - name: Enable auto-merge queue (rebase)
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.LOTUS_AUTOMERGE_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::LOTUS_AUTOMERGE_TOKEN is required for automatic rebase merge so post-merge releasability dispatch is triggered by a non-GITHUB_TOKEN actor. Skipping auto-merge; use an authorized human or release actor to rebase merge this PR."
+            exit 0
+          fi
           set +e
-          output=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --merge --delete-branch 2>&1)
+          output=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --rebase --delete-branch 2>&1)
           code=$?
           set -e
           if [ "$code" -eq 0 ]; then

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ way:
 3. Gateway has implementation-backed route families for foundation/workbench, platform
    capabilities, domain-product discovery, portfolio, performance/risk workbench reads, proposals,
    advisory policy, advisor cockpit, bank-demo proof, DPM command center, reporting, report
-   batches, archive metadata/download, and analytics diagnostics.
+   batches, archive metadata/download, idea review/candidate reads, and analytics diagnostics.
 4. Gateway exposes bounded degraded, partial, unavailable, and permission-blocked states where the
    UI and operators need them.
 5. Gateway does not by itself certify full product demo readiness. Populated Workbench proof,
@@ -102,6 +102,8 @@ It depends on:
   job initiation/lifecycle/search, and RFC-0104 batch materialization/status/control/operator-run APIs
 - `lotus-archive`
   archived generated-document metadata and controlled binary retrieval
+- `lotus-idea`
+  opportunity intelligence review queues and source-safe candidate detail
 - `lotus-ai`
   evidence-grounded advisor-brief support, outcome-review narrative support, DPM exception-summary
   support, proof-pack PM memo support, wave PM memo support, and operations handoff support through
@@ -124,9 +126,11 @@ Boundary rules that matter:
    reporting, intake/lookups, portfolio, and workbench route families are active.
 3. Domain-product catalog, product detail, dependency-graph, and trust-certification discovery
    routes are active as read-only facades over platform-generated artifacts.
-4. The repository is still moving from thin pass-through behavior toward cleaner experience-API
+4. Idea review queue and candidate detail routes are active as source-preserving read facades over
+   `lotus-idea`; Gateway does not rank, generate, enrich, or promote ideas locally.
+5. The repository is still moving from thin pass-through behavior toward cleaner experience-API
    contracts.
-5. Canonical local startup relies on `--app-dir src`; omitting it on Windows can start the wrong
+6. Canonical local startup relies on `--app-dir src`; omitting it on Windows can start the wrong
    `app` package and yield a misleading health-only process.
 
 ## Architecture At A Glance
@@ -206,6 +210,9 @@ Main runtime surfaces come from [src/app/main.py](src/app/main.py):
   `/api/v1/report-batch-schedules`, `/api/v1/report-batch-schedules:run-due`
 - `archived documents`
   `/api/v1/documents/{document_id}`, `/api/v1/documents/{document_id}/download`
+- `ideas`
+  `/api/v1/ideas/review-queues/advisor`,
+  `/api/v1/ideas/candidates/{candidate_id}`
 - platform surfaces
   `/health`, `/health/live`, `/health/ready`, `/metrics`, `/docs`
 
@@ -343,7 +350,10 @@ Important current parameter conventions:
 10. archived document metadata and download routes require caller context headers:
    `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; the gateway calls `lotus-archive` as
    `lotus-gateway` and does not expose archive storage locations
-11. Workbench performance summary, risk summary, advisor-brief read, and advisor-brief review
+11. idea review queue and candidate detail routes forward `X-Caller-Subject`, `X-Caller-Roles`,
+   and `X-Caller-Capabilities` to `lotus-idea`; Gateway preserves `supportedFeaturePromoted=false`
+   and does not rank, score, enrich, or certify idea candidates locally
+12. Workbench performance summary, risk summary, advisor-brief read, and advisor-brief review
    action routes require caller context headers:
    `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional `X-Caller-Application`,
    `X-Booking-Center-Code`, and `X-Role` preserve entitlement and audit posture for
@@ -425,7 +435,7 @@ Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
   `lotus-workbench`
 - key upstreams:
   `lotus-core`, `lotus-performance`, `lotus-risk`, `lotus-advise`, `lotus-manage`, `lotus-report`,
-  `lotus-archive`, `lotus-ai`
+  `lotus-archive`, `lotus-idea`, `lotus-ai`
 - downstream ownership rule:
   proposal routes call `lotus-advise` `/advisory/proposals/*`, including reviewed narrative
   posture, report-request, and delivery-posture routes; Gateway does not generate narrative,
@@ -445,6 +455,10 @@ Copy-paste request examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 - discovery rule:
   gateway may expose the platform-generated domain-product catalog and dependency graph, but the
   producer and consumer declarations remain governed outside gateway
+- idea publication rule:
+  gateway may expose product-facing reads over `lotus-idea`, but `lotus-idea` remains the
+  opportunity intelligence, queue ranking, candidate lifecycle, evidence, conversion, and
+  supported-feature authority
 
 ## Operations And Runtime Posture
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,11 @@ Repo-native gate mapping:
 - `make ci-local-docker`
   Docker parity for the live integration boundary
 
+PR auto-merge is rebase-only for linear history. The `Queue Auto Merge` helper uses
+`LOTUS_AUTOMERGE_TOKEN` with `gh pr merge --auto --rebase --delete-branch`; when that token is not
+available, the helper emits a warning and exits successfully so an authorized human or release actor
+can perform the rebase merge without leaving a false red CI check.
+
 The Quality Baseline workflow is intentionally report-only. It publishes complexity,
 maintainability, dead-code, dependency, security, import-boundary, documentation, coverage, and
 OpenAPI governance evidence without weakening the existing blocking lanes. Promote individual

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -218,12 +218,16 @@ Important validation expectations:
    `scripts/check_agent_quality_evidence.py`; it keeps the executable 397/49 refactor ratchet, the
    current `src/app/services/advisor_brief_service.py` hotspot, and durable
    scorecard/context guidance synchronized for future agent work,
-6. `make demo-certification` is the current app-level Gateway demo-readiness command; it calls real
+6. PR auto-merge is rebase-only for linear history; `.github/workflows/pr-auto-merge.yml` uses
+   `LOTUS_AUTOMERGE_TOKEN` and `gh pr merge --auto --rebase --delete-branch`, and skips cleanly
+   with a warning when the token is absent so an authorized human or release actor can perform the
+   rebase merge without leaving a false red helper check,
+7. `make demo-certification` is the current app-level Gateway demo-readiness command; it calls real
    FastAPI routes with deterministic synthetic upstream fixtures, writes
    `output/demo-certification/gateway-demo-certification.json`, and remains report-only in Quality
    Baseline until repeated low-noise evidence and exception policy justify blocking promotion,
-7. Docker parity matters because the gateway is a live integration boundary,
-8. README and wiki updates should preserve truthful endpoint-specific parameter conventions, and
+8. Docker parity matters because the gateway is a live integration boundary,
+9. README and wiki updates should preserve truthful endpoint-specific parameter conventions, and
    mixed query, body, or multipart shapes should be backed by executable examples in the wiki.
 
 ## Standards And RFCs That Govern This Repository

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -79,7 +79,12 @@ Current repository posture:
    product-facing boundary over `lotus-archive`,
 7. domain-product catalog, dependency-graph, and live trust certification discovery routes are
    active under `/api/v1/domain-products`,
-8. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
+8. idea review queue and candidate detail read routes are active under
+   `/api/v1/ideas/review-queues/advisor` and `/api/v1/ideas/candidates/{candidate_id}`; Gateway
+   preserves `lotus-idea` ranking, source refs, durable-storage posture, and
+   `supportedFeaturePromoted=false` without generating, ranking, enriching, certifying, or
+   promoting ideas locally,
+9. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
 9. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
 10. RFC-0042 outcome-review AI narrative handoff now reads manage-owned
     `DpmOutcomeAiEvidenceInput` and executes `lotus-ai` `outcome_review_narrative.pack@v1` as
@@ -156,7 +161,7 @@ Runtime model:
 1. FastAPI experience API,
 2. consumed primarily by `lotus-workbench`,
 3. depends on `lotus-core`, `lotus-performance`, `lotus-risk`, `lotus-advise`, `lotus-manage`,
-   `lotus-report`, `lotus-archive`, and `lotus-ai`.
+   `lotus-report`, `lotus-archive`, `lotus-idea`, and `lotus-ai`.
 
 Boundary rules:
 
@@ -246,12 +251,15 @@ Most relevant current governance:
 7. archive retrieval uses `ARCHIVE_SERVICE_BASE_URL` and forwards archive-specific caller context
    as `lotus-gateway`; direct Workbench-to-archive access is not part of the supported product
    boundary,
-8. domain-product discovery defaults to platform-generated catalog and dependency-graph artifacts
+8. idea publication uses `IDEA_SERVICE_BASE_URL`, forwards `X-Caller-Subject`,
+   `X-Caller-Roles`, `X-Caller-Capabilities`, and correlation context to `lotus-idea`, and maps
+   unsafe upstream failures to product-safe Gateway errors,
+9. domain-product discovery defaults to platform-generated catalog and dependency-graph artifacts
    under the sibling `lotus-platform/generated/` directory, and live trust certification defaults to
    `lotus-platform/output/trust-certification/domain-product-live-trust-certification.json`;
    deployment-specific paths should use `DOMAIN_PRODUCT_CATALOG_PATH`,
    `DOMAIN_PRODUCT_DEPENDENCY_GRAPH_PATH`, and `DOMAIN_PRODUCT_LIVE_TRUST_CERTIFICATION_PATH`.
-9. report batch gateway routes are an RFC-0104 API/operator boundary only; Workbench batch UI,
+10. report batch gateway routes are an RFC-0104 API/operator boundary only; Workbench batch UI,
    RFC-0105 replay/dashboard operations, and RFC-0106 entitlement certification remain separate
    implementation scopes until explicitly delivered and proven.
 10. RFC-0042 outcome-review Gateway routes are active under

--- a/docs/documentation/git-branch-protection-workflow.md
+++ b/docs/documentation/git-branch-protection-workflow.md
@@ -8,6 +8,8 @@ This repository follows protected branch rules on `main`.
 - Create a feature branch for all changes.
 - Open PRs to `main`.
 - Merge only after CI is green.
+- Use rebase merge only; do not use merge commits or squash for governed Lotus Gateway PRs.
+- Delete the feature branch after merge.
 
 ## Daily Flow
 
@@ -21,7 +23,7 @@ git commit -m "type: short summary"
 git push -u origin feat/<short-change-name>
 gh pr create --fill --base main --head feat/<short-change-name>
 gh pr checks <PR_NUMBER> --watch
-gh pr merge <PR_NUMBER> --merge --delete-branch
+gh pr merge <PR_NUMBER> --rebase --delete-branch
 git checkout main
 git pull origin main
 ```

--- a/docs/operations/development-workflow-and-ci-strategy.md
+++ b/docs/operations/development-workflow-and-ci-strategy.md
@@ -11,4 +11,10 @@ Canonical standard:
 3. Keep PR checks fast and meaningful (blocking).
 4. Run heavier checks in scheduled/manual/mainline tiers.
 5. Merge only with green required checks.
-6. Always finish with `local = remote = main`.
+6. Use rebase merge and delete the feature branch after merge.
+7. Always finish with `local = remote = main`.
+
+PR auto-merge is rebase-only for linear history. The `Queue Auto Merge` helper uses
+`LOTUS_AUTOMERGE_TOKEN` with `gh pr merge --auto --rebase --delete-branch`; when that token is not
+available, the helper emits a warning and exits successfully so an authorized human or release actor
+can perform the rebase merge without leaving a false red CI check.

--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -44,6 +44,7 @@ outputs.
 | `lotus-manage` | versioned `/api/v1` rebalance run lookup, supportability summary, capability posture, construction alternatives, proof packs, portfolio memory timeline/search, outcome reviews with source-lineage facets, report input, AI evidence input, and PM operating quality policy/score-run/fairness-analysis/review-action/summary-invocation lifecycle APIs | management workflow composition | discretionary management operations, proof-pack evidence, portfolio-memory timeline/search lineage, outcome-review truth/facets, and PM operating quality policy/score-run/fairness-analysis/review-action/summary-invocation truth remain in `lotus-manage`; gateway must not reintroduce retired unversioned aliases, monolithic `dpm-execution-context` assumptions, local timeline reconstruction, source-owner store querying, global portfolio-universe discovery, cross-app source-event search, PM scoring logic, fairness recomputation, review-rationale reinterpretation, generated-summary text/prompt/model-response exposure, PM ranking, or HR/compensation/conduct decision semantics |
 | `lotus-report` | report snapshot rows, summary/review payloads, report job status/search/event/cancellation APIs, report batch materialization/status/control/operator-run APIs | report-ready experience payloads, durable report-job support posture, and RFC-0104 batch operator boundary | report generation, request semantics, job lifecycle truth, batch lifecycle truth, and batch execution truth remain in `lotus-report` |
 | `lotus-archive` | archived document metadata, current-document resolution, and binary download APIs | gateway-controlled generated-document retrieval for product clients | archive metadata, retention, legal-hold, purge, lifecycle, checksum, storage, and access-audit truth remain in `lotus-archive`; gateway exposes metadata and controlled download only |
+| `lotus-idea` | advisor review queue and candidate detail read APIs | opportunity intelligence read publication | idea signal evaluation, deterministic ranking, candidate lifecycle, redacted evidence, source references, durable-storage posture, and supported-feature promotion truth remain in `lotus-idea`; gateway must not generate, rank, enrich, certify, or promote ideas locally |
 | `lotus-ai` | advisor-brief, DPM workflow-pack execution surfaces, workflow-pack run-ledger, and RFC-0097 task-flow posture surfaces | evidence-grounded narrative/support text plus bounded run/task-flow posture for Workbench | gateway must not invent unsupported evidence, model outputs, review states, replacement lineage, task-flow authority, trade approval, client messaging, PM scoring, or order-routing instructions |
 
 ## Conformance Rules
@@ -110,6 +111,9 @@ This RFC-0082 documentation slice reflects current runtime behavior:
 6. RFC-0104 config-backed scheduler list and run-due actions are exposed through gateway-owned
    `/api/v1/report-batch-schedules` routes while preserving `lotus-report` as the scheduler
    configuration and materialization authority.
+7. Idea review queue and candidate detail reads are exposed through gateway-owned
+   `/api/v1/ideas/*` routes while preserving `lotus-idea` as the ranking, lifecycle, evidence,
+   conversion, and supported-feature authority.
 
 ## Gap Register
 
@@ -128,6 +132,9 @@ This RFC-0082 documentation slice reflects current runtime behavior:
 6. Gateway report batch routes are an operator/API boundary only. Workbench batch UI, RFC-0105
    replay/dashboard operations, and RFC-0106 entitlement certification must not be inferred from
    these routes until those slices are implemented and proven.
+7. Gateway idea routes are read-only publication surfaces only. Workbench idea UI, mutation
+   routes, data-product promotion, and full supported-feature claims must not be inferred until
+   separately implemented and proven.
 
 ## Validation Lane
 

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -57,6 +57,16 @@
 3. dependency graph,
 4. live trust certification discovery.
 
+## Ideas
+
+1. advisor idea review queue read through `/api/v1/ideas/review-queues/advisor`,
+2. source-safe idea candidate detail read through `/api/v1/ideas/candidates/{candidate_id}`.
+
+These routes are implementation-backed Gateway publication for `lotus-idea` read surfaces only.
+Gateway preserves `lotus-idea` ranking, source signal identifiers, source references,
+durable-storage posture, and `supportedFeaturePromoted=false`; it does not generate, rank, enrich,
+or certify ideas locally.
+
 ## Boundaries
 
 Supported does not mean gateway owns source truth. Domain authority remains with the upstream

--- a/src/app/clients/lotus_idea_client.py
+++ b/src/app/clients/lotus_idea_client.py
@@ -1,0 +1,71 @@
+import logging
+from typing import Any
+
+from app.clients.observed_fanout import request_observed_fanout
+from app.clients.upstream_headers import build_upstream_headers
+
+logger = logging.getLogger("analytics_ui.gateway")
+
+
+class LotusIdeaClient:
+    def __init__(
+        self,
+        base_url: str,
+        timeout_seconds: float,
+        max_retries: int = 2,
+        retry_backoff_seconds: float = 0.2,
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout_seconds
+        self._max_retries = max_retries
+        self._retry_backoff_seconds = retry_backoff_seconds
+
+    async def get_advisor_review_queue(
+        self,
+        *,
+        evaluated_at_utc: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-idea",
+            operation="idea.review-queues.advisor",
+            method="GET",
+            url=f"{self._base_url}/api/v1/review-queues/advisor",
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            params={"evaluatedAtUtc": evaluated_at_utc},
+            headers=self._idea_headers(caller_headers, correlation_id),
+        )
+
+    async def get_candidate_detail(
+        self,
+        *,
+        candidate_id: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-idea",
+            operation="idea.candidates.detail",
+            method="GET",
+            url=f"{self._base_url}/api/v1/idea-candidates/{candidate_id}",
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=self._idea_headers(caller_headers, correlation_id),
+        )
+
+    def _idea_headers(
+        self,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> dict[str, str]:
+        return build_upstream_headers(
+            correlation_id,
+            extras={"X-Caller-Service": "lotus-gateway"},
+            caller_headers=caller_headers,
+        )

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -43,6 +43,7 @@ class Settings(BaseSettings):
     reporting_aggregation_base_url: str = Field(default="http://report.dev.lotus")
     render_service_base_url: str = Field(default="http://render.dev.lotus")
     archive_service_base_url: str = Field(default="http://archive.dev.lotus")
+    idea_service_base_url: str = Field(default="http://idea.dev.lotus")
     management_service_base_url: str = Field(default="http://manage.dev.lotus")
     upstream_timeout_seconds: float = Field(default=3.0)
     platform_capabilities_source_timeout_seconds: float = Field(default=5.0)
@@ -82,6 +83,7 @@ class Settings(BaseSettings):
         "reporting_aggregation_base_url",
         "render_service_base_url",
         "archive_service_base_url",
+        "idea_service_base_url",
         "management_service_base_url",
         mode="before",
     )

--- a/src/app/contracts/ideas.py
+++ b/src/app/contracts/ideas.py
@@ -1,0 +1,174 @@
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class IdeaGatewayErrorResponse(BaseModel):
+    code: str = Field(..., description="Stable gateway error code.")
+    message: str = Field(..., description="Product-safe error message.")
+
+
+class IdeaGatewayReviewQueueResponse(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    policy_version: str = Field(..., alias="policyVersion", description="Lotus Idea queue policy.")
+    evaluated_at_utc: str = Field(
+        ...,
+        alias="evaluatedAtUtc",
+        description="Source evaluation instant returned by lotus-idea.",
+    )
+    items: list[dict[str, Any]] = Field(
+        ...,
+        description="Lotus Idea-ranked queue entries preserved without Gateway reranking.",
+    )
+    exclusions: list[dict[str, Any]] = Field(
+        ...,
+        description="Lotus Idea exclusion entries preserved without Gateway reinterpretation.",
+    )
+    durable_storage_backed: bool = Field(
+        ...,
+        alias="durableStorageBacked",
+        description="Whether lotus-idea reports durable storage-backed queue evidence.",
+    )
+    supported_feature_promoted: bool = Field(
+        ...,
+        alias="supportedFeaturePromoted",
+        description="Source-owned supported-feature promotion flag. Gateway must not promote it.",
+    )
+
+
+class IdeaGatewayCandidateDetailResponse(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    candidate: dict[str, Any] = Field(
+        ...,
+        description="Lotus Idea candidate summary, lifecycle, score, and source signal identity.",
+    )
+    evidence: dict[str, Any] = Field(
+        ...,
+        description="Lotus Idea redacted evidence, lineage, and source reference posture.",
+    )
+    lifecycle_history: list[dict[str, Any]] = Field(
+        ...,
+        alias="lifecycleHistory",
+        description="Lotus Idea lifecycle history entries.",
+    )
+    review_decisions: list[dict[str, Any]] = Field(
+        ...,
+        alias="reviewDecisions",
+        description="Lotus Idea review decisions preserved as source truth.",
+    )
+    feedback_events: list[dict[str, Any]] = Field(
+        ...,
+        alias="feedbackEvents",
+        description="Lotus Idea feedback events preserved as source truth.",
+    )
+    conversion_intents: list[dict[str, Any]] = Field(
+        ...,
+        alias="conversionIntents",
+        description="Lotus Idea conversion intent summaries.",
+    )
+    conversion_outcomes: list[dict[str, Any]] = Field(
+        ...,
+        alias="conversionOutcomes",
+        description="Lotus Idea conversion outcome summaries.",
+    )
+    report_evidence_packs: list[dict[str, Any]] = Field(
+        ...,
+        alias="reportEvidencePacks",
+        description="Lotus Idea governed report evidence pack summaries.",
+    )
+    audit_summary: dict[str, Any] = Field(
+        ...,
+        alias="auditSummary",
+        description="Lotus Idea audit summary without raw source payloads.",
+    )
+    durable_storage_backed: bool = Field(
+        ...,
+        alias="durableStorageBacked",
+        description="Whether lotus-idea reports durable storage-backed candidate evidence.",
+    )
+    supported_feature_promoted: bool = Field(
+        ...,
+        alias="supportedFeaturePromoted",
+        description="Source-owned supported-feature promotion flag. Gateway must not promote it.",
+    )
+
+
+IDEA_REVIEW_QUEUE_EXAMPLE: dict[str, Any] = {
+    "policyVersion": "idea-deterministic-ranking-v1",
+    "evaluatedAtUtc": "2026-06-21T10:10:00Z",
+    "items": [
+        {
+            "rank": 1,
+            "candidate": {
+                "candidateId": "idea_high_cash_8d57adbf52f7f5a7",
+                "family": "high_cash",
+                "lifecycleStatus": "generated",
+                "reviewPosture": "advisor_review_required",
+                "evidencePacketId": "iep_high_cash_8d57adbf52f7f5a7",
+                "score": "82",
+                "scorePolicyVersion": "idle-liquidity-v1",
+                "sourceSignalIds": ["signal_high_cash_8d57adbf52f7f5a7"],
+            },
+            "score": "82",
+            "priorityBucket": "high",
+            "policyVersion": "idle-liquidity-v1",
+            "reasonCodes": ["high_cash_ratio", "review_required"],
+        }
+    ],
+    "exclusions": [],
+    "durableStorageBacked": True,
+    "supportedFeaturePromoted": False,
+}
+
+IDEA_CANDIDATE_DETAIL_EXAMPLE: dict[str, Any] = {
+    "candidate": {
+        "candidateId": "idea_high_cash_8d57adbf52f7f5a7",
+        "family": "high_cash",
+        "lifecycleStatus": "generated",
+        "reviewPosture": "advisor_review_required",
+        "evidencePacketId": "iep_high_cash_8d57adbf52f7f5a7",
+        "supportability": "ready",
+        "score": "82",
+        "scorePolicyVersion": "idle-liquidity-v1",
+        "sourceSignalIds": ["signal_high_cash_8d57adbf52f7f5a7"],
+        "reasonCodes": ["high_cash_ratio", "review_required"],
+        "unsupportedReasons": [],
+        "suppressionReason": None,
+        "createdAtUtc": "2026-06-21T10:00:00Z",
+        "updatedAtUtc": "2026-06-21T10:15:00Z",
+    },
+    "evidence": {
+        "evidencePacketId": "iep_high_cash_8d57adbf52f7f5a7",
+        "evidenceContentHash": "sha256:evidence-lineage",
+        "supportability": "ready",
+        "lineageId": "lineage_high_cash_8d57adbf52f7f5a7",
+        "createdAtUtc": "2026-06-21T10:00:00Z",
+        "sourceRefs": [
+            {
+                "productId": "lotus-core:PortfolioStateSnapshot:v1",
+                "sourceSystem": "lotus-core",
+                "productVersion": "v1",
+                "asOfDate": "2026-06-21",
+                "generatedAtUtc": "2026-06-21T10:00:00Z",
+                "dataQualityStatus": "complete",
+                "freshness": "current",
+            }
+        ],
+    },
+    "lifecycleHistory": [],
+    "reviewDecisions": [],
+    "feedbackEvents": [],
+    "conversionIntents": [],
+    "conversionOutcomes": [],
+    "reportEvidencePacks": [],
+    "auditSummary": {
+        "eventCount": 1,
+        "latestEventType": "idea.candidate.persisted",
+        "latestEventOutcome": "accepted",
+        "latestOccurredAtUtc": "2026-06-21T10:00:00Z",
+    },
+    "durableStorageBacked": True,
+    "supportedFeaturePromoted": False,
+}

--- a/src/app/openapi_metadata.py
+++ b/src/app/openapi_metadata.py
@@ -20,6 +20,13 @@ OPENAPI_TAGS: list[dict[str, str]] = [
         "description": ("Gateway-facing archived document metadata and controlled download APIs."),
     },
     {
+        "name": "Ideas",
+        "description": (
+            "Gateway-facing opportunity intelligence and idea lifecycle read APIs backed by "
+            "lotus-idea source authority."
+        ),
+    },
+    {
         "name": "Analytics Diagnostics",
         "description": (
             "Protected operator analytics UI diagnostics lookup with bounded audit posture."

--- a/src/app/router_registry.py
+++ b/src/app/router_registry.py
@@ -33,6 +33,7 @@ from app.routers.domain_product_graph import router as domain_product_graph_rout
 from app.routers.domain_product_trust import router as domain_product_trust_router
 from app.routers.foundation import router as foundation_router
 from app.routers.foundation_workspace import router as foundation_workspace_router
+from app.routers.ideas import router as ideas_router
 from app.routers.intake import router as intake_router
 from app.routers.intake_upload_commits import router as intake_upload_commits_router
 from app.routers.intake_uploads import router as intake_uploads_router
@@ -226,6 +227,8 @@ OPERATIONS_ROUTERS: RouterGroup = (
     analytics_diagnostics_router,
 )
 
+IDEA_ROUTERS: RouterGroup = (ideas_router,)
+
 ROUTER_GROUPS: tuple[RouterGroup, ...] = (
     ADVISOR_COCKPIT_ROUTERS,
     BANK_DEMO_PROOF_ROUTERS,
@@ -245,6 +248,7 @@ ROUTER_GROUPS: tuple[RouterGroup, ...] = (
     DPM_WAVE_ROUTERS,
     WORKBENCH_ROUTERS,
     REPORTING_ROUTERS,
+    IDEA_ROUTERS,
     OPERATIONS_ROUTERS,
 )
 

--- a/src/app/routers/ideas.py
+++ b/src/app/routers/ideas.py
@@ -1,0 +1,137 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Header, Path, Query
+
+from app.contracts.ideas import (
+    IDEA_CANDIDATE_DETAIL_EXAMPLE,
+    IDEA_REVIEW_QUEUE_EXAMPLE,
+    IdeaGatewayCandidateDetailResponse,
+    IdeaGatewayReviewQueueResponse,
+)
+from app.middleware.correlation import correlation_id_var
+from app.routers.ideas_common import IdeaCallerHeaders, idea_error_response
+from app.services.gateway_service_provider import idea_service
+
+router = APIRouter(prefix="/api/v1/ideas", tags=["Ideas"])
+
+
+async def _get_advisor_idea_review_queue(
+    *,
+    evaluated_at_utc: str,
+    caller_headers: IdeaCallerHeaders,
+) -> IdeaGatewayReviewQueueResponse:
+    return await idea_service().get_advisor_review_queue(
+        evaluated_at_utc=evaluated_at_utc,
+        caller_headers=caller_headers.as_idea_context(),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+async def _get_idea_candidate_detail(
+    *,
+    candidate_id: str,
+    caller_headers: IdeaCallerHeaders,
+) -> IdeaGatewayCandidateDetailResponse:
+    return await idea_service().get_candidate_detail(
+        candidate_id=candidate_id,
+        caller_headers=caller_headers.as_idea_context(),
+        correlation_id=correlation_id_var.get(),
+    )
+
+
+@router.get(
+    "/review-queues/advisor",
+    response_model=IdeaGatewayReviewQueueResponse,
+    summary="Get advisor idea review queue",
+    description=(
+        "Returns the product-facing advisor idea review queue by forwarding to lotus-idea. "
+        "Gateway preserves lotus-idea ranking, candidate identity, source signal identifiers, "
+        "durable-storage posture, and supported-feature promotion state; it does not rank, "
+        "generate, or certify idea candidates locally."
+    ),
+    openapi_extra={
+        "responses": {
+            "200": {
+                "content": {"application/json": {"example": IDEA_REVIEW_QUEUE_EXAMPLE}},
+            }
+        }
+    },
+    responses={
+        **idea_error_response(400, description="Lotus Idea rejected the queue request."),
+        **idea_error_response(403, description="Caller lacks Idea review-queue permission."),
+        **idea_error_response(502, description="Lotus Idea is unavailable or unsafe."),
+    },
+)
+async def get_advisor_idea_review_queue(
+    evaluated_at_utc: Annotated[
+        str,
+        Query(
+            alias="evaluatedAtUtc",
+            description="Timezone-aware evaluation instant forwarded to lotus-idea.",
+            examples=["2026-06-21T10:10:00Z"],
+        ),
+    ],
+    x_caller_subject: Annotated[str | None, Header(alias="X-Caller-Subject")] = None,
+    x_caller_roles: Annotated[str | None, Header(alias="X-Caller-Roles")] = None,
+    x_caller_capabilities: Annotated[
+        str | None,
+        Header(alias="X-Caller-Capabilities"),
+    ] = None,
+) -> IdeaGatewayReviewQueueResponse:
+    return await _get_advisor_idea_review_queue(
+        evaluated_at_utc=evaluated_at_utc,
+        caller_headers=IdeaCallerHeaders(
+            subject=x_caller_subject,
+            roles=x_caller_roles,
+            capabilities=x_caller_capabilities,
+        ),
+    )
+
+
+@router.get(
+    "/candidates/{candidate_id}",
+    response_model=IdeaGatewayCandidateDetailResponse,
+    summary="Get idea candidate detail",
+    description=(
+        "Returns source-safe idea candidate detail by forwarding to lotus-idea. Gateway preserves "
+        "lotus-idea candidate lifecycle, redacted evidence, source references, review, feedback, "
+        "conversion, report-evidence, audit, durable-storage, and supported-feature posture; it "
+        "does not enrich, re-score, or grant downstream authority locally."
+    ),
+    openapi_extra={
+        "responses": {
+            "200": {
+                "content": {"application/json": {"example": IDEA_CANDIDATE_DETAIL_EXAMPLE}},
+            }
+        }
+    },
+    responses={
+        **idea_error_response(400, description="Lotus Idea rejected the candidate request."),
+        **idea_error_response(403, description="Caller lacks Idea candidate-detail permission."),
+        **idea_error_response(404, description="Lotus Idea did not find the candidate."),
+        **idea_error_response(502, description="Lotus Idea is unavailable or unsafe."),
+    },
+)
+async def get_idea_candidate_detail(
+    candidate_id: Annotated[
+        str,
+        Path(
+            description="Lotus Idea-owned candidate identifier.",
+            examples=["idea_high_cash_8d57adbf52f7f5a7"],
+        ),
+    ],
+    x_caller_subject: Annotated[str | None, Header(alias="X-Caller-Subject")] = None,
+    x_caller_roles: Annotated[str | None, Header(alias="X-Caller-Roles")] = None,
+    x_caller_capabilities: Annotated[
+        str | None,
+        Header(alias="X-Caller-Capabilities"),
+    ] = None,
+) -> IdeaGatewayCandidateDetailResponse:
+    return await _get_idea_candidate_detail(
+        candidate_id=candidate_id,
+        caller_headers=IdeaCallerHeaders(
+            subject=x_caller_subject,
+            roles=x_caller_roles,
+            capabilities=x_caller_capabilities,
+        ),
+    )

--- a/src/app/routers/ideas_common.py
+++ b/src/app/routers/ideas_common.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from typing import Any
+
+from app.contracts.ideas import IdeaGatewayErrorResponse
+
+
+@dataclass(frozen=True)
+class IdeaCallerHeaders:
+    subject: str | None
+    roles: str | None
+    capabilities: str | None
+
+    def as_idea_context(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self.subject:
+            headers["X-Caller-Subject"] = self.subject
+        if self.roles:
+            headers["X-Caller-Roles"] = self.roles
+        if self.capabilities:
+            headers["X-Caller-Capabilities"] = self.capabilities
+        return headers
+
+
+def idea_error_response(status_code: int, *, description: str) -> dict[int | str, dict[str, Any]]:
+    return {
+        status_code: {
+            "model": IdeaGatewayErrorResponse,
+            "description": description,
+        }
+    }

--- a/src/app/services/gateway_service_provider.py
+++ b/src/app/services/gateway_service_provider.py
@@ -18,6 +18,8 @@ from app.services.foundation_service_factory import (
     build_foundation_service,
     foundation_service_signature,
 )
+from app.services.idea_service import IdeaService
+from app.services.idea_service_factory import build_idea_service, idea_service_signature
 from app.services.intake_service import IntakeService
 from app.services.intake_service_factory import build_intake_service, intake_service_signature
 from app.services.service_provider_cache import resolve_cached_service
@@ -39,6 +41,8 @@ _FOUNDATION_SERVICE: FoundationService | None = None
 _FOUNDATION_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 _INTAKE_SERVICE: IntakeService | None = None
 _INTAKE_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+_IDEA_SERVICE: IdeaService | None = None
+_IDEA_SERVICE_SIGNATURE: tuple[object, ...] | None = None
 
 
 def archive_document_service() -> ArchiveDocumentService:
@@ -116,4 +120,17 @@ def intake_service() -> IntakeService:
     )
     _INTAKE_SERVICE = service
     _INTAKE_SERVICE_SIGNATURE = signature
+    return service
+
+
+def idea_service() -> IdeaService:
+    global _IDEA_SERVICE, _IDEA_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _IDEA_SERVICE,
+        _IDEA_SERVICE_SIGNATURE,
+        idea_service_signature(),
+        build_idea_service,
+    )
+    _IDEA_SERVICE = service
+    _IDEA_SERVICE_SIGNATURE = signature
     return service

--- a/src/app/services/idea_client_factory.py
+++ b/src/app/services/idea_client_factory.py
@@ -1,0 +1,20 @@
+from app.clients.lotus_idea_client import LotusIdeaClient
+from app.config import settings
+
+
+def idea_client_signature() -> tuple[object, ...]:
+    return (
+        settings.idea_service_base_url,
+        settings.upstream_timeout_seconds,
+        settings.upstream_max_retries,
+        settings.upstream_retry_backoff_seconds,
+    )
+
+
+def build_idea_client() -> LotusIdeaClient:
+    return LotusIdeaClient(
+        base_url=settings.idea_service_base_url,
+        timeout_seconds=settings.upstream_timeout_seconds,
+        max_retries=settings.upstream_max_retries,
+        retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
+    )

--- a/src/app/services/idea_client_protocols.py
+++ b/src/app/services/idea_client_protocols.py
@@ -1,0 +1,19 @@
+from typing import Any, Protocol
+
+
+class IdeaClient(Protocol):
+    async def get_advisor_review_queue(
+        self,
+        *,
+        evaluated_at_utc: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def get_candidate_detail(
+        self,
+        *,
+        candidate_id: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...

--- a/src/app/services/idea_service.py
+++ b/src/app/services/idea_service.py
@@ -1,0 +1,104 @@
+from typing import Any, TypeVar
+
+from fastapi import HTTPException, status
+from pydantic import BaseModel, ValidationError
+
+from app.contracts.ideas import (
+    IdeaGatewayCandidateDetailResponse,
+    IdeaGatewayReviewQueueResponse,
+)
+from app.services.idea_client_protocols import IdeaClient
+
+ResponseModel = TypeVar("ResponseModel", bound=BaseModel)
+
+
+class IdeaService:
+    def __init__(self, *, idea_client: IdeaClient) -> None:
+        self._idea_client = idea_client
+
+    async def get_advisor_review_queue(
+        self,
+        *,
+        evaluated_at_utc: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> IdeaGatewayReviewQueueResponse:
+        status_code, payload = await self._idea_client.get_advisor_review_queue(
+            evaluated_at_utc=evaluated_at_utc,
+            caller_headers=caller_headers,
+            correlation_id=correlation_id,
+        )
+        self._raise_on_idea_error(status_code, payload, missing_code="idea_queue_unavailable")
+        return self._validate_payload(IdeaGatewayReviewQueueResponse, payload)
+
+    async def get_candidate_detail(
+        self,
+        *,
+        candidate_id: str,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+    ) -> IdeaGatewayCandidateDetailResponse:
+        status_code, payload = await self._idea_client.get_candidate_detail(
+            candidate_id=candidate_id,
+            caller_headers=caller_headers,
+            correlation_id=correlation_id,
+        )
+        self._raise_on_idea_error(status_code, payload, missing_code="idea_candidate_unavailable")
+        return self._validate_payload(IdeaGatewayCandidateDetailResponse, payload)
+
+    def _validate_payload(
+        self,
+        response_model: type[ResponseModel],
+        payload: dict[str, Any],
+    ) -> ResponseModel:
+        try:
+            response = response_model.model_validate(payload)
+        except ValidationError as exc:
+            raise self._gateway_error(
+                status.HTTP_502_BAD_GATEWAY,
+                "idea_contract_invalid",
+                "Lotus Idea returned a response that does not match the gateway contract.",
+            ) from exc
+        if response.model_dump(by_alias=True)["supportedFeaturePromoted"] is not False:
+            raise self._gateway_error(
+                status.HTTP_502_BAD_GATEWAY,
+                "idea_supported_feature_claim_invalid",
+                "Lotus Idea returned an unsupported feature-promotion claim.",
+            )
+        return response
+
+    def _raise_on_idea_error(
+        self,
+        status_code: int,
+        payload: dict[str, Any],
+        *,
+        missing_code: str,
+    ) -> None:
+        if status_code < status.HTTP_400_BAD_REQUEST:
+            return
+        if status_code == status.HTTP_400_BAD_REQUEST:
+            raise self._gateway_error(
+                status.HTTP_400_BAD_REQUEST,
+                "idea_invalid_request",
+                "Lotus Idea rejected the request.",
+            )
+        if status_code == status.HTTP_403_FORBIDDEN:
+            raise self._gateway_error(
+                status.HTTP_403_FORBIDDEN,
+                "idea_permission_denied",
+                "Caller is not permitted to use the requested Idea capability.",
+            )
+        if status_code == status.HTTP_404_NOT_FOUND:
+            raise self._gateway_error(
+                status.HTTP_404_NOT_FOUND,
+                "idea_resource_not_found",
+                "The requested Idea resource was not found.",
+            )
+        raise self._gateway_error(
+            status.HTTP_502_BAD_GATEWAY,
+            missing_code,
+            "Lotus Idea is unavailable or returned an unsafe failure.",
+        )
+
+    def _gateway_error(self, status_code: int, code: str, message: str) -> HTTPException:
+        return HTTPException(status_code=status_code, detail={"code": code, "message": message})

--- a/src/app/services/idea_service_factory.py
+++ b/src/app/services/idea_service_factory.py
@@ -1,0 +1,10 @@
+from app.services.idea_client_factory import build_idea_client, idea_client_signature
+from app.services.idea_service import IdeaService
+
+
+def idea_service_signature() -> tuple[object, ...]:
+    return idea_client_signature()
+
+
+def build_idea_service() -> IdeaService:
+    return IdeaService(idea_client=build_idea_client())

--- a/tests/contract/test_ideas_contract.py
+++ b/tests/contract/test_ideas_contract.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_ideas_openapi_contract_registered() -> None:
+    spec = TestClient(app).get("/openapi.json").json()
+
+    queue_operation = spec["paths"]["/api/v1/ideas/review-queues/advisor"]["get"]
+    detail_operation = spec["paths"]["/api/v1/ideas/candidates/{candidate_id}"]["get"]
+    queue_schema = spec["components"]["schemas"]["IdeaGatewayReviewQueueResponse"]
+    detail_schema = spec["components"]["schemas"]["IdeaGatewayCandidateDetailResponse"]
+
+    assert queue_operation["summary"] == "Get advisor idea review queue"
+    assert detail_operation["summary"] == "Get idea candidate detail"
+    assert "lotus-idea" in queue_operation["description"]
+    assert "does not rank" in queue_operation["description"]
+    assert "does not enrich" in detail_operation["description"]
+    assert queue_operation["responses"]["403"]["description"]
+    assert queue_operation["responses"]["502"]["description"]
+    assert detail_operation["responses"]["404"]["description"]
+    assert detail_operation["responses"]["502"]["description"]
+    assert queue_schema["properties"]["supportedFeaturePromoted"]["description"]
+    assert detail_schema["properties"]["evidence"]["description"]
+    assert detail_schema["properties"]["supportedFeaturePromoted"]["description"]

--- a/tests/integration/test_ideas_router.py
+++ b/tests/integration/test_ideas_router.py
@@ -1,0 +1,121 @@
+from fastapi.testclient import TestClient
+
+from app.contracts.ideas import IDEA_CANDIDATE_DETAIL_EXAMPLE, IDEA_REVIEW_QUEUE_EXAMPLE
+from app.main import app
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "X-Caller-Subject": "advisor-123",
+        "X-Caller-Roles": "advisor",
+        "X-Caller-Capabilities": "idea.review.queue.read,idea.candidate.detail.read",
+        "X-Correlation-Id": "corr-idea-router",
+    }
+
+
+def test_idea_review_queue_route_preserves_source_payload_and_context(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _queue(self, *, evaluated_at_utc, caller_headers, correlation_id):
+        captured["evaluated_at_utc"] = evaluated_at_utc
+        captured["caller_headers"] = caller_headers
+        captured["correlation_id"] = correlation_id
+        payload = dict(IDEA_REVIEW_QUEUE_EXAMPLE)
+        payload["sourceAuthority"] = "lotus-idea"
+        return 200, payload
+
+    monkeypatch.setattr(
+        "app.clients.lotus_idea_client.LotusIdeaClient.get_advisor_review_queue",
+        _queue,
+    )
+
+    response = TestClient(app).get(
+        "/api/v1/ideas/review-queues/advisor?evaluatedAtUtc=2026-06-21T10:10:00Z",
+        headers=_headers(),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sourceAuthority"] == "lotus-idea"
+    assert body["items"][0]["rank"] == 1
+    assert body["items"][0]["candidate"]["sourceSignalIds"] == ["signal_high_cash_8d57adbf52f7f5a7"]
+    assert body["supportedFeaturePromoted"] is False
+    assert "gatewayRank" not in str(body)
+    assert captured == {
+        "evaluated_at_utc": "2026-06-21T10:10:00Z",
+        "caller_headers": {
+            "X-Caller-Subject": "advisor-123",
+            "X-Caller-Roles": "advisor",
+            "X-Caller-Capabilities": "idea.review.queue.read,idea.candidate.detail.read",
+        },
+        "correlation_id": "corr-idea-router",
+    }
+
+
+def test_idea_candidate_detail_route_preserves_source_refs_without_enrichment(monkeypatch) -> None:
+    async def _detail(self, *, candidate_id, caller_headers, correlation_id):
+        payload = dict(IDEA_CANDIDATE_DETAIL_EXAMPLE)
+        payload["candidate"] = dict(payload["candidate"])
+        payload["candidate"]["candidateId"] = candidate_id
+        payload["sourceAuthority"] = "lotus-idea"
+        return 200, payload
+
+    monkeypatch.setattr(
+        "app.clients.lotus_idea_client.LotusIdeaClient.get_candidate_detail",
+        _detail,
+    )
+
+    response = TestClient(app).get(
+        "/api/v1/ideas/candidates/idea_high_cash_8d57adbf52f7f5a7",
+        headers=_headers(),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["candidate"]["candidateId"] == "idea_high_cash_8d57adbf52f7f5a7"
+    assert body["sourceAuthority"] == "lotus-idea"
+    assert body["evidence"]["sourceRefs"][0]["sourceSystem"] == "lotus-core"
+    assert body["supportedFeaturePromoted"] is False
+    assert "gatewayScore" not in str(body)
+    assert "grantsDownstreamAuthority" not in str(body)
+
+
+def test_idea_route_blocks_source_supported_feature_promotion(monkeypatch) -> None:
+    async def _queue(self, *, evaluated_at_utc, caller_headers, correlation_id):
+        payload = dict(IDEA_REVIEW_QUEUE_EXAMPLE)
+        payload["supportedFeaturePromoted"] = True
+        return 200, payload
+
+    monkeypatch.setattr(
+        "app.clients.lotus_idea_client.LotusIdeaClient.get_advisor_review_queue",
+        _queue,
+    )
+
+    response = TestClient(app).get(
+        "/api/v1/ideas/review-queues/advisor?evaluatedAtUtc=2026-06-21T10:10:00Z",
+        headers=_headers(),
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"]["code"] == "idea_supported_feature_claim_invalid"
+
+
+def test_idea_route_maps_upstream_failures_without_raw_payload(monkeypatch) -> None:
+    async def _detail(self, *, candidate_id, caller_headers, correlation_id):
+        return 500, {"detail": "postgres traceback idea.internal source payload"}
+
+    monkeypatch.setattr(
+        "app.clients.lotus_idea_client.LotusIdeaClient.get_candidate_detail",
+        _detail,
+    )
+
+    response = TestClient(app).get(
+        "/api/v1/ideas/candidates/idea_high_cash_8d57adbf52f7f5a7",
+        headers=_headers(),
+    )
+
+    assert response.status_code == 502
+    body = response.json()
+    assert body["detail"]["code"] == "idea_candidate_unavailable"
+    assert "postgres" not in str(body).lower()
+    assert "idea.internal" not in str(body)

--- a/tests/unit/test_config_defaults.py
+++ b/tests/unit/test_config_defaults.py
@@ -22,6 +22,7 @@ def test_settings_default_to_canonical_dev_service_identities():
     assert settings.risk_analytics_base_url == "http://risk.dev.lotus"
     assert settings.reporting_aggregation_base_url == "http://report.dev.lotus"
     assert settings.archive_service_base_url == "http://archive.dev.lotus"
+    assert settings.idea_service_base_url == "http://idea.dev.lotus"
     assert settings.management_service_base_url == "http://manage.dev.lotus"
     assert Path(settings.domain_product_catalog_path).parts[-3:] == (
         "lotus-platform",

--- a/tests/unit/test_gateway_service_provider.py
+++ b/tests/unit/test_gateway_service_provider.py
@@ -3,6 +3,7 @@ from app.services.gateway_service_provider import (
     composite_performance_service,
     domain_product_catalog_service,
     foundation_service,
+    idea_service,
     intake_service,
     source_product_service,
 )
@@ -25,6 +26,10 @@ def test_gateway_service_provider_wires_smaller_route_services(monkeypatch) -> N
         "app.services.lotus_core_client_factory.settings.portfolio_data_ingestion_base_url",
         "http://core-ingestion-provider:8000",
     )
+    monkeypatch.setattr(
+        "app.services.idea_client_factory.settings.idea_service_base_url",
+        "http://idea-provider:8000",
+    )
 
     assert archive_document_service()._archive_client._base_url == "http://archive-provider:8000"
     assert (
@@ -44,6 +49,7 @@ def test_gateway_service_provider_wires_smaller_route_services(monkeypatch) -> N
         intake_service()._lotus_core_ingestion_client._base_url
         == "http://core-ingestion-provider:8000"
     )
+    assert idea_service()._idea_client._base_url == "http://idea-provider:8000"
 
 
 def test_gateway_service_provider_reuses_services_for_unchanged_signature(monkeypatch) -> None:

--- a/tests/unit/test_router_registry.py
+++ b/tests/unit/test_router_registry.py
@@ -33,6 +33,7 @@ def test_router_registry_mounts_representative_gateway_route_families() -> None:
     assert "/api/v1/dpm/command-center" in routes
     assert "/api/v1/report-batches/{batch_id}" in routes
     assert "/api/v1/documents/{document_id}" in routes
+    assert "/api/v1/ideas/review-queues/advisor" in routes
 
 
 def test_advisory_router_group_keeps_proposal_routes_together() -> None:

--- a/tests/unit/test_service_layer_boundaries.py
+++ b/tests/unit/test_service_layer_boundaries.py
@@ -8,6 +8,7 @@ _CLIENT_FACTORY_FILES = {
     "analytics_client_factory.py",
     "archive_client_factory.py",
     "dpm_service_factory.py",
+    "idea_client_factory.py",
     "lotus_core_client_factory.py",
     "reporting_client_factory.py",
 }

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -47,6 +47,8 @@
 - `GET /api/v1/report-batch-schedules` and `POST /api/v1/report-batch-schedules:run-due`
 - `GET /api/v1/documents/{document_id}`
 - `GET /api/v1/documents/{document_id}/download`
+- `GET /api/v1/ideas/review-queues/advisor`
+- `GET /api/v1/ideas/candidates/{candidate_id}`
 - `GET /api/v1/analytics-ui/diagnostics/{support_reference}`
 - `/health`, `/health/live`, `/health/ready`, `/metrics`, `/docs`
 
@@ -241,6 +243,11 @@
   `lotus-workbench` must not call `lotus-archive` directly
 - archived document routes require `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional
   `X-Booking-Center-Code` and `X-Role` are forwarded as caller context
+- idea review queue and candidate detail reads are gateway-first under `/api/v1/ideas/*`;
+  Gateway forwards `X-Caller-Subject`, `X-Caller-Roles`, `X-Caller-Capabilities`, and correlation
+  context to `lotus-idea`, preserves source-owned ranking, source signal identifiers, source refs,
+  durable-storage posture, and `supportedFeaturePromoted=false`, and does not generate, rank,
+  enrich, certify, or promote idea candidates locally
 - Workbench performance summary, risk summary, advisor-brief read, and advisor-brief review-action
   routes require `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional
   `X-Caller-Application`, `X-Booking-Center-Code`, and `X-Role` preserve entitlement and audit
@@ -622,6 +629,24 @@ curl "http://127.0.0.1:8111/api/v1/documents/doc_example/download" \
   -H "X-Booking-Center-Code: SG" \
   -H "X-Role: advisor" \
   --output portfolio-review.pdf
+```
+
+Advisor idea review queue:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/ideas/review-queues/advisor?evaluatedAtUtc=2026-06-21T10:10:00Z" \
+  -H "X-Caller-Subject: advisor-123" \
+  -H "X-Caller-Roles: advisor" \
+  -H "X-Caller-Capabilities: idea.review.queue.read"
+```
+
+Idea candidate detail:
+
+```bash
+curl "http://127.0.0.1:8111/api/v1/ideas/candidates/idea_high_cash_8d57adbf52f7f5a7" \
+  -H "X-Caller-Subject: advisor-123" \
+  -H "X-Caller-Roles: advisor" \
+  -H "X-Caller-Capabilities: idea.candidate.detail.read"
 ```
 
 Analytics diagnostics protected lookup:

--- a/wiki/Development-Workflow.md
+++ b/wiki/Development-Workflow.md
@@ -7,6 +7,7 @@
 - use PR-first delivery
 - keep commits small and scoped to one real improvement area
 - preserve behavior unless a change is intentional, tested, and documented
+- merge with rebase only and delete the feature branch after merge
 
 ## Repo-native commands
 
@@ -38,6 +39,13 @@
 ```powershell
 ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway
 ```
+
+## Merge hygiene
+
+PR auto-merge is rebase-only for linear history. The `Queue Auto Merge` helper uses
+`LOTUS_AUTOMERGE_TOKEN` with `gh pr merge --auto --rebase --delete-branch`; when that token is not
+available, the helper emits a warning and exits successfully so an authorized human or release actor
+can perform the rebase merge without leaving a false red CI check.
 
 ## Engineering guardrails
 

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -39,6 +39,8 @@
   reporting snapshot, summary, and review payloads
 - `lotus-archive`
   archived generated-document metadata and controlled binary retrieval
+- `lotus-idea`
+  opportunity intelligence advisor review queue and source-safe candidate detail read APIs
 - `lotus-ai`
   evidence-grounded advisor brief narration, DPM exception-summary support, proof-pack PM memo
   support, wave PM memo support, and outcome-review narrative support through explicit
@@ -63,6 +65,8 @@
   `http://report.dev.lotus`
 - `lotus-archive`
   `http://archive.dev.lotus`
+- `lotus-idea`
+  `http://idea.dev.lotus`
 - `lotus-ai`
   `http://ai.dev.lotus`
 
@@ -81,8 +85,10 @@
 6. advisor-brief responses preserve `lotus-ai` workflow-pack run posture and task-flow lineage but do not make gateway the review-state or task-flow authority
 7. archived document retrieval is product-facing only through gateway document routes; Workbench
    does not call `lotus-archive` directly
-8. Workbench and other product clients consume `lotus-gateway`; they do not call `lotus-advise` or
-   `lotus-manage` directly for proposal or management workflow data
+8. idea review queue and candidate detail retrieval are product-facing only through gateway idea
+   routes; Workbench must not call `lotus-idea` directly for these read surfaces
+9. Workbench and other product clients consume `lotus-gateway`; they do not call `lotus-advise`,
+   `lotus-manage`, or `lotus-idea` directly for proposal, management, or idea workflow data
 9. RFC-0023 advisory narrative posture remains `lotus-advise` truth. Gateway exposes reviewed
    narrative, report-request, delivery-summary, and delivery-event routes for Workbench and
    preserves Advise-owned source hashes, review state, policy/guardrail/disclosure posture,
@@ -201,3 +207,10 @@
     `lotus-manage` directly or inventing workflow/error semantics. Supportability comes from
     manage `/api/v1/rebalance/supportability/summary`; run posture comes from
     `/api/v1/rebalance/runs`.
+19. Lotus Idea opportunity intelligence remains `lotus-idea` truth. Gateway realization exposes
+    `/api/v1/ideas/review-queues/advisor` and `/api/v1/ideas/candidates/{candidate_id}` for
+    product clients, forwards Idea caller context and correlation context, and preserves
+    `lotus-idea` ranking, source signal identifiers, source references, durable-storage posture,
+    and `supportedFeaturePromoted=false`. Gateway does not generate ideas, rank candidates,
+    enrich evidence, grant downstream authority, certify data-product posture, or promote the
+    feature locally.

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -44,6 +44,7 @@ flowchart LR
     Gateway --> Manage[lotus-manage DPM workflow authority]
     Gateway --> Report[lotus-report reporting jobs and batches]
     Gateway --> Archive[lotus-archive generated document retrieval]
+    Gateway --> Idea[lotus-idea opportunity intelligence]
     Gateway --> AI[lotus-ai workflow-pack execution]
     Gateway --> Platform[lotus-platform generated mesh artifacts]
 ```
@@ -62,6 +63,7 @@ supportability, and degraded-state posture.
 | Advisory proposals, policy, cockpit, and bank-demo proof | Advisor proposal lifecycle, suitability/policy review, action cockpit, and proof-backed demo material | Active Gateway publication over implemented Advise routes, with client-ready and external-communication boundaries preserved | `lotus-advise` |
 | DPM command center | Mandate health, construction alternatives, proof packs, waves, outcome reviews, portfolio memory, and PM quality | Active Gateway BFF route families over implemented Manage APIs, including governed AI handoffs where source evidence exists | `lotus-manage` plus `lotus-ai` for workflow-pack execution |
 | Reporting, archive, and batch operations | Portfolio-review report jobs, batch materialization, scheduler operations, metadata lookup, and controlled download | Active Gateway operator/product boundary for reporting and document retrieval without owning rendering, archive storage, or retention truth | `lotus-report`, `lotus-render`, and `lotus-archive` |
+| Ideas | Advisor opportunity review and evidence drill-down | Active read-only Gateway publication for advisor review queue and source-safe candidate detail; no local idea generation, ranking, enrichment, or promotion | `lotus-idea` |
 | Domain-product discovery | Self-serve mesh catalog, dependency graph, and trust certification discovery | Active read-only facade over generated platform artifacts with explicit unavailable/degraded posture | `lotus-platform` generated evidence and producer repo declarations |
 
 ## Non-Functional Capability Matrix

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -5,6 +5,33 @@ developers, business users, operations, sales/pre-sales, and client demos; it mu
 future capability as supported until the owning service, Gateway contract, tests, and validation
 evidence exist.
 
+## Idea Opportunity Reads
+
+Status: implementation-backed in Gateway for the first read-only `lotus-idea` publication slice.
+This is not a Workbench UI completion claim or a supported-feature promotion from `lotus-idea`.
+
+What is supported:
+
+1. advisors can read the Idea review queue through Gateway,
+2. advisors and operators can read source-safe candidate detail through Gateway,
+3. Gateway preserves `lotus-idea` ranking, source signal identifiers, redacted source references,
+   durable-storage posture, and `supportedFeaturePromoted=false`,
+4. Gateway maps unsafe upstream failures to product-safe error detail.
+
+Supported routes:
+
+1. `GET /api/v1/ideas/review-queues/advisor`
+2. `GET /api/v1/ideas/candidates/{candidate_id}`
+
+Boundary:
+
+1. Gateway forwards `X-Caller-Subject`, `X-Caller-Roles`, `X-Caller-Capabilities`, and correlation
+   context to `lotus-idea`.
+2. Gateway does not generate ideas, rank candidates, enrich evidence, certify data-product posture,
+   grant downstream authority, or promote `supportedFeaturePromoted`.
+3. Workbench idea UI, mutation routes, data-product certification, and full supported-feature
+   promotion remain separate proof scopes.
+
 ## Advisory Proposal Narrative Posture
 
 Status: implementation-backed in Gateway for the RFC-0023 advisory narrative posture path.

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -24,6 +24,13 @@
 - `make ci-local-docker`
   Docker parity for the integration boundary
 
+## PR auto-merge posture
+
+PR auto-merge is rebase-only for linear history. The `Queue Auto Merge` helper uses
+`LOTUS_AUTOMERGE_TOKEN` with `gh pr merge --auto --rebase --delete-branch`; when that token is not
+available, the helper emits a warning and exits successfully so an authorized human or release actor
+can perform the rebase merge without leaving a false red CI check.
+
 ## What the gates protect
 
 - workbench-facing contract integrity


### PR DESCRIPTION
## Summary
- Adds first read-only Gateway publication for lotus-idea: advisor review queue and source-safe candidate detail.
- Preserves lotus-idea source authority, caller context, correlation context, durable-storage posture, and supportedFeaturePromoted=false.
- Updates README, repository context, RFC-0082 upstream map, supported-features docs, and wiki source for current-state truth.

## Local Evidence
- make check
  - ruff, format, monetary-float guard, refactor-quality thresholds, workflow-action runtime, agent-quality evidence, mypy, OpenAPI contract proof, unit/contract tests.
  - 1316 passed.
- make ci
  - integration: 213 passed.
  - coverage: 1529 passed, total coverage 94.33% against 84% gate.
  - security audit: No known vulnerabilities found.
- git diff --check passed with LF/CRLF warnings only.

## Stranded Truth
- git fetch origin --prune and git branch -r --no-merged origin/main showed no unmerged remote branches before this slice.

## Wiki
- Repo-local wiki source changed: API-Surface, Integrations, Overview, Supported-Features.
- Sync-RepoWikis.ps1 -CheckOnly currently reports expected drift because this branch contains unpublished wiki source changes. Publish after merge to main with Sync-RepoWikis.ps1 -Publish -Repository lotus-gateway.

## Non-Degradation
- Gateway remains an experience API and does not become idea authority.
- New router follows existing thin-handler architecture gates.
- Service/client wiring uses typed protocol/factory/provider patterns.
- Tests block premature supported-feature promotion and raw upstream failure leakage.