### PR TITLE
fix(advisory): enforce trusted Advisor Cockpit scope (#503)

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -43,7 +43,13 @@ Current repository posture:
    event, and AI-evidence routes are routed to `lotus-advise` `/advisory/policy-*` and
    `/advisory/proposals/*/policy-evaluations`; advisor-cockpit action, preparation-packet,
    single-action, snapshot, supportability, and acknowledgement routes are routed to `lotus-advise`
-   `/advisory/cockpit/*`; advisory-copilot evidence-packet, action-run, review, supportability,
+   `/advisory/cockpit/*`. Those Cockpit reads and acknowledgements derive advisor identity, role,
+   capability, and portfolio scope from trusted server-side caller context: query `advisor_id` and
+   `role` are rejected, advisor actors cannot project another advisor id, portfolio filters must
+   match `X-Authorized-Portfolio-Id`, acknowledgement actors are bound to `X-Actor-Id`, and Gateway
+   translates the result to the exact Advise principal headers. The tactical house-view cohort
+   command remains a separate source-product route and does not receive an invented Cockpit
+   capability. Advisory-copilot evidence-packet, action-run, review, supportability,
    and proposal-version run-lineage routes are routed to `lotus-advise`
    `/advisory/copilot/*` and `/advisory/proposals/*/copilot-runs`; bank-demo proof
    scenario-contract, supported-claim register, and

--- a/docs/rfcs/RFC-0026-advisor-cockpit-gateway-publication.md
+++ b/docs/rfcs/RFC-0026-advisor-cockpit-gateway-publication.md
@@ -28,9 +28,31 @@ Supported Gateway routes:
 
 ## Boundary Rules
 
-Gateway forwards portfolio, advisor, caller role, pagination, action id, acknowledgement payload,
-tactical house-view affected-cohort payload, idempotency key, and correlation context. Gateway does
-not reconstruct:
+For every Cockpit read and acknowledgement, Gateway derives advisor identity and role from trusted
+server-side caller context. Public `advisor_id` and `role` query parameters are rejected. An
+optional portfolio remains a business filter only after it matches the singular trusted
+`X-Authorized-Portfolio-Id`; single-action reads and acknowledgements require that portfolio scope.
+Gateway binds `acknowledged_by` to `X-Actor-Id` and does not accept an actor override in the body.
+
+Gateway validates the actor, calling application, tenant, region, booking centre, legal entity,
+role, active-principal posture, capability, authorized advisor, and authorized portfolio before it
+calls Advise. It then translates the trusted context to the exact Advise principal headers:
+`X-Actor-Id`, `X-Role`, `X-Tenant-Id`, `X-Legal-Entity-Code`, `X-Service-Identity`,
+`X-Capabilities`, `X-Principal-Status`, `X-Authorized-Advisor-Id`, and
+`X-Authorized-Portfolio-Id`. Advisor callers are always bound to their authenticated actor id.
+
+The tactical house-view cohort command is a separate source-product route. It is not folded into
+the Advisor Cockpit read/acknowledgement capability model and Gateway does not invent a house-view
+capability that `lotus-advise` does not support.
+
+Workbench must strip browser authority and apply these headers from its server-side BFF principal.
+The configured canonical-runtime principal remains non-production evidence while
+`lotus-workbench#436` and `lotus-platform#563` govern the authenticated session contract; Gateway
+does not restore query-authority compatibility while that platform dependency remains open.
+
+Gateway forwards authorized portfolio filters, pagination, action id, the actor-bound
+acknowledgement payload, tactical house-view affected-cohort payload, idempotency key, and
+correlation context. Gateway does not reconstruct:
 
 1. advisory policy result,
 2. proposal memo posture,
@@ -52,15 +74,15 @@ Advise-owned cockpit supportability posture used by the Workbench canonical proo
    proves Gateway service envelopes preserve Advise-owned payload posture and propagate upstream
    acknowledgement conflicts without rewriting semantics.
 2. `tests/integration/test_advisor_cockpit_router.py`
-   proves routes forward filters, correlation ids, preparation-packet requests,
-   acknowledgement bodies, tactical house-view cohort requests, and `Idempotency-Key` to the Advise
-   client while preserving blocked/supportability posture.
+   proves routes reject browser-selected authority, fail closed for missing capability and
+   cross-portfolio access, bind the acknowledgement actor, forward exact Advise principal headers,
+   and preserve blocked/supportability posture.
 3. `tests/contract/test_advise_gateway_route_coverage.py`
    proves all supported advisor cockpit route keys are present in the FastAPI app.
 4. `tests/unit/test_upstream_clients.py`
    proves the Advise client forwards the tactical house-view cohort request to the source route.
 5. OpenAPI assertions prove the acknowledgement idempotency header and conflict response are
-   documented.
+   documented, authority query parameters are absent, and trusted context headers are visible.
 
 ## No Product Overclaim
 

--- a/src/app/clients/advise_client.py
+++ b/src/app/clients/advise_client.py
@@ -72,24 +72,26 @@ class AdviseClient(
     async def list_advisor_cockpit_actions(
         self,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get(
             "/advisory/cockpit/actions",
             params=self._clean_params(params),
-            headers=self._headers(correlation_id),
+            headers=self._headers(correlation_id, caller_headers),
             operation="advise.advisory.cockpit.actions.list",
         )
 
     async def list_advisor_cockpit_preparation_packets(
         self,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get(
             "/advisory/cockpit/preparation-packets",
             params=self._clean_params(params),
-            headers=self._headers(correlation_id),
+            headers=self._headers(correlation_id, caller_headers),
             operation="advise.advisory.cockpit.preparation-packets.list",
         )
 
@@ -97,36 +99,39 @@ class AdviseClient(
         self,
         action_item_id: str,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get(
             f"/advisory/cockpit/actions/{action_item_id}",
             params=self._clean_params(params),
-            headers=self._headers(correlation_id),
+            headers=self._headers(correlation_id, caller_headers),
             operation="advise.advisory.cockpit.actions.get",
         )
 
     async def get_advisor_cockpit_snapshot(
         self,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get(
             "/advisory/cockpit/snapshot",
             params=self._clean_params(params),
-            headers=self._headers(correlation_id),
+            headers=self._headers(correlation_id, caller_headers),
             operation="advise.advisory.cockpit.snapshot",
         )
 
     async def get_advisor_cockpit_supportability(
         self,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get(
             "/advisory/cockpit/supportability",
             params=self._clean_params(params),
-            headers=self._headers(correlation_id),
+            headers=self._headers(correlation_id, caller_headers),
             operation="advise.advisory.cockpit.supportability",
         )
 
@@ -135,13 +140,17 @@ class AdviseClient(
         action_item_id: str,
         body: dict[str, Any],
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         idempotency_key: str,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]:
         return await self._post(
             f"/advisory/cockpit/actions/{action_item_id}/acknowledgements",
             body=body,
-            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            headers=self._headers(
+                correlation_id,
+                {**caller_headers, "Idempotency-Key": idempotency_key},
+            ),
             operation="advise.advisory.cockpit.actions.acknowledge",
             params=self._clean_params(params),
         )

--- a/src/app/contracts/advisor_cockpit.py
+++ b/src/app/contracts/advisor_cockpit.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 AdvisorCockpitOwnerRole = Literal[
     "ADVISOR",
@@ -12,20 +12,18 @@ AdvisorCockpitOwnerRole = Literal[
     "REPORTING_OWNER",
     "ARCHIVE_OWNER",
     "EXECUTION_OWNER",
-    "DPM_OWNER",
+    "PORTFOLIO_MANAGER",
     "SYSTEM",
 ]
 
 
 class AdvisorCockpitAcknowledgeRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     action_item_version: int = Field(
         ge=1,
         description="Advise-owned action item version observed by the caller.",
         examples=[1],
-    )
-    acknowledged_by: str = Field(
-        description="Actor acknowledging the advisor cockpit action item.",
-        examples=["advisor_sg_001"],
     )
     acknowledgement_note: str | None = Field(
         default=None,

--- a/src/app/routers/advisor_cockpit.py
+++ b/src/app/routers/advisor_cockpit.py
@@ -1,14 +1,16 @@
 from fastapi import APIRouter, Query
 
-from app.contracts.advisor_cockpit import (
-    AdvisorCockpitEnvelopeResponse,
-    AdvisorCockpitOwnerRole,
-)
+from app.contracts.advisor_cockpit import AdvisorCockpitEnvelopeResponse
 from app.middleware.correlation import correlation_id_var
 from app.routers.advisor_cockpit_common import (
     ADVISOR_COCKPIT_READ_RESPONSES,
     cockpit_params,
 )
+from app.routers.advisor_cockpit_request import (
+    AdvisorCockpitCaller,
+    authorize_advisor_cockpit_request,
+)
+from app.services.advisor_cockpit_access_policy import ADVISOR_COCKPIT_READ_CAPABILITY
 from app.services.advisory_service_provider import advisor_cockpit_service
 
 router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
@@ -16,20 +18,23 @@ router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 async def _list_advisor_cockpit_actions(
     *,
+    caller: AdvisorCockpitCaller,
     portfolio_id: str | None,
-    advisor_id: str | None,
-    role: AdvisorCockpitOwnerRole,
     limit: int,
     cursor: str | None,
 ) -> AdvisorCockpitEnvelopeResponse:
+    entitled_portfolio_id = authorize_advisor_cockpit_request(
+        caller,
+        capability=ADVISOR_COCKPIT_READ_CAPABILITY,
+        portfolio_id=portfolio_id,
+    )
     return await advisor_cockpit_service().list_actions(
         params=cockpit_params(
-            portfolio_id=portfolio_id,
-            advisor_id=advisor_id,
-            role=role,
+            portfolio_id=entitled_portfolio_id,
             limit=limit,
             cursor=cursor,
         ),
+        caller_headers=caller.upstream_headers(),
         correlation_id=correlation_id_var.get(),
     )
 
@@ -41,25 +46,17 @@ async def _list_advisor_cockpit_actions(
     description=(
         "Lists source-owned advisor cockpit action items from lotus-advise. Gateway preserves "
         "Advise-owned action status, priority, owner role, reason codes, evidence refs, lineage "
-        "refs, and unsupported-capability posture without reconstructing advisory semantics."
+        "refs, and unsupported-capability posture without reconstructing advisory semantics. "
+        "Advisor identity and role are derived from trusted caller context."
     ),
     responses=ADVISOR_COCKPIT_READ_RESPONSES,
 )
 async def list_advisor_cockpit_actions(
+    caller: AdvisorCockpitCaller,
     portfolio_id: str | None = Query(
         default=None,
         description="Optional portfolio identifier forwarded to lotus-advise.",
         examples=["PB_SG_GLOBAL_BAL_001"],
-    ),
-    advisor_id: str | None = Query(
-        default=None,
-        description="Optional advisor identifier forwarded to lotus-advise.",
-        examples=["advisor_sg_001"],
-    ),
-    role: AdvisorCockpitOwnerRole = Query(
-        default="ADVISOR",
-        description="Caller role used by lotus-advise for source-owned cockpit projection.",
-        examples=["ADVISOR"],
     ),
     limit: int = Query(
         default=25,
@@ -75,9 +72,8 @@ async def list_advisor_cockpit_actions(
     ),
 ) -> AdvisorCockpitEnvelopeResponse:
     return await _list_advisor_cockpit_actions(
+        caller=caller,
         portfolio_id=portfolio_id,
-        advisor_id=advisor_id,
-        role=role,
         limit=limit,
         cursor=cursor,
     )

--- a/src/app/routers/advisor_cockpit_acknowledgements.py
+++ b/src/app/routers/advisor_cockpit_acknowledgements.py
@@ -3,12 +3,18 @@ from fastapi import APIRouter, Header, Path, Query
 from app.contracts.advisor_cockpit import (
     AdvisorCockpitAcknowledgeRequest,
     AdvisorCockpitEnvelopeResponse,
-    AdvisorCockpitOwnerRole,
 )
 from app.middleware.correlation import correlation_id_var
 from app.routers.advisor_cockpit_common import (
     ADVISOR_COCKPIT_ACKNOWLEDGEMENT_RESPONSES,
     cockpit_params,
+)
+from app.routers.advisor_cockpit_request import (
+    AdvisorCockpitCaller,
+    authorize_advisor_cockpit_request,
+)
+from app.services.advisor_cockpit_access_policy import (
+    ADVISOR_COCKPIT_ACKNOWLEDGE_CAPABILITY,
 )
 from app.services.advisory_service_provider import advisor_cockpit_service
 
@@ -17,17 +23,26 @@ router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 async def _acknowledge_advisor_cockpit_action(
     *,
+    caller: AdvisorCockpitCaller,
     request: AdvisorCockpitAcknowledgeRequest,
     action_item_id: str,
     idempotency_key: str,
-    portfolio_id: str | None,
-    advisor_id: str | None,
-    role: AdvisorCockpitOwnerRole,
+    portfolio_id: str,
 ) -> AdvisorCockpitEnvelopeResponse:
+    entitled_portfolio_id = authorize_advisor_cockpit_request(
+        caller,
+        capability=ADVISOR_COCKPIT_ACKNOWLEDGE_CAPABILITY,
+        portfolio_id=portfolio_id,
+        portfolio_required=True,
+    )
     return await advisor_cockpit_service().acknowledge_action(
         action_item_id=action_item_id,
-        body=request.model_dump(exclude_none=True),
-        params=cockpit_params(portfolio_id=portfolio_id, advisor_id=advisor_id, role=role),
+        body={
+            **request.model_dump(exclude_none=True),
+            "acknowledged_by": caller.actor_id,
+        },
+        params=cockpit_params(portfolio_id=entitled_portfolio_id),
+        caller_headers=caller.upstream_headers(),
         idempotency_key=idempotency_key,
         correlation_id=correlation_id_var.get(),
     )
@@ -40,11 +55,13 @@ async def _acknowledge_advisor_cockpit_action(
     description=(
         "Records an idempotent acknowledgement through lotus-advise. Gateway forwards the "
         "observed action version and idempotency key, and does not clear blocking policy, memo, "
-        "supportability, owner-role, or client-ready posture locally."
+        "supportability, owner-role, or client-ready posture locally. The acknowledging actor is "
+        "derived from trusted caller context."
     ),
     responses=ADVISOR_COCKPIT_ACKNOWLEDGEMENT_RESPONSES,
 )
 async def acknowledge_advisor_cockpit_action(
+    caller: AdvisorCockpitCaller,
     request: AdvisorCockpitAcknowledgeRequest,
     action_item_id: str = Path(
         ...,
@@ -57,27 +74,16 @@ async def acknowledge_advisor_cockpit_action(
         description="Required idempotency key for replay-safe cockpit acknowledgements.",
         examples=["idem-cockpit-ack-001"],
     ),
-    portfolio_id: str | None = Query(
-        default=None,
-        description="Optional portfolio identifier forwarded to lotus-advise.",
+    portfolio_id: str = Query(
+        ...,
+        description="Entitled portfolio identifier used for object-level action authorization.",
         examples=["PB_SG_GLOBAL_BAL_001"],
-    ),
-    advisor_id: str | None = Query(
-        default=None,
-        description="Optional advisor identifier forwarded to lotus-advise.",
-        examples=["advisor_sg_001"],
-    ),
-    role: AdvisorCockpitOwnerRole = Query(
-        default="ADVISOR",
-        description="Caller role used by lotus-advise for source-owned cockpit projection.",
-        examples=["ADVISOR"],
     ),
 ) -> AdvisorCockpitEnvelopeResponse:
     return await _acknowledge_advisor_cockpit_action(
+        caller=caller,
         request=request,
         action_item_id=action_item_id,
         idempotency_key=idempotency_key,
         portfolio_id=portfolio_id,
-        advisor_id=advisor_id,
-        role=role,
     )

--- a/src/app/routers/advisor_cockpit_action_lookup.py
+++ b/src/app/routers/advisor_cockpit_action_lookup.py
@@ -1,14 +1,16 @@
 from fastapi import APIRouter, Path, Query
 
-from app.contracts.advisor_cockpit import (
-    AdvisorCockpitEnvelopeResponse,
-    AdvisorCockpitOwnerRole,
-)
+from app.contracts.advisor_cockpit import AdvisorCockpitEnvelopeResponse
 from app.middleware.correlation import correlation_id_var
 from app.routers.advisor_cockpit_common import (
     ADVISOR_COCKPIT_READ_RESPONSES,
     cockpit_params,
 )
+from app.routers.advisor_cockpit_request import (
+    AdvisorCockpitCaller,
+    authorize_advisor_cockpit_request,
+)
+from app.services.advisor_cockpit_access_policy import ADVISOR_COCKPIT_READ_CAPABILITY
 from app.services.advisory_service_provider import advisor_cockpit_service
 
 router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
@@ -16,14 +18,20 @@ router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 async def _get_advisor_cockpit_action(
     *,
+    caller: AdvisorCockpitCaller,
     action_item_id: str,
-    portfolio_id: str | None,
-    advisor_id: str | None,
-    role: AdvisorCockpitOwnerRole,
+    portfolio_id: str,
 ) -> AdvisorCockpitEnvelopeResponse:
+    entitled_portfolio_id = authorize_advisor_cockpit_request(
+        caller,
+        capability=ADVISOR_COCKPIT_READ_CAPABILITY,
+        portfolio_id=portfolio_id,
+        portfolio_required=True,
+    )
     return await advisor_cockpit_service().get_action(
         action_item_id=action_item_id,
-        params=cockpit_params(portfolio_id=portfolio_id, advisor_id=advisor_id, role=role),
+        params=cockpit_params(portfolio_id=entitled_portfolio_id),
+        caller_headers=caller.upstream_headers(),
         correlation_id=correlation_id_var.get(),
     )
 
@@ -34,35 +42,26 @@ async def _get_advisor_cockpit_action(
     summary="Get Advisor Cockpit Action",
     description=(
         "Returns one source-owned advisor cockpit action item from lotus-advise. Gateway does "
-        "not infer policy, memo, supportability, SLA, acknowledgement, or owner-role posture."
+        "not infer policy, memo, supportability, SLA, acknowledgement, or owner-role posture. "
+        "Advisor identity and role are derived from trusted caller context."
     ),
     responses=ADVISOR_COCKPIT_READ_RESPONSES,
 )
 async def get_advisor_cockpit_action(
+    caller: AdvisorCockpitCaller,
     action_item_id: str = Path(
         ...,
         description="Advisor cockpit action item identifier owned by lotus-advise.",
         examples=["cockpit_action_policy_review_required_001"],
     ),
-    portfolio_id: str | None = Query(
-        default=None,
-        description="Optional portfolio identifier forwarded to lotus-advise.",
+    portfolio_id: str = Query(
+        ...,
+        description="Entitled portfolio identifier used for object-level action authorization.",
         examples=["PB_SG_GLOBAL_BAL_001"],
-    ),
-    advisor_id: str | None = Query(
-        default=None,
-        description="Optional advisor identifier forwarded to lotus-advise.",
-        examples=["advisor_sg_001"],
-    ),
-    role: AdvisorCockpitOwnerRole = Query(
-        default="ADVISOR",
-        description="Caller role used by lotus-advise for source-owned cockpit projection.",
-        examples=["ADVISOR"],
     ),
 ) -> AdvisorCockpitEnvelopeResponse:
     return await _get_advisor_cockpit_action(
+        caller=caller,
         action_item_id=action_item_id,
         portfolio_id=portfolio_id,
-        advisor_id=advisor_id,
-        role=role,
     )

--- a/src/app/routers/advisor_cockpit_common.py
+++ b/src/app/routers/advisor_cockpit_common.py
@@ -2,9 +2,16 @@ from typing import Any
 
 from fastapi import status
 
-from app.contracts.advisor_cockpit import AdvisorCockpitOwnerRole
-
 ADVISOR_COCKPIT_READ_RESPONSES: dict[int | str, dict[str, Any]] = {
+    status.HTTP_400_BAD_REQUEST: {
+        "description": "Required trusted Advisor Cockpit caller context is missing or invalid."
+    },
+    status.HTTP_403_FORBIDDEN: {
+        "description": "The caller or selected portfolio is outside the entitled Cockpit scope."
+    },
+    status.HTTP_401_UNAUTHORIZED: {
+        "description": "An active trusted principal and portfolio entitlement are required."
+    },
     status.HTTP_404_NOT_FOUND: {
         "description": "Advisor cockpit action item was not found by lotus-advise."
     },
@@ -23,15 +30,11 @@ ADVISOR_COCKPIT_ACKNOWLEDGEMENT_RESPONSES: dict[int | str, dict[str, Any]] = {
 def cockpit_params(
     *,
     portfolio_id: str | None,
-    advisor_id: str | None,
-    role: AdvisorCockpitOwnerRole,
     limit: int | None = None,
     cursor: str | None = None,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {
         "portfolio_id": portfolio_id,
-        "advisor_id": advisor_id,
-        "role": role,
         "limit": limit,
         "cursor": cursor,
     }

--- a/src/app/routers/advisor_cockpit_preparation_packets.py
+++ b/src/app/routers/advisor_cockpit_preparation_packets.py
@@ -1,14 +1,16 @@
 from fastapi import APIRouter, Query
 
-from app.contracts.advisor_cockpit import (
-    AdvisorCockpitEnvelopeResponse,
-    AdvisorCockpitOwnerRole,
-)
+from app.contracts.advisor_cockpit import AdvisorCockpitEnvelopeResponse
 from app.middleware.correlation import correlation_id_var
 from app.routers.advisor_cockpit_common import (
     ADVISOR_COCKPIT_READ_RESPONSES,
     cockpit_params,
 )
+from app.routers.advisor_cockpit_request import (
+    AdvisorCockpitCaller,
+    authorize_advisor_cockpit_request,
+)
+from app.services.advisor_cockpit_access_policy import ADVISOR_COCKPIT_READ_CAPABILITY
 from app.services.advisory_service_provider import advisor_cockpit_service
 
 router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
@@ -16,20 +18,23 @@ router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 async def _list_advisor_cockpit_preparation_packets(
     *,
+    caller: AdvisorCockpitCaller,
     portfolio_id: str | None,
-    advisor_id: str | None,
-    role: AdvisorCockpitOwnerRole,
     limit: int,
     cursor: str | None,
 ) -> AdvisorCockpitEnvelopeResponse:
+    entitled_portfolio_id = authorize_advisor_cockpit_request(
+        caller,
+        capability=ADVISOR_COCKPIT_READ_CAPABILITY,
+        portfolio_id=portfolio_id,
+    )
     return await advisor_cockpit_service().list_preparation_packets(
         params=cockpit_params(
-            portfolio_id=portfolio_id,
-            advisor_id=advisor_id,
-            role=role,
+            portfolio_id=entitled_portfolio_id,
             limit=limit,
             cursor=cursor,
         ),
+        caller_headers=caller.upstream_headers(),
         correlation_id=correlation_id_var.get(),
     )
 
@@ -42,25 +47,17 @@ async def _list_advisor_cockpit_preparation_packets(
         "Lists source-owned advisor cockpit preparation packets from lotus-advise. Gateway "
         "preserves meeting agenda, proposal context, memo evidence, policy posture, follow-up "
         "posture, lineage refs, and supportability exactly as supplied by Advise without "
-        "reconstructing preparation semantics."
+        "reconstructing preparation semantics. Advisor identity and role are derived from trusted "
+        "caller context."
     ),
     responses=ADVISOR_COCKPIT_READ_RESPONSES,
 )
 async def list_advisor_cockpit_preparation_packets(
+    caller: AdvisorCockpitCaller,
     portfolio_id: str | None = Query(
         default=None,
         description="Optional portfolio identifier forwarded to lotus-advise.",
         examples=["PB_SG_GLOBAL_BAL_001"],
-    ),
-    advisor_id: str | None = Query(
-        default=None,
-        description="Optional advisor identifier forwarded to lotus-advise.",
-        examples=["advisor_sg_001"],
-    ),
-    role: AdvisorCockpitOwnerRole = Query(
-        default="ADVISOR",
-        description="Caller role used by lotus-advise for source-owned cockpit projection.",
-        examples=["ADVISOR"],
     ),
     limit: int = Query(
         default=25,
@@ -76,9 +73,8 @@ async def list_advisor_cockpit_preparation_packets(
     ),
 ) -> AdvisorCockpitEnvelopeResponse:
     return await _list_advisor_cockpit_preparation_packets(
+        caller=caller,
         portfolio_id=portfolio_id,
-        advisor_id=advisor_id,
-        role=role,
         limit=limit,
         cursor=cursor,
     )

--- a/src/app/routers/advisor_cockpit_request.py
+++ b/src/app/routers/advisor_cockpit_request.py
@@ -17,18 +17,12 @@ def advisor_cockpit_caller_context(
     caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
     tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
     region: Annotated[str | None, Header(alias="X-Region")] = None,
-    booking_center_code: Annotated[
-        str | None, Header(alias="X-Booking-Center-Code")
-    ] = None,
-    legal_entity_code: Annotated[
-        str | None, Header(alias="X-Legal-Entity-Code")
-    ] = None,
+    booking_center_code: Annotated[str | None, Header(alias="X-Booking-Center-Code")] = None,
+    legal_entity_code: Annotated[str | None, Header(alias="X-Legal-Entity-Code")] = None,
     role: Annotated[str | None, Header(alias="X-Role")] = None,
     capabilities: Annotated[str | None, Header(alias="X-Caller-Capabilities")] = None,
     principal_status: Annotated[str | None, Header(alias="X-Principal-Status")] = None,
-    authorized_advisor_id: Annotated[
-        str | None, Header(alias="X-Authorized-Advisor-Id")
-    ] = None,
+    authorized_advisor_id: Annotated[str | None, Header(alias="X-Authorized-Advisor-Id")] = None,
     authorized_portfolio_id: Annotated[
         str | None, Header(alias="X-Authorized-Portfolio-Id")
     ] = None,

--- a/src/app/routers/advisor_cockpit_request.py
+++ b/src/app/routers/advisor_cockpit_request.py
@@ -1,0 +1,89 @@
+from typing import Annotated
+
+from fastapi import Depends, Header, HTTPException, Request
+
+from app.services.advisor_cockpit_access_policy import (
+    AdvisorCockpitAccessError,
+    AdvisorCockpitCallerContext,
+    require_advisor_cockpit_caller_context,
+    require_advisor_cockpit_capability,
+    require_advisor_cockpit_portfolio_scope,
+)
+
+
+def advisor_cockpit_caller_context(
+    request: Request,
+    actor_id: Annotated[str | None, Header(alias="X-Actor-Id")] = None,
+    caller_application: Annotated[str | None, Header(alias="X-Caller-Application")] = None,
+    tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    region: Annotated[str | None, Header(alias="X-Region")] = None,
+    booking_center_code: Annotated[
+        str | None, Header(alias="X-Booking-Center-Code")
+    ] = None,
+    legal_entity_code: Annotated[
+        str | None, Header(alias="X-Legal-Entity-Code")
+    ] = None,
+    role: Annotated[str | None, Header(alias="X-Role")] = None,
+    capabilities: Annotated[str | None, Header(alias="X-Caller-Capabilities")] = None,
+    principal_status: Annotated[str | None, Header(alias="X-Principal-Status")] = None,
+    authorized_advisor_id: Annotated[
+        str | None, Header(alias="X-Authorized-Advisor-Id")
+    ] = None,
+    authorized_portfolio_id: Annotated[
+        str | None, Header(alias="X-Authorized-Portfolio-Id")
+    ] = None,
+) -> AdvisorCockpitCallerContext:
+    if "advisor_id" in request.query_params or "role" in request.query_params:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "advisor_cockpit_authority_query_not_supported",
+                "message": "Advisor identity and role are derived from trusted caller context.",
+            },
+        )
+    try:
+        return require_advisor_cockpit_caller_context(
+            actor_id=actor_id,
+            caller_application=caller_application,
+            tenant_id=tenant_id,
+            region=region,
+            booking_center_code=booking_center_code,
+            legal_entity_code=legal_entity_code,
+            role=role,
+            capabilities=capabilities,
+            principal_status=principal_status,
+            authorized_advisor_id=authorized_advisor_id,
+            authorized_portfolio_id=authorized_portfolio_id,
+        )
+    except AdvisorCockpitAccessError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": exc.code, "message": exc.message},
+        ) from exc
+
+
+AdvisorCockpitCaller = Annotated[
+    AdvisorCockpitCallerContext,
+    Depends(advisor_cockpit_caller_context),
+]
+
+
+def authorize_advisor_cockpit_request(
+    caller: AdvisorCockpitCallerContext,
+    *,
+    capability: str,
+    portfolio_id: str | None,
+    portfolio_required: bool = False,
+) -> str | None:
+    try:
+        require_advisor_cockpit_capability(caller, capability)
+        return require_advisor_cockpit_portfolio_scope(
+            caller,
+            portfolio_id,
+            required=portfolio_required,
+        )
+    except AdvisorCockpitAccessError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": exc.code, "message": exc.message},
+        ) from exc

--- a/src/app/routers/advisor_cockpit_snapshot.py
+++ b/src/app/routers/advisor_cockpit_snapshot.py
@@ -1,14 +1,16 @@
 from fastapi import APIRouter, Query
 
-from app.contracts.advisor_cockpit import (
-    AdvisorCockpitEnvelopeResponse,
-    AdvisorCockpitOwnerRole,
-)
+from app.contracts.advisor_cockpit import AdvisorCockpitEnvelopeResponse
 from app.middleware.correlation import correlation_id_var
 from app.routers.advisor_cockpit_common import (
     ADVISOR_COCKPIT_READ_RESPONSES,
     cockpit_params,
 )
+from app.routers.advisor_cockpit_request import (
+    AdvisorCockpitCaller,
+    authorize_advisor_cockpit_request,
+)
+from app.services.advisor_cockpit_access_policy import ADVISOR_COCKPIT_READ_CAPABILITY
 from app.services.advisory_service_provider import advisor_cockpit_service
 
 router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
@@ -16,12 +18,17 @@ router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 async def _get_advisor_cockpit_snapshot(
     *,
+    caller: AdvisorCockpitCaller,
     portfolio_id: str | None,
-    advisor_id: str | None,
-    role: AdvisorCockpitOwnerRole,
 ) -> AdvisorCockpitEnvelopeResponse:
+    entitled_portfolio_id = authorize_advisor_cockpit_request(
+        caller,
+        capability=ADVISOR_COCKPIT_READ_CAPABILITY,
+        portfolio_id=portfolio_id,
+    )
     return await advisor_cockpit_service().get_snapshot(
-        params=cockpit_params(portfolio_id=portfolio_id, advisor_id=advisor_id, role=role),
+        params=cockpit_params(portfolio_id=entitled_portfolio_id),
+        caller_headers=caller.upstream_headers(),
         correlation_id=correlation_id_var.get(),
     )
 
@@ -33,29 +40,20 @@ async def _get_advisor_cockpit_snapshot(
     description=(
         "Returns the source-owned advisor cockpit operating snapshot from lotus-advise. Gateway "
         "preserves supportability, blocked client-ready posture, and unsupported capability "
-        "boundaries without local aggregation."
+        "boundaries without local aggregation. Advisor identity and role are derived from trusted "
+        "caller context."
     ),
     responses=ADVISOR_COCKPIT_READ_RESPONSES,
 )
 async def get_advisor_cockpit_snapshot(
+    caller: AdvisorCockpitCaller,
     portfolio_id: str | None = Query(
         default=None,
         description="Optional portfolio identifier forwarded to lotus-advise.",
         examples=["PB_SG_GLOBAL_BAL_001"],
     ),
-    advisor_id: str | None = Query(
-        default=None,
-        description="Optional advisor identifier forwarded to lotus-advise.",
-        examples=["advisor_sg_001"],
-    ),
-    role: AdvisorCockpitOwnerRole = Query(
-        default="ADVISOR",
-        description="Caller role used by lotus-advise for source-owned cockpit projection.",
-        examples=["ADVISOR"],
-    ),
 ) -> AdvisorCockpitEnvelopeResponse:
     return await _get_advisor_cockpit_snapshot(
+        caller=caller,
         portfolio_id=portfolio_id,
-        advisor_id=advisor_id,
-        role=role,
     )

--- a/src/app/routers/advisor_cockpit_supportability.py
+++ b/src/app/routers/advisor_cockpit_supportability.py
@@ -1,14 +1,16 @@
 from fastapi import APIRouter, Query
 
-from app.contracts.advisor_cockpit import (
-    AdvisorCockpitEnvelopeResponse,
-    AdvisorCockpitOwnerRole,
-)
+from app.contracts.advisor_cockpit import AdvisorCockpitEnvelopeResponse
 from app.middleware.correlation import correlation_id_var
 from app.routers.advisor_cockpit_common import (
     ADVISOR_COCKPIT_READ_RESPONSES,
     cockpit_params,
 )
+from app.routers.advisor_cockpit_request import (
+    AdvisorCockpitCaller,
+    authorize_advisor_cockpit_request,
+)
+from app.services.advisor_cockpit_access_policy import ADVISOR_COCKPIT_READ_CAPABILITY
 from app.services.advisory_service_provider import advisor_cockpit_service
 
 router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
@@ -16,12 +18,17 @@ router = APIRouter(prefix="/api/v1/advisor-cockpit", tags=["advisor-cockpit"])
 
 async def _get_advisor_cockpit_supportability(
     *,
+    caller: AdvisorCockpitCaller,
     portfolio_id: str | None,
-    advisor_id: str | None,
-    role: AdvisorCockpitOwnerRole,
 ) -> AdvisorCockpitEnvelopeResponse:
+    entitled_portfolio_id = authorize_advisor_cockpit_request(
+        caller,
+        capability=ADVISOR_COCKPIT_READ_CAPABILITY,
+        portfolio_id=portfolio_id,
+    )
     return await advisor_cockpit_service().get_supportability(
-        params=cockpit_params(portfolio_id=portfolio_id, advisor_id=advisor_id, role=role),
+        params=cockpit_params(portfolio_id=entitled_portfolio_id),
+        caller_headers=caller.upstream_headers(),
         correlation_id=correlation_id_var.get(),
     )
 
@@ -33,29 +40,20 @@ async def _get_advisor_cockpit_supportability(
     description=(
         "Returns source-owned advisor cockpit supportability from lotus-advise. Gateway preserves "
         "downstream Gateway, Workbench, data-product, client-ready publication, and external "
-        "communication boundaries exactly as supplied by Advise."
+        "communication boundaries exactly as supplied by Advise. Advisor identity and role are "
+        "derived from trusted caller context."
     ),
     responses=ADVISOR_COCKPIT_READ_RESPONSES,
 )
 async def get_advisor_cockpit_supportability(
+    caller: AdvisorCockpitCaller,
     portfolio_id: str | None = Query(
         default=None,
         description="Optional portfolio identifier forwarded to lotus-advise.",
         examples=["PB_SG_GLOBAL_BAL_001"],
     ),
-    advisor_id: str | None = Query(
-        default=None,
-        description="Optional advisor identifier forwarded to lotus-advise.",
-        examples=["advisor_sg_001"],
-    ),
-    role: AdvisorCockpitOwnerRole = Query(
-        default="ADVISOR",
-        description="Caller role used by lotus-advise for source-owned cockpit projection.",
-        examples=["ADVISOR"],
-    ),
 ) -> AdvisorCockpitEnvelopeResponse:
     return await _get_advisor_cockpit_supportability(
+        caller=caller,
         portfolio_id=portfolio_id,
-        advisor_id=advisor_id,
-        role=role,
     )

--- a/src/app/services/advisor_cockpit_access_policy.py
+++ b/src/app/services/advisor_cockpit_access_policy.py
@@ -1,0 +1,215 @@
+import re
+from dataclasses import dataclass
+from typing import cast, get_args
+
+from app.contracts.advisor_cockpit import AdvisorCockpitOwnerRole
+
+ADVISOR_COCKPIT_READ_CAPABILITY = "advisory.advisor_cockpit.read"
+ADVISOR_COCKPIT_ACKNOWLEDGE_CAPABILITY = "advisory.advisor_cockpit.acknowledge"
+
+_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_SUPPORTED_ROLES = frozenset(get_args(AdvisorCockpitOwnerRole))
+
+
+@dataclass(frozen=True)
+class AdvisorCockpitCallerContext:
+    actor_id: str
+    caller_application: str
+    tenant_id: str
+    region: str
+    booking_center_code: str
+    legal_entity_code: str
+    role: AdvisorCockpitOwnerRole
+    capabilities: frozenset[str]
+    principal_status: str
+    authorized_advisor_id: str | None
+    authorized_portfolio_id: str | None
+
+    def upstream_headers(self) -> dict[str, str]:
+        headers = {
+            "X-Actor-Id": self.actor_id,
+            "X-Role": self.role,
+            "X-Tenant-Id": self.tenant_id,
+            "X-Legal-Entity-Code": self.legal_entity_code,
+            "X-Service-Identity": "lotus-gateway",
+            "X-Capabilities": ",".join(sorted(self.capabilities)),
+            "X-Principal-Status": self.principal_status,
+        }
+        if self.authorized_advisor_id is not None:
+            headers["X-Authorized-Advisor-Id"] = self.authorized_advisor_id
+        if self.authorized_portfolio_id is not None:
+            headers["X-Authorized-Portfolio-Id"] = self.authorized_portfolio_id
+        return headers
+
+
+class AdvisorCockpitAccessError(ValueError):
+    def __init__(self, *, code: str, message: str, status_code: int):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+def require_advisor_cockpit_caller_context(
+    *,
+    actor_id: str | None,
+    caller_application: str | None,
+    tenant_id: str | None,
+    region: str | None,
+    booking_center_code: str | None,
+    legal_entity_code: str | None,
+    role: str | None,
+    capabilities: str | None,
+    principal_status: str | None,
+    authorized_advisor_id: str | None,
+    authorized_portfolio_id: str | None,
+) -> AdvisorCockpitCallerContext:
+    required = _required_fields(
+        actor_id=actor_id,
+        caller_application=caller_application,
+        tenant_id=tenant_id,
+        region=region,
+        booking_center_code=booking_center_code,
+        legal_entity_code=legal_entity_code,
+        role=role,
+        capabilities=capabilities,
+        principal_status=principal_status,
+    )
+    resolved_role = required["X-Role"].upper()
+    resolved_principal_status = required["X-Principal-Status"].upper()
+    resolved_capabilities = _identifier_set(required["X-Caller-Capabilities"])
+    optional_scope = {
+        "authorized_advisor_id": _clean(authorized_advisor_id),
+        "authorized_portfolio_id": _clean(authorized_portfolio_id),
+    }
+
+    if resolved_role not in _SUPPORTED_ROLES:
+        raise _access_denied()
+    if resolved_principal_status != "ACTIVE":
+        raise AdvisorCockpitAccessError(
+            code="advisor_cockpit_principal_invalid",
+            message="Advisor Cockpit access requires an active authenticated principal.",
+            status_code=401,
+        )
+    if not resolved_capabilities:
+        raise _invalid_context()
+    if any(
+        not _IDENTIFIER_PATTERN.fullmatch(value)
+        for value in (
+            required["X-Actor-Id"],
+            required["X-Caller-Application"],
+            required["X-Tenant-Id"],
+            required["X-Region"],
+            required["X-Booking-Center-Code"],
+            required["X-Legal-Entity-Code"],
+            *resolved_capabilities,
+            *(value for value in optional_scope.values() if value is not None),
+        )
+    ):
+        raise _invalid_context()
+
+    resolved_authorized_advisor_id = optional_scope["authorized_advisor_id"]
+    if resolved_role == "ADVISOR":
+        if resolved_authorized_advisor_id not in {None, required["X-Actor-Id"]}:
+            raise _access_denied()
+        resolved_authorized_advisor_id = required["X-Actor-Id"]
+
+    return AdvisorCockpitCallerContext(
+        actor_id=required["X-Actor-Id"],
+        caller_application=required["X-Caller-Application"],
+        tenant_id=required["X-Tenant-Id"],
+        region=required["X-Region"],
+        booking_center_code=required["X-Booking-Center-Code"],
+        legal_entity_code=required["X-Legal-Entity-Code"].upper(),
+        role=cast(AdvisorCockpitOwnerRole, resolved_role),
+        capabilities=resolved_capabilities,
+        principal_status=resolved_principal_status,
+        authorized_advisor_id=resolved_authorized_advisor_id,
+        authorized_portfolio_id=optional_scope["authorized_portfolio_id"],
+    )
+
+
+def require_advisor_cockpit_capability(
+    caller: AdvisorCockpitCallerContext,
+    capability: str,
+) -> None:
+    if capability not in caller.capabilities:
+        raise _access_denied()
+
+
+def require_advisor_cockpit_portfolio_scope(
+    caller: AdvisorCockpitCallerContext,
+    portfolio_id: str | None,
+    *,
+    required: bool = False,
+) -> str | None:
+    requested_portfolio_id = _clean(portfolio_id)
+    entitled_portfolio_id = caller.authorized_portfolio_id
+    if required and requested_portfolio_id is None:
+        raise AdvisorCockpitAccessError(
+            code="advisor_cockpit_portfolio_required",
+            message="A portfolio is required for this advisor workflow.",
+            status_code=422,
+        )
+    if requested_portfolio_id is not None and entitled_portfolio_id is None:
+        raise AdvisorCockpitAccessError(
+            code="advisor_cockpit_portfolio_scope_required",
+            message="Trusted portfolio entitlement is required for this advisor workflow.",
+            status_code=401,
+        )
+    if requested_portfolio_id is not None and requested_portfolio_id != entitled_portfolio_id:
+        raise AdvisorCockpitAccessError(
+            code="advisor_cockpit_portfolio_access_denied",
+            message="Advisor Cockpit access is not available for this portfolio.",
+            status_code=403,
+        )
+    return requested_portfolio_id or entitled_portfolio_id
+
+
+def _required_fields(**values: str | None) -> dict[str, str]:
+    headers = {
+        "X-Actor-Id": _clean(values["actor_id"]),
+        "X-Caller-Application": _clean(values["caller_application"]),
+        "X-Tenant-Id": _clean(values["tenant_id"]),
+        "X-Region": _clean(values["region"]),
+        "X-Booking-Center-Code": _clean(values["booking_center_code"]),
+        "X-Legal-Entity-Code": _clean(values["legal_entity_code"]),
+        "X-Role": _clean(values["role"]),
+        "X-Caller-Capabilities": _clean(values["capabilities"]),
+        "X-Principal-Status": _clean(values["principal_status"]),
+    }
+    missing = [name for name, value in headers.items() if value is None]
+    if missing:
+        raise AdvisorCockpitAccessError(
+            code="advisor_cockpit_caller_context_missing",
+            message="Required Advisor Cockpit caller context is missing.",
+            status_code=400,
+        )
+    return {name: value for name, value in headers.items() if value is not None}
+
+
+def _identifier_set(value: str) -> frozenset[str]:
+    return frozenset(part.strip() for part in value.split(",") if part.strip())
+
+
+def _invalid_context() -> AdvisorCockpitAccessError:
+    return AdvisorCockpitAccessError(
+        code="advisor_cockpit_caller_context_invalid",
+        message="Advisor Cockpit caller context is invalid.",
+        status_code=400,
+    )
+
+
+def _access_denied() -> AdvisorCockpitAccessError:
+    return AdvisorCockpitAccessError(
+        code="advisor_cockpit_access_denied",
+        message="Advisor Cockpit access is not available for this caller.",
+        status_code=403,
+    )
+
+
+def _clean(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None

--- a/src/app/services/advisor_cockpit_access_policy.py
+++ b/src/app/services/advisor_cockpit_access_policy.py
@@ -75,45 +75,29 @@ def require_advisor_cockpit_caller_context(
         capabilities=capabilities,
         principal_status=principal_status,
     )
-    resolved_role = required["X-Role"].upper()
-    resolved_principal_status = required["X-Principal-Status"].upper()
-    resolved_capabilities = _identifier_set(required["X-Caller-Capabilities"])
-    optional_scope = {
-        "authorized_advisor_id": _clean(authorized_advisor_id),
-        "authorized_portfolio_id": _clean(authorized_portfolio_id),
-    }
+    return _context_from_fields(
+        required,
+        authorized_advisor_id=_clean(authorized_advisor_id),
+        authorized_portfolio_id=_clean(authorized_portfolio_id),
+    )
 
-    if resolved_role not in _SUPPORTED_ROLES:
-        raise _access_denied()
-    if resolved_principal_status != "ACTIVE":
-        raise AdvisorCockpitAccessError(
-            code="advisor_cockpit_principal_invalid",
-            message="Advisor Cockpit access requires an active authenticated principal.",
-            status_code=401,
-        )
-    if not resolved_capabilities:
-        raise _invalid_context()
-    if any(
-        not _IDENTIFIER_PATTERN.fullmatch(value)
-        for value in (
-            required["X-Actor-Id"],
-            required["X-Caller-Application"],
-            required["X-Tenant-Id"],
-            required["X-Region"],
-            required["X-Booking-Center-Code"],
-            required["X-Legal-Entity-Code"],
-            *resolved_capabilities,
-            *(value for value in optional_scope.values() if value is not None),
-        )
-    ):
-        raise _invalid_context()
 
-    resolved_authorized_advisor_id = optional_scope["authorized_advisor_id"]
-    if resolved_role == "ADVISOR":
-        if resolved_authorized_advisor_id not in {None, required["X-Actor-Id"]}:
-            raise _access_denied()
-        resolved_authorized_advisor_id = required["X-Actor-Id"]
-
+def _context_from_fields(
+    required: dict[str, str],
+    *,
+    authorized_advisor_id: str | None,
+    authorized_portfolio_id: str | None,
+) -> AdvisorCockpitCallerContext:
+    role = required["X-Role"].upper()
+    principal_status = required["X-Principal-Status"].upper()
+    capabilities = _identifier_set(required["X-Caller-Capabilities"])
+    _validate_principal(role, principal_status, capabilities)
+    _validate_identifiers(required, capabilities, authorized_advisor_id, authorized_portfolio_id)
+    advisor_scope = _authorized_advisor_scope(
+        role=role,
+        actor_id=required["X-Actor-Id"],
+        authorized_advisor_id=authorized_advisor_id,
+    )
     return AdvisorCockpitCallerContext(
         actor_id=required["X-Actor-Id"],
         caller_application=required["X-Caller-Application"],
@@ -121,12 +105,62 @@ def require_advisor_cockpit_caller_context(
         region=required["X-Region"],
         booking_center_code=required["X-Booking-Center-Code"],
         legal_entity_code=required["X-Legal-Entity-Code"].upper(),
-        role=cast(AdvisorCockpitOwnerRole, resolved_role),
-        capabilities=resolved_capabilities,
-        principal_status=resolved_principal_status,
-        authorized_advisor_id=resolved_authorized_advisor_id,
-        authorized_portfolio_id=optional_scope["authorized_portfolio_id"],
+        role=cast(AdvisorCockpitOwnerRole, role),
+        capabilities=capabilities,
+        principal_status=principal_status,
+        authorized_advisor_id=advisor_scope,
+        authorized_portfolio_id=authorized_portfolio_id,
     )
+
+
+def _validate_principal(
+    role: str,
+    principal_status: str,
+    capabilities: frozenset[str],
+) -> None:
+    if role not in _SUPPORTED_ROLES:
+        raise _access_denied()
+    if principal_status != "ACTIVE":
+        raise AdvisorCockpitAccessError(
+            code="advisor_cockpit_principal_invalid",
+            message="Advisor Cockpit access requires an active authenticated principal.",
+            status_code=401,
+        )
+    if not capabilities:
+        raise _invalid_context()
+
+
+def _validate_identifiers(
+    required: dict[str, str],
+    capabilities: frozenset[str],
+    authorized_advisor_id: str | None,
+    authorized_portfolio_id: str | None,
+) -> None:
+    identifiers = (
+        required["X-Actor-Id"],
+        required["X-Caller-Application"],
+        required["X-Tenant-Id"],
+        required["X-Region"],
+        required["X-Booking-Center-Code"],
+        required["X-Legal-Entity-Code"],
+        *capabilities,
+        *(value for value in (authorized_advisor_id, authorized_portfolio_id) if value),
+    )
+    if any(not _IDENTIFIER_PATTERN.fullmatch(value) for value in identifiers):
+        raise _invalid_context()
+
+
+def _authorized_advisor_scope(
+    *,
+    role: str,
+    actor_id: str,
+    authorized_advisor_id: str | None,
+) -> str | None:
+    if role != "ADVISOR":
+        return authorized_advisor_id
+    if authorized_advisor_id not in {None, actor_id}:
+        raise _access_denied()
+    return actor_id
 
 
 def require_advisor_cockpit_capability(

--- a/src/app/services/advisor_cockpit_client_protocols.py
+++ b/src/app/services/advisor_cockpit_client_protocols.py
@@ -6,6 +6,7 @@ class AdvisorCockpitClient(Protocol):
         self,
         *,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
 
@@ -13,6 +14,7 @@ class AdvisorCockpitClient(Protocol):
         self,
         *,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
 
@@ -21,6 +23,7 @@ class AdvisorCockpitClient(Protocol):
         *,
         action_item_id: str,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
 
@@ -28,6 +31,7 @@ class AdvisorCockpitClient(Protocol):
         self,
         *,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
 
@@ -35,6 +39,7 @@ class AdvisorCockpitClient(Protocol):
         self,
         *,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
 
@@ -44,6 +49,7 @@ class AdvisorCockpitClient(Protocol):
         action_item_id: str,
         body: dict[str, Any],
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         idempotency_key: str,
         correlation_id: str,
     ) -> tuple[int, dict[str, Any]]: ...

--- a/src/app/services/advisor_cockpit_service.py
+++ b/src/app/services/advisor_cockpit_service.py
@@ -23,10 +23,12 @@ class AdvisorCockpitService:
         self,
         *,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> AdvisorCockpitEnvelopeResponse:
         upstream_status, upstream_payload = await self._advise_client.list_advisor_cockpit_actions(
             params=params,
+            caller_headers=caller_headers,
             correlation_id=correlation_id,
         )
         self._raise_for_upstream_error(upstream_status, upstream_payload)
@@ -36,6 +38,7 @@ class AdvisorCockpitService:
         self,
         *,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> AdvisorCockpitEnvelopeResponse:
         (
@@ -43,6 +46,7 @@ class AdvisorCockpitService:
             upstream_payload,
         ) = await self._advise_client.list_advisor_cockpit_preparation_packets(
             params=params,
+            caller_headers=caller_headers,
             correlation_id=correlation_id,
         )
         self._raise_for_upstream_error(upstream_status, upstream_payload)
@@ -53,11 +57,13 @@ class AdvisorCockpitService:
         *,
         action_item_id: str,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> AdvisorCockpitEnvelopeResponse:
         upstream_status, upstream_payload = await self._advise_client.get_advisor_cockpit_action(
             action_item_id=action_item_id,
             params=params,
+            caller_headers=caller_headers,
             correlation_id=correlation_id,
         )
         self._raise_for_upstream_error(upstream_status, upstream_payload)
@@ -67,10 +73,12 @@ class AdvisorCockpitService:
         self,
         *,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> AdvisorCockpitEnvelopeResponse:
         upstream_status, upstream_payload = await self._advise_client.get_advisor_cockpit_snapshot(
             params=params,
+            caller_headers=caller_headers,
             correlation_id=correlation_id,
         )
         self._raise_for_upstream_error(upstream_status, upstream_payload)
@@ -80,6 +88,7 @@ class AdvisorCockpitService:
         self,
         *,
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> AdvisorCockpitEnvelopeResponse:
         (
@@ -87,6 +96,7 @@ class AdvisorCockpitService:
             upstream_payload,
         ) = await self._advise_client.get_advisor_cockpit_supportability(
             params=params,
+            caller_headers=caller_headers,
             correlation_id=correlation_id,
         )
         self._raise_for_upstream_error(upstream_status, upstream_payload)
@@ -98,6 +108,7 @@ class AdvisorCockpitService:
         action_item_id: str,
         body: dict[str, Any],
         params: dict[str, Any],
+        caller_headers: dict[str, str],
         idempotency_key: str,
         correlation_id: str,
     ) -> AdvisorCockpitEnvelopeResponse:
@@ -108,6 +119,7 @@ class AdvisorCockpitService:
             action_item_id=action_item_id,
             body=body,
             params=params,
+            caller_headers=caller_headers,
             idempotency_key=idempotency_key,
             correlation_id=correlation_id,
         )

--- a/tests/integration/test_advisor_cockpit_router.py
+++ b/tests/integration/test_advisor_cockpit_router.py
@@ -5,9 +5,7 @@ from app.main import app
 
 def _caller_headers(
     *,
-    capabilities: str = (
-        "advisory.advisor_cockpit.read,advisory.advisor_cockpit.acknowledge"
-    ),
+    capabilities: str = ("advisory.advisor_cockpit.read,advisory.advisor_cockpit.acknowledge"),
     role: str = "ADVISOR",
     portfolio_id: str | None = "PB_SG_GLOBAL_BAL_001",
 ) -> dict[str, str]:
@@ -81,7 +79,11 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
         }
 
     async def _fake_get_action(
-        self, action_item_id, params, caller_headers, correlation_id  # noqa: ANN001
+        self,
+        action_item_id,
+        params,
+        caller_headers,
+        correlation_id,  # noqa: ANN001
     ):
         _ = self
         captured["get_action"] = {
@@ -98,7 +100,10 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
         }
 
     async def _fake_preparation_packets(
-        self, params, caller_headers, correlation_id  # noqa: ANN001
+        self,
+        params,
+        caller_headers,
+        correlation_id,  # noqa: ANN001
     ):
         _ = self
         captured["preparation_packets"] = {
@@ -120,7 +125,10 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
         }
 
     async def _fake_supportability(
-        self, params, caller_headers, correlation_id  # noqa: ANN001
+        self,
+        params,
+        caller_headers,
+        correlation_id,  # noqa: ANN001
     ):
         _ = self
         captured["supportability"] = {
@@ -281,9 +289,7 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
     assert acknowledgement_response.json()["data"]["action_item"]["status"] == "PENDING_REVIEW"
     assert house_view_response.json()["data"]["product_name"] == "TacticalHouseViewAffectedCohort"
     expected_advisor_headers = _expected_upstream_headers(
-        capability=(
-            "advisory.advisor_cockpit.acknowledge,advisory.advisor_cockpit.read"
-        )
+        capability=("advisory.advisor_cockpit.acknowledge,advisory.advisor_cockpit.read")
     )
     for operation in (
         "list",
@@ -332,12 +338,11 @@ def test_advisor_cockpit_openapi_documents_boundary_and_idempotency() -> None:
     assert "HOUSE_VIEW_IMPACT_REVIEW" in house_view_operation["description"]
     assert "does not discover candidate portfolios" in house_view_operation["description"]
     assert "does not clear blocking policy" in ack_operation["description"]
-    assert "acknowledging actor is derived from trusted caller context" in ack_operation[
-        "description"
-    ]
+    assert (
+        "acknowledging actor is derived from trusted caller context" in ack_operation["description"]
+    )
     assert not any(
-        parameter["name"] in {"advisor_id", "role"}
-        and parameter["in"] == "query"
+        parameter["name"] in {"advisor_id", "role"} and parameter["in"] == "query"
         for parameter in action_operation["parameters"]
     )
     assert {
@@ -381,9 +386,7 @@ def test_advisor_cockpit_rejects_browser_selected_authority() -> None:
     )
 
     assert response.status_code == 422
-    assert response.json()["detail"]["code"] == (
-        "advisor_cockpit_authority_query_not_supported"
-    )
+    assert response.json()["detail"]["code"] == ("advisor_cockpit_authority_query_not_supported")
 
 
 def test_advisor_cockpit_fails_closed_without_trusted_context_or_capability() -> None:
@@ -396,9 +399,7 @@ def test_advisor_cockpit_fails_closed_without_trusted_context_or_capability() ->
     )
 
     assert missing_context.status_code == 400
-    assert missing_context.json()["detail"]["code"] == (
-        "advisor_cockpit_caller_context_missing"
-    )
+    assert missing_context.json()["detail"]["code"] == ("advisor_cockpit_caller_context_missing")
     assert missing_capability.status_code == 403
     assert missing_capability.json()["detail"]["code"] == "advisor_cockpit_access_denied"
 
@@ -413,9 +414,7 @@ def test_advisor_cockpit_rejects_cross_portfolio_access_before_upstream_call() -
     )
 
     assert response.status_code == 403
-    assert response.json()["detail"]["code"] == (
-        "advisor_cockpit_portfolio_access_denied"
-    )
+    assert response.json()["detail"]["code"] == ("advisor_cockpit_portfolio_access_denied")
 
 
 def test_advisor_cockpit_action_lookup_requires_entitled_portfolio() -> None:
@@ -447,9 +446,9 @@ def test_advisor_cockpit_acknowledgement_rejects_body_actor_override() -> None:
 
 
 def test_tactical_house_view_route_does_not_claim_cockpit_authority() -> None:
-    operation = app.openapi()["paths"][
-        "/api/v1/advisor-cockpit/house-view-cohorts/evaluate"
-    ]["post"]
+    operation = app.openapi()["paths"]["/api/v1/advisor-cockpit/house-view-cohorts/evaluate"][
+        "post"
+    ]
 
     assert not any(
         parameter["in"] == "header" and "Capability" in parameter["name"]

--- a/tests/integration/test_advisor_cockpit_router.py
+++ b/tests/integration/test_advisor_cockpit_router.py
@@ -3,12 +3,55 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
+def _caller_headers(
+    *,
+    capabilities: str = (
+        "advisory.advisor_cockpit.read,advisory.advisor_cockpit.acknowledge"
+    ),
+    role: str = "ADVISOR",
+    portfolio_id: str | None = "PB_SG_GLOBAL_BAL_001",
+) -> dict[str, str]:
+    headers = {
+        "X-Actor-Id": "advisor_sg_001",
+        "X-Caller-Application": "lotus-workbench",
+        "X-Tenant-Id": "tenant-sg",
+        "X-Region": "APAC",
+        "X-Booking-Center-Code": "SG",
+        "X-Legal-Entity-Code": "SGPB",
+        "X-Role": role,
+        "X-Caller-Capabilities": capabilities,
+        "X-Principal-Status": "ACTIVE",
+        "X-Authorized-Advisor-Id": "advisor_sg_001",
+    }
+    if portfolio_id is not None:
+        headers["X-Authorized-Portfolio-Id"] = portfolio_id
+    return headers
+
+
+def _expected_upstream_headers(*, capability: str) -> dict[str, str]:
+    return {
+        "X-Actor-Id": "advisor_sg_001",
+        "X-Role": "ADVISOR",
+        "X-Tenant-Id": "tenant-sg",
+        "X-Legal-Entity-Code": "SGPB",
+        "X-Service-Identity": "lotus-gateway",
+        "X-Capabilities": capability,
+        "X-Principal-Status": "ACTIVE",
+        "X-Authorized-Advisor-Id": "advisor_sg_001",
+        "X-Authorized-Portfolio-Id": "PB_SG_GLOBAL_BAL_001",
+    }
+
+
 def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch):
     captured: dict[str, object] = {}
 
-    async def _fake_list(self, params, correlation_id):  # noqa: ANN001
+    async def _fake_list(self, params, caller_headers, correlation_id):  # noqa: ANN001
         _ = self
-        captured["list"] = {"params": params, "correlation_id": correlation_id}
+        captured["list"] = {
+            "params": params,
+            "caller_headers": caller_headers,
+            "correlation_id": correlation_id,
+        }
         return 200, {
             "items": [
                 {
@@ -21,9 +64,13 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
             "total_count": 1,
         }
 
-    async def _fake_snapshot(self, params, correlation_id):  # noqa: ANN001
+    async def _fake_snapshot(self, params, caller_headers, correlation_id):  # noqa: ANN001
         _ = self
-        captured["snapshot"] = {"params": params, "correlation_id": correlation_id}
+        captured["snapshot"] = {
+            "params": params,
+            "caller_headers": caller_headers,
+            "correlation_id": correlation_id,
+        }
         return 200, {
             "snapshot_id": "cockpit_snapshot_PB_SG_GLOBAL_BAL_001",
             "supportability": {
@@ -33,11 +80,14 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
             },
         }
 
-    async def _fake_get_action(self, action_item_id, params, correlation_id):  # noqa: ANN001
+    async def _fake_get_action(
+        self, action_item_id, params, caller_headers, correlation_id  # noqa: ANN001
+    ):
         _ = self
         captured["get_action"] = {
             "action_item_id": action_item_id,
             "params": params,
+            "caller_headers": caller_headers,
             "correlation_id": correlation_id,
         }
         return 200, {
@@ -47,9 +97,15 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
             "owner_role": "ADVISOR",
         }
 
-    async def _fake_preparation_packets(self, params, correlation_id):  # noqa: ANN001
+    async def _fake_preparation_packets(
+        self, params, caller_headers, correlation_id  # noqa: ANN001
+    ):
         _ = self
-        captured["preparation_packets"] = {"params": params, "correlation_id": correlation_id}
+        captured["preparation_packets"] = {
+            "params": params,
+            "caller_headers": caller_headers,
+            "correlation_id": correlation_id,
+        }
         return 200, {
             "items": [
                 {
@@ -63,9 +119,15 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
             "total_count": 1,
         }
 
-    async def _fake_supportability(self, params, correlation_id):  # noqa: ANN001
+    async def _fake_supportability(
+        self, params, caller_headers, correlation_id  # noqa: ANN001
+    ):
         _ = self
-        captured["supportability"] = {"params": params, "correlation_id": correlation_id}
+        captured["supportability"] = {
+            "params": params,
+            "caller_headers": caller_headers,
+            "correlation_id": correlation_id,
+        }
         return 200, {
             "posture": "ADVISE_GATEWAY_WORKBENCH_CANONICAL_PROOF_SUPPORTED",
             "supportability": {
@@ -80,6 +142,7 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
         action_item_id,
         body,
         params,
+        caller_headers,
         idempotency_key,
         correlation_id,  # noqa: ANN001
     ):
@@ -88,6 +151,7 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
             "action_item_id": action_item_id,
             "body": body,
             "params": params,
+            "caller_headers": caller_headers,
             "idempotency_key": idempotency_key,
             "correlation_id": correlation_id,
         }
@@ -99,7 +163,10 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
 
     async def _fake_house_view(self, body, correlation_id):  # noqa: ANN001
         _ = self
-        captured["house_view"] = {"body": body, "correlation_id": correlation_id}
+        captured["house_view"] = {
+            "body": body,
+            "correlation_id": correlation_id,
+        }
         return 200, {
             "product_name": "TacticalHouseViewAffectedCohort",
             "affected_portfolios": [{"portfolio_id": "PB_SG_GLOBAL_BAL_001"}],
@@ -140,52 +207,46 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
         "/api/v1/advisor-cockpit/actions",
         params={
             "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-            "advisor_id": "advisor_sg_001",
-            "role": "ADVISOR",
             "limit": "25",
         },
-        headers={"X-Correlation-Id": "corr-cockpit-list"},
+        headers={**_caller_headers(), "X-Correlation-Id": "corr-cockpit-list"},
     )
     snapshot_response = client.get(
         "/api/v1/advisor-cockpit/snapshot",
-        params={"portfolio_id": "PB_SG_GLOBAL_BAL_001", "role": "ADVISOR"},
-        headers={"X-Correlation-Id": "corr-cockpit-snapshot"},
+        params={"portfolio_id": "PB_SG_GLOBAL_BAL_001"},
+        headers={**_caller_headers(), "X-Correlation-Id": "corr-cockpit-snapshot"},
     )
     action_response = client.get(
         "/api/v1/advisor-cockpit/actions/cockpit_action_001",
         params={
             "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-            "advisor_id": "advisor_sg_001",
-            "role": "ADVISOR",
         },
-        headers={"X-Correlation-Id": "corr-cockpit-get-action"},
+        headers={**_caller_headers(), "X-Correlation-Id": "corr-cockpit-get-action"},
     )
     preparation_packets_response = client.get(
         "/api/v1/advisor-cockpit/preparation-packets",
         params={
             "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-            "advisor_id": "advisor_sg_001",
-            "role": "ADVISOR",
             "limit": "10",
         },
-        headers={"X-Correlation-Id": "corr-cockpit-prep"},
+        headers={**_caller_headers(), "X-Correlation-Id": "corr-cockpit-prep"},
     )
     supportability_response = client.get(
         "/api/v1/advisor-cockpit/supportability",
-        params={"portfolio_id": "PB_SG_GLOBAL_BAL_001", "role": "ADVISOR"},
-        headers={"X-Correlation-Id": "corr-cockpit-supportability"},
+        params={"portfolio_id": "PB_SG_GLOBAL_BAL_001"},
+        headers={**_caller_headers(), "X-Correlation-Id": "corr-cockpit-supportability"},
     )
     acknowledgement_response = client.post(
         "/api/v1/advisor-cockpit/actions/cockpit_action_001/acknowledgements",
-        params={"portfolio_id": "PB_SG_GLOBAL_BAL_001", "role": "ADVISOR"},
+        params={"portfolio_id": "PB_SG_GLOBAL_BAL_001"},
         json={
             "action_item_version": 1,
-            "acknowledged_by": "advisor_sg_001",
             "acknowledgement_note": "Reviewed pending policy action.",
         },
         headers={
             "Idempotency-Key": "idem-cockpit-ack",
             "X-Correlation-Id": "corr-cockpit-ack",
+            **_caller_headers(),
         },
     )
     house_view_response = client.post(
@@ -196,7 +257,9 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
                 "candidate_portfolios": [{"portfolio_id": "PB_SG_GLOBAL_BAL_001"}],
             }
         },
-        headers={"X-Correlation-Id": "corr-cockpit-house-view"},
+        headers={
+            "X-Correlation-Id": "corr-cockpit-house-view",
+        },
     )
 
     assert list_response.status_code == 200
@@ -217,61 +280,39 @@ def test_advisor_cockpit_routes_forward_to_advise_without_rewriting(monkeypatch)
     )
     assert acknowledgement_response.json()["data"]["action_item"]["status"] == "PENDING_REVIEW"
     assert house_view_response.json()["data"]["product_name"] == "TacticalHouseViewAffectedCohort"
-    assert captured == {
-        "list": {
-            "params": {
-                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-                "advisor_id": "advisor_sg_001",
-                "role": "ADVISOR",
-                "limit": 25,
-            },
-            "correlation_id": "corr-cockpit-list",
-        },
-        "snapshot": {
-            "params": {"portfolio_id": "PB_SG_GLOBAL_BAL_001", "role": "ADVISOR"},
-            "correlation_id": "corr-cockpit-snapshot",
-        },
-        "get_action": {
-            "action_item_id": "cockpit_action_001",
-            "params": {
-                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-                "advisor_id": "advisor_sg_001",
-                "role": "ADVISOR",
-            },
-            "correlation_id": "corr-cockpit-get-action",
-        },
-        "preparation_packets": {
-            "params": {
-                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-                "advisor_id": "advisor_sg_001",
-                "role": "ADVISOR",
-                "limit": 10,
-            },
-            "correlation_id": "corr-cockpit-prep",
-        },
-        "supportability": {
-            "params": {"portfolio_id": "PB_SG_GLOBAL_BAL_001", "role": "ADVISOR"},
-            "correlation_id": "corr-cockpit-supportability",
-        },
-        "acknowledge": {
-            "action_item_id": "cockpit_action_001",
-            "body": {
-                "action_item_version": 1,
-                "acknowledged_by": "advisor_sg_001",
-                "acknowledgement_note": "Reviewed pending policy action.",
-            },
-            "params": {"portfolio_id": "PB_SG_GLOBAL_BAL_001", "role": "ADVISOR"},
-            "idempotency_key": "idem-cockpit-ack",
-            "correlation_id": "corr-cockpit-ack",
-        },
-        "house_view": {
-            "body": {
-                "tactical_view": {"tactical_view_id": "thv_2026_05_asia_duration"},
-                "candidate_portfolios": [{"portfolio_id": "PB_SG_GLOBAL_BAL_001"}],
-            },
-            "correlation_id": "corr-cockpit-house-view",
-        },
+    expected_advisor_headers = _expected_upstream_headers(
+        capability=(
+            "advisory.advisor_cockpit.acknowledge,advisory.advisor_cockpit.read"
+        )
+    )
+    for operation in (
+        "list",
+        "snapshot",
+        "get_action",
+        "preparation_packets",
+        "supportability",
+        "acknowledge",
+    ):
+        assert captured[operation]["caller_headers"] == expected_advisor_headers  # type: ignore[index]
+
+    assert captured["list"]["params"] == {  # type: ignore[index]
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "limit": 25,
     }
+    assert captured["snapshot"]["params"] == {  # type: ignore[index]
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+    }
+    assert captured["get_action"]["action_item_id"] == "cockpit_action_001"  # type: ignore[index]
+    assert captured["preparation_packets"]["params"] == {  # type: ignore[index]
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "limit": 10,
+    }
+    assert captured["acknowledge"]["body"] == {  # type: ignore[index]
+        "action_item_version": 1,
+        "acknowledged_by": "advisor_sg_001",
+        "acknowledgement_note": "Reviewed pending policy action.",
+    }
+    assert captured["house_view"]["correlation_id"] == "corr-cockpit-house-view"  # type: ignore[index]
 
 
 def test_advisor_cockpit_openapi_documents_boundary_and_idempotency() -> None:
@@ -287,9 +328,34 @@ def test_advisor_cockpit_openapi_documents_boundary_and_idempotency() -> None:
 
     assert "without reconstructing advisory semantics" in action_operation["description"]
     assert "without reconstructing preparation semantics" in preparation_operation["description"]
+    assert "derived from trusted caller context" in action_operation["description"]
     assert "HOUSE_VIEW_IMPACT_REVIEW" in house_view_operation["description"]
     assert "does not discover candidate portfolios" in house_view_operation["description"]
     assert "does not clear blocking policy" in ack_operation["description"]
+    assert "acknowledging actor is derived from trusted caller context" in ack_operation[
+        "description"
+    ]
+    assert not any(
+        parameter["name"] in {"advisor_id", "role"}
+        and parameter["in"] == "query"
+        for parameter in action_operation["parameters"]
+    )
+    assert {
+        parameter["name"]
+        for parameter in action_operation["parameters"]
+        if parameter["in"] == "header"
+    } >= {
+        "X-Actor-Id",
+        "X-Tenant-Id",
+        "X-Region",
+        "X-Booking-Center-Code",
+        "X-Legal-Entity-Code",
+        "X-Role",
+        "X-Caller-Capabilities",
+        "X-Principal-Status",
+        "X-Authorized-Advisor-Id",
+        "X-Authorized-Portfolio-Id",
+    }
     assert ack_operation["responses"]["409"]["description"] == (
         "lotus-advise rejected a conflicting acknowledgement idempotency key."
     )
@@ -298,4 +364,94 @@ def test_advisor_cockpit_openapi_documents_boundary_and_idempotency() -> None:
         and parameter["in"] == "header"
         and parameter["required"] is True
         for parameter in ack_operation["parameters"]
+    )
+
+    acknowledge_schema = schema["components"]["schemas"]["AdvisorCockpitAcknowledgeRequest"]
+    assert "acknowledged_by" not in acknowledge_schema["properties"]
+    assert acknowledge_schema["additionalProperties"] is False
+
+
+def test_advisor_cockpit_rejects_browser_selected_authority() -> None:
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/advisor-cockpit/actions",
+        params={"advisor_id": "another_advisor", "role": "DESK_HEAD"},
+        headers=_caller_headers(),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == (
+        "advisor_cockpit_authority_query_not_supported"
+    )
+
+
+def test_advisor_cockpit_fails_closed_without_trusted_context_or_capability() -> None:
+    client = TestClient(app)
+
+    missing_context = client.get("/api/v1/advisor-cockpit/actions")
+    missing_capability = client.get(
+        "/api/v1/advisor-cockpit/actions",
+        headers=_caller_headers(capabilities="portfolio.read"),
+    )
+
+    assert missing_context.status_code == 400
+    assert missing_context.json()["detail"]["code"] == (
+        "advisor_cockpit_caller_context_missing"
+    )
+    assert missing_capability.status_code == 403
+    assert missing_capability.json()["detail"]["code"] == "advisor_cockpit_access_denied"
+
+
+def test_advisor_cockpit_rejects_cross_portfolio_access_before_upstream_call() -> None:
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/advisor-cockpit/actions",
+        params={"portfolio_id": "PB_NOT_ENTITLED"},
+        headers=_caller_headers(),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == (
+        "advisor_cockpit_portfolio_access_denied"
+    )
+
+
+def test_advisor_cockpit_action_lookup_requires_entitled_portfolio() -> None:
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/advisor-cockpit/actions/cockpit_action_001",
+        headers=_caller_headers(),
+    )
+
+    assert response.status_code == 422
+
+
+def test_advisor_cockpit_acknowledgement_rejects_body_actor_override() -> None:
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/advisor-cockpit/actions/cockpit_action_001/acknowledgements",
+        params={"portfolio_id": "PB_SG_GLOBAL_BAL_001"},
+        headers={**_caller_headers(), "Idempotency-Key": "idem-actor-override"},
+        json={
+            "action_item_version": 1,
+            "acknowledged_by": "another_advisor",
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["type"] == "extra_forbidden"
+
+
+def test_tactical_house_view_route_does_not_claim_cockpit_authority() -> None:
+    operation = app.openapi()["paths"][
+        "/api/v1/advisor-cockpit/house-view-cohorts/evaluate"
+    ]["post"]
+
+    assert not any(
+        parameter["in"] == "header" and "Capability" in parameter["name"]
+        for parameter in operation.get("parameters", [])
     )

--- a/tests/unit/test_advisor_cockpit_access_policy.py
+++ b/tests/unit/test_advisor_cockpit_access_policy.py
@@ -19,9 +19,7 @@ def _context(**overrides: str | None):
         "booking_center_code": "SG",
         "legal_entity_code": "SGPB",
         "role": "ADVISOR",
-        "capabilities": (
-            "advisory.advisor_cockpit.read,advisory.advisor_cockpit.acknowledge"
-        ),
+        "capabilities": ("advisory.advisor_cockpit.read,advisory.advisor_cockpit.acknowledge"),
         "principal_status": "ACTIVE",
         "authorized_advisor_id": "advisor_sg_001",
         "authorized_portfolio_id": "PB_SG_GLOBAL_BAL_001",
@@ -46,9 +44,7 @@ def test_caller_context_preserves_bounded_trusted_authority() -> None:
         "X-Tenant-Id": "tenant-sg",
         "X-Legal-Entity-Code": "SGPB",
         "X-Service-Identity": "lotus-gateway",
-        "X-Capabilities": (
-            "advisory.advisor_cockpit.acknowledge,advisory.advisor_cockpit.read"
-        ),
+        "X-Capabilities": ("advisory.advisor_cockpit.acknowledge,advisory.advisor_cockpit.read"),
         "X-Principal-Status": "ACTIVE",
         "X-Authorized-Advisor-Id": "advisor_sg_001",
         "X-Authorized-Portfolio-Id": "PB_SG_GLOBAL_BAL_001",

--- a/tests/unit/test_advisor_cockpit_access_policy.py
+++ b/tests/unit/test_advisor_cockpit_access_policy.py
@@ -1,0 +1,142 @@
+import pytest
+
+from app.services.advisor_cockpit_access_policy import (
+    ADVISOR_COCKPIT_ACKNOWLEDGE_CAPABILITY,
+    ADVISOR_COCKPIT_READ_CAPABILITY,
+    AdvisorCockpitAccessError,
+    require_advisor_cockpit_caller_context,
+    require_advisor_cockpit_capability,
+    require_advisor_cockpit_portfolio_scope,
+)
+
+
+def _context(**overrides: str | None):
+    values: dict[str, str | None] = {
+        "actor_id": "advisor_sg_001",
+        "caller_application": "lotus-workbench",
+        "tenant_id": "tenant-sg",
+        "region": "APAC",
+        "booking_center_code": "SG",
+        "legal_entity_code": "SGPB",
+        "role": "ADVISOR",
+        "capabilities": (
+            "advisory.advisor_cockpit.read,advisory.advisor_cockpit.acknowledge"
+        ),
+        "principal_status": "ACTIVE",
+        "authorized_advisor_id": "advisor_sg_001",
+        "authorized_portfolio_id": "PB_SG_GLOBAL_BAL_001",
+    }
+    values.update(overrides)
+    return require_advisor_cockpit_caller_context(**values)
+
+
+def test_caller_context_preserves_bounded_trusted_authority() -> None:
+    caller = _context()
+
+    assert caller.actor_id == "advisor_sg_001"
+    assert caller.role == "ADVISOR"
+    assert caller.capabilities == frozenset(
+        {ADVISOR_COCKPIT_READ_CAPABILITY, ADVISOR_COCKPIT_ACKNOWLEDGE_CAPABILITY}
+    )
+    assert caller.authorized_advisor_id == "advisor_sg_001"
+    assert caller.authorized_portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert caller.upstream_headers() == {
+        "X-Actor-Id": "advisor_sg_001",
+        "X-Role": "ADVISOR",
+        "X-Tenant-Id": "tenant-sg",
+        "X-Legal-Entity-Code": "SGPB",
+        "X-Service-Identity": "lotus-gateway",
+        "X-Capabilities": (
+            "advisory.advisor_cockpit.acknowledge,advisory.advisor_cockpit.read"
+        ),
+        "X-Principal-Status": "ACTIVE",
+        "X-Authorized-Advisor-Id": "advisor_sg_001",
+        "X-Authorized-Portfolio-Id": "PB_SG_GLOBAL_BAL_001",
+    }
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "actor_id",
+        "caller_application",
+        "tenant_id",
+        "region",
+        "booking_center_code",
+        "legal_entity_code",
+        "role",
+        "capabilities",
+        "principal_status",
+    ],
+)
+def test_caller_context_rejects_missing_authority_fields(field: str) -> None:
+    with pytest.raises(AdvisorCockpitAccessError) as exc:
+        _context(**{field: None})
+
+    assert exc.value.code == "advisor_cockpit_caller_context_missing"
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_code", "expected_status"),
+    [
+        ({"actor_id": "../../advisor"}, "advisor_cockpit_caller_context_invalid", 400),
+        (
+            {"authorized_portfolio_id": "../../portfolio"},
+            "advisor_cockpit_caller_context_invalid",
+            400,
+        ),
+        ({"role": "RELATIONSHIP_MANAGER"}, "advisor_cockpit_access_denied", 403),
+        (
+            {"authorized_advisor_id": "advisor_sg_999"},
+            "advisor_cockpit_access_denied",
+            403,
+        ),
+        ({"principal_status": "LOCKED"}, "advisor_cockpit_principal_invalid", 401),
+    ],
+)
+def test_caller_context_rejects_malformed_or_unsupported_authority(
+    overrides: dict[str, str],
+    expected_code: str,
+    expected_status: int,
+) -> None:
+    with pytest.raises(AdvisorCockpitAccessError) as exc:
+        _context(**overrides)
+
+    assert exc.value.code == expected_code
+    assert exc.value.status_code == expected_status
+
+
+def test_capability_and_portfolio_checks_fail_closed() -> None:
+    caller = _context()
+
+    require_advisor_cockpit_capability(caller, ADVISOR_COCKPIT_READ_CAPABILITY)
+    assert (
+        require_advisor_cockpit_portfolio_scope(caller, "PB_SG_GLOBAL_BAL_001")
+        == "PB_SG_GLOBAL_BAL_001"
+    )
+
+    with pytest.raises(AdvisorCockpitAccessError) as capability_error:
+        require_advisor_cockpit_capability(caller, "advisory.advisor_cockpit.admin")
+    with pytest.raises(AdvisorCockpitAccessError) as portfolio_error:
+        require_advisor_cockpit_portfolio_scope(caller, "PB_NOT_ENTITLED")
+
+    assert capability_error.value.code == "advisor_cockpit_access_denied"
+    assert portfolio_error.value.code == "advisor_cockpit_portfolio_access_denied"
+
+
+def test_requested_portfolio_requires_explicit_entitlement() -> None:
+    caller = _context(authorized_portfolio_id=None)
+
+    with pytest.raises(AdvisorCockpitAccessError) as exc:
+        require_advisor_cockpit_portfolio_scope(caller, "PB_SG_GLOBAL_BAL_001")
+
+    assert exc.value.code == "advisor_cockpit_portfolio_scope_required"
+    assert exc.value.status_code == 401
+
+
+def test_advisor_scope_is_derived_from_the_authenticated_actor() -> None:
+    caller = _context(authorized_advisor_id=None)
+
+    assert caller.authorized_advisor_id == caller.actor_id
+    assert caller.upstream_headers()["X-Authorized-Advisor-Id"] == caller.actor_id

--- a/tests/unit/test_advisor_cockpit_service.py
+++ b/tests/unit/test_advisor_cockpit_service.py
@@ -3,6 +3,11 @@ from fastapi import HTTPException
 
 from app.services.advisor_cockpit_service import AdvisorCockpitService
 
+CALLER_HEADERS = {
+    "X-Actor-Id": "advisor_sg_001",
+    "X-Tenant-Id": "tenant-sg",
+}
+
 
 class _FakeAdviseClient:
     def __init__(self) -> None:
@@ -29,12 +34,17 @@ class _FakeAdviseClient:
         self,
         *,
         params: dict[str, object],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, object]]:
         self.calls.append(
             (
                 "list_advisor_cockpit_actions",
-                {"params": params, "correlation_id": correlation_id},
+                {
+                    "params": params,
+                    "caller_headers": caller_headers,
+                    "correlation_id": correlation_id,
+                },
             )
         )
         return self.status, self.payload
@@ -43,12 +53,17 @@ class _FakeAdviseClient:
         self,
         *,
         params: dict[str, object],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, object]]:
         self.calls.append(
             (
                 "list_advisor_cockpit_preparation_packets",
-                {"params": params, "correlation_id": correlation_id},
+                {
+                    "params": params,
+                    "caller_headers": caller_headers,
+                    "correlation_id": correlation_id,
+                },
             )
         )
         return self.status, self.payload
@@ -58,6 +73,7 @@ class _FakeAdviseClient:
         *,
         action_item_id: str,
         params: dict[str, object],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, object]]:
         self.calls.append(
@@ -66,6 +82,7 @@ class _FakeAdviseClient:
                 {
                     "action_item_id": action_item_id,
                     "params": params,
+                    "caller_headers": caller_headers,
                     "correlation_id": correlation_id,
                 },
             )
@@ -76,12 +93,17 @@ class _FakeAdviseClient:
         self,
         *,
         params: dict[str, object],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, object]]:
         self.calls.append(
             (
                 "get_advisor_cockpit_snapshot",
-                {"params": params, "correlation_id": correlation_id},
+                {
+                    "params": params,
+                    "caller_headers": caller_headers,
+                    "correlation_id": correlation_id,
+                },
             )
         )
         return self.status, self.payload
@@ -90,12 +112,17 @@ class _FakeAdviseClient:
         self,
         *,
         params: dict[str, object],
+        caller_headers: dict[str, str],
         correlation_id: str,
     ) -> tuple[int, dict[str, object]]:
         self.calls.append(
             (
                 "get_advisor_cockpit_supportability",
-                {"params": params, "correlation_id": correlation_id},
+                {
+                    "params": params,
+                    "caller_headers": caller_headers,
+                    "correlation_id": correlation_id,
+                },
             )
         )
         return self.status, self.payload
@@ -106,6 +133,7 @@ class _FakeAdviseClient:
         action_item_id: str,
         body: dict[str, object],
         params: dict[str, object],
+        caller_headers: dict[str, str],
         idempotency_key: str,
         correlation_id: str,
     ) -> tuple[int, dict[str, object]]:
