### PR TITLE
Publish authenticated advisor own-book contract (#500)

### DIFF
--- a/CODEBASE-REVIEW-LEDGER.md
+++ b/CODEBASE-REVIEW-LEDGER.md
@@ -20,9 +20,11 @@ Current branch: `feat/authenticated-advisor-book-500`
   manager, date, booking-centre, non-null tenant, count, duplicate-row, or source-contract mismatch
   fails closed. Null Core tenant scope and legacy advisor projection remain explicit degraded
   posture. The route never falls back to the global portfolio catalogue.
-- Measured signal: the feature remains bounded to dedicated `advisor_book` modules; the mapping
-  service is 305 lines and the router is 192 lines, both below the current 397-line source-file
-  quality ceiling. Existing client, service, router, and provider ownership guards remain green.
+- Measured signal: the feature remains bounded to dedicated `advisor_book` modules. The mapping
+  service is 241 lines, supportability policy is 93 lines, router is 104 lines, and request-input
+  module is 114 lines, all below the current 316-line source-file quality ceiling; every function
+  is within the 49-line ceiling. Existing client, service, router, and provider ownership guards
+  remain green.
 - Proof: focused client, source-contract, access-policy, service, provider, integration-router,
   OpenAPI, and layer-boundary tests cover path encoding, exact caller capability, missing context,
   cross-scope rejection, cross-tenant denial, duplicate evidence, explicit empty, filter-empty,

--- a/CODEBASE-REVIEW-LEDGER.md
+++ b/CODEBASE-REVIEW-LEDGER.md
@@ -1,8 +1,43 @@
 # Codebase Review Ledger
 
-Date: 2026-06-21
+Last updated: 2026-07-18
 Repository: `lotus-gateway`
-Branch: `fix/gateway-issue-129-report-capability-query-params`
+Current branch: `feat/authenticated-advisor-book-500`
+
+## Authenticated Advisor Own-Book Experience Contract
+
+- Scope: GitHub issue #500, raised from Workbench portfolio-selector discovery because the global
+  portfolio catalogue cannot prove an authenticated advisor's book of business.
+- Source authority: `lotus-core` owns `PortfolioManagerBookMembership:v1`, effective portfolio
+  membership, assignment basis, source record evidence, freshness, content identity, and lineage.
+  Gateway owns the bounded product-facing own-book projection and caller-context enforcement.
+- Change: added a path-safe Core control-plane client call, strict source model, focused
+  client protocol, own-book mapping service, cached factory/provider, executable response example,
+  and `GET /api/v1/advisor-book/portfolios` with explicit business date, exact filters,
+  deterministic sort, and bounded paging.
+- Security and truth boundary: manager identity comes only from trusted `X-Actor-Id`; exact
+  supported role plus `advisor.book.read`, tenant, region, and booking centre are required. A
+  manager, date, booking-centre, non-null tenant, count, duplicate-row, or source-contract mismatch
+  fails closed. Null Core tenant scope and legacy advisor projection remain explicit degraded
+  posture. The route never falls back to the global portfolio catalogue.
+- Measured signal: the feature remains bounded to dedicated `advisor_book` modules; the mapping
+  service is 305 lines and the router is 192 lines, both below the current 397-line source-file
+  quality ceiling. Existing client, service, router, and provider ownership guards remain green.
+- Proof: focused client, source-contract, access-policy, service, provider, integration-router,
+  OpenAPI, and layer-boundary tests cover path encoding, exact caller capability, missing context,
+  cross-scope rejection, cross-tenant denial, duplicate evidence, explicit empty, filter-empty,
+  tenant degradation, legacy projection, upstream failure, deterministic paging, and no
+  browser-owned advisor identity. Repository-wide gates are recorded on issue #500 before PR
+  review.
+- Durable documentation: supported-feature source, wiki supported features/API examples,
+  RFC-0082 upstream-family classification, README parameter conventions, and repository context
+  are updated in the same slice.
+- Existing follow-up owners: Gateway/Workbench #436 owns production authenticated principal
+  resolution; Core #513 owns richer effective-dated relationship roles until its local work is
+  packaged, reviewed, merged, and exact-main validated. No duplicate downstream issue was opened.
+- No-claim boundary: team, delegated, supervisory, household, assets-under-management, attention,
+  suitability, recommendation, client communication, order, and execution coverage remain out of
+  scope unless separately sourced and proven.
 
 ## Capability Contract Issue Triage
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ as the claim-controlled demo entrypoints.
 It depends on:
 
 - `lotus-core`
-  portfolio, booking, lookup, ingestion, simulation, and supportability inputs
+  portfolio, authenticated portfolio-manager book membership, booking, lookup, ingestion,
+  simulation, and supportability inputs
 - `lotus-performance`
   performance workspace analytics and evidence lineage
 - `lotus-risk`
@@ -362,7 +363,10 @@ Important current parameter conventions:
    headers. The response preserves Report-owned configuration and output availability while Gateway
    publishes only implemented submission paths; ordering eligibility is not distribution approval
    or document-completion evidence
-7. intake upload routes accept camelCase multipart aliases such as `entityType`, `sampleSize`, and
+7. advisor-book discovery uses camelCase `asOfDate`, `clientId`, `mandateType`, `sortBy`, and
+   `sortOrder`; requires trusted actor, tenant, region, booking centre, exact supported role, and
+   `advisor.book.read`; and exposes no browser-authored advisor-id override
+8. intake upload routes accept camelCase multipart aliases such as `entityType`, `sampleSize`, and
    `allowPartial`
 8. some lookup filters intentionally remain snake_case, such as `cif_id`, `booking_center`,
    `product_type`, and `instrument_page_limit`

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -70,6 +70,12 @@ Current repository posture:
 4. source-backed report ordering configuration and selected-scope eligibility are active under
    `/api/v1/report-ordering/options`; `lotus-report` remains catalogue authority, Gateway publishes
    only implemented submission paths, and client/book scopes do not imply portfolio membership,
+5. authenticated advisor own-book discovery is active under
+   `/api/v1/advisor-book/portfolios`; Gateway derives the manager only from trusted caller context,
+   consumes Core `PortfolioManagerBookMembership:v1`, preserves assignment basis and provenance,
+   rejects cross-scope evidence, reports null Core tenant scope as degraded, and does not fall back
+   to the global portfolio catalogue or infer team, delegate, supervisor, household,
+   assets-under-management, attention, suitability, communication, or execution truth,
 5. report job initiation/search/status/event-history/cancellation routes are active for
    gateway-first portfolio review report job workflows under `/api/v1/reports/portfolio-reviews`,
    `/api/v1/report-jobs`, and `/api/v1/report-jobs/*`,

--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -31,6 +31,7 @@ outputs.
 | projected-state calls | `/simulation-sessions/*/projected-*` | Snapshot and simulation watchlist | projected position and summary views | watch for semantics that should move to a governed analytics service |
 | `get_portfolio_analytics_reference` | `/integration/portfolios/{portfolio_id}/analytics/reference` | Analytics Input | upstream source context for analytics consumers | do not compute analytics conclusions in gateway |
 | `get_benchmark_assignment` | `/integration/portfolios/{portfolio_id}/benchmark-assignment` | Analytics Input | benchmark context for workspace composition | benchmark meaning remains core-governed input |
+| `get_portfolio_manager_book_memberships` | `POST /integration/portfolio-manager-books/{portfolio_manager_id}/memberships` | Operational Read | authenticated advisor own-book discovery | derive the manager from trusted caller context; preserve Core membership evidence; never widen through the global portfolio catalogue or infer team, delegated, supervisory, or household scope |
 | `get_benchmark_catalog` | `/integration/benchmarks/catalog` | Analytics Input watchlist | selector and catalog composition | keep catalog interpretation out of gateway |
 | support overview and readiness calls | `/support/portfolios/{portfolio_id}/*` | Control-plane and support metadata | show supportability and readiness | preserve partial readiness and gap details |
 
@@ -121,6 +122,12 @@ This RFC-0082 documentation slice reflects current runtime behavior:
    explicit scope eligibility, and preserves Report-owned output availability and reason codes.
    It does not expand client or advisor-book membership, publish unimplemented schedule/source
    workflow submission paths, grant distribution approval, or infer document completion.
+9. Authenticated advisor own-book discovery is exposed through gateway-owned
+   `/api/v1/advisor-book/portfolios`. Gateway derives manager identity from trusted caller
+   context, consumes Core `PortfolioManagerBookMembership:v1`, rejects cross-scope evidence,
+   preserves source provenance and legacy-assignment basis, and reports null source tenant scope
+   as degraded. It does not use the global catalogue as a fallback or infer delegated, team,
+   supervisor, household, assets-under-management, attention, suitability, or execution truth.
 
 ## Gap Register
 

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -28,6 +28,15 @@
 5. advisory copilot evidence packets, action runs, review decisions, supportability, and
    proposal-version run lineage,
 6. bank-demo proof scenario contract, supported-claim register, and proof-pack capture.
+7. authenticated own-book portfolio discovery through `GET /api/v1/advisor-book/portfolios`,
+   backed by Core `PortfolioManagerBookMembership:v1` and bounded to trusted caller context.
+
+Advisor-book discovery supports an explicit business date, exact client and mandate filters,
+deterministic sorting, and bounded paging. It identifies governed role assignments separately from
+the bounded legacy advisor projection, reports missing Core tenant scope as degraded, rejects
+cross-tenant or cross-booking-centre evidence, and never falls back to the global portfolio
+catalogue. Team, delegated, supervisory, household, assets-under-management, attention,
+suitability, recommendation, communication, and execution claims are not supported by this route.
 
 ## DPM Command Center
 

--- a/src/app/clients/lotus_core_portfolio_query_client.py
+++ b/src/app/clients/lotus_core_portfolio_query_client.py
@@ -1,4 +1,5 @@
 from typing import Any
+from urllib.parse import quote
 
 from app.clients.lotus_core_transaction_params import build_portfolio_transaction_query_params
 
@@ -27,6 +28,38 @@ class LotusCorePortfolioQueryClientMixin:
         payload: dict[str, Any],
     ) -> tuple[int, dict[str, Any]]:
         raise NotImplementedError
