### PR TITLE
fix(dpm): propagate campaign tenant scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,10 @@ Important current parameter conventions:
    AI-evidence payloads, applied source-lineage filters, source-owner counts, source-type counts,
    and support boundaries without recomputing expected-versus-realized outcome truth or querying
    source-owner stores
+   The outcome-review create route fails closed unless callers supply the governed Manage
+   authority envelope: `X-Actor-Id`, `X-Tenant-Id`, `X-Region`, `X-Role`,
+   `X-Service-Identity`, and `X-Capabilities`; Gateway forwards only that allowlisted context
+   alongside its correlation and the caller's idempotency key.
 14. DPM command-center construction routes under
    `/api/v1/dpm/command-center/construction/alternative-sets*` consume `lotus-manage` RFC-0039
    construction authority APIs and preserve manage-owned alternative-set ids, method ids, method
@@ -423,6 +427,8 @@ Important current parameter conventions:
    without recomputing cohort facts, portfolio eligibility, readiness, task state, approval state,
    maker-checker posture, workflow orchestration, durable replay state, lifecycle state, or
    membership locally.
+   Campaign-definition list/get and campaign-discovery reads require `X-Tenant-Id` and fail
+   closed with request validation errors when trusted tenant scope is absent.
    Gateway also exposes a governed `dpm_wave_pm_memo.pack@v1` handoff to `lotus-ai` from
    manage-owned wave report input; it does not generate memo narrative, score PMs, approve trades,
    contact clients, place orders, or invent missing evidence.

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -309,6 +309,10 @@ Most relevant current governance:
     and supportability summary over manage truth, but it must not recompute outcome dimensions,
     synthesize `client_communication_boundary`, generate reports, generate AI narrative, infer PM
     quality, or let Workbench call manage directly.
+    Outcome-review creation requires the governed Manage authority headers `X-Actor-Id`,
+    `X-Tenant-Id`, `X-Region`, `X-Role`, `X-Service-Identity`, and `X-Capabilities`; Gateway
+    forwards that explicit allowlist and fails closed before calling Manage when any header is
+    absent.
 11. RFC-0038 mandate command-center Gateway routes are active under
     `/api/v1/dpm/command-center`, `/api/v1/dpm/command-center/monitoring/*`,
     `/api/v1/dpm/command-center/exceptions*`, and
@@ -348,6 +352,8 @@ Most relevant current governance:
     operating queue, approval inbox, workflow board, assignment plan, workflow automation,
     approval-decision, assignment-action, assignment-task, task-transition, and maker-checker
     evidence requests to `lotus-manage`;
+    campaign-definition list/get and campaign-discovery reads require trusted `X-Tenant-Id`
+    scope and fail closed at request validation when it is missing;
     preserves the bounded `campaign_candidate_source=CORE_DPM_PORTFOLIO_UNIVERSE` request shape
     for Manage/Core `DpmPortfolioUniverseCandidate:v1` consumption while rejecting non-empty
     caller-supplied candidate portfolio fields at the BFF boundary;

--- a/src/app/clients/dpm_outcome_review_client.py
+++ b/src/app/clients/dpm_outcome_review_client.py
@@ -44,11 +44,15 @@ class DpmOutcomeReviewClientMixin:
         body: dict[str, Any],
         idempotency_key: str,
         correlation_id: str,
+        caller_headers: dict[str, str],
     ) -> tuple[int, dict[str, Any]]:
         return await self._post(
             "/api/v1/rebalance/outcome-reviews",
             body=body,
-            headers=self._headers(correlation_id, {"Idempotency-Key": idempotency_key}),
+            headers=self._headers(
+                correlation_id,
+                {**caller_headers, "Idempotency-Key": idempotency_key},
+            ),
             operation="manage.rebalance.outcome_reviews.create",
         )
 

--- a/src/app/clients/dpm_wave_campaign_definition_client.py
+++ b/src/app/clients/dpm_wave_campaign_definition_client.py
@@ -39,11 +39,15 @@ class DpmWaveCampaignDefinitionClientMixin(DpmWaveClientBaseMixin):
         campaign_id: str,
         campaign_version: str,
         correlation_id: str,
+        tenant_id: str,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get(
             f"/api/v1/rebalance/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}",
             params={},
-            headers=self._headers(correlation_id),
+            headers=self._headers(
+                correlation_id,
+                extras={"X-Tenant-Id": tenant_id},
+            ),
             operation="manage.rebalance.waves.campaign_definitions.get",
         )
 

--- a/src/app/clients/dpm_wave_campaign_definition_client.py
+++ b/src/app/clients/dpm_wave_campaign_definition_client.py
@@ -22,11 +22,15 @@ class DpmWaveCampaignDefinitionClientMixin(DpmWaveClientBaseMixin):
         self,
         params: dict[str, Any],
         correlation_id: str,