@@ -116,6 +144,7 @@ class _FakeAdviseClient:
                     "action_item_id": action_item_id,
                     "body": body,
                     "params": params,
+                    "caller_headers": caller_headers,
                     "idempotency_key": idempotency_key,
                     "correlation_id": correlation_id,
                 },
@@ -132,7 +161,10 @@ class _FakeAdviseClient:
         self.calls.append(
             (
                 "evaluate_advisor_cockpit_house_view_cohort",
-                {"body": body, "correlation_id": correlation_id},
+                {
+                    "body": body,
+                    "correlation_id": correlation_id,
+                },
             )
         )
         return self.status, self.payload
@@ -149,6 +181,7 @@ async def test_advisor_cockpit_service_preserves_advise_owned_action_posture() -
             "advisor_id": "advisor_sg_001",
             "role": "ADVISOR",
         },
+        caller_headers=CALLER_HEADERS,
         correlation_id="corr-cockpit-list",
     )
 
@@ -164,6 +197,7 @@ async def test_advisor_cockpit_service_preserves_advise_owned_action_posture() -
                     "advisor_id": "advisor_sg_001",
                     "role": "ADVISOR",
                 },
+                "caller_headers": CALLER_HEADERS,
                 "correlation_id": "corr-cockpit-list",
             },
         )
