### PR TITLE
Fix exact Workbench simulation forwarding

### DIFF
--- a/scripts/certify_demo_readiness.py
+++ b/scripts/certify_demo_readiness.py
@@ -378,7 +378,13 @@ def _certify_sandbox_policy(client: TestClient, evidence: CertificationEvidence)
         apply_path,
         headers={"X-Correlation-Id": CORRELATION_ID},
         json={
-            "changes": [{"security_id": "EQ_GLOBAL", "transaction_type": "BUY", "quantity": 50.0}],
+            "changes": [
+                {
+                    "security_id": "EQ_GLOBAL",
+                    "transaction_type": "BUY",
+                    "quantity": "50.0000000000",
+                }
+            ],
             "evaluate_policy": True,
         },
     )

--- a/src/app/contracts/workbench_sandbox.py
+++ b/src/app/contracts/workbench_sandbox.py
@@ -22,12 +22,16 @@ def _reject_financial_float(value: object) -> object:
 def _require_numeric_18_10(value: Decimal) -> Decimal:
     if not value.is_finite():
         raise ValueError("financial value must be finite")
-    normalized = value.normalize()
-    exponent = normalized.as_tuple().exponent
+    value_tuple = value.as_tuple()
+    exponent = value_tuple.exponent
     if not isinstance(exponent, int):
         raise ValueError("financial value must have a numeric exponent")
+    significant_digits = list(value_tuple.digits)
+    while significant_digits and significant_digits[-1] == 0:
+        significant_digits.pop()
+        exponent += 1
     fractional_digits = max(-exponent, 0)
-    integer_digits = 0 if normalized.is_zero() else max(normalized.adjusted() + 1, 0)
+    integer_digits = 0 if not significant_digits else max(len(significant_digits) + exponent, 0)
     if fractional_digits > 10:
         raise ValueError("financial value exceeds NUMERIC(18,10) scale")
     if integer_digits > 8:

--- a/src/app/contracts/workbench_sandbox.py
+++ b/src/app/contracts/workbench_sandbox.py
@@ -1,10 +1,45 @@
-from pydantic import BaseModel, Field
+from decimal import Decimal
+from numbers import Real
+from typing import Annotated
+
+from pydantic import AfterValidator, BaseModel, BeforeValidator, Field
 
 from app.contracts.workbench_common import (
     WorkbenchPartialFailure,
     WorkbenchProjectedPositionView,
     WorkbenchProjectedSummary,
 )
+
+
+def _reject_financial_float(value: object) -> object:
+    if isinstance(value, Real) and not isinstance(value, int):
+        raise ValueError(
+            "floating-point input is not permitted; use a decimal string or lossless integer"
+        )
+    return value
+
+
+def _require_numeric_18_10(value: Decimal) -> Decimal:
+    if not value.is_finite():
+        raise ValueError("financial value must be finite")
+    normalized = value.normalize()
+    exponent = normalized.as_tuple().exponent
+    if not isinstance(exponent, int):
+        raise ValueError("financial value must have a numeric exponent")
+    fractional_digits = max(-exponent, 0)
+    integer_digits = 0 if normalized.is_zero() else max(normalized.adjusted() + 1, 0)
+    if fractional_digits > 10:
+        raise ValueError("financial value exceeds NUMERIC(18,10) scale")
+    if integer_digits > 8:
+        raise ValueError("financial value exceeds NUMERIC(18,10) magnitude")
+    return value
+
+
+ExactSandboxDecimal = Annotated[
+    Decimal,
+    BeforeValidator(_reject_financial_float, json_schema_input_type=str | int),
+    AfterValidator(_require_numeric_18_10),
+]
 
 
 class WorkbenchSandboxSessionCreateRequest(BaseModel):
@@ -40,20 +75,29 @@ class WorkbenchSandboxChangeInput(BaseModel):
         description="Transaction intent applied in the sandbox, such as BUY or SELL.",
         examples=["BUY"],
     )
