### PR TITLE
[codex] Preserve canonical gateway upstream contracts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - REPORTING_AGGREGATION_BASE_URL=${REPORTING_AGGREGATION_BASE_URL:-http://host.docker.internal:8300}
       - RENDER_SERVICE_BASE_URL=${RENDER_SERVICE_BASE_URL:-http://host.docker.internal:8310}
       - ARCHIVE_SERVICE_BASE_URL=${ARCHIVE_SERVICE_BASE_URL:-http://host.docker.internal:8150}
+      - IDEA_SERVICE_BASE_URL=${IDEA_SERVICE_BASE_URL:-http://host.docker.internal:8330}
       - DOMAIN_PRODUCT_CATALOG_PATH=${DOMAIN_PRODUCT_CATALOG_PATH:-/lotus-platform/generated/domain-product-catalog.json}
       - DOMAIN_PRODUCT_DEPENDENCY_GRAPH_PATH=${DOMAIN_PRODUCT_DEPENDENCY_GRAPH_PATH:-/lotus-platform/generated/domain-product-dependency-graph.json}
       - DOMAIN_PRODUCT_LIVE_TRUST_CERTIFICATION_PATH=${DOMAIN_PRODUCT_LIVE_TRUST_CERTIFICATION_PATH:-/lotus-platform/output/trust-certification/domain-product-live-trust-certification.json}

--- a/src/app/clients/dpm_outcome_review_client.py
+++ b/src/app/clients/dpm_outcome_review_client.py
@@ -42,12 +42,13 @@ class DpmOutcomeReviewClientMixin:
     async def create_outcome_review(
         self,
         body: dict[str, Any],
+        idempotency_key: str,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         return await self._post(
             "/api/v1/rebalance/outcome-reviews",
             body=body,
-            headers=self._headers(correlation_id),
+            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
             operation="manage.rebalance.outcome_reviews.create",
         )
 

--- a/src/app/clients/lotus_analytics_workspace_payloads.py
+++ b/src/app/clients/lotus_analytics_workspace_payloads.py
@@ -32,6 +32,7 @@ def build_workspace_summary_payload(
         payload["report_ccy"] = reporting_currency
     if report_start_date:
         payload["report_start_date"] = report_start_date
+        payload["performance_start_date"] = report_start_date
     if benchmark_id:
         payload["benchmark"] = _workspace_summary_benchmark(benchmark_id)
     return payload

--- a/src/app/clients/lotus_idea_client.py
+++ b/src/app/clients/lotus_idea_client.py
@@ -23,7 +23,7 @@ class LotusIdeaClient:
     async def get_advisor_review_queue(
         self,
         *,
-        evaluated_at_utc: str,
+        evaluated_at_utc: str | None,
         caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
@@ -36,7 +36,11 @@ class LotusIdeaClient:
             timeout_seconds=self._timeout,
             max_retries=self._max_retries,
             backoff_seconds=self._retry_backoff_seconds,
-            params={"evaluatedAtUtc": evaluated_at_utc},
+            params=(
+                {"evaluatedAtUtc": evaluated_at_utc}
+                if evaluated_at_utc is not None
+                else {}
+            ),
             headers=self._idea_headers(caller_headers, correlation_id),
         )
 

--- a/src/app/clients/lotus_idea_client.py
+++ b/src/app/clients/lotus_idea_client.py
@@ -36,11 +36,7 @@ class LotusIdeaClient:
             timeout_seconds=self._timeout,
             max_retries=self._max_retries,
             backoff_seconds=self._retry_backoff_seconds,
-            params=(
-                {"evaluatedAtUtc": evaluated_at_utc}
-                if evaluated_at_utc is not None
-                else {}
-            ),
+            params=({"evaluatedAtUtc": evaluated_at_utc} if evaluated_at_utc is not None else {}),
             headers=self._idea_headers(caller_headers, correlation_id),
         )
 

--- a/src/app/routers/dpm_command_center_outcome_reviews.py
+++ b/src/app/routers/dpm_command_center_outcome_reviews.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter
+from typing import Annotated
+
+from fastapi import APIRouter, Header
 
 from app.contracts.dpm_command_center import (
     DpmOutcomeReviewForwardRequest,
@@ -18,9 +20,11 @@ router = APIRouter(
 async def _create_outcome_review(
     *,
     request: DpmOutcomeReviewForwardRequest,
+    idempotency_key: str,
 ) -> DpmOutcomeReviewGatewayResponse:
     return await dpm_command_center_service().create_outcome_review(
         body=request.body,
+        idempotency_key=idempotency_key,
         correlation_id=correlation_id_var.get(),
     )
 
@@ -38,7 +42,15 @@ async def _create_outcome_review(
 )
 async def create_outcome_review(
     request: DpmOutcomeReviewForwardRequest,
+    idempotency_key: Annotated[
+        str,
+        Header(
+            alias="Idempotency-Key",
+            description="Caller-supplied idempotency key forwarded unchanged to lotus-manage.",
+        ),
+    ],
 ) -> DpmOutcomeReviewGatewayResponse:
     return await _create_outcome_review(
         request=request,
+        idempotency_key=idempotency_key,
     )

--- a/src/app/routers/ideas.py
+++ b/src/app/routers/ideas.py
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/api/v1/ideas", tags=["Ideas"])
 
 async def _get_advisor_idea_review_queue(
     *,
-    evaluated_at_utc: str,
+    evaluated_at_utc: str | None,
     caller_headers: IdeaCallerHeaders,
 ) -> IdeaGatewayReviewQueueResponse:
     return await idea_service().get_advisor_review_queue(
@@ -64,13 +64,16 @@ async def _get_idea_candidate_detail(
 )
 async def get_advisor_idea_review_queue(
     evaluated_at_utc: Annotated[
-        str,
+        str | None,
         Query(
             alias="evaluatedAtUtc",
-            description="Timezone-aware evaluation instant forwarded to lotus-idea.",
+            description=(
+                "Optional timezone-aware evaluation instant forwarded to lotus-idea. "
+                "When omitted, lotus-idea returns its governed active advisor queue snapshot."
+            ),
             examples=["2026-06-21T10:10:00Z"],
         ),
-    ],
+    ] = None,
     x_caller_subject: Annotated[str | None, Header(alias="X-Caller-Subject")] = None,
     x_caller_roles: Annotated[str | None, Header(alias="X-Caller-Roles")] = None,
     x_caller_capabilities: Annotated[

--- a/src/app/services/dpm_client_protocols.py
+++ b/src/app/services/dpm_client_protocols.py
@@ -136,6 +136,7 @@ class DpmCommandCenterClient(Protocol):
     async def create_outcome_review(
         self,
         body: dict[str, Any],
+        idempotency_key: str,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
 

--- a/src/app/services/dpm_command_center_service.py
+++ b/src/app/services/dpm_command_center_service.py
@@ -232,10 +232,12 @@ class DpmCommandCenterService(
     async def create_outcome_review(
         self,
         body: dict[str, Any],
+        idempotency_key: str,
         correlation_id: str,
     ) -> DpmOutcomeReviewGatewayResponse:
         upstream_status, upstream_payload = await self._dpm_client.create_outcome_review(
             body=body,
+            idempotency_key=idempotency_key,
             correlation_id=correlation_id,
         )
         return self._compose_response(upstream_status, upstream_payload, correlation_id)

--- a/src/app/services/dpm_command_center_service.py
+++ b/src/app/services/dpm_command_center_service.py
@@ -9,12 +9,8 @@ from app.contracts.dpm_command_center import (
 from app.services import dpm_command_center_supportability
 from app.services.ai_client_protocols import LotusAiWorkflowClient
 from app.services.dpm_client_protocols import DpmCommandCenterClient
-from app.services.dpm_command_center_exception_summary import (
-    DpmCommandCenterExceptionSummaryMixin,
-)
-from app.services.dpm_command_center_outcome_narrative import (
-    DpmCommandCenterOutcomeNarrativeMixin,
-)
+from app.services.dpm_command_center_exception_summary import DpmCommandCenterExceptionSummaryMixin
+from app.services.dpm_command_center_outcome_narrative import DpmCommandCenterOutcomeNarrativeMixin
 from app.services.dpm_pm_operating_quality_service import DpmPmOperatingQualityServiceMixin
 from app.services.upstream_envelope import build_product_safe_upstream_status_gateway_envelope
 

--- a/src/app/services/idea_client_protocols.py
+++ b/src/app/services/idea_client_protocols.py
@@ -5,7 +5,7 @@ class IdeaClient(Protocol):
     async def get_advisor_review_queue(
         self,
         *,
-        evaluated_at_utc: str,
+        evaluated_at_utc: str | None,
         caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...

--- a/src/app/services/idea_service.py
+++ b/src/app/services/idea_service.py
@@ -19,7 +19,7 @@ class IdeaService:
     async def get_advisor_review_queue(
         self,
         *,
-        evaluated_at_utc: str,
+        evaluated_at_utc: str | None,
         caller_headers: dict[str, str],
         correlation_id: str,
     ) -> IdeaGatewayReviewQueueResponse:

--- a/tests/integration/test_dpm_command_center_router.py
+++ b/tests/integration/test_dpm_command_center_router.py
@@ -883,9 +883,12 @@ def test_dpm_command_center_pm_quality_summary_invocation_routes_preserve_manage
 def test_dpm_command_center_outcome_review_create_preserves_manage_truth(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    async def _fake_create_outcome_review(self, body, correlation_id):  # noqa: ANN001
+    async def _fake_create_outcome_review(  # noqa: ANN001
+        self, body, idempotency_key, correlation_id
+    ):
         _ = self
         captured["body"] = body
+        captured["idempotency_key"] = idempotency_key
         captured["correlation_id"] = correlation_id
         return 200, {
             "outcome_review_id": "or_1",
@@ -909,13 +912,17 @@ def test_dpm_command_center_outcome_review_create_preserves_manage_truth(monkeyp
     response = client.post(
         "/api/v1/dpm/command-center/outcome-reviews",
         json={"body": {"rebalance_run_id": "rr_1", "proof_pack_id": "ppack_1"}},
-        headers={"X-Correlation-Id": "corr-router-1"},
+        headers={
+            "Idempotency-Key": "idem-router-outcome-1",
+            "X-Correlation-Id": "corr-router-1",
+        },
     )
 
     assert response.status_code == 200
     payload = response.json()
     assert captured == {
         "body": {"rebalance_run_id": "rr_1", "proof_pack_id": "ppack_1"},
+        "idempotency_key": "idem-router-outcome-1",
         "correlation_id": "corr-router-1",
     }
     assert payload["correlation_id"] == "corr-router-1"

--- a/tests/integration/test_ideas_router.py
+++ b/tests/integration/test_ideas_router.py
@@ -60,6 +60,42 @@ def test_idea_review_queue_route_preserves_source_payload_and_context(monkeypatc
     }
 
 
+def test_idea_review_queue_route_allows_active_queue_without_evaluation_time(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _queue(self, *, evaluated_at_utc, caller_headers, correlation_id):
+        captured["evaluated_at_utc"] = evaluated_at_utc
+        captured["caller_headers"] = caller_headers
+        captured["correlation_id"] = correlation_id
+        payload = dict(IDEA_REVIEW_QUEUE_EXAMPLE)
+        payload["sourceAuthority"] = "lotus-idea"
+        return 200, payload
+
+    monkeypatch.setattr(
+        "app.clients.lotus_idea_client.LotusIdeaClient.get_advisor_review_queue",
+        _queue,
+    )
+
+    response = TestClient(app).get(
+        "/api/v1/ideas/review-queues/advisor",
+        headers=_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["sourceAuthority"] == "lotus-idea"
+    assert captured["evaluated_at_utc"] is None
+    assert captured["caller_headers"] == {
+        "X-Caller-Subject": "advisor-123",
+        "X-Caller-Roles": "advisor",
+        "X-Caller-Capabilities": "idea.review.queue.read,idea.candidate.detail.read",
+        "X-Caller-Tenant-Ids": "tenant-private-bank-sg",
+        "X-Caller-Book-Ids": "book-advisor-001",
+        "X-Caller-Portfolio-Ids": "PB_SG_GLOBAL_BAL_001",
+        "X-Caller-Client-Ids": "client-001",
+    }
+    assert captured["correlation_id"] == "corr-idea-router"
+
+
 def test_idea_candidate_detail_route_preserves_source_refs_without_enrichment(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/unit/test_docker_compose_runtime_config.py
+++ b/tests/unit/test_docker_compose_runtime_config.py
@@ -18,6 +18,9 @@ def test_gateway_compose_mounts_domain_product_artifacts_read_only() -> None:
         "/lotus-platform/output/trust-certification/"
         "domain-product-live-trust-certification.json}"
     ) in compose_text
+    assert (
+        "IDEA_SERVICE_BASE_URL=${IDEA_SERVICE_BASE_URL:-http://host.docker.internal:8330}"
+    ) in compose_text
     assert "../lotus-platform/generated:/lotus-platform/generated:ro" in compose_text
     assert (
         "../lotus-platform/output/trust-certification:/lotus-platform/output/trust-certification:ro"

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -23,8 +23,15 @@ class _FakeDpmClient:
 
         return _missing
 
-    async def create_outcome_review(self, body, correlation_id):  # noqa: ANN001
-        self.calls.append({"method": "create", "body": body, "correlation_id": correlation_id})
+    async def create_outcome_review(self, body, idempotency_key, correlation_id):  # noqa: ANN001
+        self.calls.append(
+            {
+                "method": "create",
+                "body": body,
+                "idempotency_key": idempotency_key,
+                "correlation_id": correlation_id,
+            }
+        )
         return self.result
 
     async def get_command_center(self, params, correlation_id):  # noqa: ANN001
@@ -782,6 +789,7 @@ async def test_dpm_command_center_preserves_manage_payload_and_supportability() 
 
     response = await service.create_outcome_review(
         body={"rebalance_run_id": "rr_1"},
+        idempotency_key="idem-outcome-1",
         correlation_id="corr-1",
     )
 
@@ -795,6 +803,7 @@ async def test_dpm_command_center_preserves_manage_payload_and_supportability() 
         {
             "method": "create",
             "body": {"rebalance_run_id": "rr_1"},
+            "idempotency_key": "idem-outcome-1",
             "correlation_id": "corr-1",
         }
     ]
@@ -912,6 +921,7 @@ async def test_dpm_command_center_preserves_manage_supportability_states(state: 
 
     response = await service.create_outcome_review(
         body={"rebalance_run_id": "rr_1"},
+        idempotency_key=f"idem-{state.lower()}",
         correlation_id=f"corr-{state.lower()}",
     )
 
@@ -928,7 +938,9 @@ async def test_dpm_command_center_forwards_manage_errors_as_product_safe_detail(
 
     with pytest.raises(HTTPException) as exc_info:
         await service.create_outcome_review(
-            body={"rebalance_run_id": "rr_1"}, correlation_id="corr-3"
+            body={"rebalance_run_id": "rr_1"},
+            idempotency_key="idem-outcome-error",
+            correlation_id="corr-3",
         )
 
     assert exc_info.value.status_code == 409

--- a/tests/unit/test_lotus_analytics_workspace_payloads.py
+++ b/tests/unit/test_lotus_analytics_workspace_payloads.py
@@ -16,6 +16,7 @@ def test_build_workspace_summary_payload_uses_explicit_period_and_dedupes_freque
     assert payload["input_mode"] == "stateful"
     assert payload["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
     assert payload["report_start_date"] == "2026-01-01"
+    assert payload["performance_start_date"] == "2026-01-01"
     assert payload["report_ccy"] == "USD"
     assert payload["periods"] == [
         {"period": "EXPLICIT", "frequencies": ["monthly", "quarterly", "yearly"]}
@@ -47,3 +48,4 @@ def test_build_workspace_summary_payload_preserves_caller_periods() -> None:
     assert "benchmark" not in payload
     assert "report_ccy" not in payload
     assert "report_start_date" not in payload
+    assert "performance_start_date" not in payload

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -12,6 +12,7 @@ from app.clients.lotus_analytics_client import LotusAnalyticsClient
 from app.clients.lotus_core_ingestion_client import LotusCoreIngestionClient
 from app.clients.lotus_core_query_client import LotusCoreQueryClient
 from app.clients.lotus_core_transaction_params import build_portfolio_transaction_query_params
+from app.clients.lotus_idea_client import LotusIdeaClient
 from app.clients.reporting_client import ReportingClient
 from app.middleware.correlation import trace_id_var
 
@@ -116,6 +117,41 @@ def _fanout_records(records, *, service: str):
         in {"gateway.analytics.fanout.completed", "gateway.analytics.fanout.degraded"}
         and record.extra_fields["service"] == service
     ]
+
+
+@pytest.mark.asyncio
+async def test_lotus_idea_client_omits_active_queue_timestamp_when_not_supplied():
+    client = LotusIdeaClient(base_url="http://lotus-idea", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"sourceAuthority": "lotus-idea"})
+
+    status_code, payload = await client.get_advisor_review_queue(
+        evaluated_at_utc=None,
+        caller_headers={"X-Caller-Subject": "advisor-123"},
+        correlation_id="corr-idea-active",
+    )
+
+    assert status_code == 200
+    assert payload == {"sourceAuthority": "lotus-idea"}
+    assert _FakeAsyncClient.calls[0]["url"] == "http://lotus-idea/api/v1/review-queues/advisor"
+    assert _FakeAsyncClient.calls[0]["params"] == {}
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Caller-Subject"] == "advisor-123"
+    assert _FakeAsyncClient.calls[0]["headers"]["X-Correlation-Id"] == "corr-idea-active"
+
+
+@pytest.mark.asyncio
+async def test_lotus_idea_client_forwards_explicit_queue_timestamp():
+    client = LotusIdeaClient(base_url="http://lotus-idea", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"sourceAuthority": "lotus-idea"})
+
+    await client.get_advisor_review_queue(
+        evaluated_at_utc="2026-06-21T10:10:00Z",
+        caller_headers={},
+        correlation_id="corr-idea-explicit",
+    )
+
+    assert _FakeAsyncClient.calls[0]["params"] == {
+        "evaluatedAtUtc": "2026-06-21T10:10:00Z",
+    }
 
 
 @pytest.mark.asyncio
@@ -2562,7 +2598,11 @@ async def test_dpm_client_uses_only_canonical_manage_api_v1_contracts():
         ),
         (
             "create_outcome_review",
-            {"body": {"rebalance_run_id": "rr_1"}, "correlation_id": "corr-5"},
+            {
+                "body": {"rebalance_run_id": "rr_1"},
+                "idempotency_key": "idem-outcome-review-1",
+                "correlation_id": "corr-5",
+            },
             "http://dpm/api/v1/rebalance/outcome-reviews",
         ),
         (

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -2272,7 +2272,11 @@ async def test_dpm_client_uses_only_canonical_manage_api_v1_contracts():
         ),
         (
             client.create_outcome_review,
-            {"body": {"rebalance_run_id": "rr_1"}, "correlation_id": "corr-rfc36-canonical"},
+            {
+                "body": {"rebalance_run_id": "rr_1"},
+                "idempotency_key": "idem-outcome-review-canonical",
+                "correlation_id": "corr-rfc36-canonical",
+            },
         ),
         (
             client.list_outcome_reviews,

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -486,7 +486,7 @@ curl -X POST "http://127.0.0.1:8111/api/v1/dpm/command-center/outcome-reviews" \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: outcome-review-or_20260415_001" \
   -H "X-Correlation-Id: corr-rfc42-outcome-review-1" \
-  -d "{\"portfolio_id\":\"PB_SG_GLOBAL_BAL_001\",\"rebalance_run_id\":\"rr_20260415_001\",\"proof_pack_id\":\"ppack_20260415_001\",\"requested_by\":\"dpm_sg_1\"}"
+  -d "{\"body\":{\"portfolio_id\":\"PB_SG_GLOBAL_BAL_001\",\"rebalance_run_id\":\"rr_20260415_001\",\"proof_pack_id\":\"ppack_20260415_001\",\"requested_by\":\"dpm_sg_1\"}}"
 ```
 
 DPM outcome-review supportability:

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -484,8 +484,9 @@ DPM outcome-review create:
 ```bash
 curl -X POST "http://127.0.0.1:8111/api/v1/dpm/command-center/outcome-reviews" \
   -H "Content-Type: application/json" \
+  -H "Idempotency-Key: outcome-review-or_20260415_001" \
   -H "X-Correlation-Id: corr-rfc42-outcome-review-1" \
-  -d "{\"body\":{\"portfolio_id\":\"PB_SG_GLOBAL_BAL_001\",\"rebalance_run_id\":\"rr_20260415_001\",\"proof_pack_id\":\"ppack_20260415_001\",\"requested_by\":\"dpm_sg_1\"}}"
+  -d "{\"portfolio_id\":\"PB_SG_GLOBAL_BAL_001\",\"rebalance_run_id\":\"rr_20260415_001\",\"proof_pack_id\":\"ppack_20260415_001\",\"requested_by\":\"dpm_sg_1\"}"
 ```
 
 DPM outcome-review supportability:


### PR DESCRIPTION
## Summary
- forward explicit performance start dates using the canonical performance contract keys
- require and forward DPM outcome-review idempotency keys through Gateway
- make the Idea advisor queue timestamp optional and forward active-queue requests without synthetic parameters
- set the local Docker default for `IDEA_SERVICE_BASE_URL` so Gateway can reach Lotus Idea from clean stack runs

## Validation
- `python -m pytest tests/unit/test_lotus_analytics_workspace_payloads.py tests/unit/test_upstream_clients.py::test_lotus_analytics_client_workspace_summary_uses_canonical_summary_contract -q`
- `python -m pytest tests/integration/test_dpm_command_center_router.py tests/unit/test_dpm_command_center_service.py -q`
- `python -m pytest tests/unit/test_upstream_clients.py::test_dpm_client_outcome_review_command_routes -q`
- `python -m pytest tests/unit/test_docker_compose_runtime_config.py tests/integration/test_ideas_router.py tests/unit/test_upstream_clients.py::test_lotus_idea_client_omits_active_queue_timestamp_when_not_supplied tests/unit/test_upstream_clients.py::test_lotus_idea_client_forwards_explicit_queue_timestamp -q`
- Gateway rebuilt in the canonical local stack and the no-timestamp Idea queue route returned 200 through Gateway and Workbench BFF
- coordinated `npm run live:validate` passed for `PB_SG_GLOBAL_BAL_001` from `lotus-workbench`