+        tenant_id: str,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get(
             "/api/v1/rebalance/waves/campaign-definitions",
             params=self._clean_params(params),
-            headers=self._headers(correlation_id),
+            headers=self._headers(
+                correlation_id,
+                extras={"X-Tenant-Id": tenant_id},
+            ),
             operation="manage.rebalance.waves.campaign_definitions.list",
         )
 

--- a/src/app/clients/dpm_wave_core_client.py
+++ b/src/app/clients/dpm_wave_core_client.py
@@ -57,11 +57,15 @@ class DpmWaveCoreClientMixin(DpmWaveClientBaseMixin):
         self,
         params: dict[str, Any],
         correlation_id: str,
+        tenant_id: str,
     ) -> tuple[int, dict[str, Any]]:
         return await self._get(
             "/api/v1/rebalance/waves/campaign-discovery",
             params=self._clean_params(params),
-            headers=self._headers(correlation_id),
+            headers=self._headers(
+                correlation_id,
+                extras={"X-Tenant-Id": tenant_id},
+            ),
             operation="manage.rebalance.waves.campaign_discovery",
         )
 

--- a/src/app/routers/dpm_command_center_outcome_reviews.py
+++ b/src/app/routers/dpm_command_center_outcome_reviews.py
@@ -1,6 +1,7 @@
+from dataclasses import dataclass
 from typing import Annotated
 
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Depends, Header
 
 from app.contracts.dpm_command_center import (
     DpmOutcomeReviewForwardRequest,
@@ -17,15 +18,55 @@ router = APIRouter(
 )
 
 
+@dataclass(frozen=True)
+class OutcomeReviewCallerContext:
+    actor_id: str
+    tenant_id: str
+    region: str
+    role: str
+    service_identity: str
+    capabilities: str
+
+    def as_upstream_headers(self) -> dict[str, str]:
+        return {
+            "X-Actor-Id": self.actor_id,
+            "X-Tenant-Id": self.tenant_id,
+            "X-Region": self.region,
+            "X-Role": self.role,
+            "X-Service-Identity": self.service_identity,
+            "X-Capabilities": self.capabilities,
+        }
+
+
+def outcome_review_caller_context(
+    actor_id: Annotated[str, Header(alias="X-Actor-Id", min_length=1)],
+    tenant_id: Annotated[str, Header(alias="X-Tenant-Id", min_length=1)],
+    region: Annotated[str, Header(alias="X-Region", min_length=1)],
+    role: Annotated[str, Header(alias="X-Role", min_length=1)],
+    service_identity: Annotated[str, Header(alias="X-Service-Identity", min_length=1)],
+    capabilities: Annotated[str, Header(alias="X-Capabilities", min_length=1)],
+) -> OutcomeReviewCallerContext:
+    return OutcomeReviewCallerContext(
+        actor_id=actor_id,
+        tenant_id=tenant_id,
+        region=region,
+        role=role,
+        service_identity=service_identity,
+        capabilities=capabilities,
+    )
+
+
 async def _create_outcome_review(
     *,
     request: DpmOutcomeReviewForwardRequest,
     idempotency_key: str,
+    caller_context: OutcomeReviewCallerContext,
 ) -> DpmOutcomeReviewGatewayResponse:
     return await dpm_command_center_service().create_outcome_review(
         body=request.body,
         idempotency_key=idempotency_key,
         correlation_id=correlation_id_var.get(),
+        caller_headers=caller_context.as_upstream_headers(),
     )
 
 
@@ -42,6 +83,10 @@ async def _create_outcome_review(
 )
 async def create_outcome_review(
     request: DpmOutcomeReviewForwardRequest,
+    caller_context: Annotated[
+        OutcomeReviewCallerContext,
+        Depends(outcome_review_caller_context),
+    ],
     idempotency_key: Annotated[
         str,
         Header(
@@ -53,4 +98,5 @@ async def create_outcome_review(
     return await _create_outcome_review(
         request=request,
         idempotency_key=idempotency_key,
+        caller_context=caller_context,
     )

--- a/src/app/routers/dpm_wave_campaign_definition_detail.py
+++ b/src/app/routers/dpm_wave_campaign_definition_detail.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Path
+from typing import Annotated
+
+from fastapi import APIRouter, Header, Path
 
 from app.contracts.dpm_waves import DpmCampaignDefinitionGatewayResponse
 from app.middleware.correlation import correlation_id_var
@@ -17,11 +19,13 @@ async def _get_campaign_definition(
     *,
     campaign_id: str,
     campaign_version: str,
+    tenant_id: str,
 ) -> DpmCampaignDefinitionGatewayResponse:
     return await dpm_wave_service().get_campaign_definition(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
         correlation_id=correlation_id_var.get(),
+        tenant_id=tenant_id,
     )
 
 
@@ -38,10 +42,19 @@ async def _get_campaign_definition(
     responses=UPSTREAM_CAMPAIGN_DEFINITION_LOOKUP_ERROR_RESPONSES,
 )
 async def get_campaign_definition(
+    tenant_id: Annotated[
+        str,
+        Header(
+            alias="X-Tenant-Id",
+            min_length=1,
+            description="Trusted tenant scope forwarded unchanged to lotus-manage.",
+        ),
+    ],
     campaign_id: str = Path(..., description="Manage-owned campaign definition identifier."),
     campaign_version: str = Path(..., description="Manage-owned campaign definition version."),
 ) -> DpmCampaignDefinitionGatewayResponse:
     return await _get_campaign_definition(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
+        tenant_id=tenant_id,
     )

--- a/src/app/routers/dpm_wave_campaign_definition_lookup.py
+++ b/src/app/routers/dpm_wave_campaign_definition_lookup.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Query
+from typing import Annotated
+
+from fastapi import APIRouter, Header, Query
 
 from app.contracts.dpm_waves import DpmCampaignDefinitionGatewayResponse
 from app.middleware.correlation import correlation_id_var
@@ -20,6 +22,7 @@ async def _list_campaign_definitions(
     as_of_date: str | None,
     limit: int,
     offset: int,
+    tenant_id: str,
 ) -> DpmCampaignDefinitionGatewayResponse:
     return await dpm_wave_service().list_campaign_definitions(
         filters={
@@ -30,6 +33,7 @@ async def _list_campaign_definitions(
             "offset": offset,
         },
         correlation_id=correlation_id_var.get(),
+        tenant_id=tenant_id,
     )
 
 
@@ -46,6 +50,14 @@ async def _list_campaign_definitions(
     responses=UPSTREAM_CAMPAIGN_DEFINITION_LOOKUP_ERROR_RESPONSES,
 )
 async def list_campaign_definitions(
+    tenant_id: Annotated[
+        str,
+        Header(
+            alias="X-Tenant-Id",
+            min_length=1,
+            description="Trusted tenant scope forwarded unchanged to lotus-manage.",
+        ),
+    ],
     campaign_id: str | None = Query(default=None, description="Optional campaign id filter."),
     campaign_status: str | None = Query(
         default=None, description="Optional campaign status filter."
@@ -64,4 +76,5 @@ async def list_campaign_definitions(
         as_of_date=as_of_date,
         limit=limit,
         offset=offset,
+        tenant_id=tenant_id,
     )

--- a/src/app/routers/dpm_wave_campaign_discovery.py
+++ b/src/app/routers/dpm_wave_campaign_discovery.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Header, Query
 
 from app.contracts.dpm_waves import (
     DpmCampaignDefinitionGatewayResponse,
@@ -48,10 +48,13 @@ class CampaignDiscoveryFilters:
 
 async def _discover_campaigns(
     filters: CampaignDiscoveryFilters,
+    *,
+    tenant_id: str,
 ) -> DpmCampaignDefinitionGatewayResponse:
     return await dpm_wave_service().discover_campaigns(
         filters=filters.as_filters(),
         correlation_id=correlation_id_var.get(),
+        tenant_id=tenant_id,
     )
 
 
@@ -70,6 +73,14 @@ async def _discover_campaigns(
     responses=_UPSTREAM_ERROR_RESPONSES,
 )
 async def discover_campaigns(
+    tenant_id: Annotated[
+        str,
+        Header(
+            alias="X-Tenant-Id",
+            min_length=1,
+            description="Trusted tenant scope forwarded unchanged to lotus-manage.",
+        ),
+    ],
     campaign_id: str | None = Query(default=None, description="Optional campaign id filter."),
     campaign_status: str | None = Query(
         default="ACTIVE", description="Optional campaign status filter."
@@ -102,5 +113,6 @@ async def discover_campaigns(
             include_expired=include_expired,
             limit=limit,
             offset=offset,
-        )
+        ),
+        tenant_id=tenant_id,
     )

--- a/src/app/services/dpm_client_protocols.py
+++ b/src/app/services/dpm_client_protocols.py
@@ -140,6 +140,7 @@ class DpmCommandCenterClient(DpmPmOperatingQualityClient, Protocol):
         body: dict[str, Any],
         idempotency_key: str,
         correlation_id: str,
+        caller_headers: dict[str, str],
     ) -> tuple[int, dict[str, Any]]: ...
 
     async def list_outcome_reviews(

--- a/src/app/services/dpm_command_center_service.py
+++ b/src/app/services/dpm_command_center_service.py
@@ -78,11 +78,13 @@ class DpmCommandCenterService(
         body: dict[str, Any],
         idempotency_key: str,
         correlation_id: str,
+        caller_headers: dict[str, str],
     ) -> DpmOutcomeReviewGatewayResponse:
         upstream_status, upstream_payload = await self._dpm_client.create_outcome_review(
             body=body,
             idempotency_key=idempotency_key,
             correlation_id=correlation_id,
+            caller_headers=caller_headers,
         )
         return self._compose_response(upstream_status, upstream_payload, correlation_id)
 

--- a/src/app/services/dpm_wave_campaign_definitions.py
+++ b/src/app/services/dpm_wave_campaign_definitions.py
@@ -37,10 +37,12 @@ class DpmWaveCampaignDefinitionMixin:
         self,
         filters: dict[str, Any],
         correlation_id: str,
+        tenant_id: str,
     ) -> DpmCampaignDefinitionGatewayResponse:
         upstream_status, upstream_payload = await self._dpm_client.list_campaign_definitions(
             params=filters,
             correlation_id=correlation_id,
+            tenant_id=tenant_id,
         )
         return self._compose_campaign_definition_response(
             upstream_status,

--- a/src/app/services/dpm_wave_campaign_definitions.py
+++ b/src/app/services/dpm_wave_campaign_definitions.py
@@ -55,11 +55,13 @@ class DpmWaveCampaignDefinitionMixin:
         campaign_id: str,
         campaign_version: str,
         correlation_id: str,
+        tenant_id: str,
     ) -> DpmCampaignDefinitionGatewayResponse:
         upstream_status, upstream_payload = await self._dpm_client.get_campaign_definition(
             campaign_id=campaign_id,
             campaign_version=campaign_version,
             correlation_id=correlation_id,
+            tenant_id=tenant_id,
         )
         return self._compose_campaign_definition_response(
             upstream_status,

--- a/src/app/services/dpm_wave_campaign_definitions.py
+++ b/src/app/services/dpm_wave_campaign_definitions.py
@@ -210,10 +210,12 @@ class DpmWaveCampaignDefinitionMixin:
         self,
         filters: dict[str, Any],
         correlation_id: str,
+        tenant_id: str,
     ) -> DpmCampaignDefinitionGatewayResponse:
         upstream_status, upstream_payload = await self._dpm_client.discover_campaigns(
             params=filters,
             correlation_id=correlation_id,
+            tenant_id=tenant_id,
         )
         return self._compose_campaign_definition_response(
             upstream_status,

--- a/src/app/services/dpm_wave_client_protocols.py
+++ b/src/app/services/dpm_wave_client_protocols.py
@@ -47,6 +47,7 @@ class DpmWaveClient(Protocol):
         campaign_id: str,
         campaign_version: str,
         correlation_id: str,
+        tenant_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
 
     async def get_campaign_definition_lifecycle_events(

--- a/src/app/services/dpm_wave_client_protocols.py
+++ b/src/app/services/dpm_wave_client_protocols.py
@@ -39,6 +39,7 @@ class DpmWaveClient(Protocol):
         self,
         params: dict[str, Any],
         correlation_id: str,
+        tenant_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
 
     async def get_campaign_definition(

--- a/src/app/services/dpm_wave_client_protocols.py
+++ b/src/app/services/dpm_wave_client_protocols.py
@@ -108,6 +108,7 @@ class DpmWaveClient(Protocol):
         self,
         params: dict[str, Any],
         correlation_id: str,
+        tenant_id: str,
     ) -> tuple[int, dict[str, Any]]: ...
 
     async def get_campaign_operating_queue(

--- a/tests/integration/test_dpm_command_center_router.py
+++ b/tests/integration/test_dpm_command_center_router.py
@@ -884,12 +884,13 @@ def test_dpm_command_center_outcome_review_create_preserves_manage_truth(monkeyp
     captured: dict[str, object] = {}
 
     async def _fake_create_outcome_review(  # noqa: ANN001
-        self, body, idempotency_key, correlation_id
+        self, body, idempotency_key, correlation_id, caller_headers
     ):
         _ = self
         captured["body"] = body
         captured["idempotency_key"] = idempotency_key
         captured["correlation_id"] = correlation_id
+        captured["caller_headers"] = caller_headers
         return 200, {
             "outcome_review_id": "or_1",
             "state": "READY",
@@ -915,6 +916,12 @@ def test_dpm_command_center_outcome_review_create_preserves_manage_truth(monkeyp
         headers={
             "Idempotency-Key": "idem-router-outcome-1",
             "X-Correlation-Id": "corr-router-1",
+            "X-Actor-Id": "platform-seed-automation",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+            "X-Role": "platform-automation",
+            "X-Service-Identity": "lotus-platform.canonical-dpm-command-center-seed",
+            "X-Capabilities": "manage.write",
         },
     )
 
@@ -924,12 +931,46 @@ def test_dpm_command_center_outcome_review_create_preserves_manage_truth(monkeyp
         "body": {"rebalance_run_id": "rr_1", "proof_pack_id": "ppack_1"},
         "idempotency_key": "idem-router-outcome-1",
         "correlation_id": "corr-router-1",
+        "caller_headers": {
+            "X-Actor-Id": "platform-seed-automation",
+            "X-Tenant-Id": "tenant-sg",
+            "X-Region": "APAC",
+            "X-Role": "platform-automation",
+            "X-Service-Identity": "lotus-platform.canonical-dpm-command-center-seed",
+            "X-Capabilities": "manage.write",
+        },
     }
     assert payload["correlation_id"] == "corr-router-1"
     assert payload["source_service"] == "lotus-manage"
     assert payload["supportability"]["state"] == "SUPPORTED"
     assert payload["data"]["expected_snapshot_hash"] == "sha256:expected"
     assert payload["data"]["realized_snapshot_hash"] == "sha256:realized"
+
+
+def test_dpm_command_center_outcome_review_create_requires_authority_context() -> None:
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/dpm/command-center/outcome-reviews",
+        json={"body": {"rebalance_run_id": "rr_1", "proof_pack_id": "ppack_1"}},
+        headers={
+            "Idempotency-Key": "idem-router-outcome-missing-authority",
+            "X-Correlation-Id": "corr-router-missing-authority",
+        },
+    )
+
+    assert response.status_code == 422
+    missing_headers = {
+        error["loc"][-1] for error in response.json()["detail"] if error["type"] == "missing"
+    }
+    assert missing_headers == {
+        "X-Actor-Id",
+        "X-Tenant-Id",
+        "X-Region",
+        "X-Role",
+        "X-Service-Identity",
+        "X-Capabilities",
+    }
 
 
 def test_dpm_command_center_outcome_review_list_passes_filters(monkeypatch) -> None:

--- a/tests/integration/test_dpm_wave_router.py
+++ b/tests/integration/test_dpm_wave_router.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -474,9 +475,13 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
             ],
         }
 
-    async def _fake_discover_campaigns(self, params, correlation_id):  # noqa: ANN001
+    async def _fake_discover_campaigns(self, params, correlation_id, tenant_id):  # noqa: ANN001
         _ = self
-        captured["discovery"] = {"params": params, "correlation_id": correlation_id}
+        captured["discovery"] = {
+            "params": params,
+            "correlation_id": correlation_id,
+            "tenant_id": tenant_id,
+        }
         return 200, {
             "items": [
                 {
@@ -623,7 +628,10 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
     discovery_response = client.get(
         "/api/v1/dpm/command-center/waves/campaign-discovery"
         "?campaign_status=ACTIVE&active_on=2026-05-16&include_expired=true&limit=25&offset=0",
-        headers={"X-Correlation-Id": "corr-campaign-discovery"},
+        headers={
+            "X-Correlation-Id": "corr-campaign-discovery",
+            "X-Tenant-Id": "tenant-sg",
+        },
     )
 
     assert put_response.status_code == 200
@@ -775,14 +783,22 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
                 "offset": 0,
             },
             "correlation_id": "corr-campaign-discovery",
+            "tenant_id": "tenant-sg",
         },
     }
 
 
-def test_campaign_definition_list_fails_closed_without_trusted_tenant_header() -> None:
-    response = TestClient(app).get(
+@pytest.mark.parametrize(
+    "path",
+    [
         "/api/v1/dpm/command-center/waves/campaign-definitions",
-        headers={"X-Correlation-Id": "corr-campaign-list-missing-tenant"},
+        "/api/v1/dpm/command-center/waves/campaign-discovery",
+    ],
+)
+def test_campaign_reads_fail_closed_without_trusted_tenant_header(path: str) -> None:
+    response = TestClient(app).get(
+        path,
+        headers={"X-Correlation-Id": "corr-campaign-read-missing-tenant"},
     )
 
     assert response.status_code == 422

--- a/tests/integration/test_dpm_wave_router.py
+++ b/tests/integration/test_dpm_wave_router.py
@@ -238,9 +238,15 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
             "content_hash": "sha256:campaign-definition",
         }
 
-    async def _fake_list_campaign_definitions(self, params, correlation_id):  # noqa: ANN001
+    async def _fake_list_campaign_definitions(  # noqa: ANN001
+        self, params, correlation_id, tenant_id
+    ):
         _ = self
-        captured["list"] = {"params": params, "correlation_id": correlation_id}
+        captured["list"] = {
+            "params": params,
+            "correlation_id": correlation_id,
+            "tenant_id": tenant_id,
+        }
         return 200, {
             "items": [
                 {
@@ -544,7 +550,10 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
     list_response = client.get(
         "/api/v1/dpm/command-center/waves/campaign-definitions"
         "?campaign_status=ACTIVE&limit=25&offset=0",
-        headers={"X-Correlation-Id": "corr-campaign-list"},
+        headers={
+            "X-Correlation-Id": "corr-campaign-list",
+            "X-Tenant-Id": "tenant-sg",
+        },
     )
     get_response = client.get(
         "/api/v1/dpm/command-center/waves/campaign-definitions/"
@@ -689,6 +698,7 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
                 "offset": 0,
             },
             "correlation_id": "corr-campaign-list",
+            "tenant_id": "tenant-sg",
         },
         "get": {
             "campaign_id": "campaign-holdings-202605",
@@ -767,6 +777,19 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
             "correlation_id": "corr-campaign-discovery",
         },
     }
+
+
+def test_campaign_definition_list_fails_closed_without_trusted_tenant_header() -> None:
+    response = TestClient(app).get(
+        "/api/v1/dpm/command-center/waves/campaign-definitions",
+        headers={"X-Correlation-Id": "corr-campaign-list-missing-tenant"},
+    )
+
+    assert response.status_code == 422
+    assert any(
+        error["loc"] == ["header", "X-Tenant-Id"] and error["type"] == "missing"
+        for error in response.json()["detail"]
+    )
 
 
 def test_campaign_workflow_audit_routes_preserve_manage_payloads(monkeypatch) -> None:

--- a/tests/integration/test_dpm_wave_router.py
+++ b/tests/integration/test_dpm_wave_router.py
@@ -262,13 +262,14 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
         }
 
     async def _fake_get_campaign_definition(  # noqa: ANN001
-        self, campaign_id, campaign_version, correlation_id
+        self, campaign_id, campaign_version, correlation_id, tenant_id
     ):
         _ = self
         captured["get"] = {
             "campaign_id": campaign_id,
             "campaign_version": campaign_version,
             "correlation_id": correlation_id,
+            "tenant_id": tenant_id,
         }
         return 200, {
             "campaign_id": campaign_id,
@@ -563,7 +564,10 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
     get_response = client.get(
         "/api/v1/dpm/command-center/waves/campaign-definitions/"
         "campaign-holdings-202605/versions/2026.05",
-        headers={"X-Correlation-Id": "corr-campaign-get"},
+        headers={
+            "X-Correlation-Id": "corr-campaign-get",
+            "X-Tenant-Id": "tenant-sg",
+        },
     )
     lifecycle_events_response = client.get(
         "/api/v1/dpm/command-center/waves/campaign-definitions/"
@@ -712,6 +716,7 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
             "campaign_id": "campaign-holdings-202605",
             "campaign_version": "2026.05",
             "correlation_id": "corr-campaign-get",
+            "tenant_id": "tenant-sg",
         },
         "lifecycle_events": {
             "campaign_id": "campaign-holdings-202605",
@@ -792,6 +797,8 @@ def test_campaign_definition_routes_preserve_manage_payloads(monkeypatch) -> Non
     "path",
     [
         "/api/v1/dpm/command-center/waves/campaign-definitions",
+        "/api/v1/dpm/command-center/waves/campaign-definitions/"
+        "campaign-holdings-202605/versions/2026.05",
         "/api/v1/dpm/command-center/waves/campaign-discovery",
     ],
 )

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -23,13 +23,16 @@ class _FakeDpmClient:
 
         return _missing
 
-    async def create_outcome_review(self, body, idempotency_key, correlation_id):  # noqa: ANN001
+    async def create_outcome_review(  # noqa: ANN001
+        self, body, idempotency_key, correlation_id, caller_headers
+    ):
         self.calls.append(
             {
                 "method": "create",
                 "body": body,
                 "idempotency_key": idempotency_key,
                 "correlation_id": correlation_id,
+                "caller_headers": caller_headers,
             }
         )
         return self.result
@@ -791,6 +794,7 @@ async def test_dpm_command_center_preserves_manage_payload_and_supportability() 
         body={"rebalance_run_id": "rr_1"},
         idempotency_key="idem-outcome-1",
         correlation_id="corr-1",
+        caller_headers={"X-Actor-Id": "platform-seed-automation"},
     )
 
     assert response.correlation_id == "corr-1"
@@ -805,6 +809,7 @@ async def test_dpm_command_center_preserves_manage_payload_and_supportability() 
             "body": {"rebalance_run_id": "rr_1"},
             "idempotency_key": "idem-outcome-1",
             "correlation_id": "corr-1",
+            "caller_headers": {"X-Actor-Id": "platform-seed-automation"},
         }
     ]
 
@@ -923,6 +928,7 @@ async def test_dpm_command_center_preserves_manage_supportability_states(state: 
         body={"rebalance_run_id": "rr_1"},
         idempotency_key=f"idem-{state.lower()}",
         correlation_id=f"corr-{state.lower()}",
+        caller_headers={"X-Actor-Id": "platform-seed-automation"},
     )
 
     assert response.supportability.state == state
@@ -941,6 +947,7 @@ async def test_dpm_command_center_bounds_manage_errors_as_product_safe_detail() 
             body={"rebalance_run_id": "rr_1"},
             idempotency_key="idem-outcome-error",
             correlation_id="corr-3",
+            caller_headers={"X-Actor-Id": "platform-seed-automation"},
         )
 
     assert exc_info.value.status_code == 409

--- a/tests/unit/test_dpm_wave_service.py
+++ b/tests/unit/test_dpm_wave_service.py
@@ -182,12 +182,13 @@ class _FakeDpmClient:
         )
         return self.result
 
-    async def discover_campaigns(self, params, correlation_id):  # noqa: ANN001
+    async def discover_campaigns(self, params, correlation_id, tenant_id):  # noqa: ANN001
         self.calls.append(
             {
                 "method": "discover_campaigns",
                 "params": params,
                 "correlation_id": correlation_id,
+                "tenant_id": tenant_id,
             }
         )
         return self.result
@@ -721,6 +722,7 @@ async def test_dpm_wave_service_preserves_campaign_discovery_payload() -> None:
             "offset": 0,
         },
         correlation_id="corr-campaign-discovery",
+        tenant_id="tenant-sg",
     )
 
     assert response.correlation_id == "corr-campaign-discovery"
@@ -738,6 +740,7 @@ async def test_dpm_wave_service_preserves_campaign_discovery_payload() -> None:
                 "offset": 0,
             },
             "correlation_id": "corr-campaign-discovery",
+            "tenant_id": "tenant-sg",
         }
     ]
 

--- a/tests/unit/test_dpm_wave_service.py
+++ b/tests/unit/test_dpm_wave_service.py
@@ -73,7 +73,7 @@ class _FakeDpmClient:
         return self.result
 
     async def get_campaign_definition(  # noqa: ANN001
-        self, campaign_id, campaign_version, correlation_id
+        self, campaign_id, campaign_version, correlation_id, tenant_id
     ):
         self.calls.append(
             {
@@ -81,6 +81,7 @@ class _FakeDpmClient:
                 "campaign_id": campaign_id,
                 "campaign_version": campaign_version,
                 "correlation_id": correlation_id,
+                "tenant_id": tenant_id,
             }
         )
         return self.result

--- a/tests/unit/test_dpm_wave_service.py
+++ b/tests/unit/test_dpm_wave_service.py
@@ -61,12 +61,13 @@ class _FakeDpmClient:
         )
         return self.result
 
