### PR TITLE
Publish governed Idea candidate action BFF routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ It depends on:
 - `lotus-archive`
   archived generated-document metadata and controlled binary retrieval
 - `lotus-idea`
-  opportunity intelligence review queues and source-safe candidate detail
+  opportunity intelligence review queues, source-safe candidate detail, and source-owned candidate
+  review, feedback, and conversion-intent recording
 - `lotus-ai`
   evidence-grounded advisor-brief support, outcome-review narrative support, DPM exception-summary
   support, proof-pack PM memo support, wave PM memo support, and operations handoff support through
@@ -126,8 +127,9 @@ Boundary rules that matter:
    reporting, intake/lookups, portfolio, and workbench route families are active.
 3. Domain-product catalog, product detail, dependency-graph, and trust-certification discovery
    routes are active as read-only facades over platform-generated artifacts.
-4. Idea review queue and candidate detail routes are active as source-preserving read facades over
-   `lotus-idea`; Gateway does not rank, generate, enrich, or promote ideas locally.
+4. Idea queue/detail reads and bounded candidate review, feedback, and conversion-intent routes are
+   active as source-preserving BFF facades over `lotus-idea`; Gateway does not rank, generate,
+   enrich, authorize, or promote ideas locally.
 5. The repository is still moving from thin pass-through behavior toward cleaner experience-API
    contracts.
 6. Canonical local startup relies on `--app-dir src`; omitting it on Windows can start the wrong
@@ -364,12 +366,14 @@ Important current parameter conventions:
 10. archived document metadata and download routes require caller context headers:
    `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; the gateway calls `lotus-archive` as
    `lotus-gateway` and does not expose archive storage locations
-11. idea review queue and candidate detail routes forward `X-Caller-Subject`, `X-Caller-Roles`,
+11. Idea queue/detail and candidate action routes forward `X-Caller-Subject`, `X-Caller-Roles`,
    `X-Caller-Capabilities`, `X-Caller-Tenant-Ids`, `X-Caller-Book-Ids`,
-   `X-Caller-Portfolio-Ids`, and `X-Caller-Client-Ids` to `lotus-idea` for
-   entitlement-scope enforcement. Gateway preserves
+   `X-Caller-Portfolio-Ids`, `X-Caller-Client-Ids`, and optional
+   `X-Lotus-Trusted-Caller-Context` to `lotus-idea` for entitlement-scope enforcement. Candidate
+   mutations require `Idempotency-Key` and forward correlation/trace context and optional
+   `X-Causation-Id`. Gateway preserves
    `supportedFeaturePromoted=false` and does not rank, score, enrich, or certify idea candidates
-   locally
+   locally, grant downstream authority, or create downstream execution records
 12. Workbench performance summary, risk summary, advisor-brief read, and advisor-brief review
    action routes require caller context headers:
    `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional `X-Caller-Application`,

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -79,12 +79,14 @@ Current repository posture:
    product-facing boundary over `lotus-archive`,
 7. domain-product catalog, dependency-graph, and live trust certification discovery routes are
    active under `/api/v1/domain-products`,
-8. idea review queue and candidate detail read routes are active under
-   `/api/v1/ideas/review-queues/advisor` and `/api/v1/ideas/candidates/{candidate_id}`; Gateway
-   forwards entitlement-scope headers for both idea read routes, preserves `lotus-idea` ranking,
-   source refs, durable-storage posture, and
-   `supportedFeaturePromoted=false` without generating, ranking, enriching, certifying, or
-   promoting ideas locally,
+8. idea review queue/detail reads and candidate review-action, feedback, and conversion-intent
+   recordings are active under `/api/v1/ideas/*`; Gateway forwards caller entitlement scope, optional
+   trusted context, correlation/trace context, and for mutations `Idempotency-Key` plus optional
+   causation. It preserves `lotus-idea` ranking, source refs, durable-storage posture, accepted or
+   replayed source outcomes, and `supportedFeaturePromoted=false` without generating, ranking,
+   enriching, certifying, authorizing, or promoting ideas locally. These BFF routes do not claim
+   Workbench completion, data-product certification, downstream realization, execution, or client
+   communication readiness,
 9. upstream service consumption is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
 9. the advisor-brief path now calls the explicit `lotus-ai` workflow-pack execution seam and consumes the returned run identity directly instead of inferring it from task audit request ids; it also preserves bounded RFC-0097 task-flow posture and replacement lineage from `lotus-ai` without making gateway the task-flow authority,
 10. RFC-0042 outcome-review AI narrative handoff now reads manage-owned

--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -133,9 +133,10 @@ This RFC-0082 documentation slice reflects current runtime behavior:
 6. Gateway report batch routes are an operator/API boundary only. Workbench batch UI, RFC-0105
    replay/dashboard operations, and RFC-0106 entitlement certification must not be inferred from
    these routes until those slices are implemented and proven.
-7. Gateway idea routes are read-only publication surfaces only. Workbench idea UI, mutation
-   routes, data-product promotion, and full supported-feature claims must not be inferred until
-   separately implemented and proven.
+7. Gateway Idea reads and candidate-scoped review-action, feedback, and conversion-intent routes are
+   implementation-backed BFF surfaces. Workbench action affordances, canonical runtime proof,
+   data-product promotion, downstream realization, and full supported-feature claims must not be
+   inferred until separately implemented and proven.
 
 ## Validation Lane
 

--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -44,7 +44,7 @@ outputs.
 | `lotus-manage` | versioned `/api/v1` rebalance run lookup, supportability summary, capability posture, construction alternatives, proof packs, portfolio memory timeline/search, outcome reviews with source-lineage facets, report input, AI evidence input, and PM operating quality policy/score-run/fairness-analysis/review-action/summary-invocation lifecycle APIs | management workflow composition | discretionary management operations, proof-pack evidence, portfolio-memory timeline/search lineage, outcome-review truth/facets, and PM operating quality policy/score-run/fairness-analysis/review-action/summary-invocation truth remain in `lotus-manage`; gateway must not reintroduce retired unversioned aliases, monolithic `dpm-execution-context` assumptions, local timeline reconstruction, source-owner store querying, global portfolio-universe discovery, cross-app source-event search, PM scoring logic, fairness recomputation, review-rationale reinterpretation, generated-summary text/prompt/model-response exposure, PM ranking, or HR/compensation/conduct decision semantics |
 | `lotus-report` | report snapshot rows, summary/review payloads, report job status/search/event/cancellation APIs, report batch materialization/status/control/operator-run APIs | report-ready experience payloads, durable report-job support posture, and RFC-0104 batch operator boundary | report generation, request semantics, job lifecycle truth, batch lifecycle truth, and batch execution truth remain in `lotus-report` |
 | `lotus-archive` | archived document metadata, current-document resolution, and binary download APIs | gateway-controlled generated-document retrieval for product clients | archive metadata, retention, legal-hold, purge, lifecycle, checksum, storage, and access-audit truth remain in `lotus-archive`; gateway exposes metadata and controlled download only |
-| `lotus-idea` | advisor review queue and candidate detail read APIs | opportunity intelligence read publication | idea signal evaluation, deterministic ranking, candidate lifecycle, redacted evidence, source references, entitlement-scope enforcement, durable-storage posture, and supported-feature promotion truth remain in `lotus-idea`; gateway must not generate, rank, enrich, certify, or promote ideas locally |
+| `lotus-idea` | advisor review queue, candidate detail, and candidate-scoped review-action, feedback, and conversion-intent APIs | opportunity intelligence BFF publication and source-safe action recording | idea signal evaluation, deterministic ranking, candidate lifecycle, review, feedback, conversion intent, redacted evidence, source references, entitlement-scope enforcement, durable-storage posture, and supported-feature promotion truth remain in `lotus-idea`; gateway must not generate, rank, enrich, certify, authorize, promote, or grant downstream authority locally |
 | `lotus-ai` | advisor-brief, DPM workflow-pack execution surfaces, workflow-pack run-ledger, and RFC-0097 task-flow posture surfaces | evidence-grounded narrative/support text plus bounded run/task-flow posture for Workbench | gateway must not invent unsupported evidence, model outputs, review states, replacement lineage, task-flow authority, trade approval, client messaging, PM scoring, or order-routing instructions |
 
 ## Conformance Rules