+
+    async def _post_control_plane_resource(
+        self,
+        *,
+        operation: str,
+        path: str,
+        correlation_id: str,
+        payload: dict[str, Any],
+    ) -> tuple[int, dict[str, Any]]:
+        raise NotImplementedError
+
+    async def get_portfolio_manager_book_memberships(
+        self,
+        *,
+        portfolio_manager_id: str,
+        as_of_date: str,
+        booking_center_code: str,
+        portfolio_types: list[str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        manager_path_segment = quote(portfolio_manager_id, safe="")
+        return await self._post_control_plane_resource(
+            operation="core.integration.portfolio-manager-books.memberships.get",
+            path=(f"/integration/portfolio-manager-books/{manager_path_segment}/memberships"),
+            correlation_id=correlation_id,
+            payload={
+                "as_of_date": as_of_date,
+                "booking_center_code": booking_center_code,
+                "portfolio_types": portfolio_types,
+                "include_inactive": False,
+            },
+        )
 
     async def list_portfolios(
         self,

--- a/src/app/contracts/advisor_book.py
+++ b/src/app/contracts/advisor_book.py
@@ -1,0 +1,219 @@
+from datetime import date, datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class AdvisorBookScope(BaseModel):
+    kind: Literal["own_book"] = Field(
+        description="Source-backed advisor-book scope represented by this response.",
+        examples=["own_book"],
+    )
+    label: Literal["My book"] = Field(
+        description="Business label for the authenticated advisor's own supported book scope.",
+        examples=["My book"],
+    )
+    as_of_date: date = Field(
+        description="Business date used by Core to resolve effective portfolio membership.",
+        examples=["2026-04-10"],
+    )
+    booking_center_code: str = Field(
+        description="Trusted caller booking center applied to the source membership request.",
+        examples=["Singapore"],
+    )
+
+
+class AdvisorBookPortfolio(BaseModel):
+    portfolio_id: str = Field(
+        description="Canonical portfolio identifier in the authenticated advisor's source book.",
+        examples=["PB_SG_GLOBAL_BAL_001"],
+    )
+    display_name: str = Field(
+        description=(
+            "Source-safe portfolio display label. The first-wave source uses the canonical "
+            "portfolio identifier when it publishes no separate display name."
+        ),
+        examples=["PB_SG_GLOBAL_BAL_001"],
+    )
+    client_id: str = Field(
+        description="Client identifier published by the Core book-membership source product.",
+        examples=["CIF_SG_GLOBAL_BAL_001"],
+    )
+    base_currency: str = Field(
+        description="Portfolio base currency from the source-owned membership row.",
+        examples=["USD"],
+    )
+    booking_center_code: str = Field(
+        description="Booking center from the source-owned membership row.",
+        examples=["Singapore"],
+    )
+    mandate_type: str = Field(
+        description="Portfolio or mandate classification from the source-owned membership row.",
+        examples=["DISCRETIONARY"],
+    )
+    status: str = Field(
+        description="Portfolio lifecycle status from the source-owned membership row.",
+        examples=["ACTIVE"],
+    )
+    opened_on: date = Field(
+        description="Portfolio opening date carried by the source membership evidence.",
+        examples=["2025-03-31"],
+    )
+    closed_on: date | None = Field(
+        default=None,
+        description="Portfolio closing date when reported by the source membership evidence.",
+        examples=[None],
+    )
+    membership_source: Literal["PortfolioManagerBookMembership:v1"] = Field(
+        description="Versioned Core source product that established this book membership.",
+        examples=["PortfolioManagerBookMembership:v1"],
+    )
+    membership_reference: str = Field(
+        description="Opaque source record reference retained for support and audit review.",
+        examples=["portfolio:PB_SG_GLOBAL_BAL_001"],
+    )
+
+
+class AdvisorBookPage(BaseModel):
+    total_count: int = Field(
+        ge=0,
+        description="Total source memberships after supported Gateway filters are applied.",
+        examples=[1],
+    )
+    offset: int = Field(
+        ge=0,
+        description="Zero-based result offset requested by the caller.",
+        examples=[0],
+    )
+    limit: int = Field(
+        ge=1,
+        le=100,
+        description="Maximum number of portfolio memberships returned on this page.",
+        examples=[25],
+    )
+    returned_count: int = Field(
+        ge=0,
+        description="Number of portfolio memberships returned on this page.",
+        examples=[1],
+    )
+    sort_by: Literal["portfolio_id", "client_id", "mandate_type"] = Field(
+        description="Stable business field used for deterministic result ordering.",
+        examples=["portfolio_id"],
+    )
+    sort_order: Literal["asc", "desc"] = Field(
+        description="Direction applied to the deterministic result ordering.",
+        examples=["asc"],
+    )
+
+
+class AdvisorBookSupportability(BaseModel):
+    state: Literal["ready", "empty", "degraded"] = Field(
+        description="Product-safe availability posture for the authenticated advisor book.",
+        examples=["degraded"],
+    )
+    reason_code: Literal[
+        "advisor_book_ready",
+        "advisor_book_empty",
+        "advisor_book_tenant_scope_not_reported",
+    ] = Field(
+        description="Bounded reason explaining the advisor-book availability posture.",
+        examples=["advisor_book_tenant_scope_not_reported"],
+    )
+    tenant_scope: Literal["source_confirmed", "trusted_context_only"] = Field(
+        description=(
+            "Whether Core confirmed tenant scope or Gateway only has trusted caller context. "
+            "Trusted-context-only posture is not tenant-isolation certification."
+        ),
+        examples=["trusted_context_only"],
+    )
+    limitations: list[str] = Field(
+        default_factory=list,
+        description="Bounded no-claim limitations that remain for this first-wave scope.",
+        examples=[["tenant_scope_not_reported", "delegated_scope_not_supported"]],
+    )
+
+
+class AdvisorBookProvenance(BaseModel):
+    product_name: Literal["PortfolioManagerBookMembership"] = Field(
+        description="Core source-data product name retained by Gateway.",
+        examples=["PortfolioManagerBookMembership"],
+    )
+    product_version: Literal["v1"] = Field(
+        description="Core source-data product version retained by Gateway.",
+        examples=["v1"],
+    )
+    generated_at: datetime = Field(
+        description="UTC timestamp when Core generated the source membership response.",
+        examples=["2026-04-10T02:00:00Z"],
+    )
+    latest_evidence_timestamp: datetime | None = Field(
+        default=None,
+        description="Latest source membership evidence timestamp reported by Core.",
+        examples=["2026-04-10T01:59:00Z"],
+    )
+    freshness_status: str = Field(
+        description="Source-owned freshness posture retained without reinterpretation.",
+        examples=["CURRENT"],
+    )
+    data_quality_status: str = Field(
+        description="Source-owned data-quality posture retained without reinterpretation.",
+        examples=["ACCEPTED"],
+    )
+    source_evidence_current: bool = Field(
+        description="Whether Core considers the membership evidence current for the request.",
+        examples=[True],
+    )
+    snapshot_id: str | None = Field(
+        default=None,
+        description="Deterministic source snapshot identity when Core publishes one.",
+        examples=["pm_book_membership:2e7dfe0c"],
+    )
+    content_hash: str = Field(
+        description="Source-owned deterministic membership content hash.",
+        examples=["sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"],
+    )
+    lineage: dict[str, str] = Field(
+        default_factory=dict,
+        description="Bounded Core lineage fields retained for support and audit use.",
+        examples=[{"source_field": "advisor_id", "source_owner": "lotus-core"}],
+    )
+
+
+class AdvisorBookResponse(BaseModel):
+    correlation_id: str = Field(
+        description="Opaque request correlation identifier.",
+        examples=["corr-advisor-book-001"],
+    )
+    contract_version: Literal["v1"] = Field(
+        default="v1",
+        description="Version of the Gateway advisor-book experience contract.",
+        examples=["v1"],
+    )
+    scope: AdvisorBookScope
+    page: AdvisorBookPage
+    items: list[AdvisorBookPortfolio] = Field(
+        default_factory=list,
+        description="Source-backed portfolio memberships on the requested result page.",
+    )
+    supportability: AdvisorBookSupportability
+    provenance: AdvisorBookProvenance | None = Field(
+        default=None,
+        description=(
+            "Bounded Core source provenance, absent only for an explicit empty source book."
+        ),
+    )
+
+
+class AdvisorBookErrorResponse(BaseModel):
+    code: str = Field(
+        description="Stable product-safe advisor-book error code.",
+        examples=["advisor_book_access_denied"],
+    )
+    message: str = Field(
+        description="Product-safe error explanation without upstream response content.",
+        examples=["Advisor-book access is not available for this caller."],
+    )
+    correlation_id: str = Field(
+        description="Opaque request correlation identifier for support follow-up.",
+        examples=["corr-advisor-book-001"],
+    )

--- a/src/app/contracts/advisor_book.py
+++ b/src/app/contracts/advisor_book.py
@@ -72,6 +72,13 @@ class AdvisorBookPortfolio(BaseModel):
         description="Opaque source record reference retained for support and audit review.",
         examples=["portfolio:PB_SG_GLOBAL_BAL_001"],
     )
+    membership_basis: Literal["governed_role_assignment", "legacy_advisor_projection"] = Field(
+        description=(
+            "Whether membership is established by a governed portfolio role or the bounded "
+            "legacy advisor projection published by Core."
+        ),
+        examples=["governed_role_assignment"],
+    )
 
 
 class AdvisorBookPage(BaseModel):
@@ -114,7 +121,10 @@ class AdvisorBookSupportability(BaseModel):
     reason_code: Literal[
         "advisor_book_ready",
         "advisor_book_empty",
+        "advisor_book_filter_empty",
+        "advisor_book_source_incomplete",
         "advisor_book_tenant_scope_not_reported",
+        "advisor_book_legacy_projection",
     ] = Field(
         description="Bounded reason explaining the advisor-book availability posture.",
         examples=["advisor_book_tenant_scope_not_reported"],

--- a/src/app/contracts/advisor_book_examples.py
+++ b/src/app/contracts/advisor_book_examples.py
@@ -31,6 +31,7 @@ ADVISOR_BOOK_RESPONSE_EXAMPLE = AdvisorBookResponse.model_validate(
                 "closed_on": None,
                 "membership_source": "PortfolioManagerBookMembership:v1",
                 "membership_reference": "portfolio:PB_SG_GLOBAL_BAL_001",
+                "membership_basis": "legacy_advisor_projection",
             }
         ],
         "supportability": {

--- a/src/app/contracts/advisor_book_examples.py
+++ b/src/app/contracts/advisor_book_examples.py
@@ -1,0 +1,57 @@
+from app.contracts.advisor_book import AdvisorBookResponse
+
+ADVISOR_BOOK_RESPONSE_EXAMPLE = AdvisorBookResponse.model_validate(
+    {
+        "correlation_id": "corr-advisor-book-001",
+        "contract_version": "v1",
+        "scope": {
+            "kind": "own_book",
+            "label": "My book",
+            "as_of_date": "2026-04-10",
+            "booking_center_code": "Singapore",
+        },
+        "page": {
+            "total_count": 1,
+            "offset": 0,
+            "limit": 25,
+            "returned_count": 1,
+            "sort_by": "portfolio_id",
+            "sort_order": "asc",
+        },
+        "items": [
+            {
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "display_name": "PB_SG_GLOBAL_BAL_001",
+                "client_id": "CIF_SG_GLOBAL_BAL_001",
+                "base_currency": "USD",
+                "booking_center_code": "Singapore",
+                "mandate_type": "DISCRETIONARY",
+                "status": "ACTIVE",
+                "opened_on": "2025-03-31",
+                "closed_on": None,
+                "membership_source": "PortfolioManagerBookMembership:v1",
+                "membership_reference": "portfolio:PB_SG_GLOBAL_BAL_001",
+            }
+        ],
+        "supportability": {
+            "state": "degraded",
+            "reason_code": "advisor_book_tenant_scope_not_reported",
+            "tenant_scope": "trusted_context_only",
+            "limitations": ["tenant_scope_not_reported", "delegated_scope_not_supported"],
+        },
+        "provenance": {
+            "product_name": "PortfolioManagerBookMembership",
+            "product_version": "v1",
+            "generated_at": "2026-04-10T02:00:00Z",
+            "latest_evidence_timestamp": "2026-04-10T01:59:00Z",
+            "freshness_status": "CURRENT",
+            "data_quality_status": "ACCEPTED",
+            "source_evidence_current": True,
+            "snapshot_id": "pm_book_membership:2e7dfe0c",
+            "content_hash": (
+                "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            ),
+            "lineage": {"source_field": "advisor_id", "source_owner": "lotus-core"},
+        },
+    }
+).model_dump(mode="json")

--- a/src/app/openapi_metadata.py
+++ b/src/app/openapi_metadata.py
@@ -1,4 +1,11 @@
 OPENAPI_TAGS: list[dict[str, str]] = [
+    {
+        "name": "advisor-book",
+        "description": (
+            "Authenticated advisor own-book discovery backed by Core portfolio-manager "
+            "membership, with explicit source and tenant supportability."
+        ),
+    },
     {"name": "Reports", "description": "Gateway-facing reporting data and command APIs."},
     {
         "name": "Report Jobs",

--- a/src/app/router_groups/advisory.py
+++ b/src/app/router_groups/advisory.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from app.routers.advisor_book import router as advisor_book_router
 from app.routers.advisor_cockpit import router as advisor_cockpit_router
 from app.routers.advisor_cockpit_acknowledgements import (
     router as advisor_cockpit_acknowledgements_router,
@@ -157,6 +158,8 @@ from app.routers.proposal_workflow_evidence import (
 from app.routers.proposals import router as proposals_router
 
 RouterGroup = tuple[APIRouter, ...]
+
+ADVISOR_BOOK_ROUTERS: RouterGroup = (advisor_book_router,)
 
 ADVISOR_COCKPIT_ROUTERS: RouterGroup = (
     advisor_cockpit_router,

--- a/src/app/router_registry.py
+++ b/src/app/router_registry.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, FastAPI
 from fastapi.routing import APIRoute
 
 from app.router_groups.advisory import (
+    ADVISOR_BOOK_ROUTERS,
     ADVISOR_COCKPIT_ROUTERS,
     ADVISORY_COPILOT_ROUTERS,
     ADVISORY_POLICY_ROUTERS,
@@ -233,6 +234,7 @@ OPERATIONS_ROUTERS: RouterGroup = (
 IDEA_ROUTERS: RouterGroup = (ideas_router, ideas_actions_router)
 
 ROUTER_GROUPS: tuple[RouterGroup, ...] = (
+    ADVISOR_BOOK_ROUTERS,
     ADVISOR_COCKPIT_ROUTERS,
     BANK_DEMO_PROOF_ROUTERS,
     ADVISORY_WORKSPACE_ROUTERS,

--- a/src/app/routers/advisor_book.py
+++ b/src/app/routers/advisor_book.py
@@ -1,12 +1,16 @@
-from datetime import date
-from typing import Annotated, Literal
+from typing import Annotated
 
-from fastapi import APIRouter, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
 from app.contracts.advisor_book import AdvisorBookErrorResponse, AdvisorBookResponse
 from app.contracts.advisor_book_examples import ADVISOR_BOOK_RESPONSE_EXAMPLE
 from app.middleware.correlation import correlation_id_var
+from app.routers.advisor_book_request import (
+    AdvisorBookCallerHeaders,
+    advisor_book_caller_headers,
+    advisor_book_query,
+)
 from app.services.advisor_book_access_policy import (
     AdvisorBookCallerContextError,
     require_advisor_book_caller_context,
@@ -19,43 +23,23 @@ router = APIRouter(prefix="/api/v1/advisor-book", tags=["advisor-book"])
 
 async def _get_advisor_book(
     *,
-    as_of_date: date,
-    client_id: str | None,
-    mandate_type: Literal["ADVISORY", "DISCRETIONARY"] | None,
-    sort_by: Literal["portfolio_id", "client_id", "mandate_type"],
-    sort_order: Literal["asc", "desc"],
-    offset: int,
-    limit: int,
-    actor_id: str | None,
-    caller_application: str | None,
-    tenant_id: str | None,
-    region: str | None,
-    booking_center_code: str | None,
-    role: str | None,
-    capabilities: str | None,
+    query: AdvisorBookQuery,
+    caller_headers: AdvisorBookCallerHeaders,
 ) -> AdvisorBookResponse | JSONResponse:
     correlation_id = correlation_id_var.get()
     try:
         caller = require_advisor_book_caller_context(
-            actor_id=actor_id,
-            caller_application=caller_application,
-            tenant_id=tenant_id,
-            region=region,
-            booking_center_code=booking_center_code,
-            role=role,
-            capabilities=capabilities,
+            actor_id=caller_headers.actor_id,
+            caller_application=caller_headers.caller_application,
+            tenant_id=caller_headers.tenant_id,
+            region=caller_headers.region,
+            booking_center_code=caller_headers.booking_center_code,
+            role=caller_headers.role,
+            capabilities=caller_headers.capabilities,
         )
         return await advisor_book_service().get_advisor_book(
             caller=caller,
-            query=AdvisorBookQuery(
-                as_of_date=as_of_date,
-                client_id=_optional_filter(client_id),
-                mandate_type=mandate_type,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                offset=offset,
-                limit=limit,
-            ),
+            query=query,
             correlation_id=correlation_id,
         )
     except (AdvisorBookCallerContextError, AdvisorBookServiceError) as exc:
@@ -65,21 +49,6 @@ async def _get_advisor_book(
             message=exc.message,
             correlation_id=correlation_id,
         )
-
-
-def _optional_filter(value: str | None) -> str | None:
-    if value is None:
-        return None
-    cleaned = value.strip()
-    if not cleaned:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={
-                "code": "advisor_book_filter_invalid",
-                "message": "Advisor-book filters must contain a business identifier.",
-            },
-        )
-    return cleaned
 
 
 def _error_response(
@@ -126,67 +95,10 @@ def _error_response(
     },
 )
 async def get_advisor_book(
-    as_of_date: Annotated[
-        date,
-        Query(
-            alias="asOfDate",
-            description="Business date used to resolve effective advisor-book membership.",
-            examples=["2026-04-10"],
-        ),
-    ],
-    client_id: Annotated[
-        str | None,
-        Query(
-            alias="clientId",
-            min_length=1,
-            max_length=128,
-            description="Optional exact client identifier within the authenticated book.",
-        ),
-    ] = None,
-    mandate_type: Annotated[
-        Literal["ADVISORY", "DISCRETIONARY"] | None,
-        Query(
-            alias="mandateType",
-            description="Optional supported mandate type within the authenticated book.",
-        ),
-    ] = None,
-    sort_by: Annotated[
-        Literal["portfolio_id", "client_id", "mandate_type"],
-        Query(alias="sortBy", description="Business field used for deterministic ordering."),
-    ] = "portfolio_id",
-    sort_order: Annotated[
-        Literal["asc", "desc"],
-        Query(alias="sortOrder", description="Deterministic result ordering direction."),
-    ] = "asc",
-    offset: Annotated[
-        int,
-        Query(ge=0, description="Zero-based result offset within the authenticated book."),
-    ] = 0,
-    limit: Annotated[
-        int,
-        Query(ge=1, le=100, description="Maximum number of portfolios returned on this page."),
-    ] = 25,
-    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
-    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
-    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
-    region: Annotated[str | None, Header(alias="X-Region")] = None,
-    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
-    role: Annotated[str | None, Header(alias="X-Role")] = None,
-    capabilities: Annotated[str | None, Header(alias="X-Caller-Capabilities")] = None,
+    query: Annotated[AdvisorBookQuery, Depends(advisor_book_query)],
+    caller_headers: Annotated[AdvisorBookCallerHeaders, Depends(advisor_book_caller_headers)],
 ) -> AdvisorBookResponse | JSONResponse:
     return await _get_advisor_book(
-        as_of_date=as_of_date,
-        client_id=client_id,
-        mandate_type=mandate_type,
-        sort_by=sort_by,
-        sort_order=sort_order,
-        offset=offset,
-        limit=limit,
-        actor_id=actor_id,
-        caller_application=caller_application,
-        tenant_id=tenant_id,
-        region=region,
-        booking_center_code=booking_center_code,
-        role=role,
-        capabilities=capabilities,
+        query=query,
+        caller_headers=caller_headers,
     )

--- a/src/app/routers/advisor_book.py
+++ b/src/app/routers/advisor_book.py
@@ -1,0 +1,192 @@
+from datetime import date
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Header, HTTPException, Query, status
+from fastapi.responses import JSONResponse
+
+from app.contracts.advisor_book import AdvisorBookErrorResponse, AdvisorBookResponse
+from app.contracts.advisor_book_examples import ADVISOR_BOOK_RESPONSE_EXAMPLE
+from app.middleware.correlation import correlation_id_var
+from app.services.advisor_book_access_policy import (
+    AdvisorBookCallerContextError,
+    require_advisor_book_caller_context,
+)
+from app.services.advisor_book_service import AdvisorBookQuery, AdvisorBookServiceError
+from app.services.advisor_book_service_provider import advisor_book_service
+
+router = APIRouter(prefix="/api/v1/advisor-book", tags=["advisor-book"])
+
+
+async def _get_advisor_book(
+    *,
+    as_of_date: date,
+    client_id: str | None,
+    mandate_type: Literal["ADVISORY", "DISCRETIONARY"] | None,
+    sort_by: Literal["portfolio_id", "client_id", "mandate_type"],
+    sort_order: Literal["asc", "desc"],
+    offset: int,
+    limit: int,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+    capabilities: str | None,
+) -> AdvisorBookResponse | JSONResponse:
+    correlation_id = correlation_id_var.get()
+    try:
+        caller = require_advisor_book_caller_context(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            role=role,
+            capabilities=capabilities,
+        )
+        return await advisor_book_service().get_advisor_book(
+            caller=caller,
+            query=AdvisorBookQuery(
+                as_of_date=as_of_date,
+                client_id=_optional_filter(client_id),
+                mandate_type=mandate_type,
+                sort_by=sort_by,
+                sort_order=sort_order,
+                offset=offset,
+                limit=limit,
+            ),
+            correlation_id=correlation_id,
+        )
+    except (AdvisorBookCallerContextError, AdvisorBookServiceError) as exc:
+        return _error_response(
+            status_code=exc.status_code,
+            code=exc.code,
+            message=exc.message,
+            correlation_id=correlation_id,
+        )
+
+
+def _optional_filter(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": "advisor_book_filter_invalid",
+                "message": "Advisor-book filters must contain a business identifier.",
+            },
+        )
+    return cleaned
+
+
+def _error_response(
+    *, status_code: int, code: str, message: str, correlation_id: str
+) -> JSONResponse:
+    error = AdvisorBookErrorResponse(
+        code=code,
+        message=message,
+        correlation_id=correlation_id,
+    )
+    return JSONResponse(status_code=status_code, content=error.model_dump(mode="json"))
+
+
+@router.get(
+    "/portfolios",
+    response_model=AdvisorBookResponse,
+    summary="Get my advisor book",
+    description=(
+        "Returns the authenticated advisor's source-backed portfolio book for the requested "
+        "business date and trusted booking centre. The scope is derived only from trusted caller "
+        "context; callers cannot request another advisor's book. Results may be filtered, sorted, "
+        "and paged without widening the Core membership cohort. The response explicitly reports "
+        "tenant-scope and legacy-membership limitations and does not claim delegated, team, "
+        "household, assets-under-management, or attention-indicator coverage."
+    ),
+    responses={
+        200: {
+            "description": "Source-backed portfolios in the authenticated advisor's own book.",
+            "content": {"application/json": {"example": ADVISOR_BOOK_RESPONSE_EXAMPLE}},
+        },
+        400: {
+            "model": AdvisorBookErrorResponse,
+            "description": "Required trusted advisor context is missing or invalid.",
+        },
+        403: {
+            "model": AdvisorBookErrorResponse,
+            "description": "The caller is not entitled to the requested own-book experience.",
+        },
+        422: {"description": "A business-date, filter, sort, or paging input is invalid."},
+        502: {
+            "model": AdvisorBookErrorResponse,
+            "description": "The source book is unavailable or could not be safely verified.",
+        },
+    },
+)
+async def get_advisor_book(
+    as_of_date: Annotated[
+        date,
+        Query(
+            alias="asOfDate",
+            description="Business date used to resolve effective advisor-book membership.",
+            examples=["2026-04-10"],
+        ),
+    ],
+    client_id: Annotated[
+        str | None,
+        Query(
+            alias="clientId",
+            min_length=1,
+            max_length=128,
+            description="Optional exact client identifier within the authenticated book.",
+        ),
+    ] = None,
+    mandate_type: Annotated[
+        Literal["ADVISORY", "DISCRETIONARY"] | None,
+        Query(
+            alias="mandateType",
+            description="Optional supported mandate type within the authenticated book.",
+        ),
+    ] = None,
+    sort_by: Annotated[
+        Literal["portfolio_id", "client_id", "mandate_type"],
+        Query(alias="sortBy", description="Business field used for deterministic ordering."),
+    ] = "portfolio_id",
+    sort_order: Annotated[
+        Literal["asc", "desc"],
+        Query(alias="sortOrder", description="Deterministic result ordering direction."),
+    ] = "asc",
+    offset: Annotated[
+        int,
+        Query(ge=0, description="Zero-based result offset within the authenticated book."),
+    ] = 0,
+    limit: Annotated[
+        int,
+        Query(ge=1, le=100, description="Maximum number of portfolios returned on this page."),
+    ] = 25,
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+    capabilities: Annotated[str | None, Header(alias="X-Caller-Capabilities")] = None,
+) -> AdvisorBookResponse | JSONResponse:
+    return await _get_advisor_book(
+        as_of_date=as_of_date,
+        client_id=client_id,
+        mandate_type=mandate_type,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        offset=offset,
+        limit=limit,
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+        capabilities=capabilities,
+    )

--- a/src/app/routers/advisor_book_request.py
+++ b/src/app/routers/advisor_book_request.py
@@ -1,0 +1,114 @@
+from dataclasses import dataclass
+from datetime import date
+from typing import Annotated, Literal
+
+from fastapi import Header, HTTPException, Query, status
+
+from app.services.advisor_book_service import AdvisorBookQuery
+
+_AsOfDate = Annotated[
+    date,
+    Query(
+        alias="asOfDate",
+        description="Business date used to resolve effective advisor-book membership.",
+        examples=["2026-04-10"],
+    ),
+]
+_ClientId = Annotated[
+    str | None,
+    Query(
+        alias="clientId",
+        min_length=1,
+        max_length=128,
+        description="Optional exact client identifier within the authenticated book.",
+    ),
+]
+_MandateType = Annotated[
+    Literal["ADVISORY", "DISCRETIONARY"] | None,
+    Query(
+        alias="mandateType",
+        description="Optional supported mandate type within the authenticated book.",
+    ),
+]
+_SortBy = Annotated[
+    Literal["portfolio_id", "client_id", "mandate_type"],
+    Query(alias="sortBy", description="Business field used for deterministic ordering."),
+]
+_SortOrder = Annotated[
+    Literal["asc", "desc"],
+    Query(alias="sortOrder", description="Deterministic result ordering direction."),
+]
+_Offset = Annotated[
+    int,
+    Query(ge=0, description="Zero-based result offset within the authenticated book."),
+]
+_Limit = Annotated[
+    int,
+    Query(ge=1, le=100, description="Maximum number of portfolios returned on this page."),
+]
+
+
+@dataclass(frozen=True)
+class AdvisorBookCallerHeaders:
+    actor_id: str | None
+    caller_application: str | None
+    tenant_id: str | None
+    region: str | None
+    booking_center_code: str | None
+    role: str | None
+    capabilities: str | None
+
+
+def advisor_book_caller_headers(
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+    capabilities: Annotated[str | None, Header(alias="X-Caller-Capabilities")] = None,
+) -> AdvisorBookCallerHeaders:
+    return AdvisorBookCallerHeaders(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+        capabilities=capabilities,
+    )
+
+
+def advisor_book_query(
+    as_of_date: _AsOfDate,
+    client_id: _ClientId = None,
+    mandate_type: _MandateType = None,
+    sort_by: _SortBy = "portfolio_id",
+    sort_order: _SortOrder = "asc",
+    offset: _Offset = 0,
+    limit: _Limit = 25,
+) -> AdvisorBookQuery:
+    return AdvisorBookQuery(
+        as_of_date=as_of_date,
+        client_id=_optional_filter(client_id),
+        mandate_type=mandate_type,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        offset=offset,
+        limit=limit,
+    )
+
+
+def _optional_filter(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": "advisor_book_filter_invalid",
+                "message": "Advisor-book filters must contain a business identifier.",
+            },
+        )
+    return cleaned

--- a/src/app/services/advisor_book_access_policy.py
+++ b/src/app/services/advisor_book_access_policy.py
@@ -34,7 +34,38 @@ def require_advisor_book_caller_context(
     role: str | None,
     capabilities: str | None,
 ) -> AdvisorBookCallerContext:
-    cleaned = {
+    cleaned = _required_caller_fields(
+        actor_id=actor_id,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        role=role,
+        capabilities=capabilities,
+    )
+    resolved_actor_id = cleaned["X-Actor-Id"]
+    resolved_role = cleaned["X-Role"]
+    _validate_actor_id(resolved_actor_id)
+    _validate_access(role=resolved_role, capabilities=cleaned["X-Caller-Capabilities"])
+    return AdvisorBookCallerContext(
+        portfolio_manager_id=resolved_actor_id,
+        tenant_id=cleaned["X-Tenant-Id"],
+        region=cleaned["X-Region"],
+        booking_center_code=cleaned["X-Booking-Center-Code"],
+        role=resolved_role,
+        caller_application=_clean(caller_application) or "lotus-gateway",
+    )
+
+
+def _required_caller_fields(
+    *,
+    actor_id: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+    capabilities: str | None,
+) -> dict[str, str]:
+    fields = {
         "X-Actor-Id": _clean(actor_id),
         "X-Tenant-Id": _clean(tenant_id),
         "X-Region": _clean(region),
@@ -42,42 +73,34 @@ def require_advisor_book_caller_context(
         "X-Role": _clean(role),
         "X-Caller-Capabilities": _clean(capabilities),
     }
-    missing = [name for name, value in cleaned.items() if value is None]
+    missing = [name for name, value in fields.items() if value is None]
     if missing:
         raise AdvisorBookCallerContextError(
             code="advisor_book_caller_context_missing",
             message="Required advisor-book caller context is missing.",
             status_code=400,
         )
+    return {name: value for name, value in fields.items() if value is not None}
 
-    resolved_actor_id = cleaned["X-Actor-Id"] or ""
-    if not _ACTOR_ID_PATTERN.fullmatch(resolved_actor_id):
+
+def _validate_actor_id(actor_id: str) -> None:
+    if not _ACTOR_ID_PATTERN.fullmatch(actor_id):
         raise AdvisorBookCallerContextError(
             code="advisor_book_caller_context_invalid",
             message="Advisor-book caller identity is invalid.",
             status_code=400,
         )
 
-    resolved_role = cleaned["X-Role"] or ""
-    resolved_capabilities = _capability_set(cleaned["X-Caller-Capabilities"] or "")
-    if (
-        resolved_role not in ADVISOR_BOOK_ROLES
-        or ADVISOR_BOOK_READ_CAPABILITY not in resolved_capabilities
+
+def _validate_access(*, role: str, capabilities: str) -> None:
+    if role not in ADVISOR_BOOK_ROLES or ADVISOR_BOOK_READ_CAPABILITY not in _capability_set(
+        capabilities
     ):
         raise AdvisorBookCallerContextError(
             code="advisor_book_access_denied",
             message="Advisor-book access is not available for this caller.",
             status_code=403,
         )
-
-    return AdvisorBookCallerContext(
-        portfolio_manager_id=resolved_actor_id,
-        tenant_id=cleaned["X-Tenant-Id"] or "",
-        region=cleaned["X-Region"] or "",
-        booking_center_code=cleaned["X-Booking-Center-Code"] or "",
-        role=resolved_role,
-        caller_application=_clean(caller_application) or "lotus-gateway",
-    )
 
 
 def _capability_set(value: str) -> frozenset[str]:

--- a/src/app/services/advisor_book_access_policy.py
+++ b/src/app/services/advisor_book_access_policy.py
@@ -1,0 +1,91 @@
+import re
+from dataclasses import dataclass
+
+ADVISOR_BOOK_READ_CAPABILITY = "advisor.book.read"
+ADVISOR_BOOK_ROLES = frozenset({"ADVISOR", "RELATIONSHIP_MANAGER", "PORTFOLIO_MANAGER"})
+_ACTOR_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+@dataclass(frozen=True)
+class AdvisorBookCallerContext:
+    portfolio_manager_id: str
+    tenant_id: str
+    region: str
+    booking_center_code: str
+    role: str
+    caller_application: str
+
+
+class AdvisorBookCallerContextError(ValueError):
+    def __init__(self, *, code: str, message: str, status_code: int):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+def require_advisor_book_caller_context(
+    *,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    role: str | None,
+    capabilities: str | None,
+) -> AdvisorBookCallerContext:
+    cleaned = {
+        "X-Actor-Id": _clean(actor_id),
+        "X-Tenant-Id": _clean(tenant_id),
+        "X-Region": _clean(region),
+        "X-Booking-Center-Code": _clean(booking_center_code),
+        "X-Role": _clean(role),
+        "X-Caller-Capabilities": _clean(capabilities),
+    }
+    missing = [name for name, value in cleaned.items() if value is None]
+    if missing:
+        raise AdvisorBookCallerContextError(
+            code="advisor_book_caller_context_missing",
+            message="Required advisor-book caller context is missing.",
+            status_code=400,
+        )
+
+    resolved_actor_id = cleaned["X-Actor-Id"] or ""
+    if not _ACTOR_ID_PATTERN.fullmatch(resolved_actor_id):
+        raise AdvisorBookCallerContextError(
+            code="advisor_book_caller_context_invalid",
+            message="Advisor-book caller identity is invalid.",
+            status_code=400,
+        )
+
+    resolved_role = cleaned["X-Role"] or ""
+    resolved_capabilities = _capability_set(cleaned["X-Caller-Capabilities"] or "")
+    if (
+        resolved_role not in ADVISOR_BOOK_ROLES
+        or ADVISOR_BOOK_READ_CAPABILITY not in resolved_capabilities
+    ):
+        raise AdvisorBookCallerContextError(
+            code="advisor_book_access_denied",
+            message="Advisor-book access is not available for this caller.",
+            status_code=403,
+        )
+
+    return AdvisorBookCallerContext(
+        portfolio_manager_id=resolved_actor_id,
+        tenant_id=cleaned["X-Tenant-Id"] or "",
+        region=cleaned["X-Region"] or "",
+        booking_center_code=cleaned["X-Booking-Center-Code"] or "",
+        role=resolved_role,
+        caller_application=_clean(caller_application) or "lotus-gateway",
+    )
+
+
+def _capability_set(value: str) -> frozenset[str]:
+    return frozenset(part.strip() for part in value.split(",") if part.strip())
+
+
+def _clean(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None

--- a/src/app/services/advisor_book_client_protocols.py
+++ b/src/app/services/advisor_book_client_protocols.py
@@ -1,0 +1,13 @@
+from typing import Any, Protocol
+
+
+class AdvisorBookMembershipClient(Protocol):
+    async def get_portfolio_manager_book_memberships(
+        self,
+        *,
+        portfolio_manager_id: str,
+        as_of_date: str,
+        booking_center_code: str,
+        portfolio_types: list[str],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]: ...

--- a/src/app/services/advisor_book_service.py
+++ b/src/app/services/advisor_book_service.py
@@ -10,7 +10,6 @@ from app.contracts.advisor_book import (
     AdvisorBookProvenance,
     AdvisorBookResponse,
     AdvisorBookScope,
-    AdvisorBookSupportability,
 )
 from app.services.advisor_book_access_policy import AdvisorBookCallerContext
 from app.services.advisor_book_client_protocols import AdvisorBookMembershipClient
@@ -18,19 +17,16 @@ from app.services.advisor_book_source_contract import (
     SourceAdvisorBookMember,
     SourceAdvisorBookResponse,
 )
+from app.services.advisor_book_supportability import (
+    advisor_book_supportability,
+    empty_advisor_book_supportability,
+)
 
 AdvisorBookSortField = Literal["portfolio_id", "client_id", "mandate_type"]
 AdvisorBookSortOrder = Literal["asc", "desc"]
 AdvisorBookMandateType = Literal["ADVISORY", "DISCRETIONARY"]
 
 _SUPPORTED_PORTFOLIO_TYPES = ["ADVISORY", "DISCRETIONARY"]
-_BASE_LIMITATIONS = [
-    "delegated_scope_not_supported",
-    "team_scope_not_supported",
-    "household_scope_not_supported",
-    "assets_under_management_not_reported",
-    "attention_indicators_not_reported",
-]
 
 
 @dataclass(frozen=True)
@@ -146,7 +142,7 @@ def _project_response(
             sort_order=query.sort_order,
         ),
         items=[_portfolio(member) for member in page_members],
-        supportability=_supportability(source=source, filtered_count=len(filtered)),
+        supportability=advisor_book_supportability(source=source, filtered_count=len(filtered)),
         provenance=AdvisorBookProvenance(
             product_name=source.product_name,
             product_version=source.product_version,
@@ -197,61 +193,6 @@ def _portfolio(member: SourceAdvisorBookMember) -> AdvisorBookPortfolio:
     )
 
 
-def _supportability(
-    *, source: SourceAdvisorBookResponse, filtered_count: int
-) -> AdvisorBookSupportability:
-    limitations = list(_BASE_LIMITATIONS)
-    tenant_scope: Literal["source_confirmed", "trusted_context_only"] = "source_confirmed"
-    has_legacy_projection = any(
-        member.membership_source == "legacy_advisor_projection" for member in source.members
-    )
-    if source.tenant_id is None:
-        tenant_scope = "trusted_context_only"
-        limitations.insert(0, "tenant_scope_not_reported")
-    if has_legacy_projection:
-        limitations.append("legacy_advisor_projection_present")
-
-    if not source.members:
-        return AdvisorBookSupportability(
-            state="empty",
-            reason_code="advisor_book_empty",
-            tenant_scope=tenant_scope,
-            limitations=limitations,
-        )
-    reason_code: Literal[
-        "advisor_book_source_incomplete",
-        "advisor_book_tenant_scope_not_reported",
-        "advisor_book_legacy_projection",
-    ]
-    if source.supportability.state == "INCOMPLETE":
-        limitations.append("source_membership_incomplete")
-        reason_code = "advisor_book_source_incomplete"
-    elif source.tenant_id is None:
-        reason_code = "advisor_book_tenant_scope_not_reported"
-    elif has_legacy_projection:
-        reason_code = "advisor_book_legacy_projection"
-    elif filtered_count == 0:
-        return AdvisorBookSupportability(
-            state="empty",
-            reason_code="advisor_book_filter_empty",
-            tenant_scope=tenant_scope,
-            limitations=limitations,
-        )
-    else:
-        return AdvisorBookSupportability(
-            state="ready",
-            reason_code="advisor_book_ready",
-            tenant_scope=tenant_scope,
-            limitations=limitations,
-        )
-    return AdvisorBookSupportability(
-        state="degraded",
-        reason_code=reason_code,
-        tenant_scope=tenant_scope,
-        limitations=limitations,
-    )
-
-
 def _empty_response(
     *,
     caller: AdvisorBookCallerContext,
@@ -270,12 +211,7 @@ def _empty_response(
             sort_order=query.sort_order,
         ),
         items=[],
-        supportability=AdvisorBookSupportability(
-            state="empty",
-            reason_code="advisor_book_empty",
-            tenant_scope="trusted_context_only",
-            limitations=["tenant_scope_not_reported", *_BASE_LIMITATIONS],
-        ),
+        supportability=empty_advisor_book_supportability(),
         provenance=None,
     )
 

--- a/src/app/services/advisor_book_service.py
+++ b/src/app/services/advisor_book_service.py
@@ -1,0 +1,305 @@
+from dataclasses import dataclass
+from datetime import date
+from typing import Literal
+
+from pydantic import ValidationError
+
+from app.contracts.advisor_book import (
+    AdvisorBookPage,
+    AdvisorBookPortfolio,
+    AdvisorBookProvenance,
+    AdvisorBookResponse,
+    AdvisorBookScope,
+    AdvisorBookSupportability,
+)
+from app.services.advisor_book_access_policy import AdvisorBookCallerContext
+from app.services.advisor_book_client_protocols import AdvisorBookMembershipClient
+from app.services.advisor_book_source_contract import (
+    SourceAdvisorBookMember,
+    SourceAdvisorBookResponse,
+)
+
+AdvisorBookSortField = Literal["portfolio_id", "client_id", "mandate_type"]
+AdvisorBookSortOrder = Literal["asc", "desc"]
+AdvisorBookMandateType = Literal["ADVISORY", "DISCRETIONARY"]
+
+_SUPPORTED_PORTFOLIO_TYPES = ["ADVISORY", "DISCRETIONARY"]
+_BASE_LIMITATIONS = [
+    "delegated_scope_not_supported",
+    "team_scope_not_supported",
+    "household_scope_not_supported",
+    "assets_under_management_not_reported",
+    "attention_indicators_not_reported",
+]
+
+
+@dataclass(frozen=True)
+class AdvisorBookQuery:
+    as_of_date: date
+    client_id: str | None = None
+    mandate_type: AdvisorBookMandateType | None = None
+    sort_by: AdvisorBookSortField = "portfolio_id"
+    sort_order: AdvisorBookSortOrder = "asc"
+    offset: int = 0
+    limit: int = 25
+
+
+class AdvisorBookServiceError(RuntimeError):
+    def __init__(self, *, code: str, message: str, status_code: int):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+class AdvisorBookService:
+    def __init__(self, *, membership_client: AdvisorBookMembershipClient) -> None:
+        self._membership_client = membership_client
+
+    async def get_advisor_book(
+        self,
+        *,
+        caller: AdvisorBookCallerContext,
+        query: AdvisorBookQuery,
+        correlation_id: str,
+    ) -> AdvisorBookResponse:
+        try:
+            (
+                status_code,
+                payload,
+            ) = await self._membership_client.get_portfolio_manager_book_memberships(
+                portfolio_manager_id=caller.portfolio_manager_id,
+                as_of_date=query.as_of_date.isoformat(),
+                booking_center_code=caller.booking_center_code,
+                portfolio_types=_SUPPORTED_PORTFOLIO_TYPES,
+                correlation_id=correlation_id,
+            )
+        except Exception as exc:
+            raise _source_unavailable() from exc
+
+        if status_code == 404:
+            return _empty_response(caller=caller, query=query, correlation_id=correlation_id)
+        if status_code != 200:
+            raise _source_unavailable()
+
+        try:
+            source = SourceAdvisorBookResponse.model_validate(payload)
+        except ValidationError as exc:
+            raise _source_contract_invalid() from exc
+        _validate_source_scope(source=source, caller=caller, query=query)
+        return _project_response(
+            source=source,
+            caller=caller,
+            query=query,
+            correlation_id=correlation_id,
+        )
+
+
+def _validate_source_scope(
+    *,
+    source: SourceAdvisorBookResponse,
+    caller: AdvisorBookCallerContext,
+    query: AdvisorBookQuery,
+) -> None:
+    if (
+        source.portfolio_manager_id != caller.portfolio_manager_id
+        or source.booking_center_code != caller.booking_center_code
+        or source.as_of_date != query.as_of_date
+        or source.supportability.returned_portfolio_count != len(source.members)
+        or any(
+            member.booking_center_code != caller.booking_center_code for member in source.members
+        )
+        or len({member.portfolio_id for member in source.members}) != len(source.members)
+    ):
+        raise _source_contract_invalid()
+    if source.tenant_id is not None and source.tenant_id != caller.tenant_id:
+        raise AdvisorBookServiceError(
+            code="advisor_book_tenant_scope_mismatch",
+            message="Advisor-book access is not available for this tenant scope.",
+            status_code=403,
+        )
+
+
+def _project_response(
+    *,
+    source: SourceAdvisorBookResponse,
+    caller: AdvisorBookCallerContext,
+    query: AdvisorBookQuery,
+    correlation_id: str,
+) -> AdvisorBookResponse:
+    filtered = [member for member in source.members if _matches(member, query)]
+    ordered = sorted(
+        filtered,
+        key=lambda member: (_sort_value(member, query.sort_by), member.portfolio_id),
+        reverse=query.sort_order == "desc",
+    )
+    page_members = ordered[query.offset : query.offset + query.limit]
+    return AdvisorBookResponse(
+        correlation_id=correlation_id,
+        scope=_scope(caller, query),
+        page=AdvisorBookPage(
+            total_count=len(filtered),
+            offset=query.offset,
+            limit=query.limit,
+            returned_count=len(page_members),
+            sort_by=query.sort_by,
+            sort_order=query.sort_order,
+        ),
+        items=[_portfolio(member) for member in page_members],
+        supportability=_supportability(source=source, filtered_count=len(filtered)),
+        provenance=AdvisorBookProvenance(
+            product_name=source.product_name,
+            product_version=source.product_version,
+            generated_at=source.generated_at,
+            latest_evidence_timestamp=source.latest_evidence_timestamp,
+            freshness_status=source.freshness_status,
+            data_quality_status=source.data_quality_status,
+            source_evidence_current=source.source_evidence_current,
+            snapshot_id=source.snapshot_id,
+            content_hash=source.content_hash,
+            lineage=source.lineage,
+        ),
+    )
+
+
+def _matches(member: SourceAdvisorBookMember, query: AdvisorBookQuery) -> bool:
+    return (query.client_id is None or member.client_id == query.client_id) and (
+        query.mandate_type is None or member.portfolio_type == query.mandate_type
+    )
+
+
+def _sort_value(member: SourceAdvisorBookMember, sort_by: AdvisorBookSortField) -> str:
+    if sort_by == "client_id":
+        return member.client_id
+    if sort_by == "mandate_type":
+        return member.portfolio_type
+    return member.portfolio_id
+
+
+def _portfolio(member: SourceAdvisorBookMember) -> AdvisorBookPortfolio:
+    return AdvisorBookPortfolio(
+        portfolio_id=member.portfolio_id,
+        display_name=member.portfolio_id,
+        client_id=member.client_id,
+        base_currency=member.base_currency,
+        booking_center_code=member.booking_center_code,
+        mandate_type=member.portfolio_type,
+        status=member.status,
+        opened_on=member.open_date,
+        closed_on=member.close_date,
+        membership_source="PortfolioManagerBookMembership:v1",
+        membership_reference=member.source_record_id,
+        membership_basis=(
+            "governed_role_assignment"
+            if member.membership_source == "party_role_assignment"
+            else "legacy_advisor_projection"
+        ),
+    )
+
+
+def _supportability(
+    *, source: SourceAdvisorBookResponse, filtered_count: int
+) -> AdvisorBookSupportability:
+    limitations = list(_BASE_LIMITATIONS)
+    tenant_scope: Literal["source_confirmed", "trusted_context_only"] = "source_confirmed"
+    has_legacy_projection = any(
+        member.membership_source == "legacy_advisor_projection" for member in source.members
+    )
+    if source.tenant_id is None:
+        tenant_scope = "trusted_context_only"
+        limitations.insert(0, "tenant_scope_not_reported")
+    if has_legacy_projection:
+        limitations.append("legacy_advisor_projection_present")
+
+    if not source.members:
+        return AdvisorBookSupportability(
+            state="empty",
+            reason_code="advisor_book_empty",
+            tenant_scope=tenant_scope,
+            limitations=limitations,
+        )
+    reason_code: Literal[
+        "advisor_book_source_incomplete",
+        "advisor_book_tenant_scope_not_reported",
+        "advisor_book_legacy_projection",
+    ]
+    if source.supportability.state == "INCOMPLETE":
+        limitations.append("source_membership_incomplete")
+        reason_code = "advisor_book_source_incomplete"
+    elif source.tenant_id is None:
+        reason_code = "advisor_book_tenant_scope_not_reported"
+    elif has_legacy_projection:
+        reason_code = "advisor_book_legacy_projection"
+    elif filtered_count == 0:
+        return AdvisorBookSupportability(
+            state="empty",
+            reason_code="advisor_book_filter_empty",
+            tenant_scope=tenant_scope,
+            limitations=limitations,
+        )
+    else:
+        return AdvisorBookSupportability(
+            state="ready",
+            reason_code="advisor_book_ready",
+            tenant_scope=tenant_scope,
+            limitations=limitations,
+        )
+    return AdvisorBookSupportability(
+        state="degraded",
+        reason_code=reason_code,
+        tenant_scope=tenant_scope,
+        limitations=limitations,
+    )
+
+
+def _empty_response(
+    *,
+    caller: AdvisorBookCallerContext,
+    query: AdvisorBookQuery,
+    correlation_id: str,
+) -> AdvisorBookResponse:
+    return AdvisorBookResponse(
+        correlation_id=correlation_id,
+        scope=_scope(caller, query),
+        page=AdvisorBookPage(
+            total_count=0,
+            offset=query.offset,
+            limit=query.limit,
+            returned_count=0,
+            sort_by=query.sort_by,
+            sort_order=query.sort_order,
+        ),
+        items=[],
+        supportability=AdvisorBookSupportability(
+            state="empty",
+            reason_code="advisor_book_empty",
+            tenant_scope="trusted_context_only",
+            limitations=["tenant_scope_not_reported", *_BASE_LIMITATIONS],
+        ),
+        provenance=None,
+    )
+
+
+def _scope(caller: AdvisorBookCallerContext, query: AdvisorBookQuery) -> AdvisorBookScope:
+    return AdvisorBookScope(
+        kind="own_book",
+        label="My book",
+        as_of_date=query.as_of_date,
+        booking_center_code=caller.booking_center_code,
+    )
+
+
+def _source_unavailable() -> AdvisorBookServiceError:
+    return AdvisorBookServiceError(
+        code="advisor_book_source_unavailable",
+        message="Advisor-book information is temporarily unavailable.",
+        status_code=502,
+    )
+
+
+def _source_contract_invalid() -> AdvisorBookServiceError:
+    return AdvisorBookServiceError(
+        code="advisor_book_source_contract_invalid",
+        message="Advisor-book information could not be safely verified.",
+        status_code=502,
+    )

--- a/src/app/services/advisor_book_service_factory.py
+++ b/src/app/services/advisor_book_service_factory.py
@@ -1,0 +1,13 @@
+from app.services.advisor_book_service import AdvisorBookService
+from app.services.lotus_core_client_factory import (
+    build_lotus_core_query_client,
+    lotus_core_query_client_signature,
+)
+
+
+def advisor_book_service_signature() -> tuple[object, ...]:
+    return lotus_core_query_client_signature()
+
+
+def build_advisor_book_service() -> AdvisorBookService:
+    return AdvisorBookService(membership_client=build_lotus_core_query_client())

--- a/src/app/services/advisor_book_service_provider.py
+++ b/src/app/services/advisor_book_service_provider.py
@@ -1,0 +1,22 @@
+from app.services.advisor_book_service import AdvisorBookService
+from app.services.advisor_book_service_factory import (
+    advisor_book_service_signature,
+    build_advisor_book_service,
+)
+from app.services.service_provider_cache import resolve_cached_service
+
+_ADVISOR_BOOK_SERVICE: AdvisorBookService | None = None
+_ADVISOR_BOOK_SERVICE_SIGNATURE: tuple[object, ...] | None = None
+
+
+def advisor_book_service() -> AdvisorBookService:
+    global _ADVISOR_BOOK_SERVICE, _ADVISOR_BOOK_SERVICE_SIGNATURE
+    service, signature = resolve_cached_service(
+        _ADVISOR_BOOK_SERVICE,
+        _ADVISOR_BOOK_SERVICE_SIGNATURE,
+        advisor_book_service_signature(),
+        build_advisor_book_service,
+    )
+    _ADVISOR_BOOK_SERVICE = service
+    _ADVISOR_BOOK_SERVICE_SIGNATURE = signature
+    return service

--- a/src/app/services/advisor_book_source_contract.py
+++ b/src/app/services/advisor_book_source_contract.py
@@ -1,0 +1,50 @@
+from datetime import date, datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SourceAdvisorBookMember(BaseModel):
+    portfolio_id: str
+    client_id: str
+    booking_center_code: str
+    portfolio_type: str
+    status: str
+    open_date: date
+    close_date: date | None = None
+    base_currency: str
+    source_record_id: str
+    membership_source: Literal["party_role_assignment", "legacy_advisor_projection"]
+    role_type: str | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class SourceAdvisorBookSupportability(BaseModel):
+    state: Literal["READY", "INCOMPLETE"]
+    reason: str
+    returned_portfolio_count: int = Field(ge=0)
+    filters_applied: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class SourceAdvisorBookResponse(BaseModel):
+    product_name: Literal["PortfolioManagerBookMembership"]
+    product_version: Literal["v1"]
+    portfolio_manager_id: str
+    tenant_id: str | None = None
+    generated_at: datetime
+    as_of_date: date
+    latest_evidence_timestamp: datetime | None = None
+    snapshot_id: str | None = None
+    content_hash: str
+    data_quality_status: str
+    source_evidence_current: bool
+    freshness_status: str
+    booking_center_code: str | None = None
+    members: list[SourceAdvisorBookMember] = Field(default_factory=list)
+    supportability: SourceAdvisorBookSupportability
+    lineage: dict[str, str] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="ignore")

--- a/src/app/services/advisor_book_supportability.py
+++ b/src/app/services/advisor_book_supportability.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+from typing import Literal
+
+from app.contracts.advisor_book import AdvisorBookSupportability
+from app.services.advisor_book_source_contract import SourceAdvisorBookResponse
+
+_BASE_LIMITATIONS = (
+    "delegated_scope_not_supported",
+    "team_scope_not_supported",
+    "household_scope_not_supported",
+    "assets_under_management_not_reported",
+    "attention_indicators_not_reported",
+)
+
+
+@dataclass(frozen=True)
+class _AdvisorBookSupportContext:
+    tenant_scope: Literal["source_confirmed", "trusted_context_only"]
+    limitations: tuple[str, ...]
+    has_legacy_projection: bool
+
+
+def advisor_book_supportability(
+    *, source: SourceAdvisorBookResponse, filtered_count: int
+) -> AdvisorBookSupportability:
+    context = _support_context(source)
+    if not source.members:
+        return AdvisorBookSupportability(
+            state="empty",
+            reason_code="advisor_book_empty",
+            tenant_scope=context.tenant_scope,
+            limitations=list(context.limitations),
+        )
+    reason_code: Literal[
+        "advisor_book_source_incomplete",
+        "advisor_book_tenant_scope_not_reported",
+        "advisor_book_legacy_projection",
+    ]
+    limitations = list(context.limitations)
+    if source.supportability.state == "INCOMPLETE":
+        limitations.append("source_membership_incomplete")
+        reason_code = "advisor_book_source_incomplete"
+    elif source.tenant_id is None:
+        reason_code = "advisor_book_tenant_scope_not_reported"
+    elif context.has_legacy_projection:
+        reason_code = "advisor_book_legacy_projection"
+    elif filtered_count == 0:
+        return AdvisorBookSupportability(
+            state="empty",
+            reason_code="advisor_book_filter_empty",
+            tenant_scope=context.tenant_scope,
+            limitations=list(context.limitations),
+        )
+    else:
+        return AdvisorBookSupportability(
+            state="ready",
+            reason_code="advisor_book_ready",
+            tenant_scope=context.tenant_scope,
+            limitations=list(context.limitations),
+        )
+    return AdvisorBookSupportability(
+        state="degraded",
+        reason_code=reason_code,
+        tenant_scope=context.tenant_scope,
+        limitations=limitations,
+    )
+
+
+def empty_advisor_book_supportability() -> AdvisorBookSupportability:
+    return AdvisorBookSupportability(
+        state="empty",
+        reason_code="advisor_book_empty",
+        tenant_scope="trusted_context_only",
+        limitations=["tenant_scope_not_reported", *_BASE_LIMITATIONS],
+    )
+
+
+def _support_context(source: SourceAdvisorBookResponse) -> _AdvisorBookSupportContext:
+    limitations = list(_BASE_LIMITATIONS)
+    has_legacy_projection = any(
+        member.membership_source == "legacy_advisor_projection" for member in source.members
+    )
+    if has_legacy_projection:
+        limitations.append("legacy_advisor_projection_present")
+    tenant_scope: Literal["source_confirmed", "trusted_context_only"] = "source_confirmed"
+    if source.tenant_id is None:
+        limitations.insert(0, "tenant_scope_not_reported")
+        tenant_scope = "trusted_context_only"
+    return _AdvisorBookSupportContext(
+        tenant_scope=tenant_scope,
+        limitations=tuple(limitations),
+        has_legacy_projection=has_legacy_projection,
+    )

--- a/tests/integration/test_advisor_book_router.py
+++ b/tests/integration/test_advisor_book_router.py
@@ -1,0 +1,157 @@
+from fastapi.testclient import TestClient
+
+from app.contracts.advisor_book import AdvisorBookResponse
+from app.contracts.advisor_book_examples import ADVISOR_BOOK_RESPONSE_EXAMPLE
+from app.main import app
+from app.services.advisor_book_service import AdvisorBookServiceError
+
+client = TestClient(app)
+
+
+class _AdvisorBookService:
+    def __init__(self, *, error: AdvisorBookServiceError | None = None) -> None:
+        self.error = error
+        self.calls: list[dict[str, object]] = []
+
+    async def get_advisor_book(self, **kwargs) -> AdvisorBookResponse:
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return AdvisorBookResponse.model_validate(ADVISOR_BOOK_RESPONSE_EXAMPLE)
+
+
+def _headers(**overrides: str) -> dict[str, str]:
+    headers = {
+        "X-Actor-Id": "PM_SG_001",
+        "X-Caller-Application": "lotus-workbench",
+        "X-Tenant-Id": "tenant-sg",
+        "X-Region": "APAC",
+        "X-Booking-Center-Code": "Singapore",
+        "X-Role": "ADVISOR",
+        "X-Caller-Capabilities": "advisor.book.read",
+        "X-Correlation-Id": "corr-advisor-book",
+    }
+    headers.update(overrides)
+    return headers
+
+
+def test_advisor_book_route_derives_own_book_scope_from_trusted_headers(monkeypatch) -> None:
+    service = _AdvisorBookService()
+    monkeypatch.setattr("app.routers.advisor_book.advisor_book_service", lambda: service)
+
+    response = client.get(
+        "/api/v1/advisor-book/portfolios",
+        params={
+            "asOfDate": "2026-04-10",
+            "clientId": " CIF_SG_001 ",
+            "mandateType": "ADVISORY",
+            "sortBy": "client_id",
+            "sortOrder": "desc",
+            "offset": 5,
+            "limit": 10,
+        },
+        headers=_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == ADVISOR_BOOK_RESPONSE_EXAMPLE
+    assert len(service.calls) == 1
+    call = service.calls[0]
+    assert call["caller"].portfolio_manager_id == "PM_SG_001"
+    assert call["caller"].tenant_id == "tenant-sg"
+    assert call["query"].client_id == "CIF_SG_001"
+    assert call["query"].mandate_type == "ADVISORY"
+    assert call["query"].sort_by == "client_id"
+    assert call["query"].offset == 5
+    assert call["correlation_id"] == "corr-advisor-book"
+
+
+def test_advisor_book_route_rejects_missing_trusted_context_before_service(monkeypatch) -> None:
+    service = _AdvisorBookService()
+    monkeypatch.setattr("app.routers.advisor_book.advisor_book_service", lambda: service)
+
+    response = client.get(
+        "/api/v1/advisor-book/portfolios",
+        params={"asOfDate": "2026-04-10"},
+        headers={"X-Actor-Id": "PM_SG_001"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "advisor_book_caller_context_missing"
+    assert service.calls == []
+
+
+def test_advisor_book_route_requires_exact_role_and_capability(monkeypatch) -> None:
+    service = _AdvisorBookService()
+    monkeypatch.setattr("app.routers.advisor_book.advisor_book_service", lambda: service)
+
+    response = client.get(
+        "/api/v1/advisor-book/portfolios",
+        params={"asOfDate": "2026-04-10"},
+        headers=_headers(**{"X-Caller-Capabilities": "advisor.book.read.all"}),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["code"] == "advisor_book_access_denied"
+    assert service.calls == []
+
+
+def test_advisor_book_route_returns_product_safe_source_error(monkeypatch) -> None:
+    service = _AdvisorBookService(
+        error=AdvisorBookServiceError(
+            code="advisor_book_source_unavailable",
+            message="Advisor-book information is temporarily unavailable.",
+            status_code=502,
+        )
+    )
+    monkeypatch.setattr("app.routers.advisor_book.advisor_book_service", lambda: service)
+
+    response = client.get(
+        "/api/v1/advisor-book/portfolios",
+        params={"asOfDate": "2026-04-10"},
+        headers=_headers(),
+    )
+
+    assert response.status_code == 502
+    assert response.json() == {
+        "code": "advisor_book_source_unavailable",
+        "message": "Advisor-book information is temporarily unavailable.",
+        "correlation_id": "corr-advisor-book",
+    }
+
+
+def test_advisor_book_route_rejects_blank_filter() -> None:
+    response = client.get(
+        "/api/v1/advisor-book/portfolios",
+        params={"asOfDate": "2026-04-10", "clientId": "   "},
+        headers=_headers(),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "advisor_book_filter_invalid"
+
+
+def test_advisor_book_openapi_exposes_bounded_own_book_contract() -> None:
+    operation = app.openapi()["paths"]["/api/v1/advisor-book/portfolios"]["get"]
+    parameters = {item["name"] for item in operation["parameters"]}
+    example = operation["responses"]["200"]["content"]["application/json"]["example"]
+
+    assert operation["summary"] == "Get my advisor book"
+    assert "another advisor's book" in operation["description"]
+    assert "advisorId" not in parameters
+    assert {
+        "asOfDate",
+        "clientId",
+        "mandateType",
+        "sortBy",
+        "sortOrder",
+        "offset",
+        "limit",
+        "X-Actor-Id",
+        "X-Tenant-Id",
+        "X-Caller-Capabilities",
+    } <= parameters
+    assert operation["responses"]["200"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/AdvisorBookResponse"
+    }
+    assert AdvisorBookResponse.model_validate(example)

--- a/tests/unit/test_advisor_book_access_policy.py
+++ b/tests/unit/test_advisor_book_access_policy.py
@@ -1,0 +1,98 @@
+import pytest
+
+from app.services.advisor_book_access_policy import (
+    AdvisorBookCallerContextError,
+    require_advisor_book_caller_context,
+)
+
+
+def _headers(**overrides: str | None) -> dict[str, str | None]:
+    values: dict[str, str | None] = {
+        "actor_id": "advisor_sg_001",
+        "caller_application": "lotus-workbench",
+        "tenant_id": "tenant-sg",
+        "region": "APAC",
+        "booking_center_code": "Singapore",
+        "role": "ADVISOR",
+        "capabilities": "portfolio.read,advisor.book.read",
+    }
+    values.update(overrides)
+    return values
+
+
+def test_advisor_book_context_derives_manager_identity_from_trusted_actor() -> None:
+    context = require_advisor_book_caller_context(**_headers())
+
+    assert context.portfolio_manager_id == "advisor_sg_001"
+    assert context.tenant_id == "tenant-sg"
+    assert context.booking_center_code == "Singapore"
+    assert context.role == "ADVISOR"
+    assert context.caller_application == "lotus-workbench"
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    [
+        "actor_id",
+        "tenant_id",
+        "region",
+        "booking_center_code",
+        "role",
+        "capabilities",
+    ],
+)
+def test_advisor_book_context_fails_closed_when_required_context_is_missing(
+    missing_field: str,
+) -> None:
+    with pytest.raises(AdvisorBookCallerContextError) as exc_info:
+        require_advisor_book_caller_context(**_headers(**{missing_field: None}))
+
+    assert exc_info.value.code == "advisor_book_caller_context_missing"
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.parametrize("role", ["CLIENT", "OPERATIONS", "SUPERVISOR", "advisor"])
+def test_advisor_book_context_rejects_unimplemented_roles(role: str) -> None:
+    with pytest.raises(AdvisorBookCallerContextError) as exc_info:
+        require_advisor_book_caller_context(**_headers(role=role))
+
+    assert exc_info.value.code == "advisor_book_access_denied"
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        "portfolio.read",
+        "advisor.book.read.all",
+        "Advisor.Book.Read",
+        "advisor_book_read",
+    ],
+)
+def test_advisor_book_context_requires_exact_read_capability(capabilities: str) -> None:
+    with pytest.raises(AdvisorBookCallerContextError) as exc_info:
+        require_advisor_book_caller_context(**_headers(capabilities=capabilities))
+
+    assert exc_info.value.code == "advisor_book_access_denied"
+
+
+@pytest.mark.parametrize(
+    "actor_id",
+    ["../advisor", "advisor/other", "", "a" * 129],
+)
+def test_advisor_book_context_rejects_unsafe_actor_identity(actor_id: str) -> None:
+    expected_code = (
+        "advisor_book_caller_context_missing"
+        if not actor_id.strip()
+        else "advisor_book_caller_context_invalid"
+    )
+    with pytest.raises(AdvisorBookCallerContextError) as exc_info:
+        require_advisor_book_caller_context(**_headers(actor_id=actor_id))
+
+    assert exc_info.value.code == expected_code
+
+
+def test_advisor_book_context_defaults_the_internal_caller_application() -> None:
+    context = require_advisor_book_caller_context(**_headers(caller_application=" "))
+
+    assert context.caller_application == "lotus-gateway"

--- a/tests/unit/test_advisor_book_contracts.py
+++ b/tests/unit/test_advisor_book_contracts.py
@@ -1,0 +1,52 @@
+from app.contracts.advisor_book import AdvisorBookResponse
+from app.contracts.advisor_book_examples import ADVISOR_BOOK_RESPONSE_EXAMPLE
+
+
+def test_advisor_book_openapi_example_is_executable_contract_truth() -> None:
+    response = AdvisorBookResponse.model_validate(ADVISOR_BOOK_RESPONSE_EXAMPLE)
+
+    assert response.scope.kind == "own_book"
+    assert response.scope.label == "My book"
+    assert response.page.total_count == 1
+    assert response.items[0].membership_source == "PortfolioManagerBookMembership:v1"
+    assert response.supportability.state == "degraded"
+    assert response.supportability.tenant_scope == "trusted_context_only"
+    assert response.provenance is not None
+    assert response.provenance.product_name == "PortfolioManagerBookMembership"
+
+
+def test_advisor_book_contract_keeps_empty_scope_explicit() -> None:
+    response = AdvisorBookResponse.model_validate(
+        {
+            "correlation_id": "corr-empty-book",
+            "scope": {
+                "kind": "own_book",
+                "label": "My book",
+                "as_of_date": "2026-04-10",
+                "booking_center_code": "Singapore",
+            },
+            "page": {
+                "total_count": 0,
+                "offset": 0,
+                "limit": 25,
+                "returned_count": 0,
+                "sort_by": "portfolio_id",
+                "sort_order": "asc",
+            },
+            "items": [],
+            "supportability": {
+                "state": "empty",
+                "reason_code": "advisor_book_empty",
+                "tenant_scope": "trusted_context_only",
+                "limitations": [
+                    "tenant_scope_not_reported",
+                    "delegated_scope_not_supported",
+                ],
+            },
+        }
+    )
+
+    assert response.items == []
+    assert response.page.total_count == 0
+    assert response.supportability.reason_code == "advisor_book_empty"
+    assert response.provenance is None

--- a/tests/unit/test_advisor_book_documentation.py
+++ b/tests/unit/test_advisor_book_documentation.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+_ROOT = Path(__file__).parents[2]
+
+
+def _read(relative_path: str) -> str:
+    return (_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _squash(value: str) -> str:
+    return " ".join(value.split())
+
+
+def test_supported_feature_docs_preserve_authenticated_own_book_boundary() -> None:
+    docs = _read("docs/supported-features.md")
+    wiki = _read("wiki/Supported-Features.md")
+
+    for content in (docs, wiki):
+        assert "/api/v1/advisor-book/portfolios" in content
+        assert "PortfolioManagerBookMembership:v1" in content
+        assert "global portfolio catalogue" in _squash(content)
+        assert "tenant" in content.lower()
+    assert "advisor.book.read" in wiki
+    assert "no advisor-id override" in wiki
+
+
+def test_rfc_0082_map_classifies_advisor_book_as_core_operational_read() -> None:
+    family_map = _read("docs/standards/RFC-0082-upstream-contract-family-map.md")
+
+    assert "get_portfolio_manager_book_memberships" in family_map
+    assert "Operational Read" in family_map
+    assert "never widen through the global portfolio catalogue" in family_map
+
+
+def test_operator_example_requires_complete_trusted_caller_context() -> None:
+    api_surface = _read("wiki/API-Surface.md")
+
+    for value in (
+        "asOfDate=2026-04-10",
+        "X-Actor-Id: PM_SG_001",
+        "X-Tenant-Id: tenant-sg",
+        "X-Booking-Center-Code: Singapore",
+        "X-Role: ADVISOR",
+        "X-Caller-Capabilities: advisor.book.read",
+    ):
+        assert value in api_surface
+    assert "there is no advisor-id query override" in _squash(api_surface)
+
+
+def test_repository_context_and_review_ledger_record_known_follow_up_owners() -> None:
+    context = _read("REPOSITORY-ENGINEERING-CONTEXT.md")
+    ledger = _read("CODEBASE-REVIEW-LEDGER.md")
+
+    assert "PortfolioManagerBookMembership:v1" in context
+    assert "Gateway/Workbench #436" in ledger
+    assert "Core #513" in ledger
+    assert "No duplicate downstream issue was opened" in ledger

--- a/tests/unit/test_advisor_book_service.py
+++ b/tests/unit/test_advisor_book_service.py
@@ -1,0 +1,272 @@
+from datetime import date
+from typing import Any
+
+import pytest
+
+from app.services.advisor_book_access_policy import AdvisorBookCallerContext
+from app.services.advisor_book_service import (
+    AdvisorBookQuery,
+    AdvisorBookService,
+    AdvisorBookServiceError,
+)
+
+
+class _MembershipClient:
+    def __init__(self, *, status_code: int = 200, payload: dict[str, Any] | None = None):
+        self.status_code = status_code
+        self.payload = payload or {}
+        self.calls: list[dict[str, Any]] = []
+
+    async def get_portfolio_manager_book_memberships(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.status_code, self.payload
+
+
+def _caller(**overrides: str) -> AdvisorBookCallerContext:
+    values = {
+        "portfolio_manager_id": "PM_SG_001",
+        "tenant_id": "tenant-sg",
+        "region": "APAC",
+        "booking_center_code": "Singapore",
+        "role": "ADVISOR",
+        "caller_application": "lotus-workbench",
+    }
+    values.update(overrides)
+    return AdvisorBookCallerContext(**values)
+
+
+def _member(
+    portfolio_id: str,
+    *,
+    client_id: str = "CIF_SG_001",
+    portfolio_type: str = "ADVISORY",
+    booking_center_code: str = "Singapore",
+    membership_source: str = "party_role_assignment",
+) -> dict[str, object]:
+    return {
+        "portfolio_id": portfolio_id,
+        "client_id": client_id,
+        "booking_center_code": booking_center_code,
+        "portfolio_type": portfolio_type,
+        "status": "ACTIVE",
+        "open_date": "2025-03-31",
+        "close_date": None,
+        "base_currency": "SGD",
+        "source_record_id": f"portfolio:{portfolio_id}",
+        "membership_source": membership_source,
+        "role_type": "ADVISOR" if membership_source == "party_role_assignment" else None,
+    }
+
+
+def _payload(
+    *,
+    members: list[dict[str, object]] | None = None,
+    tenant_id: str | None = "tenant-sg",
+    portfolio_manager_id: str = "PM_SG_001",
+    booking_center_code: str = "Singapore",
+) -> dict[str, object]:
+    resolved_members = members if members is not None else [_member("PB_SG_001")]
+    return {
+        "product_name": "PortfolioManagerBookMembership",
+        "product_version": "v1",
+        "portfolio_manager_id": portfolio_manager_id,
+        "tenant_id": tenant_id,
+        "generated_at": "2026-04-10T02:00:00Z",
+        "as_of_date": "2026-04-10",
+        "latest_evidence_timestamp": "2026-04-10T01:59:00Z",
+        "snapshot_id": "pm_book_membership:2e7dfe0c",
+        "content_hash": "sha256:0123456789abcdef",
+        "data_quality_status": "ACCEPTED" if resolved_members else "MISSING",
+        "source_evidence_current": bool(resolved_members),
+        "freshness_status": "CURRENT" if resolved_members else "UNAVAILABLE",
+        "booking_center_code": booking_center_code,
+        "members": resolved_members,
+        "supportability": {
+            "state": "READY" if resolved_members else "INCOMPLETE",
+            "reason": (
+                "PM_BOOK_MEMBERSHIP_READY" if resolved_members else "PM_BOOK_MEMBERSHIP_EMPTY"
+            ),
+            "returned_portfolio_count": len(resolved_members),
+            "filters_applied": ["portfolio_manager_id", "as_of_date"],
+        },
+        "lineage": {"source_system": "lotus-core"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_service_requests_authenticated_own_book_and_projects_governed_membership() -> None:
+    client = _MembershipClient(payload=_payload())
+    service = AdvisorBookService(membership_client=client)
+
+    response = await service.get_advisor_book(
+        caller=_caller(),
+        query=AdvisorBookQuery(as_of_date=date(2026, 4, 10)),
+        correlation_id="corr-book",
+    )
+
+    assert client.calls == [
+        {
+            "portfolio_manager_id": "PM_SG_001",
+            "as_of_date": "2026-04-10",
+            "booking_center_code": "Singapore",
+            "portfolio_types": ["ADVISORY", "DISCRETIONARY"],
+            "correlation_id": "corr-book",
+        }
+    ]
+    assert response.scope.label == "My book"
+    assert response.items[0].membership_basis == "governed_role_assignment"
+    assert response.supportability.state == "ready"
+    assert response.supportability.tenant_scope == "source_confirmed"
+
+
+@pytest.mark.asyncio
+async def test_service_filters_sorts_and_pages_source_memberships_deterministically() -> None:
+    members = [
+        _member("PB_003", client_id="CIF_002", portfolio_type="DISCRETIONARY"),
+        _member("PB_001", client_id="CIF_001", portfolio_type="ADVISORY"),
+        _member("PB_002", client_id="CIF_001", portfolio_type="ADVISORY"),
+    ]
+    service = AdvisorBookService(
+        membership_client=_MembershipClient(payload=_payload(members=members))
+    )
+
+    response = await service.get_advisor_book(
+        caller=_caller(),
+        query=AdvisorBookQuery(
+            as_of_date=date(2026, 4, 10),
+            client_id="CIF_001",
+            mandate_type="ADVISORY",
+            sort_by="client_id",
+            sort_order="desc",
+            offset=1,
+            limit=1,
+        ),
+        correlation_id="corr-page",
+    )
+
+    assert response.page.total_count == 2
+    assert response.page.returned_count == 1
+    assert [item.portfolio_id for item in response.items] == ["PB_001"]
+
+
+@pytest.mark.asyncio
+async def test_service_reports_filter_empty_without_claiming_source_book_is_empty() -> None:
+    service = AdvisorBookService(membership_client=_MembershipClient(payload=_payload()))
+
+    response = await service.get_advisor_book(
+        caller=_caller(),
+        query=AdvisorBookQuery(as_of_date=date(2026, 4, 10), client_id="CIF_UNKNOWN"),
+        correlation_id="corr-filter",
+    )
+
+    assert response.items == []
+    assert response.supportability.reason_code == "advisor_book_filter_empty"
+    assert response.provenance is not None
+
+
+@pytest.mark.asyncio
+async def test_service_marks_null_source_tenant_as_degraded_not_certified() -> None:
+    service = AdvisorBookService(
+        membership_client=_MembershipClient(payload=_payload(tenant_id=None))
+    )
+
+    response = await service.get_advisor_book(
+        caller=_caller(),
+        query=AdvisorBookQuery(as_of_date=date(2026, 4, 10)),
+        correlation_id="corr-tenant",
+    )
+
+    assert response.supportability.state == "degraded"
+    assert response.supportability.reason_code == "advisor_book_tenant_scope_not_reported"
+    assert response.supportability.tenant_scope == "trusted_context_only"
+
+
+@pytest.mark.asyncio
+async def test_service_marks_legacy_advisor_projection_as_degraded() -> None:
+    payload = _payload(members=[_member("PB_001", membership_source="legacy_advisor_projection")])
+    service = AdvisorBookService(membership_client=_MembershipClient(payload=payload))
+
+    response = await service.get_advisor_book(
+        caller=_caller(),
+        query=AdvisorBookQuery(as_of_date=date(2026, 4, 10)),
+        correlation_id="corr-legacy",
+    )
+
+    assert response.items[0].membership_basis == "legacy_advisor_projection"
+    assert response.supportability.state == "degraded"
+    assert response.supportability.reason_code == "advisor_book_legacy_projection"
+
+
+@pytest.mark.asyncio
+async def test_service_translates_source_not_found_to_explicit_empty_book() -> None:
+    service = AdvisorBookService(membership_client=_MembershipClient(status_code=404))
+
+    response = await service.get_advisor_book(
+        caller=_caller(),
+        query=AdvisorBookQuery(as_of_date=date(2026, 4, 10)),
+        correlation_id="corr-empty",
+    )
+
+    assert response.items == []
+    assert response.supportability.reason_code == "advisor_book_empty"
+    assert response.provenance is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        _payload(portfolio_manager_id="PM_OTHER"),
+        _payload(booking_center_code="Zurich"),
+        _payload(members=[_member("PB_001", booking_center_code="Zurich")]),
+        _payload(members=[_member("PB_DUPLICATE"), _member("PB_DUPLICATE")]),
+    ],
+)
+async def test_service_fails_closed_on_cross_scope_or_duplicate_source_rows(
+    payload: dict[str, object],
+) -> None:
+    service = AdvisorBookService(membership_client=_MembershipClient(payload=payload))
+
+    with pytest.raises(AdvisorBookServiceError) as raised:
+        await service.get_advisor_book(
+            caller=_caller(),
+            query=AdvisorBookQuery(as_of_date=date(2026, 4, 10)),
+            correlation_id="corr-invalid",
+        )
+
+    assert raised.value.code == "advisor_book_source_contract_invalid"
+    assert raised.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_service_rejects_cross_tenant_source_response() -> None:
+    service = AdvisorBookService(
+        membership_client=_MembershipClient(payload=_payload(tenant_id="tenant-other"))
+    )
+
+    with pytest.raises(AdvisorBookServiceError) as raised:
+        await service.get_advisor_book(
+            caller=_caller(),
+            query=AdvisorBookQuery(as_of_date=date(2026, 4, 10)),
+            correlation_id="corr-cross-tenant",
+        )
+
+    assert raised.value.code == "advisor_book_tenant_scope_mismatch"
+    assert raised.value.status_code == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [400, 401, 403, 500, 503])
+async def test_service_returns_product_safe_error_for_source_failures(status_code: int) -> None:
+    service = AdvisorBookService(membership_client=_MembershipClient(status_code=status_code))
+
+    with pytest.raises(AdvisorBookServiceError) as raised:
+        await service.get_advisor_book(
+            caller=_caller(),
+            query=AdvisorBookQuery(as_of_date=date(2026, 4, 10)),
+            correlation_id="corr-upstream",
+        )
+
+    assert raised.value.code == "advisor_book_source_unavailable"
+    assert raised.value.status_code == 502
+    assert "Core" not in raised.value.message

--- a/tests/unit/test_advisor_book_service_provider.py
+++ b/tests/unit/test_advisor_book_service_provider.py
@@ -1,0 +1,44 @@
+from app.services import advisor_book_service_provider
+from app.services.advisor_book_service import AdvisorBookService
+
+
+def test_advisor_book_service_provider_caches_by_upstream_signature(monkeypatch) -> None:
+    signatures = iter([("core-a",), ("core-a",), ("core-b",)])
+    built = [object(), object()]
+    build_calls: list[int] = []
+
+    monkeypatch.setattr(
+        advisor_book_service_provider,
+        "advisor_book_service_signature",
+        lambda: next(signatures),
+    )
+
+    def _build():
+        build_calls.append(1)
+        return built[len(build_calls) - 1]
+
+    monkeypatch.setattr(advisor_book_service_provider, "build_advisor_book_service", _build)
+    monkeypatch.setattr(advisor_book_service_provider, "_ADVISOR_BOOK_SERVICE", None)
+    monkeypatch.setattr(advisor_book_service_provider, "_ADVISOR_BOOK_SERVICE_SIGNATURE", None)
+
+    first = advisor_book_service_provider.advisor_book_service()
+    second = advisor_book_service_provider.advisor_book_service()
+    third = advisor_book_service_provider.advisor_book_service()
+
+    assert first is second is built[0]
+    assert third is built[1]
+    assert len(build_calls) == 2
+
+
+def test_advisor_book_factory_builds_typed_service(monkeypatch) -> None:
+    from app.services import advisor_book_service_factory
+
+    client = object()
+    monkeypatch.setattr(
+        advisor_book_service_factory, "build_lotus_core_query_client", lambda: client
+    )
+
+    service = advisor_book_service_factory.build_advisor_book_service()
+
+    assert isinstance(service, AdvisorBookService)
+    assert service._membership_client is client

--- a/tests/unit/test_advisor_book_source_contract.py
+++ b/tests/unit/test_advisor_book_source_contract.py
@@ -1,0 +1,76 @@
+import pytest
+from pydantic import ValidationError
+
+from app.services.advisor_book_source_contract import SourceAdvisorBookResponse
+
+
+def _source_payload() -> dict[str, object]:
+    return {
+        "product_name": "PortfolioManagerBookMembership",
+        "product_version": "v1",
+        "portfolio_manager_id": "PM_SG_001",
+        "tenant_id": None,
+        "generated_at": "2026-04-10T02:00:00Z",
+        "as_of_date": "2026-04-10",
+        "latest_evidence_timestamp": "2026-04-10T01:59:00Z",
+        "snapshot_id": "pm_book_membership:2e7dfe0c",
+        "content_hash": "sha256:0123456789abcdef",
+        "data_quality_status": "COMPLETE",
+        "source_evidence_current": True,
+        "freshness_status": "CURRENT",
+        "booking_center_code": "Singapore",
+        "members": [
+            {
+                "portfolio_id": "PB_SG_001",
+                "client_id": "CIF_SG_001",
+                "booking_center_code": "Singapore",
+                "portfolio_type": "ADVISORY",
+                "status": "ACTIVE",
+                "open_date": "2025-03-31",
+                "close_date": None,
+                "base_currency": "SGD",
+                "source_record_id": "portfolio:PB_SG_001",
+                "membership_source": "party_role_assignment",
+                "role_type": "ADVISOR",
+            }
+        ],
+        "supportability": {
+            "state": "READY",
+            "reason": "PORTFOLIO_MANAGER_BOOK_READY",
+            "returned_portfolio_count": 1,
+            "filters_applied": ["booking_center_code"],
+        },
+        "lineage": {"source_owner": "lotus-core"},
+        "restatement_version": "restatement-v1",
+    }
+
+
+def test_source_advisor_book_contract_accepts_current_core_shape() -> None:
+    source = SourceAdvisorBookResponse.model_validate(_source_payload())
+
+    assert source.portfolio_manager_id == "PM_SG_001"
+    assert source.members[0].membership_source == "party_role_assignment"
+    assert source.tenant_id is None
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("product_name", "PortfolioCatalogue"),
+        ("product_version", "v2"),
+        ("members.0.membership_source", "derived_guess"),
+    ],
+)
+def test_source_advisor_book_contract_rejects_unsupported_source_identity(
+    field: str, value: str
+) -> None:
+    payload = _source_payload()
+    if field.startswith("members"):
+        members = payload["members"]
+        assert isinstance(members, list)
+        members[0]["membership_source"] = value
+    else:
+        payload[field] = value
+
+    with pytest.raises(ValidationError):
+        SourceAdvisorBookResponse.model_validate(payload)

--- a/tests/unit/test_lotus_core_client_boundaries.py
+++ b/tests/unit/test_lotus_core_client_boundaries.py
@@ -44,6 +44,7 @@ def test_lotus_core_portfolio_query_routes_live_in_dedicated_client_mixin() -> N
     portfolio_methods = _async_function_names(_CLIENT_ROOT / "lotus_core_portfolio_query_client.py")
 
     extracted_methods = {
+        "get_portfolio_manager_book_memberships",
         "get_cashflow_projection",
         "get_portfolio",
         "get_portfolio_cash_balances",

--- a/tests/unit/test_router_registry.py
+++ b/tests/unit/test_router_registry.py
@@ -40,6 +40,7 @@ def test_router_registry_mounts_representative_gateway_route_families() -> None:
     assert "/api/v1/report-batches/{batch_id}" in routes
     assert "/api/v1/documents/{document_id}" in routes
     assert "/api/v1/ideas/review-queues/advisor" in routes
+    assert "/api/v1/advisor-book/portfolios" in routes
 
 
 def test_advisory_router_group_keeps_proposal_routes_together() -> None:

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1341,6 +1341,38 @@ async def test_lotus_core_query_client_fetches_benchmark_assignment():
 
 
 @pytest.mark.asyncio
+async def test_lotus_core_query_client_fetches_portfolio_manager_book_memberships():
+    client = LotusCoreQueryClient(
+        base_url="http://core-query",
+        control_plane_base_url="http://core-control",
+        timeout_seconds=2.0,
+    )
+    _FakeAsyncClient.queue_json(200, {"portfolio_manager_id": "PM SG/001", "members": []})
+
+    status_code, payload = await client.get_portfolio_manager_book_memberships(
+        portfolio_manager_id="PM SG/001",
+        as_of_date="2026-03-28",
+        booking_center_code="SG",
+        portfolio_types=["ADVISORY", "DISCRETIONARY"],
+        correlation_id="corr-advisor-book",
+    )
+
+    assert status_code == 200
+    assert payload["portfolio_manager_id"] == "PM SG/001"
+    request = _FakeAsyncClient.calls[0]
+    assert request["url"] == (
+        "http://core-control/integration/portfolio-manager-books/PM%20SG%2F001/memberships"
+    )
+    assert request["json"] == {
+        "as_of_date": "2026-03-28",
+        "booking_center_code": "SG",
+        "portfolio_types": ["ADVISORY", "DISCRETIONARY"],
+        "include_inactive": False,
+    }
+    assert request["headers"]["X-Correlation-Id"] == "corr-advisor-book"
+
+
+@pytest.mark.asyncio
 async def test_lotus_analytics_client_non_json_and_non_dict_payload_handling():
     client = LotusAnalyticsClient(base_url="http://lotus-performance", timeout_seconds=2.0)
     _FakeAsyncClient.queue_text(503, "lotus-performance unavailable")

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -18,6 +18,7 @@ or governed ingress endpoints without embedding environment-specific hostnames i
 - `POST /api/v1/source-products/portfolios/{portfolio_id}/external-order-execution-acknowledgement`
 - `POST /api/v1/proposals/*` and `GET /api/v1/proposals/*`
 - `GET` and `POST /api/v1/advisory-copilot/*`
+- `GET /api/v1/advisor-book/portfolios`
 - `GET` and `POST /api/v1/advisory/bank-demo-proof/*`
 - `POST /api/v1/intake/*`
 - `GET /api/v1/lookups/*`
@@ -65,6 +66,10 @@ or governed ingress endpoints without embedding environment-specific hostnames i
   Gateway lets lotus-core resolve the latest governed portfolio date first, then uses that same
   date for cashflow, cash balances, readiness, and performance composition. Gateway host time is
   not a portfolio business-date authority.
+- advisor-book discovery requires camelCase `asOfDate` plus trusted actor, tenant, region, booking
+  centre, role, and capability headers. The actor identifies the manager's own book; there is no
+  advisor-id query override. Optional `clientId`, `mandateType`, `sortBy`, `sortOrder`, `offset`,
+  and `limit` inputs only narrow or order the source cohort.
 - platform capabilities uses camelCase query parameters `consumerSystem` and `tenantId`
 - platform capabilities publishes `normalized.navigation.command_center=true` only when the
   `lotus_manage` source publishes governed Manage support capability such as
@@ -473,6 +478,23 @@ curl -X POST "$GATEWAY_BASE_URL/api/v1/workbench/DEMO_ADV_USD_001/performance/ad
   -H "X-Role: advisor" \
   -d "{\"action_type\":\"ACCEPT\",\"reviewed_by\":\"advisor-123\",\"reason\":\"Approved for client discussion.\"}"
 ```
+
+Authenticated advisor own-book discovery:
+
+```bash
+curl "$GATEWAY_BASE_URL/api/v1/advisor-book/portfolios?asOfDate=2026-04-10&sortBy=client_id&limit=25" \
+  -H "X-Actor-Id: PM_SG_001" \
+  -H "X-Caller-Application: lotus-workbench" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -H "X-Booking-Center-Code: Singapore" \
+  -H "X-Role: ADVISOR" \
+  -H "X-Caller-Capabilities: advisor.book.read"
+```
+
+The response contains only the source-backed own-book cohort for the trusted actor and booking
+centre. Treat `trusted_context_only`, `legacy_advisor_projection`, and other limitations as
+operating boundaries; do not promote them to tenant certification or authoritative role coverage.
 
 Report ordering options for a selected portfolio:
 

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -5,6 +5,38 @@ developers, business users, operations, sales/pre-sales, and client demos; it mu
 future capability as supported until the owning service, Gateway contract, tests, and validation
 evidence exist.
 
+## Authenticated Advisor Book
+
+Status: implementation-backed in Gateway for an authenticated advisor's own source-backed
+portfolio book. Workbench portfolio-switcher completion and production principal resolution remain
+separate owning slices.
+
+Business outcome:
+
+1. an advisor can retrieve, search, sort, and page the portfolios in their own supported book for
+   an explicit business date,
+2. portfolio membership comes from Core rather than browser filtering of the global portfolio
+   catalogue,
+3. the response distinguishes governed portfolio-role assignments from the bounded legacy advisor
+   projection and makes missing tenant confirmation visible as degraded.
+
+Supported route:
+
+1. `GET /api/v1/advisor-book/portfolios`
+
+Authority and boundary:
+
+1. `lotus-core` owns `PortfolioManagerBookMembership:v1`, effective portfolio membership, source
+   evidence, freshness, and lineage,
+2. Gateway derives the portfolio manager only from trusted `X-Actor-Id`, requires an entitled
+   advisor role and `advisor.book.read`, constrains the Core request to the trusted booking centre,
+   and exposes no advisor-id override,
+3. a non-null conflicting source tenant, booking centre, manager, business date, duplicate
+   portfolio, or malformed contract fails closed,
+4. null Core tenant scope is explicit degraded posture and is not tenant-isolation certification,
+5. team, delegate, supervisor, household, assets-under-management, attention, suitability,
+   recommendation, client communication, order, and execution coverage are not claimed.
+
 ## Report Ordering Options
 
 Status: implementation-backed in Gateway for source-backed configuration discovery and


### PR DESCRIPTION
## Outcome

Publishes a source-backed authenticated advisor own-book contract at `GET /api/v1/advisor-book/portfolios`.

- derives the manager only from trusted `X-Actor-Id`; there is no advisor-id override
- requires exact supported role, `advisor.book.read`, tenant, region, and booking-centre context
- consumes Core `PortfolioManagerBookMembership:v1` for an explicit business date
- supports exact client/mandate filters, deterministic sort, bounded paging, and explicit empty state
- rejects cross-manager, date, booking-centre, non-null tenant, count, duplicate-row, and malformed source evidence
- distinguishes governed role assignment from bounded legacy advisor projection
- reports null Core tenant scope as degraded and never falls back to the global portfolio catalogue
- keeps team, delegated, supervisory, household, AUM, attention, suitability, communication, and execution claims out of scope

## Architecture and maintainability

The feature is isolated into typed `advisor_book` contract, source model, access policy, client protocol, mapping/supportability services, cached factory/provider, request dependency, and router modules. Final-head measurements against `origin/main`:

- 16 signed commits, within the governed branch budget
- service orchestration: 241 lines
- supportability policy: 93 lines
- router: 104 lines
- request input module: 114 lines
- repository ceilings remain 316 lines per source file and 49 lines per function

## Validation

- `make check` — 1,511 unit/contract tests; ruff, mypy across 711 source files, OpenAPI, modularity and quality guards passed
- `make ci` — 233 integration tests; 1,744 combined tests; 94.43% coverage; migration smoke and dependency audit passed
- `make ci-local-docker` — Python 3.11 image build, 1,511 unit/contract tests and 233 integration tests passed; compose resources removed afterward
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway -AllowUnpublishedSourceChanges` — exactly two intentional unpublished wiki-source pages; publish after merge
- all 16 commits verify as SSH signed

## Governance

- RFC-0082 classifies the new Core call as Operational Read
- supported features, README, repository context, review ledger, and repo-authored wiki source are updated
- stranded-truth audit found no unmerged remote Gateway governance branch
- production authenticated principal resolution remains Gateway/Workbench #436
- richer effective-dated relationship roles remain Core #513 until merged and exact-main proven
- no new reusable skill gap was found; the existing pre-merge and refactor gates caught and drove the required module split

Tier: Experience API. Required PR Merge Gate checks remain mandatory; heavy main releasability proof will be recorded after merge.

Fixes #500