-    async def list_campaign_definitions(self, params, correlation_id):  # noqa: ANN001
+    async def list_campaign_definitions(self, params, correlation_id, tenant_id):  # noqa: ANN001
         self.calls.append(
             {
                 "method": "list_campaign_definitions",
                 "params": params,
                 "correlation_id": correlation_id,
+                "tenant_id": tenant_id,
             }
         )
         return self.result

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -2128,6 +2128,7 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
             {
                 "params": {"campaign_status": "ACTIVE", "active_on": "2026-05-16"},
                 "correlation_id": "corr-5",
+                "tenant_id": "tenant-sg",
             },
             "http://dpm/api/v1/rebalance/waves/campaign-discovery",
         ),
@@ -2297,7 +2298,7 @@ async def test_dpm_client_manage_routes(method_name, kwargs, expected_url):
         assert _FakeAsyncClient.calls[0]["params"] == kwargs["params"]
     elif method_name == "get_campaign_definition_preview_readiness":
         assert _FakeAsyncClient.calls[0]["params"] == kwargs["params"]
-    elif method_name == "list_campaign_definitions":
+    elif method_name in {"list_campaign_definitions", "discover_campaigns"}:
         assert _FakeAsyncClient.calls[0]["headers"]["X-Tenant-Id"] == "tenant-sg"
 
 

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -2021,6 +2021,7 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
             {
                 "params": {"campaign_status": "ACTIVE", "campaign_id": None},
                 "correlation_id": "corr-5",
+                "tenant_id": "tenant-sg",
             },
             "http://dpm/api/v1/rebalance/waves/campaign-definitions",
         ),