@@ -111,9 +111,10 @@ This RFC-0082 documentation slice reflects current runtime behavior:
 6. RFC-0104 config-backed scheduler list and run-due actions are exposed through gateway-owned
    `/api/v1/report-batch-schedules` routes while preserving `lotus-report` as the scheduler
    configuration and materialization authority.
-7. Idea review queue and candidate detail reads are exposed through gateway-owned
-   `/api/v1/ideas/*` routes while preserving `lotus-idea` as the ranking, lifecycle, evidence,
-   conversion, entitlement-scope enforcement, and supported-feature authority.
+7. Idea review queue/detail reads and candidate-scoped review-action, feedback, and conversion-intent
+   recording are exposed through gateway-owned `/api/v1/ideas/*` routes while preserving
+   `lotus-idea` as the ranking, lifecycle, review, feedback, conversion, evidence,
+   entitlement-scope enforcement, idempotency, audit, and supported-feature authority.
 
 ## Gap Register
 

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -60,12 +60,20 @@
 ## Ideas
 
 1. advisor idea review queue read through `/api/v1/ideas/review-queues/advisor`,
-2. source-safe idea candidate detail read through `/api/v1/ideas/candidates/{candidate_id}`.
+2. source-safe idea candidate detail read through `/api/v1/ideas/candidates/{candidate_id}`,
+3. candidate-scoped review-action recording through
+   `/api/v1/ideas/candidates/{candidate_id}/review-actions`,
+4. candidate-scoped feedback recording through `/api/v1/ideas/candidates/{candidate_id}/feedback`,
+5. candidate-scoped conversion-intent recording through
+   `/api/v1/ideas/candidates/{candidate_id}/conversion-intents`.
 
-These routes are implementation-backed Gateway publication for `lotus-idea` read surfaces only.
-Gateway preserves `lotus-idea` ranking, source signal identifiers, source references,
-durable-storage posture, caller entitlement-scope forwarding for published idea reads, and
-`supportedFeaturePromoted=false`; it does not generate, rank, enrich, or certify ideas locally.
+These are implementation-backed Gateway BFF routes over `lotus-idea`; they do not promote an Idea
+supported feature or claim Workbench, runtime, data-product, suitability, execution, or client
+communication readiness. Gateway preserves `lotus-idea` ranking, source signal identifiers, source
+references, durable-storage posture, accepted/replayed mutation outcomes, and
+`supportedFeaturePromoted=false`. For mutations it forwards trusted caller context, entitlement
+scope, `Idempotency-Key`, correlation and trace context, and optional `X-Causation-Id` without
+deriving lifecycle, authorization, audit, or downstream authority locally.
 
 ## Boundaries
 

--- a/src/app/clients/lotus_idea_client.py
+++ b/src/app/clients/lotus_idea_client.py
@@ -2,7 +2,10 @@ import logging
 from typing import Any
 
 from app.clients.observed_fanout import request_observed_fanout
-from app.clients.upstream_headers import build_upstream_headers
+from app.clients.upstream_headers import (
+    build_idempotent_upstream_headers,
+    build_upstream_headers,
+)
 
 logger = logging.getLogger("analytics_ui.gateway")
 
@@ -59,6 +62,99 @@ class LotusIdeaClient:
             headers=self._idea_headers(caller_headers, correlation_id),
         )
 