@@ -198,6 +232,7 @@ async def test_advisor_cockpit_service_preserves_advise_owned_preparation_packet
             "role": "ADVISOR",
             "limit": 10,
         },
+        caller_headers=CALLER_HEADERS,
         correlation_id="corr-cockpit-prep",
     )
 
@@ -214,6 +249,7 @@ async def test_advisor_cockpit_service_preserves_advise_owned_preparation_packet
                     "role": "ADVISOR",
                     "limit": 10,
                 },
+                "caller_headers": CALLER_HEADERS,
                 "correlation_id": "corr-cockpit-prep",
             },
         )
@@ -243,7 +279,10 @@ async def test_advisor_cockpit_service_preserves_house_view_cohort_product() -> 
     assert advise_client.calls == [
         (
             "evaluate_advisor_cockpit_house_view_cohort",
-            {"body": body, "correlation_id": "corr-house-view"},
+            {
+                "body": body,
+                "correlation_id": "corr-house-view",
+            },
         )
     ]
 
@@ -264,6 +303,7 @@ async def test_advisor_cockpit_service_maps_acknowledgement_conflict_to_safe_det
             action_item_id="cockpit_action_001",
             body={"action_item_version": 1, "acknowledged_by": "advisor_sg_001"},
             params={"portfolio_id": "PB_SG_GLOBAL_BAL_001", "role": "ADVISOR"},
