### PR TITLE
Preserve source-resolved Portfolio workspace dates

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -262,16 +262,19 @@ Most relevant current governance:
 3. gateway fixes should not smuggle domain logic out of authoritative upstream services,
 4. reporting query, cashflow projection, projected summary, and benchmark catalog upstream calls remain RFC-0082 watchlist surfaces,
 5. integration drift is most dangerous here because it directly affects the product UI,
-6. repo-local `wiki/` content should summarize route families and operator flows without duplicating
+6. an omitted optional portfolio workspace `as_of_date` must remain omitted for the initial
+   lotus-core AUM request; Gateway then aligns the remaining workspace sources and analytics to
+   the source-resolved date rather than substituting its host wall clock,
+7. repo-local `wiki/` content should summarize route families and operator flows without duplicating
    the full `docs/` tree.
-7. archive retrieval uses `ARCHIVE_SERVICE_BASE_URL` and forwards archive-specific caller context
+8. archive retrieval uses `ARCHIVE_SERVICE_BASE_URL` and forwards archive-specific caller context
    as `lotus-gateway`; direct Workbench-to-archive access is not part of the supported product
    boundary,
-8. idea publication uses `IDEA_SERVICE_BASE_URL`, forwards `X-Caller-Subject`,
+9. idea publication uses `IDEA_SERVICE_BASE_URL`, forwards `X-Caller-Subject`,
    `X-Caller-Roles`, `X-Caller-Capabilities`, entitlement-scope headers for published idea reads,
    and correlation context to `lotus-idea`, and maps unsafe upstream failures to product-safe
    Gateway errors,
-9. domain-product discovery defaults to platform-generated catalog and dependency-graph artifacts
+10. domain-product discovery defaults to platform-generated catalog and dependency-graph artifacts
    under the sibling `lotus-platform/generated/` directory, and live trust certification defaults to
    `lotus-platform/output/trust-certification/domain-product-live-trust-certification.json`;
    deployment-specific paths should use `DOMAIN_PRODUCT_CATALOG_PATH`,

