### PR TITLE
Reject unsupported advisor-book portfolio types (#518)

### DIFF
--- a/src/app/contracts/advisor_book.py
+++ b/src/app/contracts/advisor_book.py
@@ -3,6 +3,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+AdvisorBookMandateType = Literal["ADVISORY", "DISCRETIONARY"]
+
 
 class AdvisorBookScope(BaseModel):
     kind: Literal["own_book"] = Field(
@@ -47,8 +49,11 @@ class AdvisorBookPortfolio(BaseModel):
         description="Booking center from the source-owned membership row.",
         examples=["Singapore"],
     )
-    mandate_type: str = Field(
-        description="Portfolio or mandate classification from the source-owned membership row.",
+    mandate_type: AdvisorBookMandateType = Field(
+        description=(
+            "Supported portfolio or mandate classification verified from the source-owned "
+            "membership row."
+        ),
         examples=["DISCRETIONARY"],
     )
     status: str = Field(

--- a/src/app/services/advisor_book_service.py
+++ b/src/app/services/advisor_book_service.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
 from datetime import date
-from typing import Literal
+from typing import Literal, cast
 
 from pydantic import ValidationError
 
 from app.contracts.advisor_book import (
+    AdvisorBookMandateType,
     AdvisorBookPage,
     AdvisorBookPortfolio,
     AdvisorBookProvenance,
@@ -24,9 +25,11 @@ from app.services.advisor_book_supportability import (
 
 AdvisorBookSortField = Literal["portfolio_id", "client_id", "mandate_type"]
 AdvisorBookSortOrder = Literal["asc", "desc"]
-AdvisorBookMandateType = Literal["ADVISORY", "DISCRETIONARY"]
 
-_SUPPORTED_PORTFOLIO_TYPES = ["ADVISORY", "DISCRETIONARY"]
+_SUPPORTED_PORTFOLIO_TYPES: tuple[AdvisorBookMandateType, ...] = (
+    "ADVISORY",
+    "DISCRETIONARY",
+)
 
 
 @dataclass(frozen=True)
@@ -67,7 +70,7 @@ class AdvisorBookService:
                 portfolio_manager_id=caller.portfolio_manager_id,
                 as_of_date=query.as_of_date.isoformat(),
                 booking_center_code=caller.booking_center_code,
-                portfolio_types=_SUPPORTED_PORTFOLIO_TYPES,
+                portfolio_types=list(_SUPPORTED_PORTFOLIO_TYPES),
                 correlation_id=correlation_id,
             )
         except Exception as exc:
@@ -105,6 +108,7 @@ def _validate_source_scope(
         or any(
             member.booking_center_code != caller.booking_center_code for member in source.members
         )
+        or any(member.portfolio_type not in _SUPPORTED_PORTFOLIO_TYPES for member in source.members)
         or len({member.portfolio_id for member in source.members}) != len(source.members)
     ):
         raise _source_contract_invalid()
@@ -179,7 +183,7 @@ def _portfolio(member: SourceAdvisorBookMember) -> AdvisorBookPortfolio:
         client_id=member.client_id,
         base_currency=member.base_currency,
         booking_center_code=member.booking_center_code,
-        mandate_type=member.portfolio_type,
+        mandate_type=cast(AdvisorBookMandateType, member.portfolio_type),
         status=member.status,
         opened_on=member.open_date,
         closed_on=member.close_date,

--- a/tests/unit/test_advisor_book_service.py
+++ b/tests/unit/test_advisor_book_service.py
@@ -220,9 +220,10 @@ async def test_service_translates_source_not_found_to_explicit_empty_book() -> N
         _payload(booking_center_code="Zurich"),
         _payload(members=[_member("PB_001", booking_center_code="Zurich")]),
         _payload(members=[_member("PB_DUPLICATE"), _member("PB_DUPLICATE")]),
+        _payload(members=[_member("PB_UNSUPPORTED", portfolio_type="EXECUTION_ONLY")]),
     ],
 )
-async def test_service_fails_closed_on_cross_scope_or_duplicate_source_rows(
+async def test_service_fails_closed_on_invalid_source_rows(
     payload: dict[str, object],
 ) -> None:
     service = AdvisorBookService(membership_client=_MembershipClient(payload=payload))


### PR DESCRIPTION
## Outcome

Closes #518 by enforcing the published Advisory/Discretionary own-book boundary on Core membership responses before filtering, paging, or public projection.

Originating review: https://github.com/sgajbi/lotus-gateway/pull/502#discussion_r3609083664

## Implementation

- Define one canonical public `AdvisorBookMandateType`.
- Use that type for the public advisor-book portfolio contract and supported Core request set.
- Validate every returned source member against the supported set through the existing business-safe source-contract error.
- Keep the upstream DTO open enough to convert source drift into a stable Gateway response.
- Add a default-query regression with an unsupported source portfolio type.

## Validation

- Focused advisor-book/router/contract tests: 31 passed.
- `make check`: passed, including Ruff, formatting, quality thresholds, workflow runtime governance, folder guides, mypy over 718 source files, OpenAPI contract, and 1,568 unit/contract tests.
- Commit `9d9fedd7b95d8a078cc0d133f555fd2cb98d8ca1`: verified SSH signature.

## Documentation decision

No README/wiki/context change. Existing repo truth already limits authenticated own-book publication to supported source-backed portfolios and declares fail-closed source semantics; this change makes code and OpenAPI typing conform to that truth.

## Scope boundary

No Core classification change, new mandate type, Workbench-local filtering, team/delegate inference, or suitability/execution authority.