+            caller_headers=CALLER_HEADERS,
             idempotency_key="idem-cockpit-ack",
             correlation_id="corr-cockpit-ack",
         )
@@ -282,6 +322,7 @@ async def test_advisor_cockpit_service_maps_acknowledgement_conflict_to_safe_det
                 "action_item_id": "cockpit_action_001",
                 "body": {"action_item_version": 1, "acknowledged_by": "advisor_sg_001"},
                 "params": {"portfolio_id": "PB_SG_GLOBAL_BAL_001", "role": "ADVISOR"},
+                "caller_headers": CALLER_HEADERS,
                 "idempotency_key": "idem-cockpit-ack",
                 "correlation_id": "corr-cockpit-ack",
             },

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -3441,39 +3441,49 @@ async def test_advise_client_advisor_cockpit_routes_forward_filters_and_idempote
 
     action_filters = {
         "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-        "advisor_id": "advisor_sg_001",
-        "role": "ADVISOR",
         "limit": 25,
         "cursor": None,
     }
     acknowledgement_filters = {
         "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-        "advisor_id": None,
-        "role": "ADVISOR",
+    }
+    caller_headers = {
+        "X-Actor-Id": "advisor_sg_001",
+        "X-Tenant-Id": "tenant-sg",
+        "X-Region": "APAC",
     }
 