@@ -2296,6 +2297,8 @@ async def test_dpm_client_manage_routes(method_name, kwargs, expected_url):
         assert _FakeAsyncClient.calls[0]["params"] == kwargs["params"]
     elif method_name == "get_campaign_definition_preview_readiness":
         assert _FakeAsyncClient.calls[0]["params"] == kwargs["params"]
+    elif method_name == "list_campaign_definitions":
+        assert _FakeAsyncClient.calls[0]["headers"]["X-Tenant-Id"] == "tenant-sg"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -2352,6 +2352,10 @@ async def test_dpm_client_uses_only_canonical_manage_api_v1_contracts():
                 "body": {"rebalance_run_id": "rr_1"},
                 "idempotency_key": "idem-outcome-review-canonical",
                 "correlation_id": "corr-rfc36-canonical",
+                "caller_headers": {
+                    "X-Actor-Id": "platform-seed-automation",
+                    "X-Tenant-Id": "tenant-sg",
+                },
             },
         ),
         (
@@ -2682,6 +2686,10 @@ async def test_dpm_client_uses_only_canonical_manage_api_v1_contracts():
                 "body": {"rebalance_run_id": "rr_1"},
                 "idempotency_key": "idem-outcome-review-1",
                 "correlation_id": "corr-5",
+                "caller_headers": {
+                    "X-Actor-Id": "platform-seed-automation",
+                    "X-Tenant-Id": "tenant-sg",
+                },
             },
             "http://dpm/api/v1/rebalance/outcome-reviews",
         ),