+    async def record_candidate_review_action(
+        self,
+        *,
+        candidate_id: str,
+        body: dict[str, Any],
+        caller_headers: dict[str, str],
+        correlation_id: str,
+        idempotency_key: str,
+        causation_id: str | None,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._record_candidate_action(
+            operation="idea.candidates.review-actions.record",
+            candidate_id=candidate_id,
+            action_path="review-actions",
+            body=body,
+            caller_headers=caller_headers,
+            correlation_id=correlation_id,
+            idempotency_key=idempotency_key,
+            causation_id=causation_id,
+        )
+
+    async def record_candidate_feedback(
+        self,
+        *,
+        candidate_id: str,
+        body: dict[str, Any],
+        caller_headers: dict[str, str],
+        correlation_id: str,
+        idempotency_key: str,
+        causation_id: str | None,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._record_candidate_action(
+            operation="idea.candidates.feedback.record",
+            candidate_id=candidate_id,
+            action_path="feedback",
+            body=body,
+            caller_headers=caller_headers,
+            correlation_id=correlation_id,
+            idempotency_key=idempotency_key,
+            causation_id=causation_id,
+        )
+
+    async def record_candidate_conversion_intent(
+        self,
+        *,
+        candidate_id: str,
+        body: dict[str, Any],
+        caller_headers: dict[str, str],
+        correlation_id: str,
+        idempotency_key: str,
+        causation_id: str | None,
+    ) -> tuple[int, dict[str, Any]]:
+        return await self._record_candidate_action(
+            operation="idea.candidates.conversion-intents.record",
+            candidate_id=candidate_id,
+            action_path="conversion-intents",
+            body=body,
+            caller_headers=caller_headers,
+            correlation_id=correlation_id,
+            idempotency_key=idempotency_key,
+            causation_id=causation_id,
+        )
+
+    async def _record_candidate_action(
+        self,
+        *,
+        operation: str,
+        candidate_id: str,
+        action_path: str,
+        body: dict[str, Any],
+        caller_headers: dict[str, str],
+        correlation_id: str,
+        idempotency_key: str,
+        causation_id: str | None,
+    ) -> tuple[int, dict[str, Any]]:
+        return await request_observed_fanout(
+            logger=logger,
+            service="lotus-idea",
+            operation=operation,
+            method="POST",
+            url=f"{self._base_url}/api/v1/idea-candidates/{candidate_id}/{action_path}",
+            timeout_seconds=self._timeout,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=self._idea_mutation_headers(
+                caller_headers,
+                correlation_id,
+                idempotency_key=idempotency_key,
+                causation_id=causation_id,
+            ),
+            json_body=body,
+        )
+
     def _idea_headers(
         self,
         caller_headers: dict[str, str],
@@ -69,3 +165,21 @@ class LotusIdeaClient:
             extras={"X-Caller-Service": "lotus-gateway"},
             caller_headers=caller_headers,
         )
+
+    def _idea_mutation_headers(
+        self,
+        caller_headers: dict[str, str],
+        correlation_id: str,
+        *,
+        idempotency_key: str,
+        causation_id: str | None,
+    ) -> dict[str, str]:
+        headers = build_idempotent_upstream_headers(
+            correlation_id,
+            idempotency_key,
+            caller_headers=caller_headers,
+        )
+        headers["X-Caller-Service"] = "lotus-gateway"
+        if causation_id:
+            headers["X-Causation-Id"] = causation_id
+        return headers

--- a/src/app/contracts/ideas.py
+++ b/src/app/contracts/ideas.py
@@ -1,4 +1,5 @@
-from typing import Any
+from datetime import datetime
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -92,6 +93,141 @@ class IdeaGatewayCandidateDetailResponse(BaseModel):
         ...,
         alias="supportedFeaturePromoted",
         description="Source-owned supported-feature promotion flag. Gateway must not promote it.",
+    )
+
+
+class IdeaCandidateActionRequest(BaseModel):
+    """Base request contract for Idea-owned candidate mutations.
+
+    Gateway validates transport shape only. Lotus Idea remains authoritative for candidate state,
+    entitlement decisions, idempotency semantics, audit, and every business transition.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class IdeaCandidateReviewActionRequest(IdeaCandidateActionRequest):
+    review_id: str = Field(..., alias="reviewId", min_length=1)
+    action: Literal[
+        "approve_for_conversion",
+        "reject",
+        "no_action",
+        "suppress",
+        "snooze",
+        "escalate_to_pm",
+        "escalate_to_compliance",
+    ]
+    reason_codes: tuple[str, ...] = Field(..., alias="reasonCodes", min_length=1)
+    decided_at_utc: datetime = Field(..., alias="decidedAtUtc")
+    suppression_reason: (
+        Literal[
+            "duplicate",
+            "recently_rejected",
+            "below_materiality",
+            "unsupported_evidence",
+            "manual_suppression",
+        ]
+        | None
+    ) = Field(default=None, alias="suppressionReason")
+    snoozed_until_utc: datetime | None = Field(default=None, alias="snoozedUntilUtc")
+
+
+class IdeaCandidateFeedbackRequest(IdeaCandidateActionRequest):
+    feedback_id: str = Field(..., alias="feedbackId", min_length=1)
+    outcome: Literal[
+        "useful",
+        "not_useful",
+        "duplicate",
+        "too_late",
+        "missing_context",
+        "unsupported_claim",
+    ]
+    reason_codes: tuple[str, ...] = Field(..., alias="reasonCodes", min_length=1)
+    recorded_at_utc: datetime = Field(..., alias="recordedAtUtc")
+
+
+class IdeaCandidateConversionIntentRequest(IdeaCandidateActionRequest):
+    conversion_intent_id: str = Field(..., alias="conversionIntentId", min_length=1)
+    target: Literal["advise_proposal", "manage_review", "report_evidence"]
+    reason_codes: tuple[str, ...] = Field(..., alias="reasonCodes", min_length=1)
+    requested_at_utc: datetime = Field(..., alias="requestedAtUtc")
+
+
+class IdeaMutationPersistenceResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    decision: str
+    candidate_id: str | None = Field(default=None, alias="candidateId")
+    lifecycle_status: str | None = Field(default=None, alias="lifecycleStatus")
+    review_posture: str | None = Field(default=None, alias="reviewPosture")
+    audit_event_type: str | None = Field(default=None, alias="auditEventType")
+
+
+class IdeaCandidateActionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    persistence: IdeaMutationPersistenceResponse
+    durable_storage_backed: bool = Field(..., alias="durableStorageBacked")
+    supported_feature_promoted: bool = Field(..., alias="supportedFeaturePromoted")
+
+
+class IdeaReviewDecisionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    review_id: str = Field(..., alias="reviewId")
+    candidate_id: str = Field(..., alias="candidateId")
+    evidence_packet_id: str = Field(..., alias="evidencePacketId")
+    action: str
+    resulting_posture: str = Field(..., alias="resultingPosture")
+    actor_role: str = Field(..., alias="actorRole")
+    reason_codes: tuple[str, ...] = Field(..., alias="reasonCodes")
+    decided_at_utc: datetime = Field(..., alias="decidedAtUtc")
+    suppression_reason: str | None = Field(default=None, alias="suppressionReason")
+    snoozed_until_utc: datetime | None = Field(default=None, alias="snoozedUntilUtc")
+    grants_downstream_authority: bool = Field(..., alias="grantsDownstreamAuthority")
+
+
+class IdeaCandidateReviewActionResponse(IdeaCandidateActionResponse):
+    review_decision: IdeaReviewDecisionResponse | None = Field(default=None, alias="reviewDecision")
+
+
+class IdeaFeedbackEventResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    feedback_id: str = Field(..., alias="feedbackId")
+    candidate_id: str = Field(..., alias="candidateId")
+    evidence_packet_id: str = Field(..., alias="evidencePacketId")
+    outcome: str
+    actor_role: str = Field(..., alias="actorRole")
+    reason_codes: tuple[str, ...] = Field(..., alias="reasonCodes")
+    recorded_at_utc: datetime = Field(..., alias="recordedAtUtc")
+
+
+class IdeaCandidateFeedbackResponse(IdeaCandidateActionResponse):
+    feedback_event: IdeaFeedbackEventResponse | None = Field(default=None, alias="feedbackEvent")
+
+
+class IdeaConversionIntentResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    conversion_intent_id: str = Field(..., alias="conversionIntentId")
+    candidate_id: str = Field(..., alias="candidateId")
+    target: str
+    source_status: str = Field(..., alias="sourceStatus")
+    target_source_authority: str = Field(..., alias="targetSourceAuthority")
+    evidence_packet_id: str = Field(..., alias="evidencePacketId")
+    evidence_content_hash: str = Field(..., alias="evidenceContentHash")
+    source_signal_ids: tuple[str, ...] = Field(..., alias="sourceSignalIds")
+    boundary: str
+    reason_codes: tuple[str, ...] = Field(..., alias="reasonCodes")
+    requested_at_utc: datetime = Field(..., alias="requestedAtUtc")
+    grants_downstream_authority: bool = Field(..., alias="grantsDownstreamAuthority")
+
+
+class IdeaCandidateConversionIntentResponse(IdeaCandidateActionResponse):
+    conversion_intent: IdeaConversionIntentResponse | None = Field(
+        default=None,
+        alias="conversionIntent",
     )
 
 

--- a/src/app/router_registry.py
+++ b/src/app/router_registry.py
@@ -34,6 +34,7 @@ from app.routers.domain_product_trust import router as domain_product_trust_rout
 from app.routers.foundation import router as foundation_router
 from app.routers.foundation_workspace import router as foundation_workspace_router
 from app.routers.ideas import router as ideas_router
+from app.routers.ideas_actions import router as ideas_actions_router
 from app.routers.intake import router as intake_router
 from app.routers.intake_upload_commits import router as intake_upload_commits_router
 from app.routers.intake_uploads import router as intake_uploads_router
@@ -227,7 +228,7 @@ OPERATIONS_ROUTERS: RouterGroup = (
     analytics_diagnostics_router,
 )
 
-IDEA_ROUTERS: RouterGroup = (ideas_router,)
+IDEA_ROUTERS: RouterGroup = (ideas_router, ideas_actions_router)
 
 ROUTER_GROUPS: tuple[RouterGroup, ...] = (
     ADVISOR_COCKPIT_ROUTERS,

--- a/src/app/routers/ideas.py
+++ b/src/app/routers/ideas.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Header, Path, Query
+from fastapi import APIRouter, Depends, Path, Query
 
 from app.contracts.ideas import (
     IDEA_CANDIDATE_DETAIL_EXAMPLE,
@@ -9,7 +9,7 @@ from app.contracts.ideas import (
     IdeaGatewayReviewQueueResponse,
 )
 from app.middleware.correlation import correlation_id_var
-from app.routers.ideas_common import IdeaCallerHeaders, idea_error_response
+from app.routers.ideas_common import IdeaCallerHeaders, idea_caller_headers, idea_error_response
 from app.services.gateway_service_provider import idea_service
 
 router = APIRouter(prefix="/api/v1/ideas", tags=["Ideas"])
@@ -74,31 +74,11 @@ async def get_advisor_idea_review_queue(
             examples=["2026-06-21T10:10:00Z"],
         ),
     ] = None,
-    x_caller_subject: Annotated[str | None, Header(alias="X-Caller-Subject")] = None,
-    x_caller_roles: Annotated[str | None, Header(alias="X-Caller-Roles")] = None,
-    x_caller_capabilities: Annotated[
-        str | None,
-        Header(alias="X-Caller-Capabilities"),
-    ] = None,
-    x_caller_tenant_ids: Annotated[str | None, Header(alias="X-Caller-Tenant-Ids")] = None,
-    x_caller_book_ids: Annotated[str | None, Header(alias="X-Caller-Book-Ids")] = None,
-    x_caller_portfolio_ids: Annotated[
-        str | None,
-        Header(alias="X-Caller-Portfolio-Ids"),
-    ] = None,
-    x_caller_client_ids: Annotated[str | None, Header(alias="X-Caller-Client-Ids")] = None,
+    caller_headers: IdeaCallerHeaders = Depends(idea_caller_headers),
 ) -> IdeaGatewayReviewQueueResponse:
     return await _get_advisor_idea_review_queue(
         evaluated_at_utc=evaluated_at_utc,
-        caller_headers=IdeaCallerHeaders(
-            subject=x_caller_subject,
-            roles=x_caller_roles,
-            capabilities=x_caller_capabilities,
-            tenant_ids=x_caller_tenant_ids,
-            book_ids=x_caller_book_ids,
-            portfolio_ids=x_caller_portfolio_ids,
-            client_ids=x_caller_client_ids,
-        ),
+        caller_headers=caller_headers,
     )
 
 
@@ -135,29 +115,9 @@ async def get_idea_candidate_detail(
             examples=["idea_high_cash_8d57adbf52f7f5a7"],
         ),
     ],
-    x_caller_subject: Annotated[str | None, Header(alias="X-Caller-Subject")] = None,
-    x_caller_roles: Annotated[str | None, Header(alias="X-Caller-Roles")] = None,
-    x_caller_capabilities: Annotated[
-        str | None,
-        Header(alias="X-Caller-Capabilities"),
-    ] = None,
-    x_caller_tenant_ids: Annotated[str | None, Header(alias="X-Caller-Tenant-Ids")] = None,
-    x_caller_book_ids: Annotated[str | None, Header(alias="X-Caller-Book-Ids")] = None,
-    x_caller_portfolio_ids: Annotated[
-        str | None,
-        Header(alias="X-Caller-Portfolio-Ids"),
-    ] = None,
-    x_caller_client_ids: Annotated[str | None, Header(alias="X-Caller-Client-Ids")] = None,
+    caller_headers: IdeaCallerHeaders = Depends(idea_caller_headers),
 ) -> IdeaGatewayCandidateDetailResponse:
     return await _get_idea_candidate_detail(
         candidate_id=candidate_id,
-        caller_headers=IdeaCallerHeaders(
-            subject=x_caller_subject,
-            roles=x_caller_roles,
-            capabilities=x_caller_capabilities,
-            tenant_ids=x_caller_tenant_ids,
-            book_ids=x_caller_book_ids,
-            portfolio_ids=x_caller_portfolio_ids,
-            client_ids=x_caller_client_ids,
-        ),
+        caller_headers=caller_headers,
     )

--- a/src/app/routers/ideas_actions.py
+++ b/src/app/routers/ideas_actions.py
@@ -1,0 +1,204 @@
+from typing import Annotated, Literal, cast
+
+from fastapi import APIRouter, Depends, Header, Path
+
+from app.contracts.ideas import (
+    IdeaCandidateConversionIntentRequest,
+    IdeaCandidateConversionIntentResponse,
+    IdeaCandidateFeedbackRequest,
+    IdeaCandidateFeedbackResponse,
+    IdeaCandidateReviewActionRequest,
+    IdeaCandidateReviewActionResponse,
+)
+from app.middleware.correlation import correlation_id_var
+from app.routers.ideas_common import IdeaCallerHeaders, idea_caller_headers, idea_error_response
+from app.services.gateway_service_provider import idea_service
+
+router = APIRouter(prefix="/api/v1/ideas", tags=["Ideas"])
+
+
+async def _record_idea_candidate_action(
+    *,
+    action: Literal[
+        "record_candidate_review_action",
+        "record_candidate_feedback",
+        "record_candidate_conversion_intent",
+    ],
+    candidate_id: str,
+    request: IdeaCandidateReviewActionRequest
+    | IdeaCandidateFeedbackRequest
+    | IdeaCandidateConversionIntentRequest,
+    response_model: type[
+        IdeaCandidateReviewActionResponse
+        | IdeaCandidateFeedbackResponse
+        | IdeaCandidateConversionIntentResponse
+    ],
+    caller_headers: IdeaCallerHeaders,
+    idempotency_key: str,
+    causation_id: str | None,
+) -> (
+    IdeaCandidateReviewActionResponse
+    | IdeaCandidateFeedbackResponse
+    | IdeaCandidateConversionIntentResponse
+):
+    return await idea_service().record_candidate_action(
+        action=action,
+        candidate_id=candidate_id,
+        request=request,
+        response_model=response_model,
+        caller_headers=caller_headers.as_idea_context(),
+        correlation_id=correlation_id_var.get(),
+        idempotency_key=idempotency_key,
+        causation_id=causation_id,
+    )
+
+
+@router.post(
+    "/candidates/{candidate_id}/review-actions",
+    response_model=IdeaCandidateReviewActionResponse,
+    summary="Record idea candidate review action",
+    description=(
+        "Forwards an advisor review action to Lotus Idea. Gateway validates only the documented "
+        "transport shape and forwards trusted caller context, idempotency, correlation, trace, and "
+        "optional causation lineage. Lotus Idea remains authoritative for entitlement, lifecycle, "
+        "replay, audit, and downstream-authority decisions; this route does not approve "
+        "suitability, compliance, mandate, execution, or client communication."
+    ),
+    responses={
+        **idea_error_response(400, description="Lotus Idea rejected the action request."),
+        **idea_error_response(403, description="Caller lacks Idea review permission."),
+        **idea_error_response(404, description="Lotus Idea did not find the candidate."),
+        **idea_error_response(409, description="Idea lifecycle or replay evidence conflicts."),
+        **idea_error_response(422, description="Lotus Idea could not validate the action request."),
+        **idea_error_response(502, description="Lotus Idea is unavailable or unsafe."),
+    },
+)
+async def record_idea_candidate_review_action(
+    request: IdeaCandidateReviewActionRequest,
+    candidate_id: Annotated[str, Path(description="Lotus Idea-owned candidate identifier.")],
+    idempotency_key: Annotated[
+        str,
+        Header(
+            alias="Idempotency-Key",
+            description="Required key forwarded unchanged to Lotus Idea for replay-safe recording.",
+        ),
+    ],
+    causation_id: Annotated[
+        str | None,
+        Header(
+            alias="X-Causation-Id",
+            description=(
+                "Optional governed parent-event identifier forwarded unchanged to Lotus Idea."
+            ),
+        ),
+    ] = None,
+    caller_headers: IdeaCallerHeaders = Depends(idea_caller_headers),
+) -> IdeaCandidateReviewActionResponse:
+    return cast(
+        IdeaCandidateReviewActionResponse,
+        await _record_idea_candidate_action(
+            action="record_candidate_review_action",
+            candidate_id=candidate_id,
+            request=request,
+            response_model=IdeaCandidateReviewActionResponse,
+            caller_headers=caller_headers,
+            idempotency_key=idempotency_key,
+            causation_id=causation_id,
+        ),
+    )
+
+
+@router.post(
+    "/candidates/{candidate_id}/feedback",
+    response_model=IdeaCandidateFeedbackResponse,
+    summary="Record idea candidate feedback",
+    description=(
+        "Forwards source-provenanced advisor feedback to Lotus Idea with trusted caller context, "
+        "idempotency, and request lineage. Gateway does not interpret feedback, mutate candidate "
+        "state locally, or grant downstream authority."
+    ),
+    responses={
+        **idea_error_response(400, description="Lotus Idea rejected the feedback request."),
+        **idea_error_response(403, description="Caller lacks Idea feedback permission."),
+        **idea_error_response(404, description="Lotus Idea did not find the candidate."),
+        **idea_error_response(409, description="Idea replay evidence conflicts."),
+        **idea_error_response(
+            422, description="Lotus Idea could not validate the feedback request."
+        ),
+        **idea_error_response(502, description="Lotus Idea is unavailable or unsafe."),
+    },
+)
+async def record_idea_candidate_feedback(
+    request: IdeaCandidateFeedbackRequest,
+    candidate_id: Annotated[str, Path(description="Lotus Idea-owned candidate identifier.")],
+    idempotency_key: Annotated[
+        str,
+        Header(
+            alias="Idempotency-Key",
+            description="Required key forwarded unchanged to Lotus Idea for replay-safe recording.",
+        ),
+    ],
+    causation_id: Annotated[str | None, Header(alias="X-Causation-Id")] = None,
+    caller_headers: IdeaCallerHeaders = Depends(idea_caller_headers),
+) -> IdeaCandidateFeedbackResponse:
+    return cast(
+        IdeaCandidateFeedbackResponse,
+        await _record_idea_candidate_action(
+            action="record_candidate_feedback",
+            candidate_id=candidate_id,
+            request=request,
+            response_model=IdeaCandidateFeedbackResponse,
+            caller_headers=caller_headers,
+            idempotency_key=idempotency_key,
+            causation_id=causation_id,
+        ),
+    )
+
+
+@router.post(
+    "/candidates/{candidate_id}/conversion-intents",
+    response_model=IdeaCandidateConversionIntentResponse,
+    summary="Record idea candidate conversion intent",
+    description=(
+        "Forwards a candidate conversion intent to Lotus Idea. The intent remains source-owned and "
+        "does not create an Advise proposal, Manage action, Report evidence pack, rebalance, "
+        "execution instruction, suitability approval, or client communication."
+    ),
+    responses={
+        **idea_error_response(
+            400, description="Lotus Idea rejected the conversion-intent request."
+        ),
+        **idea_error_response(403, description="Caller lacks Idea conversion-intent permission."),
+        **idea_error_response(404, description="Lotus Idea did not find the candidate."),
+        **idea_error_response(409, description="Idea lifecycle or replay evidence conflicts."),
+        **idea_error_response(
+            422, description="Lotus Idea could not validate the conversion-intent request."
+        ),
+        **idea_error_response(502, description="Lotus Idea is unavailable or unsafe."),
+    },
+)
+async def record_idea_candidate_conversion_intent(
+    request: IdeaCandidateConversionIntentRequest,
+    candidate_id: Annotated[str, Path(description="Lotus Idea-owned candidate identifier.")],
+    idempotency_key: Annotated[
+        str,
+        Header(
+            alias="Idempotency-Key",
+            description="Required key forwarded unchanged to Lotus Idea for replay-safe recording.",
+        ),
+    ],
+    causation_id: Annotated[str | None, Header(alias="X-Causation-Id")] = None,
+    caller_headers: IdeaCallerHeaders = Depends(idea_caller_headers),
+) -> IdeaCandidateConversionIntentResponse:
+    return cast(
+        IdeaCandidateConversionIntentResponse,
+        await _record_idea_candidate_action(
+            action="record_candidate_conversion_intent",
+            candidate_id=candidate_id,
+            request=request,
+            response_model=IdeaCandidateConversionIntentResponse,
+            caller_headers=caller_headers,
+            idempotency_key=idempotency_key,
+            causation_id=causation_id,
+        ),
+    )

--- a/src/app/routers/ideas_common.py
+++ b/src/app/routers/ideas_common.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Any
 
+from fastapi import Header
+
 from app.contracts.ideas import IdeaGatewayErrorResponse
 
 
@@ -13,6 +15,7 @@ class IdeaCallerHeaders:
     book_ids: str | None = None
     portfolio_ids: str | None = None
     client_ids: str | None = None
+    trusted_caller_context: str | None = None
 
     def as_idea_context(self) -> dict[str, str]:
         headers: dict[str, str] = {}
@@ -30,7 +33,35 @@ class IdeaCallerHeaders:
             headers["X-Caller-Portfolio-Ids"] = self.portfolio_ids
         if self.client_ids:
             headers["X-Caller-Client-Ids"] = self.client_ids
+        if self.trusted_caller_context:
+            headers["X-Lotus-Trusted-Caller-Context"] = self.trusted_caller_context
         return headers
+
+
+def idea_caller_headers(
+    x_caller_subject: str | None = Header(default=None, alias="X-Caller-Subject"),
+    x_caller_roles: str | None = Header(default=None, alias="X-Caller-Roles"),
+    x_caller_capabilities: str | None = Header(default=None, alias="X-Caller-Capabilities"),
+    x_caller_tenant_ids: str | None = Header(default=None, alias="X-Caller-Tenant-Ids"),
+    x_caller_book_ids: str | None = Header(default=None, alias="X-Caller-Book-Ids"),
+    x_caller_portfolio_ids: str | None = Header(default=None, alias="X-Caller-Portfolio-Ids"),
+    x_caller_client_ids: str | None = Header(default=None, alias="X-Caller-Client-Ids"),
+    x_lotus_trusted_caller_context: str | None = Header(
+        default=None,
+        alias="X-Lotus-Trusted-Caller-Context",
+    ),
+) -> IdeaCallerHeaders:
+    """Maps trusted transport context without deriving any Idea authority locally."""
+    return IdeaCallerHeaders(
+        subject=x_caller_subject,
+        roles=x_caller_roles,
+        capabilities=x_caller_capabilities,
+        tenant_ids=x_caller_tenant_ids,
+        book_ids=x_caller_book_ids,
+        portfolio_ids=x_caller_portfolio_ids,
+        client_ids=x_caller_client_ids,
+        trusted_caller_context=x_lotus_trusted_caller_context,
+    )
 
 
 def idea_error_response(status_code: int, *, description: str) -> dict[int | str, dict[str, Any]]:

--- a/src/app/services/idea_client_protocols.py
+++ b/src/app/services/idea_client_protocols.py
@@ -17,3 +17,36 @@ class IdeaClient(Protocol):
         caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
+
+    async def record_candidate_review_action(
+        self,
+        *,
+        candidate_id: str,
+        body: dict[str, Any],
+        caller_headers: dict[str, str],
+        correlation_id: str,
+        idempotency_key: str,
+        causation_id: str | None,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def record_candidate_feedback(
+        self,
+        *,
+        candidate_id: str,
+        body: dict[str, Any],
+        caller_headers: dict[str, str],
+        correlation_id: str,
+        idempotency_key: str,
+        causation_id: str | None,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    async def record_candidate_conversion_intent(
+        self,
+        *,
+        candidate_id: str,
+        body: dict[str, Any],
+        caller_headers: dict[str, str],
+        correlation_id: str,
+        idempotency_key: str,
+        causation_id: str | None,
+    ) -> tuple[int, dict[str, Any]]: ...

--- a/src/app/services/idea_service.py
+++ b/src/app/services/idea_service.py
@@ -1,15 +1,22 @@
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from fastapi import HTTPException, status
 from pydantic import BaseModel, ValidationError
 
 from app.contracts.ideas import (
+    IdeaCandidateActionRequest,
+    IdeaCandidateActionResponse,
     IdeaGatewayCandidateDetailResponse,
     IdeaGatewayReviewQueueResponse,
 )
 from app.services.idea_client_protocols import IdeaClient
 
 ResponseModel = TypeVar("ResponseModel", bound=BaseModel)
+IdeaCandidateActionMethod = Literal[
+    "record_candidate_review_action",
+    "record_candidate_feedback",
+    "record_candidate_conversion_intent",
+]
 
 
 class IdeaService:
@@ -45,6 +52,48 @@ class IdeaService:
         )
         self._raise_on_idea_error(status_code, payload, missing_code="idea_candidate_unavailable")
         return self._validate_payload(IdeaGatewayCandidateDetailResponse, payload)
+
+    async def record_candidate_action(
+        self,
+        *,
+        action: IdeaCandidateActionMethod,
+        candidate_id: str,
+        request: IdeaCandidateActionRequest,
+        response_model: type[ResponseModel],
+        caller_headers: dict[str, str],
+        correlation_id: str,
+        idempotency_key: str,
+        causation_id: str | None,
+    ) -> ResponseModel:
+        action_methods = {
+            "record_candidate_review_action": self._idea_client.record_candidate_review_action,
+            "record_candidate_feedback": self._idea_client.record_candidate_feedback,
+            "record_candidate_conversion_intent": (
+                self._idea_client.record_candidate_conversion_intent
+            ),
+        }
+        action_method = action_methods[action]
+        status_code, payload = await action_method(
+            candidate_id=candidate_id,
+            body=request.model_dump(by_alias=True, exclude_none=True, mode="json"),
+            caller_headers=caller_headers,
+            correlation_id=correlation_id,
+            idempotency_key=idempotency_key,
+            causation_id=causation_id,
+        )
+        self._raise_on_idea_error(
+            status_code, payload, missing_code="idea_candidate_action_unavailable"
+        )
+        response = self._validate_payload(response_model, payload)
+        if isinstance(response, IdeaCandidateActionResponse) and (
+            response.supported_feature_promoted is not False
+        ):
+            raise self._gateway_error(
+                status.HTTP_502_BAD_GATEWAY,
+                "idea_supported_feature_claim_invalid",
+                "Lotus Idea returned an unsupported feature-promotion claim.",
+            )
+        return response
 
     def _validate_payload(
         self,
@@ -93,6 +142,18 @@ class IdeaService:
                 status.HTTP_404_NOT_FOUND,
                 "idea_resource_not_found",
                 "The requested Idea resource was not found.",
+            )
+        if status_code == status.HTTP_409_CONFLICT:
+            raise self._gateway_error(
+                status.HTTP_409_CONFLICT,
+                "idea_conflict",
+                "The requested Idea action conflicts with current source state or replay evidence.",
+            )
+        if status_code == status.HTTP_422_UNPROCESSABLE_CONTENT:
+            raise self._gateway_error(
+                status.HTTP_422_UNPROCESSABLE_CONTENT,
+                "idea_validation_failed",
+                "Lotus Idea could not validate the action request.",
             )
         raise self._gateway_error(
             status.HTTP_502_BAD_GATEWAY,

--- a/tests/contract/test_ideas_contract.py
+++ b/tests/contract/test_ideas_contract.py
@@ -8,6 +8,13 @@ def test_ideas_openapi_contract_registered() -> None:
 
     queue_operation = spec["paths"]["/api/v1/ideas/review-queues/advisor"]["get"]
     detail_operation = spec["paths"]["/api/v1/ideas/candidates/{candidate_id}"]["get"]
+    review_action_operation = spec["paths"][
+        "/api/v1/ideas/candidates/{candidate_id}/review-actions"
+    ]["post"]
+    feedback_operation = spec["paths"]["/api/v1/ideas/candidates/{candidate_id}/feedback"]["post"]
+    conversion_operation = spec["paths"][
+        "/api/v1/ideas/candidates/{candidate_id}/conversion-intents"
+    ]["post"]
     queue_schema = spec["components"]["schemas"]["IdeaGatewayReviewQueueResponse"]
     detail_schema = spec["components"]["schemas"]["IdeaGatewayCandidateDetailResponse"]
 
@@ -38,3 +45,15 @@ def test_ideas_openapi_contract_registered() -> None:
     assert queue_schema["properties"]["supportedFeaturePromoted"]["description"]
     assert detail_schema["properties"]["evidence"]["description"]
     assert detail_schema["properties"]["supportedFeaturePromoted"]["description"]
+    assert review_action_operation["summary"] == "Record idea candidate review action"
+    assert feedback_operation["summary"] == "Record idea candidate feedback"
+    assert conversion_operation["summary"] == "Record idea candidate conversion intent"
+    for operation in (review_action_operation, feedback_operation, conversion_operation):
+        parameter_names = {parameter["name"] for parameter in operation["parameters"]}
+        assert {"Idempotency-Key", "X-Causation-Id", "X-Caller-Capabilities"}.issubset(
+            parameter_names
+        )
+        assert operation["responses"]["409"]["description"]
+        assert operation["responses"]["422"]["description"]
+        assert operation["responses"]["502"]["description"]
+        assert "does not" in operation["description"]

--- a/tests/integration/test_ideas_router.py
+++ b/tests/integration/test_ideas_router.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from app.contracts.ideas import IDEA_CANDIDATE_DETAIL_EXAMPLE, IDEA_REVIEW_QUEUE_EXAMPLE
@@ -181,3 +182,204 @@ def test_idea_route_maps_upstream_failures_without_raw_payload(monkeypatch) -> N
     assert body["detail"]["code"] == "idea_candidate_unavailable"
     assert "postgres" not in str(body).lower()
     assert "idea.internal" not in str(body)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "path", "body", "payload_key", "payload"),
+    [
+        (
+            "record_candidate_review_action",
+            "/review-actions",
+            {
+                "reviewId": "review-001",
+                "action": "approve_for_conversion",
+                "reasonCodes": ["review_required"],
+                "decidedAtUtc": "2026-06-21T10:15:00Z",
+            },
+            "reviewDecision",
+            {
+                "reviewId": "review-001",
+                "candidateId": "idea_high_cash_8d57adbf52f7f5a7",
+                "evidencePacketId": "iep_high_cash_8d57adbf52f7f5a7",
+                "action": "approve_for_conversion",
+                "resultingPosture": "approved_for_conversion",
+                "actorRole": "advisor",
+                "reasonCodes": ["review_required"],
+                "decidedAtUtc": "2026-06-21T10:15:00Z",
+                "suppressionReason": None,
+                "snoozedUntilUtc": None,
+                "grantsDownstreamAuthority": False,
+            },
+        ),
+        (
+            "record_candidate_feedback",
+            "/feedback",
+            {
+                "feedbackId": "feedback-001",
+                "outcome": "useful",
+                "reasonCodes": ["review_required"],
+                "recordedAtUtc": "2026-06-21T10:16:00Z",
+            },
+            "feedbackEvent",
+            {
+                "feedbackId": "feedback-001",
+                "candidateId": "idea_high_cash_8d57adbf52f7f5a7",
+                "evidencePacketId": "iep_high_cash_8d57adbf52f7f5a7",
+                "outcome": "useful",
+                "actorRole": "advisor",
+                "reasonCodes": ["review_required"],
+                "recordedAtUtc": "2026-06-21T10:16:00Z",
+            },
+        ),
+        (
+            "record_candidate_conversion_intent",
+            "/conversion-intents",
+            {
+                "conversionIntentId": "conversion-001",
+                "target": "report_evidence",
+                "reasonCodes": ["review_required"],
+                "requestedAtUtc": "2026-06-21T10:17:00Z",
+            },
+            "conversionIntent",
+            {
+                "conversionIntentId": "conversion-001",
+                "candidateId": "idea_high_cash_8d57adbf52f7f5a7",
+                "target": "report_evidence",
+                "sourceStatus": "approved_for_conversion",
+                "targetSourceAuthority": "lotus-report",
+                "evidencePacketId": "iep_high_cash_8d57adbf52f7f5a7",
+                "evidenceContentHash": "sha256:evidence-lineage",
+                "sourceSignalIds": ["signal_high_cash_8d57adbf52f7f5a7"],
+                "boundary": "intent_only",
+                "reasonCodes": ["review_required"],
+                "requestedAtUtc": "2026-06-21T10:17:00Z",
+                "grantsDownstreamAuthority": False,
+            },
+        ),
+    ],
+)
+def test_idea_candidate_action_routes_forward_source_owned_mutations(
+    monkeypatch,
+    method_name,
+    path,
+    body,
+    payload_key,
+    payload,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def _action(
+        self,
+        *,
+        candidate_id,
+        body,
+        caller_headers,
+        correlation_id,
+        idempotency_key,
+        causation_id,
+    ):
+        captured.update(
+            {
+                "candidate_id": candidate_id,
+                "body": body,
+                "caller_headers": caller_headers,
+                "correlation_id": correlation_id,
+                "idempotency_key": idempotency_key,
+                "causation_id": causation_id,
+            }
+        )
+        return 200, {
+            payload_key: payload,
+            "persistence": {
+                "decision": "accepted",
+                "candidateId": candidate_id,
+                "lifecycleStatus": "generated",
+                "reviewPosture": "advisor_review_required",
+                "auditEventType": "idea.candidate.action.recorded",
+            },
+            "durableStorageBacked": True,
+            "supportedFeaturePromoted": False,
+        }
+
+    monkeypatch.setattr(f"app.clients.lotus_idea_client.LotusIdeaClient.{method_name}", _action)
+    headers = {
+        **_headers(),
+        "Idempotency-Key": "idea-action-idem-001",
+        "X-Causation-Id": "workflow-parent-001",
+        "X-Lotus-Trusted-Caller-Context": "trusted-context-opaque",
+    }
+    response = TestClient(app).post(
+        f"/api/v1/ideas/candidates/idea_high_cash_8d57adbf52f7f5a7{path}",
+        json=body,
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    response_body = response.json()
+    assert response_body[payload_key]["candidateId"] == "idea_high_cash_8d57adbf52f7f5a7"
+    assert response_body["supportedFeaturePromoted"] is False
+    assert captured["candidate_id"] == "idea_high_cash_8d57adbf52f7f5a7"
+    assert captured["body"] == body
+    assert captured["idempotency_key"] == "idea-action-idem-001"
+    assert captured["causation_id"] == "workflow-parent-001"
+    assert captured["correlation_id"] == "corr-idea-router"
+    assert captured["caller_headers"] == {
+        "X-Caller-Subject": "advisor-123",
+        "X-Caller-Roles": "advisor",
+        "X-Caller-Capabilities": "idea.review.queue.read,idea.candidate.detail.read",
+        "X-Caller-Tenant-Ids": "tenant-private-bank-sg",
+        "X-Caller-Book-Ids": "book-advisor-001",
+        "X-Caller-Portfolio-Ids": "PB_SG_GLOBAL_BAL_001",
+        "X-Caller-Client-Ids": "client-001",
+        "X-Lotus-Trusted-Caller-Context": "trusted-context-opaque",
+    }
+
+
+def test_idea_candidate_action_rejects_body_authority_override(monkeypatch) -> None:
+    async def _action(*args, **kwargs):
+        raise AssertionError("Gateway must not forward an authority override body field.")
+
+    monkeypatch.setattr(
+        "app.clients.lotus_idea_client.LotusIdeaClient.record_candidate_review_action",
+        _action,
+    )
+    response = TestClient(app).post(
+        "/api/v1/ideas/candidates/idea_high_cash_8d57adbf52f7f5a7/review-actions",
+        json={
+            "reviewId": "review-001",
+            "action": "approve_for_conversion",
+            "reasonCodes": ["review_required"],
+            "decidedAtUtc": "2026-06-21T10:15:00Z",
+            "authorizedScope": {"portfolioIds": ["other-portfolio"]},
+        },
+        headers={**_headers(), "Idempotency-Key": "idea-action-idem-override"},
+    )
+
+    assert response.status_code == 422
+    assert "authorizedScope" in str(response.json())
+
+
+@pytest.mark.parametrize("upstream_status", [409, 422])
+def test_idea_candidate_action_preserves_source_conflict_and_validation_status(
+    monkeypatch, upstream_status
+) -> None:
+    async def _action(self, **kwargs):
+        return upstream_status, {"detail": "source-internal-detail"}
+
+    monkeypatch.setattr(
+        "app.clients.lotus_idea_client.LotusIdeaClient.record_candidate_feedback",
+        _action,
+    )
+    response = TestClient(app).post(
+        "/api/v1/ideas/candidates/idea_high_cash_8d57adbf52f7f5a7/feedback",
+        json={
+            "feedbackId": "feedback-001",
+            "outcome": "useful",
+            "reasonCodes": ["review_required"],
+            "recordedAtUtc": "2026-06-21T10:16:00Z",
+        },
+        headers={**_headers(), "Idempotency-Key": "idea-action-idem-error"},
+    )
+
+    assert response.status_code == upstream_status
+    assert "source-internal-detail" not in str(response.json())

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -155,6 +155,46 @@ async def test_lotus_idea_client_forwards_explicit_queue_timestamp():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "action_path"),
+    [
+        ("record_candidate_review_action", "review-actions"),
+        ("record_candidate_feedback", "feedback"),
+        ("record_candidate_conversion_intent", "conversion-intents"),
+    ],
+)
+async def test_lotus_idea_client_forwards_candidate_action_lineage_and_idempotency(
+    method_name, action_path
+):
+    client = LotusIdeaClient(base_url="http://lotus-idea", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"sourceAuthority": "lotus-idea"})
+
+    await getattr(client, method_name)(
+        candidate_id="idea-123",
+        body={"requestId": "action-001"},
+        caller_headers={
+            "X-Caller-Subject": "advisor-123",
+            "X-Caller-Capabilities": "idea.review.record",
+        },
+        correlation_id="corr-idea-action",
+        idempotency_key="idem-idea-action-001",
+        causation_id="parent-event-001",
+    )
+
+    call = _FakeAsyncClient.calls[0]
+    assert call["method"] == "POST"
+    assert call["url"] == f"http://lotus-idea/api/v1/idea-candidates/idea-123/{action_path}"
+    assert call["json"] == {"requestId": "action-001"}
+    assert call["headers"]["X-Caller-Service"] == "lotus-gateway"
+    assert call["headers"]["X-Caller-Subject"] == "advisor-123"
+    assert call["headers"]["X-Caller-Capabilities"] == "idea.review.record"
+    assert call["headers"]["Idempotency-Key"] == "idem-idea-action-001"
+    assert call["headers"]["X-Correlation-Id"] == "corr-idea-action"
+    assert call["headers"]["X-Causation-Id"] == "parent-event-001"
+    assert call["headers"]["X-Trace-Id"]
+
+
+@pytest.mark.asyncio
 async def test_lotus_analytics_client_calls_and_payload_handling():
     client = LotusAnalyticsClient(base_url="http://lotus-performance", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"sourceService": "lotus-performance"})

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -260,13 +260,16 @@ or governed ingress endpoints without embedding environment-specific hostnames i
   metadata before returning metadata or streaming binary content. Broader portfolio, client, and
   advisor entitlement remains upstream authorization truth; Gateway must not claim fuller document
   entitlement enforcement until that source is wired and tested.
-- idea review queue and candidate detail reads are gateway-first under `/api/v1/ideas/*`;
+- idea review queue/detail reads and candidate review-action, feedback, and conversion-intent
+  recordings are gateway-first under `/api/v1/ideas/*`;
   Gateway forwards `X-Caller-Subject`, `X-Caller-Roles`, `X-Caller-Capabilities`,
   `X-Caller-Tenant-Ids`, `X-Caller-Book-Ids`, `X-Caller-Portfolio-Ids`,
-  `X-Caller-Client-Ids`, and correlation context to `lotus-idea` for
-  `lotus-idea` entitlement-scope enforcement. Gateway preserves source-owned ranking, source
-  signal identifiers, source refs, durable-storage posture, and `supportedFeaturePromoted=false`,
-  and does not generate, rank, enrich, certify, or promote idea candidates locally
+  `X-Caller-Client-Ids`, optional `X-Lotus-Trusted-Caller-Context`, and correlation/trace context
+  to `lotus-idea` for entitlement-scope enforcement. Mutation requests require `Idempotency-Key`
+  and may carry `X-Causation-Id`; Gateway preserves source-owned ranking, source signal identifiers,
+  source refs, durable-storage posture, accepted/replayed outcomes, and
+  `supportedFeaturePromoted=false`. It does not generate, rank, enrich, certify, or promote Idea
+  candidates, grant downstream authority, or create downstream delivery/execution records locally
 - Workbench performance summary, risk summary, advisor-brief read, and advisor-brief review-action
   routes require `X-Actor-Id`, `X-Tenant-Id`, and `X-Region`; optional
   `X-Caller-Application`, `X-Booking-Center-Code`, and `X-Role` preserve entitlement and audit
@@ -689,6 +692,24 @@ curl "$GATEWAY_BASE_URL/api/v1/ideas/candidates/idea_high_cash_8d57adbf52f7f5a7"
   -H "X-Caller-Portfolio-Ids: PB_SG_GLOBAL_BAL_001" \
   -H "X-Caller-Client-Ids: client-001"
 ```
+
+Idea candidate review action:
+
+```bash
+curl -X POST "$GATEWAY_BASE_URL/api/v1/ideas/candidates/idea_high_cash_8d57adbf52f7f5a7/review-actions" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: idea-review-001" \
+  -H "X-Caller-Subject: advisor-123" \
+  -H "X-Caller-Roles: advisor" \
+  -H "X-Caller-Capabilities: idea.review.record" \
+  -H "X-Caller-Tenant-Ids: tenant-private-bank-sg" \
+  -H "X-Caller-Portfolio-Ids: PB_SG_GLOBAL_BAL_001" \
+  -d "{\"reviewId\":\"review-001\",\"action\":\"approve_for_conversion\",\"reasonCodes\":[\"review_required\"],\"decidedAtUtc\":\"2026-06-21T10:15:00Z\"}"
+```
+
+The `feedback` and `conversion-intents` routes use the same caller-context and idempotency posture.
+They record only Lotus Idea-owned workflow facts; a conversion intent does not initiate downstream
+submission, rebalance, execution, suitability approval, or client communication.
 
 Analytics diagnostics protected lookup:
 

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -5,34 +5,43 @@ developers, business users, operations, sales/pre-sales, and client demos; it mu
 future capability as supported until the owning service, Gateway contract, tests, and validation
 evidence exist.
 
-## Idea Opportunity Reads
+## Idea Opportunity BFF
 
-Status: implementation-backed in Gateway for the first read-only `lotus-idea` publication slice.
-This is not a Workbench UI completion claim or a supported-feature promotion from `lotus-idea`.
+Status: implementation-backed in Gateway for bounded `lotus-idea` reads and candidate action
+recording. This is not a Workbench UI completion claim or a supported-feature promotion from
+`lotus-idea`.
 
 What is supported:
 
 1. advisors can read the Idea review queue through Gateway,
 2. advisors and operators can read source-safe candidate detail through Gateway,
-3. Gateway preserves `lotus-idea` ranking, source signal identifiers, redacted source references,
-   durable-storage posture, and `supportedFeaturePromoted=false`,
-4. Gateway maps unsafe upstream failures to product-safe error detail.
+3. authorized callers can record a source-owned candidate review action, feedback event, or
+   conversion intent through Gateway,
+4. Gateway preserves `lotus-idea` ranking, source signal identifiers, redacted source references,
+   durable-storage posture, accepted/replayed mutation posture, and `supportedFeaturePromoted=false`,
+5. Gateway maps unsafe upstream failures to product-safe error detail.
 
 Supported routes:
 
 1. `GET /api/v1/ideas/review-queues/advisor`
 2. `GET /api/v1/ideas/candidates/{candidate_id}`
+3. `POST /api/v1/ideas/candidates/{candidate_id}/review-actions`
+4. `POST /api/v1/ideas/candidates/{candidate_id}/feedback`
+5. `POST /api/v1/ideas/candidates/{candidate_id}/conversion-intents`
 
 Boundary:
 
 1. Gateway forwards `X-Caller-Subject`, `X-Caller-Roles`, `X-Caller-Capabilities`,
    `X-Caller-Tenant-Ids`, `X-Caller-Book-Ids`, `X-Caller-Portfolio-Ids`,
-   `X-Caller-Client-Ids`, and correlation context to `lotus-idea` for
-   `lotus-idea` entitlement-scope enforcement on published idea reads.
+   `X-Caller-Client-Ids`, optional `X-Lotus-Trusted-Caller-Context`, and correlation/trace context
+   to `lotus-idea` for entitlement-scope enforcement. Mutation routes additionally require and
+   forward `Idempotency-Key` and forward optional `X-Causation-Id`.
 2. Gateway does not generate ideas, rank candidates, enrich evidence, certify data-product posture,
-   grant downstream authority, or promote `supportedFeaturePromoted`.
-3. Workbench idea UI, mutation routes, data-product certification, and full supported-feature
-   promotion remain separate proof scopes.
+   grant downstream authority, or promote `supportedFeaturePromoted`; a conversion intent does not
+   create a downstream proposal, action, report evidence pack, rebalance, execution, or client
+   communication.
+3. Workbench idea UI, canonical runtime proof, data-product certification, and full
+   supported-feature promotion remain separate proof scopes.
 
 ## Advisory Proposal Narrative Posture
 


### PR DESCRIPTION
## Summary
- publish typed Gateway BFF routes for Lotus Idea candidate review actions, feedback, and conversion-intent recording
- forward source-owned caller context, trusted context, idempotency, correlation/trace, and optional causation without accepting body authority overrides
- preserve Lotus Idea as lifecycle, entitlement, replay, audit, conversion, and downstream-authority owner; split action routing from Idea reads to retain repository complexity limits
- update OpenAPI coverage, source-contract documentation, repository context, and authored wiki truth

Closes #497.

## Validation
- `make check`
- `make ci`
- `python -m pytest tests/integration/test_ideas_router.py tests/contract/test_ideas_contract.py tests/unit/test_upstream_clients.py tests/unit/test_router_registry.py -q` (212 passed)
- `pwsh -NoProfile -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway -AllowUnpublishedSourceChanges` (expected branch-only authored-wiki delta: 2 files)

## Governance
- Stranded-truth reconciliation: `git fetch origin --prune` and `git branch -r --no-merged origin/main` found no unmerged remote branches.
- The PR is an Experience API contract slice. It does not claim Workbench completion, canonical runtime proof, data-product certification, supported-feature promotion, suitability, client publication, rebalance, execution, or downstream realization.
- No platform skill or central context change was warranted: the existing backend-delivery and pre-merge gate guidance covered the pattern. Repository-local context, API map, README, supported-feature boundary, and wiki were updated because the Gateway contract changed.
- Post-merge: publish the authored wiki source and run strict parity; then validate exact-main releasability before enabling Workbench actions.