-    await client.list_advisor_cockpit_actions(action_filters, correlation_id="corr-cockpit")
+    await client.list_advisor_cockpit_actions(
+        action_filters,
+        caller_headers=caller_headers,
+        correlation_id="corr-cockpit",
+    )
     await client.list_advisor_cockpit_preparation_packets(
         action_filters,
+        caller_headers=caller_headers,
         correlation_id="corr-cockpit",
     )
     await client.get_advisor_cockpit_action(
         "cockpit_action_001",
         acknowledgement_filters,
+        caller_headers=caller_headers,
         correlation_id="corr-cockpit",
     )
     await client.get_advisor_cockpit_snapshot(
         acknowledgement_filters,
+        caller_headers=caller_headers,
         correlation_id="corr-cockpit",
     )
     await client.get_advisor_cockpit_supportability(
         acknowledgement_filters,
+        caller_headers=caller_headers,
         correlation_id="corr-cockpit",
     )
     await client.acknowledge_advisor_cockpit_action(
         "cockpit_action_001",
         body={"action_item_version": 1, "acknowledged_by": "advisor_sg_001"},
         params=acknowledgement_filters,
+        caller_headers=caller_headers,
         idempotency_key="idem-cockpit-ack",
         correlation_id="corr-cockpit",
     )