--- a/src/app/routers/portfolio_workspace.py
+++ b/src/app/routers/portfolio_workspace.py
@@ -40,7 +40,11 @@ async def get_portfolio_workspace(
     portfolio_id: str,
     as_of_date: str | None = Query(
         default=None,
-        description="Optional as-of date in YYYY-MM-DD format for workspace composition.",
+        description=(
+            "Optional review date in YYYY-MM-DD format for workspace composition. Omit it to "
+            "use the latest governed date resolved by lotus-core; Gateway then aligns the other "
+            "workspace sources to that resolved date."
+        ),
         examples=["2026-04-10"],
     ),
     reporting_currency: str | None = Query(

--- a/src/app/services/portfolio_liquidity_response.py
+++ b/src/app/services/portfolio_liquidity_response.py
@@ -7,11 +7,8 @@ from app.contracts.portfolio_liquidity import (
 )
 from app.services.portfolio_holdings_payloads import parse_cash_balances
 from app.services.portfolio_liquidity_payloads import PortfolioLiquidityPayloads
-from app.services.portfolio_workspace_components import (
-    extract_resolved_as_of_date,
-    parse_cashflow,
-    parse_summary,
-)
+from app.services.portfolio_workspace_components import parse_cashflow, parse_summary
+from app.services.portfolio_workspace_sources import extract_resolved_as_of_date
 
 UpstreamResult = tuple[int, dict[str, Any]]
 

--- a/src/app/services/portfolio_service.py
+++ b/src/app/services/portfolio_service.py
@@ -46,7 +46,6 @@ from app.services.portfolio_workspace_components import (
     assemble_portfolio_workspace_components,
     build_portfolio_workspace_assembly_state,
     build_portfolio_workspace_response_parts,
-    extract_resolved_as_of_date,
 )
 from app.services.portfolio_workspace_response import (
     assemble_portfolio_workspace_response,
@@ -98,16 +97,16 @@ class PortfolioService(
         as_of_date: str | None = None,
         reporting_currency: str | None = None,
     ) -> PortfolioWorkspaceResponse:
-        effective_as_of_date = as_of_date or datetime.now(UTC).date().isoformat()
         source_results = await self._load_portfolio_workspace_sources(
             portfolio_id=portfolio_id,
             correlation_id=correlation_id,
-            effective_as_of_date=effective_as_of_date,
+            requested_as_of_date=as_of_date,
             reporting_currency=reporting_currency,
         )
         resolved_as_of_date = (
-            extract_resolved_as_of_date(source_results.aum_result) or effective_as_of_date
+            source_results.resolved_as_of_date or as_of_date or datetime.now(UTC).date().isoformat()
         )
+        effective_as_of_date = as_of_date or resolved_as_of_date
         performance_as_of_date = as_of_date or resolved_as_of_date
         analytics_results = await self._load_portfolio_workspace_analytics(
             portfolio_id=portfolio_id,
@@ -129,14 +128,14 @@ class PortfolioService(
         *,
         portfolio_id: str,
         correlation_id: str,
-        effective_as_of_date: str,
+        requested_as_of_date: str | None,
         reporting_currency: str | None,
     ) -> PortfolioWorkspaceSourceResults:
         return await load_portfolio_workspace_sources(
             PortfolioWorkspaceSourceLoadRequest(
                 portfolio_id=portfolio_id,
                 correlation_id=correlation_id,
-                effective_as_of_date=effective_as_of_date,
+                requested_as_of_date=requested_as_of_date,
                 reporting_currency=reporting_currency,
             ),
             PortfolioWorkspaceSourceLoaders(

--- a/src/app/services/portfolio_workspace_components.py
+++ b/src/app/services/portfolio_workspace_components.py
@@ -263,12 +263,3 @@ def parse_operations(
     if payload is None:
         return None
     return parse_operational_readiness(payload)
-
-
-def extract_resolved_as_of_date(result: tuple[int, dict[str, Any]]) -> str | None:
-    payload = optional_payload(result, "lotus-core", "IGNORED", [], [])
-    return (
-        str(payload.get("resolved_as_of_date"))
-        if payload and payload.get("resolved_as_of_date")
-        else None
-    )

--- a/src/app/services/portfolio_workspace_sources.py
+++ b/src/app/services/portfolio_workspace_sources.py
@@ -4,21 +4,13 @@ from dataclasses import dataclass
 from typing import Any
 
 UpstreamResult = tuple[int, dict[str, Any]]
-PortfolioWorkspaceSourceResultSet = tuple[
-    UpstreamResult,
-    UpstreamResult,
-    UpstreamResult,
-    UpstreamResult,
-    UpstreamResult,
-    UpstreamResult,
-]
 
 
 @dataclass(frozen=True)
 class PortfolioWorkspaceSourceLoadRequest:
     portfolio_id: str
     correlation_id: str
-    effective_as_of_date: str
+    requested_as_of_date: str | None
     reporting_currency: str | None
 
 
@@ -30,6 +22,7 @@ class PortfolioWorkspaceSourceResults:
     cashflow_result: UpstreamResult
     cash_balance_result: UpstreamResult
     readiness_result: UpstreamResult
+    resolved_as_of_date: str | None = None
 
 
 @dataclass(frozen=True)
@@ -67,15 +60,7 @@ async def load_portfolio_workspace_sources(
     request: PortfolioWorkspaceSourceLoadRequest,
     loaders: PortfolioWorkspaceSourceLoaders,
 ) -> PortfolioWorkspaceSourceResults:
-    results = await asyncio.gather(*_workspace_source_tasks(request, loaders))
-    return _portfolio_workspace_source_results(results)
-
-
-def _workspace_source_tasks(
-    request: PortfolioWorkspaceSourceLoadRequest,
-    loaders: PortfolioWorkspaceSourceLoaders,
-) -> Sequence[Awaitable[UpstreamResult]]:
-    return (
+    portfolio_result, aum_result, support_result = await asyncio.gather(
         loaders.get_portfolio_result(
             portfolio_id=request.portfolio_id,
             correlation_id=request.correlation_id,
@@ -83,45 +68,22 @@ def _workspace_source_tasks(
         loaders.query_aum_result(
             correlation_id=request.correlation_id,
             portfolio_id=request.portfolio_id,
-            as_of_date=request.effective_as_of_date,
+            as_of_date=request.requested_as_of_date,
             reporting_currency=request.reporting_currency,
         ),
         loaders.get_support_overview_result(
             portfolio_id=request.portfolio_id,
             correlation_id=request.correlation_id,
         ),
-        loaders.get_cashflow_projection_result(
-            portfolio_id=request.portfolio_id,
-            correlation_id=request.correlation_id,
-            as_of_date=request.effective_as_of_date,
-            include_projected=True,
-            horizon_days=10,
-        ),
-        loaders.query_cash_balances_result(
-            portfolio_id=request.portfolio_id,
-            correlation_id=request.correlation_id,
-            as_of_date=request.effective_as_of_date,
-            reporting_currency=request.reporting_currency,
-        ),
-        loaders.get_portfolio_readiness_result(
-            portfolio_id=request.portfolio_id,
-            correlation_id=request.correlation_id,
-            as_of_date=request.effective_as_of_date,
-        ),
     )
-
-
-def _portfolio_workspace_source_results(
-    results: Sequence[UpstreamResult],
-) -> PortfolioWorkspaceSourceResults:
-    (
-        portfolio_result,
-        aum_result,
-        support_result,
-        cashflow_result,
-        cash_balance_result,
-        readiness_result,
-    ) = results
+    resolved_as_of_date = resolve_workspace_source_as_of_date(
+        requested_as_of_date=request.requested_as_of_date,
+        aum_result=aum_result,
+        support_result=support_result,
+    )
+    cashflow_result, cash_balance_result, readiness_result = await asyncio.gather(
+        *_workspace_dated_source_tasks(request, loaders, resolved_as_of_date)
+    )
     return PortfolioWorkspaceSourceResults(
         portfolio_result=portfolio_result,
         aum_result=aum_result,
@@ -129,7 +91,58 @@ def _portfolio_workspace_source_results(
         cashflow_result=cashflow_result,
         cash_balance_result=cash_balance_result,
         readiness_result=readiness_result,
+        resolved_as_of_date=resolved_as_of_date,
     )
+
+
+def _workspace_dated_source_tasks(
+    request: PortfolioWorkspaceSourceLoadRequest,
+    loaders: PortfolioWorkspaceSourceLoaders,
+    resolved_as_of_date: str | None,
+) -> Sequence[Awaitable[UpstreamResult]]:
+    return (
+        loaders.get_cashflow_projection_result(
+            portfolio_id=request.portfolio_id,
+            correlation_id=request.correlation_id,
+            as_of_date=resolved_as_of_date,
+            include_projected=True,
+            horizon_days=10,
+        ),
+        loaders.query_cash_balances_result(
+            portfolio_id=request.portfolio_id,
+            correlation_id=request.correlation_id,
+            as_of_date=resolved_as_of_date,
+            reporting_currency=request.reporting_currency,
+        ),
+        loaders.get_portfolio_readiness_result(
+            portfolio_id=request.portfolio_id,
+            correlation_id=request.correlation_id,
+            as_of_date=resolved_as_of_date,
+        ),
+    )
+
+
+def resolve_workspace_source_as_of_date(
+    *,
+    requested_as_of_date: str | None,
+    aum_result: UpstreamResult,
+    support_result: UpstreamResult,
+) -> str | None:
+    return (
+        extract_success_date(aum_result, "resolved_as_of_date")
+        or requested_as_of_date
+        or extract_success_date(support_result, "business_date")
+    )
+
+
+def extract_success_date(result: UpstreamResult, field: str) -> str | None:
+    status_code, payload = result
+    value = payload.get(field) if 200 <= status_code < 300 else None
+    return str(value) if value else None
+
+
+def extract_resolved_as_of_date(result: UpstreamResult) -> str | None:
+    return extract_success_date(result, "resolved_as_of_date")
 
 
 async def load_portfolio_workspace_analytics(

--- a/tests/contract/test_portfolio_contract.py
+++ b/tests/contract/test_portfolio_contract.py
@@ -473,6 +473,8 @@ def test_portfolio_openapi_contract_registered() -> None:
     assert "/api/v1/portfolio/portfolios/{portfolio_id}/workflow" in spec["paths"]
     assert "/api/v1/portfolio/portfolios/{portfolio_id}/performance-snapshot" in spec["paths"]
     catalog_path = spec["paths"]["/api/v1/portfolio/portfolios"]["get"]
+    workspace_path = spec["paths"]["/api/v1/portfolio/portfolios/{portfolio_id}/workspace"]["get"]
+    workspace_parameters = {row["name"]: row for row in workspace_path["parameters"]}
     catalog_schema = spec["components"]["schemas"]["PortfolioCatalogResponse"]
     catalog_item_schema = spec["components"]["schemas"]["PortfolioCatalogItem"]
     workspace_schema = spec["components"]["schemas"]["PortfolioWorkspaceResponse"]
@@ -502,6 +504,10 @@ def test_portfolio_openapi_contract_registered() -> None:
     workspace_module_capability_schema = spec["components"]["schemas"][
         "PortfolioWorkspaceModuleCapability"
     ]
+    assert (
+        "latest governed date resolved by lotus-core"
+        in workspace_parameters["as_of_date"]["description"]
+    )
     workflow_launch_cue_schema = spec["components"]["schemas"]["PortfolioWorkflowLaunchCue"]
     readiness_schema = spec["components"]["schemas"]["PortfolioReadinessResponse"]
     readiness_indicator_schema = spec["components"]["schemas"]["PortfolioReadinessIndicator"]

--- a/tests/integration/test_portfolio_router.py
+++ b/tests/integration/test_portfolio_router.py
@@ -315,6 +315,7 @@ def test_portfolio_workspace_router_uses_source_resolved_date_for_default_perfor
         return 200, {"business_date": "2026-04-10", "publish_allowed": True}
 
     async def _readiness(*args, **kwargs):
+        captured["readiness_as_of_date"] = kwargs.get("as_of_date")
         return 200, {
             "holdings": {"status": "READY", "reasons": []},
             "pricing": {"status": "READY", "reasons": []},
@@ -324,6 +325,7 @@ def test_portfolio_workspace_router_uses_source_resolved_date_for_default_perfor
         }
 
     async def _cashflow(*args, **kwargs):
+        captured["cashflow_as_of_date"] = kwargs.get("as_of_date")
         return 200, {
             "as_of_date": "2026-04-10",
             "range_end_date": "2026-04-20",
@@ -334,6 +336,7 @@ def test_portfolio_workspace_router_uses_source_resolved_date_for_default_perfor
         }
 
     async def _cash_balances(*args, **kwargs):
+        captured["cash_balances_as_of_date"] = kwargs.get("as_of_date")
         return 200, {
             "totals": {"cash_account_count": 1, "total_balance_reporting_currency": 100.0},
             "cash_accounts": [],
@@ -360,6 +363,10 @@ def test_portfolio_workspace_router_uses_source_resolved_date_for_default_perfor
     assert response.status_code == 200
     body = response.json()
     assert body["as_of_date"] == "2026-04-10"
+    assert captured["aum_as_of_date"] is None
+    assert captured["cashflow_as_of_date"] == "2026-04-10"
+    assert captured["cash_balances_as_of_date"] == "2026-04-10"
+    assert captured["readiness_as_of_date"] == "2026-04-10"
     assert captured["analytics_reference_as_of_date"] == "2026-04-10"
     assert captured["twr_report_end_date"] == "2026-04-10"
 

--- a/tests/unit/test_portfolio_service.py
+++ b/tests/unit/test_portfolio_service.py
@@ -581,11 +581,25 @@ async def test_portfolio_workspace_uses_source_resolved_date_for_default_perform
     class _RecordingCoreClient(_StubLotusCoreQueryClient):
         def __init__(self) -> None:
             self.analytics_reference_as_of_date: str | None = None
+            self.source_as_of_dates: dict[str, str | None] = {}
 
         async def query_assets_under_management(self, **kwargs):
+            self.source_as_of_dates["aum"] = kwargs.get("as_of_date")
             payload = await super().query_assets_under_management(**kwargs)
             payload[1]["resolved_as_of_date"] = "2026-04-10"
             return payload
+
+        async def get_cashflow_projection(self, portfolio_id: str, correlation_id: str, **kwargs):
+            self.source_as_of_dates["cashflow"] = kwargs.get("as_of_date")
+            return await super().get_cashflow_projection(portfolio_id, correlation_id, **kwargs)
+
+        async def get_portfolio_cash_balances(self, **kwargs):
+            self.source_as_of_dates["cash_balances"] = kwargs.get("as_of_date")
+            return await super().get_portfolio_cash_balances(**kwargs)
+
+        async def get_portfolio_readiness(self, portfolio_id: str, correlation_id: str, **kwargs):
+            self.source_as_of_dates["readiness"] = kwargs.get("as_of_date")
+            return await super().get_portfolio_readiness(portfolio_id, correlation_id, **kwargs)
 
         async def get_portfolio_analytics_reference(
             self,
@@ -620,9 +634,17 @@ async def test_portfolio_workspace_uses_source_resolved_date_for_default_perform
     )
 
     assert response.as_of_date == "2026-04-10"
+    assert core_client.source_as_of_dates == {
+        "aum": None,
+        "cashflow": "2026-04-10",
+        "cash_balances": "2026-04-10",
+        "readiness": "2026-04-10",
+    }
     assert core_client.analytics_reference_as_of_date == "2026-04-10"
     assert analytics_client.twr_kwargs is not None
     assert analytics_client.twr_kwargs["report_end_date"] == "2026-04-10"
+    assert response.control_capabilities.historical_snapshots.requested_as_of_date == "2026-04-10"
+    assert response.control_capabilities.historical_snapshots.effective_as_of_date == "2026-04-10"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_portfolio_workspace_components.py
+++ b/tests/unit/test_portfolio_workspace_components.py
@@ -6,7 +6,6 @@ from app.services.portfolio_workspace_components import (
     assemble_portfolio_workspace_components,
     build_portfolio_workspace_assembly_state,
     build_portfolio_workspace_response_parts,
-    extract_resolved_as_of_date,
     parse_cashflow,
     parse_summary,
     parse_workspace_rebalance,
@@ -190,8 +189,3 @@ def test_assemble_workspace_components_preserves_source_warnings_and_parts() -> 
     )
     assert response_parts.workflow_cues
     assert response_parts.partial_failures == components.partial_failures
-
-
-def test_extract_resolved_as_of_date_uses_source_payload_only_when_available() -> None:
-    assert extract_resolved_as_of_date(_aum_result()) == "2026-03-28"
-    assert extract_resolved_as_of_date((503, {"resolved_as_of_date": "2026-03-28"})) is None

--- a/tests/unit/test_portfolio_workspace_sources.py
+++ b/tests/unit/test_portfolio_workspace_sources.py
@@ -5,8 +5,11 @@ from app.services.portfolio_workspace_sources import (
     PortfolioWorkspaceAnalyticsLoadRequest,
     PortfolioWorkspaceSourceLoaders,
     PortfolioWorkspaceSourceLoadRequest,
+    extract_resolved_as_of_date,
+    extract_success_date,
     load_portfolio_workspace_analytics,
     load_portfolio_workspace_sources,
+    resolve_workspace_source_as_of_date,
 )
 
 
@@ -15,7 +18,7 @@ async def test_load_portfolio_workspace_sources_queries_all_workspace_inputs() -
     calls: list[tuple[str, dict[str, object]]] = []
     results = {
         "portfolio": (200, {"portfolio_id": "PF_3003"}),
-        "aum": (200, {"portfolios": []}),
+        "aum": (200, {"resolved_as_of_date": "2026-05-28", "portfolios": []}),
         "support": (200, {"operational_readiness": {}}),
         "cashflow": (200, {"points": []}),
         "cash_balances": (200, {"cash_accounts": []}),
@@ -50,7 +53,7 @@ async def test_load_portfolio_workspace_sources_queries_all_workspace_inputs() -
         PortfolioWorkspaceSourceLoadRequest(
             portfolio_id="PF_3003",
             correlation_id="corr-workspace",
-            effective_as_of_date="2026-05-29",
+            requested_as_of_date="2026-05-29",
             reporting_currency="USD",
         ),
         PortfolioWorkspaceSourceLoaders(
@@ -69,6 +72,7 @@ async def test_load_portfolio_workspace_sources_queries_all_workspace_inputs() -
     assert source_results.cashflow_result == results["cashflow"]
     assert source_results.cash_balance_result == results["cash_balances"]
     assert source_results.readiness_result == results["readiness"]
+    assert source_results.resolved_as_of_date == "2026-05-28"
     assert calls == [
         (
             "portfolio",
@@ -98,7 +102,7 @@ async def test_load_portfolio_workspace_sources_queries_all_workspace_inputs() -
             {
                 "portfolio_id": "PF_3003",
                 "correlation_id": "corr-workspace",
-                "as_of_date": "2026-05-29",
+                "as_of_date": "2026-05-28",
                 "include_projected": True,
                 "horizon_days": 10,
             },
@@ -108,7 +112,7 @@ async def test_load_portfolio_workspace_sources_queries_all_workspace_inputs() -
             {
                 "portfolio_id": "PF_3003",
                 "correlation_id": "corr-workspace",
-                "as_of_date": "2026-05-29",
+                "as_of_date": "2026-05-28",
                 "reporting_currency": "USD",
             },
         ),
@@ -117,10 +121,33 @@ async def test_load_portfolio_workspace_sources_queries_all_workspace_inputs() -
             {
                 "portfolio_id": "PF_3003",
                 "correlation_id": "corr-workspace",
-                "as_of_date": "2026-05-29",
+                "as_of_date": "2026-05-28",
             },
         ),
     ]
+
+
+def test_resolve_workspace_source_as_of_date_prefers_source_and_safe_fallbacks() -> None:
+    assert (
+        resolve_workspace_source_as_of_date(
+            requested_as_of_date="2026-05-29",
+            aum_result=(200, {"resolved_as_of_date": "2026-05-28"}),
+            support_result=(200, {"business_date": "2026-05-27"}),
+        )
+        == "2026-05-28"
+    )
+    assert (
+        resolve_workspace_source_as_of_date(
+            requested_as_of_date=None,
+            aum_result=(503, {"resolved_as_of_date": "2099-01-01"}),
+            support_result=(200, {"business_date": "2026-05-27"}),
+        )
+        == "2026-05-27"
+    )
+    assert extract_success_date((503, {"business_date": "2099-01-01"}), "business_date") is None
+    assert extract_resolved_as_of_date((200, {"resolved_as_of_date": "2026-05-28"})) == (
+        "2026-05-28"
+    )
 
 
 @pytest.mark.asyncio

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -60,6 +60,10 @@ or governed ingress endpoints without embedding environment-specific hostnames i
 
 ## Current contract notes
 
+- Portfolio workspace `as_of_date` is an optional review-date override. When it is omitted,
+  Gateway lets lotus-core resolve the latest governed portfolio date first, then uses that same
+  date for cashflow, cash balances, readiness, and performance composition. Gateway host time is
+  not a portfolio business-date authority.
 - platform capabilities uses camelCase query parameters `consumerSystem` and `tenantId`
 - platform capabilities publishes `normalized.navigation.command_center=true` only when the
   `lotus_manage` source publishes governed Manage support capability such as


### PR DESCRIPTION
## Outcome

The Portfolio workspace now preserves lotus-core source-date authority when callers omit `as_of_date`. Gateway performs a two-stage composition: AUM resolves the governed date first, then cashflow, cash balances, readiness, and performance use that same date.

Closes #494

## Issue matrix

| Issue | Acceptance evidence | Decision |
| --- | --- | --- |
| #494 | Omitted date reaches AUM as `None`; source resolves `2026-04-10`; dated sources, analytics, response metadata, and control capabilities align to it; explicit override remains covered | Close after merge and canonical Workbench recheck |
| #493 | Campaign ledger remains open for subsequent source-contract lenses | Keep open |

## Implementation

- Replaced Gateway wall-clock defaulting with source-first resolution.
- Split workspace fan-out into identity/AUM/support resolution followed by aligned dated sources.
- Centralized successful upstream date extraction and removed the superseded component helper/type.
- Clarified OpenAPI semantics and pinned them with a contract assertion.
- Updated repo engineering context and the authored wiki API contract note.

Organization decision: the behavior remains inside the existing `portfolio_workspace_sources` composition boundary; no runtime split is justified.

## Validation

- `python -m pytest ...focused portfolio date tests... -q` — 13 passed
- `make ci` — green
  - 217 integration tests passed
  - 1,620 unit/contract/integration tests passed
  - 94.39% coverage (84% required)
  - ruff, mypy, OpenAPI, migration smoke, refactor thresholds, monetary guard, workflow governance, and pip-audit passed
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway -AllowUnpublishedSourceChanges` — one intentional authored wiki diff; publish after merge

## Durable truth

- `REPOSITORY-ENGINEERING-CONTEXT.md` records the source-date rule.
- `wiki/API-Surface.md` records operator/API semantics.
- No supported-feature claim or runtime topology changed.

## Recheck after merge

1. Publish and strictly verify Gateway wiki parity.
2. Rebuild/restart only Gateway in the canonical front-office runtime.
3. Confirm default `PB_SG_GLOBAL_BAL_001` workspace returns the governed source date.
4. Rerun the populated Workbench Portfolio smoke.