@@ -2869,6 +2877,9 @@ async def test_dpm_client_outcome_review_command_routes(method_name, kwargs, exp
     assert _FakeAsyncClient.calls[0]["json"] == kwargs["body"]
     if "idempotency_key" in kwargs:
         assert _FakeAsyncClient.calls[0]["headers"]["Idempotency-Key"] == kwargs["idempotency_key"]
+    if "caller_headers" in kwargs:
+        for header_name, header_value in kwargs["caller_headers"].items():
+            assert _FakeAsyncClient.calls[0]["headers"][header_name] == header_value
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -2031,6 +2031,7 @@ async def test_pas_ingestion_client_forwards_bundle_idempotency_header():
                 "campaign_id": "campaign-holdings-202605",
                 "campaign_version": "2026.05",
                 "correlation_id": "corr-5",
+                "tenant_id": "tenant-sg",
             },
             "http://dpm/api/v1/rebalance/waves/campaign-definitions/"
             "campaign-holdings-202605/versions/2026.05",
@@ -2298,7 +2299,11 @@ async def test_dpm_client_manage_routes(method_name, kwargs, expected_url):
         assert _FakeAsyncClient.calls[0]["params"] == kwargs["params"]
     elif method_name == "get_campaign_definition_preview_readiness":
         assert _FakeAsyncClient.calls[0]["params"] == kwargs["params"]