@@ -3489,8 +3499,6 @@ async def test_advise_client_advisor_cockpit_routes_forward_filters_and_idempote
     assert _FakeAsyncClient.calls[0]["url"] == "http://advise/advisory/cockpit/actions"
     assert _FakeAsyncClient.calls[0]["params"] == {
         "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-        "advisor_id": "advisor_sg_001",
-        "role": "ADVISOR",
         "limit": 25,
     }
     assert _FakeAsyncClient.calls[1]["url"] == (
@@ -3498,8 +3506,6 @@ async def test_advise_client_advisor_cockpit_routes_forward_filters_and_idempote
     )
     assert _FakeAsyncClient.calls[1]["params"] == {
         "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-        "advisor_id": "advisor_sg_001",
-        "role": "ADVISOR",
         "limit": 25,
     }
     assert _FakeAsyncClient.calls[2]["url"] == (
@@ -3514,7 +3520,6 @@ async def test_advise_client_advisor_cockpit_routes_forward_filters_and_idempote
     )
     assert acknowledgement_call["params"] == {
         "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-        "role": "ADVISOR",
     }
     assert acknowledgement_call["json"] == {
         "action_item_version": 1,
@@ -3528,8 +3533,14 @@ async def test_advise_client_advisor_cockpit_routes_forward_filters_and_idempote
         "tactical_view": {"tactical_view_id": "thv_2026_05_asia_duration"},
         "candidate_portfolios": [{"portfolio_id": "PB_SG_GLOBAL_BAL_001"}],
     }