-    quantity: float | None = Field(
+    quantity: ExactSandboxDecimal | None = Field(
         default=None,
-        description="Proposed transaction quantity when the sandbox change is quantity-based.",
-        examples=[2.0],
+        description=(
+            "Proposed transaction quantity as an exact NUMERIC(18,10) decimal string or lossless "
+            "integer. Fractional JSON numbers, excess scale, and magnitude overflow are rejected."
+        ),
+        examples=["2.0000000000"],
     )
-    price: float | None = Field(
+    price: Annotated[ExactSandboxDecimal, Field(gt=0)] | None = Field(
         default=None,
-        description="Optional unit price used to value the sandbox change.",
-        examples=[101.25],
+        description=(
+            "Positive unit price as an exact NUMERIC(18,10) decimal string or lossless integer. "
+            "Fractional JSON numbers, excess scale, and magnitude overflow are rejected."
+        ),
+        examples=["101.2500000000"],
     )
-    amount: float | None = Field(
+    amount: ExactSandboxDecimal | None = Field(
         default=None,
-        description="Optional monetary amount used when the sandbox change is amount-based.",
-        examples=[5000.0],
+        description=(
+            "Monetary amount as an exact NUMERIC(18,10) decimal string or lossless integer. "
+            "Fractional JSON numbers, excess scale, and magnitude overflow are rejected."
+        ),
+        examples=["5000.0000000000"],
     )
     currency: str | None = Field(
         default=None,
@@ -90,8 +134,8 @@ class WorkbenchSandboxApplyChangesRequest(BaseModel):
                     {
                         "security_id": "EQ_1",
                         "transaction_type": "BUY",
-                        "quantity": 2.0,
-                        "price": 101.25,
+                        "quantity": "2.0000000000",
+                        "price": "101.2500000000",
                         "currency": "USD",
                         "effective_date": "2026-02-24",
                         "metadata": {"ticket_id": "SIM-101", "rebalance": True},

--- a/src/app/routers/workbench_sandbox_changes.py
+++ b/src/app/routers/workbench_sandbox_changes.py
@@ -22,7 +22,7 @@ async def _apply_sandbox_changes(
         portfolio_id=portfolio_id,
         session_id=session_id,
         correlation_id=correlation_id,
-        changes=[item.model_dump(exclude_none=True) for item in request.changes],
+        changes=[item.model_dump(exclude_none=True, mode="json") for item in request.changes],
         evaluate_policy=request.evaluate_policy,
     )
 

--- a/tests/contract/test_workbench_contract.py
+++ b/tests/contract/test_workbench_contract.py
@@ -36,7 +36,7 @@ def test_workbench_sandbox_contract_shape() -> None:
                 "security_id": "EQ_1",
                 "transaction_type": "BUY",
                 "quantity": 2,
-                "price": 101.25,
+                "price": "101.2500000000",
                 "currency": "USD",
                 "effective_date": "2026-02-24",
             }

--- a/tests/contract/test_workbench_sandbox_numeric_contract.py
+++ b/tests/contract/test_workbench_sandbox_numeric_contract.py
@@ -1,0 +1,67 @@
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from app.contracts.workbench import WorkbenchSandboxChangeInput
+
+
+def _change(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "security_id": "EQ_1",
+        "transaction_type": "BUY",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_sandbox_financial_values_preserve_exact_boundaries() -> None:
+    change = WorkbenchSandboxChangeInput.model_validate(
+        _change(
+            quantity="-99999999.9999999999",
+            price="99999999.9999999999",
+            amount=0,
+        )
+    )
+
+    assert change.quantity == Decimal("-99999999.9999999999")
+    assert change.price == Decimal("99999999.9999999999")
+    assert change.amount == Decimal("0")
+    assert change.model_dump(mode="json", exclude_none=True) == {
+        "security_id": "EQ_1",
+        "transaction_type": "BUY",
+        "quantity": "-99999999.9999999999",
+        "price": "99999999.9999999999",
+        "amount": "0",
+    }
+
+
+@pytest.mark.parametrize("field", ["quantity", "price", "amount"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        0.1,
+        "1.00000000001",
+        "100000000.0000000000",
+        "NaN",
+    ],
+)
+def test_sandbox_financial_values_reject_lossy_or_unpersistable_input(
+    field: str,
+    value: object,
+) -> None:
+    with pytest.raises(ValidationError):
+        WorkbenchSandboxChangeInput.model_validate(_change(**{field: value}))
+
+
+def test_sandbox_price_must_be_positive() -> None:
+    with pytest.raises(ValidationError, match="greater than 0"):
+        WorkbenchSandboxChangeInput.model_validate(_change(price="0"))
+
+
+def test_sandbox_financial_values_may_be_omitted() -> None:
+    change = WorkbenchSandboxChangeInput.model_validate(_change())
+
+    assert change.quantity is None
+    assert change.price is None
+    assert change.amount is None

--- a/tests/contract/test_workbench_sandbox_numeric_contract.py
+++ b/tests/contract/test_workbench_sandbox_numeric_contract.py
@@ -42,6 +42,7 @@ def test_sandbox_financial_values_preserve_exact_boundaries() -> None:
     [
         0.1,
         "1.00000000001",
+        "99999999.9999999999000000000000000001",
         "100000000.0000000000",
         "NaN",
     ],

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -2886,7 +2886,14 @@ def test_workbench_sandbox_changes_router(monkeypatch):
     updated = client.post(
         "/api/v1/workbench/PF_1001/sandbox/sessions/sess_1/changes",
         json={
-            "changes": [{"security_id": "EQ_1", "transaction_type": "BUY", "quantity": 2}],
+            "changes": [
+                {
+                    "security_id": "EQ_1",
+                    "transaction_type": "BUY",
+                    "quantity": "2.0000000000",
+                    "price": "101.2500000000",
+                }
+            ],
             "evaluate_policy": True,
         },
     )
@@ -2904,5 +2911,10 @@ def test_workbench_sandbox_changes_router(monkeypatch):
     assert captured_apply["session_id"] == "sess_1"
     assert captured_apply["correlation_id"]
     assert captured_apply["changes"] == [
-        {"security_id": "EQ_1", "transaction_type": "BUY", "quantity": 2.0}
+        {
+            "security_id": "EQ_1",
+            "transaction_type": "BUY",
+            "quantity": "2.0000000000",
+            "price": "101.2500000000",
+        }
     ]


### PR DESCRIPTION
## Objective
Forward Workbench sandbox financial values to Core without a floating-point round trip.

## Changes
- accept exact NUMERIC(18,10) decimal strings and lossless integers for quantity, price, and amount
- reject fractional JSON numbers, non-finite values, excess scale, magnitude overflow, and nonpositive price
- serialize validated Decimal values to canonical strings at the Core client boundary
- document the exact request contract in OpenAPI examples/descriptions

## Validation
- 55 warning-strict contract/integration tests passed
- `make typecheck`: 714 source files clean
- `make openapi-gate`: passed
- `make lint`: passed, including monetary-float guard
- Ruff format and diff hygiene passed

## Compatibility
Intentional request hardening coordinated before lotus-core#829. Routes, responses, calculations, and runtime topology are unchanged. No wiki source changed because no operator flow changed.

Closes #511