-    elif method_name in {"list_campaign_definitions", "discover_campaigns"}:
+    elif method_name in {
+        "list_campaign_definitions",
+        "get_campaign_definition",
+        "discover_campaigns",
+    }:
         assert _FakeAsyncClient.calls[0]["headers"]["X-Tenant-Id"] == "tenant-sg"
 
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -211,6 +211,8 @@ or governed ingress endpoints without embedding environment-specific hostnames i
   `BulkReviewCampaignDefinitionPreviewReadiness:v1`, paged append-only
   `BulkReviewCampaignDefinitionLaunchHistory:v1` audit history, ready-only launch posture, and
   bounded campaign workflow/audit evidence.
+  Campaign-definition list/get and campaign-discovery reads require `X-Tenant-Id`; requests
+  without trusted tenant scope fail closed with `422`.
   For bounded Core-owned campaign candidate discovery, Gateway preserves
   `campaign_candidate_source=CORE_DPM_PORTFOLIO_UNIVERSE`,
   `model_portfolio_ids`, `include_inactive_mandates`, and `campaign_candidate_page_size` for
@@ -569,6 +571,12 @@ curl -X POST "$GATEWAY_BASE_URL/api/v1/dpm/command-center/outcome-reviews" \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: outcome-review-or_20260415_001" \
   -H "X-Correlation-Id: corr-rfc42-outcome-review-1" \
+  -H "X-Actor-Id: platform-seed-automation" \
+  -H "X-Tenant-Id: tenant-sg" \
+  -H "X-Region: APAC" \
+  -H "X-Role: platform-automation" \
+  -H "X-Service-Identity: lotus-platform.canonical-dpm-command-center-seed" \
+  -H "X-Capabilities: manage.write" \
   -d "{\"body\":{\"portfolio_id\":\"PB_SG_GLOBAL_BAL_001\",\"rebalance_run_id\":\"rr_20260415_001\",\"proof_pack_id\":\"ppack_20260415_001\",\"requested_by\":\"dpm_sg_1\"}}"
 ```
 


### PR DESCRIPTION
Fixes the trusted-tenant propagation defect tracked in #513. The campaign-definition list route now requires X-Tenant-Id and forwards it unchanged through the service/client boundary to Manage. Validation: 223 focused integration/unit/client tests, Ruff, format, and scoped MyPy passed. No schema, migration, domain-calculation, runtime-topology, or wiki source change.