-    for call in _FakeAsyncClient.calls:
+    for call in _FakeAsyncClient.calls[:6]:
         assert call["headers"]["X-Correlation-Id"] == "corr-cockpit"
+        assert call["headers"]["X-Actor-Id"] == "advisor_sg_001"
+        assert call["headers"]["X-Tenant-Id"] == "tenant-sg"
+        assert call["headers"]["X-Region"] == "APAC"
+    assert house_view_call["headers"]["X-Correlation-Id"] == "corr-cockpit"
+    assert "X-Actor-Id" not in house_view_call["headers"]
+    assert "X-Capabilities" not in house_view_call["headers"]
 
 
 @pytest.mark.asyncio

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -316,7 +316,11 @@ or governed ingress endpoints without embedding environment-specific hostnames i
   `/api/v1/advisor-cockpit/snapshot`, `/api/v1/advisor-cockpit/supportability`, and
   `/api/v1/advisor-cockpit/actions/{action_item_id}/acknowledgements`, plus
   `/api/v1/advisor-cockpit/house-view-cohorts/evaluate` for source-backed tactical house-view
-  cohort publication. Gateway preserves
+  cohort publication. Cockpit reads and acknowledgements reject caller-selected `advisor_id` and
+  `role`; Gateway derives authority from trusted caller headers, authorizes portfolio filters,
+  binds acknowledgements to the authenticated actor, and forwards the exact Advise principal
+  contract. The tactical house-view command remains outside that Cockpit capability boundary.
+  Gateway preserves
   Advise-owned action status, priority, owner role, reason codes, SLA, source refs, evidence refs,
   lineage refs, unsupported capabilities, supportability, preparation-packet posture,
   tactical house-view cohort membership, and acknowledgement state.

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -255,9 +255,10 @@ Authority and integrations:
 
 1. `lotus-advise` remains the advisor cockpit action, preparation-packet, tactical house-view
    cohort, snapshot, supportability, acknowledgement, evidence, and lineage authority.
-2. Gateway forwards portfolio, advisor, caller role, pagination, action id, acknowledgement body,
-   tactical house-view affected-cohort body, idempotency key, and correlation context to
-   `lotus-advise`.
+2. Gateway derives advisor identity and role from trusted server-side caller context. It rejects
+   public `advisor_id` and `role` authority parameters, authorizes an optional portfolio filter
+   against `X-Authorized-Portfolio-Id`, binds the acknowledgement actor to `X-Actor-Id`, and
+   forwards the exact principal contract required by `lotus-advise`.
 3. Gateway preserves Advise-owned action status, priority, owner role, reason codes, SLA, source
    refs, evidence refs, lineage refs, unsupported capabilities, preparation-packet posture,
    tactical house-view cohort membership,
@@ -265,6 +266,9 @@ Authority and integrations:
 4. Gateway does not reconstruct advisory policy results, proposal memo blockers, action
    prioritization, meeting preparation, SLA posture, supportability, client-ready publication,
    external client communication, OMS/order/fill/settlement posture, or demo-readiness claims.
+5. The tactical house-view cohort command remains a separate Advise source-product route. Gateway
+   does not manufacture a Cockpit house-view capability or apply Cockpit read authority to that
+   command.
 
 ```mermaid
 flowchart LR
@@ -278,7 +282,9 @@ Operational behavior:
 
 1. action and preparation-packet listing are paginated and bounded by Advise-owned cursor semantics,
 2. acknowledgement writes require `Idempotency-Key`,
-3. upstream validation, not-found, and idempotency-conflict outcomes are surfaced as product-safe
+3. action lookup and acknowledgement require an explicitly entitled portfolio so object-level
+   authorization does not depend on a prior list filter,
+4. upstream validation, not-found, and idempotency-conflict outcomes are surfaced as product-safe
    Gateway errors without rewriting cockpit semantics.
 
 ## Advisory Copilot Evidence And Action Runs


### PR DESCRIPTION
## Summary

- derive Advisor Cockpit scope from trusted Gateway caller context instead of public advisor/role inputs
- enforce tenant, legal-entity, booking-centre, region, role, capability, advisor and portfolio authority before reads or acknowledgements
- forward the exact trusted principal contract to lotus-advise and inject the authenticated actor into acknowledgements
- document the fail-closed authority boundary in repository context, RFC and authored wiki source

## Business outcome

Advisor Cockpit data is now constrained to the authenticated advisor's permitted book and selected portfolio. Client-controlled identifiers can no longer broaden access, which is required for a bank-buyable front-office experience.

## Validation

- `make ci-local` — passed (1,529 unit/contract tests; 239 integration tests)
- focused Cockpit tests — 228 passed
- Workbench contract tests — 3 passed
- mypy — 713 source files passed
- refactor-quality gate — passed, maximum function length 49
- wiki source parity pre-merge — passed with two intentional unpublished source changes
- all four commits carry verified SSH signatures

## Coordinated delivery

- Workbench compatibility is tracked in sgajbi/lotus-workbench#475. Until that adapter is merged, the Cockpit fails closed rather than trusting browser-supplied authority.
- The broader production session principal remains tracked by sgajbi/lotus-workbench#436 and sgajbi/lotus-platform#563.

## Publication

After merge, publish the authored Gateway wiki source and verify strict parity.

Closes #503
