### PR TITLE
feat(dpm): publish typed AI workflow execution envelopes

### DIFF
--- a/CODEBASE-REVIEW-LEDGER.md
+++ b/CODEBASE-REVIEW-LEDGER.md
@@ -1,8 +1,52 @@
 # Codebase Review Ledger
 
-Last updated: 2026-07-18
+Last updated: 2026-08-05
 Repository: `lotus-gateway`
-Current branch: `feat/authenticated-advisor-book-500`
+Current branch: `feat/dpm-ai-execution-contracts`
+
+## Typed DPM AI Workflow Execution Boundary
+
+- Scope: GitHub issue #520, discovered while preparing Workbench issue #528 to extend governed AI
+  disclosure across six DPM workflow outputs.
+- Source authority: `lotus-ai` owns workflow-pack eligibility, execution, run, review,
+  supportability, provider, evidence, artifact, freshness, supersession, replacement, and recovery
+  truth; `lotus-manage` owns consequence-bearing DPM workflow and source evidence. Gateway owns a
+  bounded product-facing validation and projection boundary only.
+- Finding: all six response contracts promised workflow execution and review evidence but exposed
+  `data` as `dict[str, object]`; reduced and inconsistent fixtures allowed source-contract drift and
+  left Workbench unable to distinguish request acceptance from output, evidence, review,
+  supportability, freshness, or client-use posture.
+- Change: introduced reusable `DpmAiWorkflowExecution` models and one expectation-driven validator
+  for proof-pack memo, wave memo, operations handoff, exception summary, outcome-review narrative,
+  and PM-quality summary routes. The validator binds service, pack, version, registration, caller,
+  authenticated identity, correlation, workflow surface, authority owner, task, run, provider, and
+  eligibility identities before returning the typed projection.
+- Measured modularity: the contract is separated into audit/evidence (115 lines), run/lineage (171
+  lines), and execution-envelope (135 lines) modules. The proof-pack facade is reduced from the
+  gate-rejected 325 lines to 178 lines by extracting its AI handoff; all production files remain
+  below the enforced 316-line file and 49-line function ceilings.
+- Projection safety: governed structured task output, runtime/review/supportability posture,
+  bounded evidence descriptors, safe artifact metadata, timestamps, and replacement/recovery
+  lineage are retained. Raw prompt selection, generated message/output preview, evidence
+  attributes, storage locations, creator fields, and unbounded control/provider narratives are
+  stripped. Invalid source output returns product-safe
+  `AI_WORKFLOW_EXECUTION_CONTRACT_INVALID` without payload or validation-detail leakage.
+- Regression proof: one versioned complete lotus-ai fixture builder serves all six families; unit,
+  contract, and integration tests cover six success paths, live and stub execution,
+  review-required, historical/superseded/replacement, recovery lineage, raw-field stripping,
+  identity mismatch, missing fields, authorization failure, and route-level product-safe `502`
+  behavior. The execution-envelope and validator modules have 100% line and branch coverage.
+- Repeatable rule: a source-published generated-output envelope must be consumer-typed, identity
+  bound, and allowlist-projected at the Gateway boundary. A generic dictionary, HTTP success, or
+  request id is not evidence that generated output is safe, available, reviewed, current, or fit
+  for client use.
+- Documentation decision: repository context and the authored supported-features wiki are updated
+  because the public Gateway contract and operator-visible failure posture changed. Central skill
+  routing and platform architecture did not change, so no central context or skill edit is needed.
+- Follow-up: containerized validation exposed that the CI-local cleanup target can remove the
+  active product Gateway container because both compose files share a default project identity.
+  The runtime was restored healthy immediately and independent operability hardening is durable in
+  #521; it is not claimed by #520.
 
 ## Authenticated Advisor Own-Book Experience Contract
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -129,8 +129,18 @@ Current repository posture:
     `lotus-gateway`; manage remains proof-pack evidence authority, `lotus-ai` remains workflow-pack
     execution authority, and Gateway does not generate memos, score PMs, approve trades, contact
     clients, place orders, or invent evidence,
-14. canonical local startup now depends on environment-scoped service identity and `--app-dir src` to avoid misleading Windows import-path failures.
-15. RFC-0108 analytics UI observability is active for selected Workbench performance summary,
+14. the six DPM AI handoff families publish one typed, product-safe
+    `DpmAiWorkflowExecution` boundary. Gateway validates lotus-ai service, pack, version, caller,
+    correlation, workflow-surface, authorization, eligibility, task, run, provider, and authority
+    identities before returning source-owned runtime, review, supportability, evidence, artifact,
+    freshness, replacement, and recovery posture. Contract drift fails closed with
+    `AI_WORKFLOW_EXECUTION_CONTRACT_INVALID`; raw prompts, free-text model output, evidence
+    attributes, storage locations, and unbounded provider telemetry are not exposed. Gateway does
+    not infer that an accepted request has produced an available, reviewed, current, or
+    client-usable output,
+15. canonical local startup now depends on environment-scoped service identity and `--app-dir src`
+    to avoid misleading Windows import-path failures.
+16. RFC-0108 analytics UI observability is active for selected Workbench performance summary,
     risk summary, advisor-brief read, and advisor-brief review-action paths, and has expanded
     fan-out coverage for central `lotus-advise`, `lotus-manage`,
     `lotus-report`, `lotus-archive`, `lotus-ai`, direct `lotus-core` query/control-plane, and

--- a/src/app/contracts/dpm_ai_execution_audit.py
+++ b/src/app/contracts/dpm_ai_execution_audit.py
@@ -1,0 +1,115 @@
+"""Bounded evidence, safety, authorization, and audit models for DPM AI output."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DpmAiExecutionEvidenceDescriptor(BaseModel):
+    """Bounded evidence descriptor without upstream telemetry attributes."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    evidence_type: str = Field(
+        min_length=1,
+        description="Stable lotus-ai evidence type supporting the workflow execution.",
+    )
+    summary: str = Field(
+        min_length=1,
+        description="Product-safe explanation of the evidence represented by this item.",
+    )
+
+
+class DpmAiExecutionEvidenceBundle(BaseModel):
+    """Bounded execution evidence published by lotus-ai."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    descriptors: list[DpmAiExecutionEvidenceDescriptor] = Field(
+        description="Evidence descriptors supporting the workflow execution result."
+    )
+
+
+class DpmAiSafetyPosture(BaseModel):
+    """Product-relevant safety posture without raw control narratives."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    safety_mode: str = Field(min_length=1, description="Safety mode applied by lotus-ai.")
+    output_label: str = Field(min_length=1, description="Governed output-use label.")
+    redaction_posture: str = Field(min_length=1, description="Applied redaction posture.")
+    disposition: str = Field(min_length=1, description="Resolved safety disposition.")
+    runtime_redaction_active: bool = Field(
+        description="Whether runtime redaction enforcement was active."
+    )
+    enforced_controls: list[str] = Field(
+        description="Stable safety control identifiers enforced for this execution."
+    )
+
+
+class DpmAiAuthorizationPosture(BaseModel):
+    """Bounded caller-authorization evidence for the execution."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    caller_app: str = Field(min_length=1, description="Caller evaluated by lotus-ai.")
+    authenticated_caller_app: str | None = Field(
+        default=None,
+        description="Authenticated caller identity bound to the request when available.",
+    )
+    caller_identity_source: str = Field(
+        min_length=1,
+        description="Source used to authenticate the caller identity.",
+    )
+    caller_identity_bound: bool = Field(
+        description="Whether the declared and authenticated caller identities were bound."
+    )
+    capability_type: str = Field(
+        min_length=1,
+        description="Capability class evaluated by lotus-ai authorization.",
+    )
+    outcome: str = Field(min_length=1, description="Authorization decision outcome.")
+    allowed: bool = Field(description="Whether lotus-ai authorized the task execution.")
+    tenant_policy_mode: str = Field(
+        min_length=1,
+        description="Tenant restriction posture applied to authorization.",
+    )
+    task_id: str = Field(
+        min_length=1,
+        description="Task identifier evaluated by authorization.",
+    )
+
+
+class DpmAiTaskAudit(BaseModel):
+    """Safe audit identity and provider posture for one workflow execution."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    request_id: str = Field(min_length=1, description="Stable lotus-ai execution request id.")
+    workflow_pack_run_id: str = Field(
+        min_length=1,
+        description="Workflow-pack run id bound to the task execution.",
+    )
+    task_id: str = Field(min_length=1, description="Executed lotus-ai task id.")
+    output_label: str = Field(min_length=1, description="Governed output-use label.")
+    provider_mode: str = Field(min_length=1, description="Provider mode used for execution.")
+    provider_id: str = Field(min_length=1, description="Resolved provider identifier.")
+    adapter_kind: str | None = Field(
+        default=None,
+        description="Resolved provider adapter kind when available.",
+    )
+    model_id: str | None = Field(
+        default=None,
+        description="Resolved model identifier when a live model was used.",
+    )
+    model_version: str | None = Field(
+        default=None,
+        description="Governed model release or deployment version when available.",
+    )
+    safety: DpmAiSafetyPosture = Field(description="Safety posture applied to the execution.")
+    authorization: DpmAiAuthorizationPosture = Field(
+        description="Caller authorization applied to the execution."
+    )
+    generated_at: str = Field(
+        min_length=1,
+        description="UTC timestamp published by lotus-ai when the result was generated.",
+    )
+    stubbed: bool = Field(description="Whether deterministic stub execution produced the result.")

--- a/src/app/contracts/dpm_ai_workflow_execution.py
+++ b/src/app/contracts/dpm_ai_workflow_execution.py
@@ -1,0 +1,135 @@
+"""Typed product boundary for governed DPM workflow-pack execution evidence."""
+
+from typing import Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.contracts.dpm_ai_execution_audit import (
+    DpmAiExecutionEvidenceBundle,
+    DpmAiTaskAudit,
+)
+from app.contracts.dpm_ai_workflow_run import DpmAiWorkflowPackRun
+
+
+class DpmAiTaskResult(BaseModel):
+    """Governed structured output without raw generated message text."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    structured_output: dict[str, object] = Field(
+        description="Structured workflow output published by the governed task contract."
+    )
+
+
+class DpmAiTaskExecution(BaseModel):
+    """Typed task execution produced by a DPM workflow pack."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    status: Literal["COMPLETED", "REJECTED", "FAILED"] = Field(
+        description="Runtime outcome of the lotus-ai task request."
+    )
+    task_id: str = Field(min_length=1, description="Executed lotus-ai task id.")
+    category: str = Field(min_length=1, description="Task category selected for execution.")
+    output_label: str = Field(min_length=1, description="Governed output-use label.")
+    result: DpmAiTaskResult = Field(description="Governed structured task result.")
+    audit: DpmAiTaskAudit = Field(description="Execution audit and provider posture.")
+    evidence: DpmAiExecutionEvidenceBundle = Field(
+        description="Evidence explaining how the task result was produced."
+    )
+
+    @model_validator(mode="after")
+    def validate_execution_identity(self) -> Self:
+        if self.task_id != self.audit.task_id:
+            raise ValueError("execution and audit task ids must match")
+        if self.output_label != self.audit.output_label:
+            raise ValueError("execution and audit output labels must match")
+        if self.output_label != self.audit.safety.output_label:
+            raise ValueError("execution and safety output labels must match")
+        if self.audit.authorization.task_id != self.task_id:
+            raise ValueError("execution and authorization task ids must match")
+        return self
+
+
+class DpmAiWorkflowEligibility(BaseModel):
+    """Eligibility decision that preceded workflow-pack execution."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    service: Literal["lotus-ai"] = Field(description="Eligibility authority service.")
+    version: str = Field(min_length=1, description="lotus-ai service version.")
+    pack_id: str = Field(min_length=1, description="Evaluated workflow-pack identifier.")
+    requested_version: str = Field(
+        min_length=1,
+        description="Evaluated workflow-pack version.",
+    )
+    eligibility_result: str = Field(
+        min_length=1,
+        description="Source-published eligibility decision.",
+    )
+    allowed: bool = Field(description="Whether execution was permitted.")
+    evaluated_registration_ref: str | None = Field(
+        default=None,
+        description="Resolved workflow-pack registration reference.",
+    )
+    caller_app: str = Field(min_length=1, description="Caller evaluated for eligibility.")
+    environment: str = Field(min_length=1, description="Environment evaluated for eligibility.")
+    caller_identity_class: str = Field(
+        min_length=1,
+        description="Caller identity class evaluated for eligibility.",
+    )
+    tenant_scope_applied: bool = Field(
+        description="Whether tenant-level eligibility scope was applied."
+    )
+    workflow_surface_applied: bool = Field(
+        description="Whether workflow-surface eligibility scope was applied."
+    )
+
+
+class DpmAiWorkflowExecution(BaseModel):
+    """Validated lotus-ai execution envelope safe for DPM product consumers."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    service: Literal["lotus-ai"] = Field(description="Workflow execution authority service.")
+    version: str = Field(min_length=1, description="lotus-ai service version.")
+    eligibility: DpmAiWorkflowEligibility = Field(
+        description="Eligibility decision applied before execution."
+    )
+    execution: DpmAiTaskExecution = Field(description="Governed task execution result.")
+    workflow_pack_run: DpmAiWorkflowPackRun = Field(
+        description="Workflow run, review, supportability, evidence, and lineage posture."
+    )
+    summary: list[str] = Field(description="Source-published summary of the execution posture.")
+
+    @model_validator(mode="after")
+    def validate_run_identity(self) -> Self:
+        run = self.workflow_pack_run
+        audit = self.execution.audit
+        eligibility = self.eligibility
+        if audit.workflow_pack_run_id != run.run_id:
+            raise ValueError("audit and workflow run ids must match")
+        if self.execution.task_id != run.task_id:
+            raise ValueError("execution and workflow run task ids must match")
+        if audit.request_id != run.request_id:
+            raise ValueError("audit and workflow run request ids must match")
+        if audit.stubbed != run.stubbed:
+            raise ValueError("audit and workflow run stub postures must match")
+        if audit.provider_mode != run.provider_mode:
+            raise ValueError("audit and workflow run provider modes must match")
+        if eligibility.pack_id != run.pack_id:
+            raise ValueError("eligibility and workflow run pack ids must match")
+        if eligibility.requested_version != run.pack_version:
+            raise ValueError("eligibility and workflow run pack versions must match")
+        if eligibility.caller_app != run.caller_app:
+            raise ValueError("eligibility and workflow run callers must match")
+        if eligibility.evaluated_registration_ref != run.registration_ref:
+            raise ValueError("eligibility and workflow run registrations must match")
+        if eligibility.version != self.version:
+            raise ValueError("eligibility and execution service versions must match")
+        structured_output_keys = self.execution.result.structured_output
+        if len(run.structured_output_keys) != len(structured_output_keys) or set(
+            run.structured_output_keys
+        ) != set(structured_output_keys):
+            raise ValueError("workflow run keys must match the structured output")
+        return self

--- a/src/app/contracts/dpm_ai_workflow_run.py
+++ b/src/app/contracts/dpm_ai_workflow_run.py
@@ -1,0 +1,171 @@
+"""Review, supportability, artifact, and lineage models for DPM AI workflow runs."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.contracts.dpm_ai_execution_audit import DpmAiExecutionEvidenceDescriptor
+
+
+class DpmAiWorkflowReviewSummary(BaseModel):
+    """Bounded review progression without raw review-event history."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    latest_review_event_at: str | None = Field(
+        default=None,
+        description="UTC timestamp of the latest review-state transition.",
+    )
+    latest_review_actor: str | None = Field(
+        default=None,
+        description="Actor recorded on the latest review-state transition.",
+    )
+    review_transition_count: int = Field(
+        ge=0,
+        description="Number of review-state transitions recorded for the run.",
+    )
+    has_review_history: bool = Field(
+        description="Whether the run has any recorded review-state history."
+    )
+
+
+class DpmAiArtifactReference(BaseModel):
+    """Safe artifact metadata without internal storage locations."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    artifact_id: str = Field(min_length=1, description="Stable governed artifact id.")
+    domain: str = Field(min_length=1, description="Platform domain owning the artifact.")
+    artifact_type: str = Field(min_length=1, description="Governed artifact type.")
+    source_object_kind: str = Field(
+        min_length=1,
+        description="Kind of source object owning the artifact.",
+    )
+    source_object_id: str = Field(min_length=1, description="Source object id.")
+    lifecycle_status: str = Field(min_length=1, description="Artifact lifecycle posture.")
+    retention_posture: str = Field(min_length=1, description="Artifact retention posture.")
+    media_type: str = Field(min_length=1, description="Stored artifact media type.")
+    byte_size: int = Field(ge=0, description="Persisted artifact size in bytes.")
+    checksum_sha256: str = Field(min_length=1, description="Artifact SHA-256 checksum.")
+    lineage_parent_artifact_id: str | None = Field(
+        default=None,
+        description="Predecessor artifact id when lineage exists.",
+    )
+    superseded_by_artifact_id: str | None = Field(
+        default=None,
+        description="Replacement artifact id when this artifact was superseded.",
+    )
+    created_at: str = Field(min_length=1, description="Artifact creation timestamp.")
+
+
+class DpmAiRecoveryLineage(BaseModel):
+    """Bounded retry or replay lineage for a recovered workflow run."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    recovery_action_type: Literal["RETRY", "REPLAY"] = Field(
+        description="Recovery action that produced the run."
+    )
+    source_queue_item_id: str = Field(
+        min_length=1,
+        description="Queue item whose request snapshot was recovered.",
+    )
+    recovery_decision_event_id: str = Field(
+        min_length=1,
+        description="Event recording the recovery decision.",
+    )
+    recovery_attempt_number: int | None = Field(
+        default=None,
+        ge=1,
+        description="Recovery attempt number when recorded.",
+    )
+    source_workflow_pack_run_id: str | None = Field(
+        default=None,
+        description="Original workflow-pack run id when available.",
+    )
+    requested_by: str | None = Field(
+        default=None,
+        description="Actor requesting recovery when recorded.",
+    )
+    evidence_ref: str | None = Field(
+        default=None,
+        description="Bounded evidence reference supporting recovery.",
+    )
+
+
+class DpmAiWorkflowPackRun(BaseModel):
+    """Product-facing workflow run, review, evidence, and lineage posture."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    run_id: str = Field(min_length=1, description="Stable workflow-pack run id.")
+    pack_id: str = Field(min_length=1, description="Workflow-pack identifier.")
+    pack_family: str = Field(min_length=1, description="Stable workflow-pack family.")
+    pack_version: str = Field(min_length=1, description="Workflow-pack version used.")
+    registration_ref: str = Field(min_length=1, description="Resolved registration reference.")
+    task_id: str = Field(min_length=1, description="Task that produced the run.")
+    request_id: str = Field(min_length=1, description="lotus-ai execution request id.")
+    caller_app: str = Field(min_length=1, description="Calling Lotus application.")
+    correlation_id: str = Field(min_length=1, description="Caller correlation identifier.")
+    workflow_surface: str | None = Field(
+        default=None,
+        description="Named workflow surface associated with the run.",
+    )
+    workflow_authority_owner: str = Field(
+        min_length=1,
+        description="Service retaining consequence-bearing workflow authority.",
+    )
+    runtime_state: Literal["STAGED", "RUNNING", "COMPLETED", "FAILED", "EXPIRED", "SUPERSEDED"] = (
+        Field(description="Current runtime state of the workflow-pack run.")
+    )
+    review_state: Literal[
+        "NOT_REVIEW_REQUIRED",
+        "AWAITING_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "REVISED",
+        "SUPERSEDED",
+        "ABANDONED",
+    ] = Field(description="Current human-review state of the workflow-pack run.")
+    supportability_status: Literal["READY", "ACTION_REQUIRED", "HISTORICAL"] = Field(
+        description="Source-published supportability posture for the run."
+    )
+    allowed_review_actions: list[Literal["ACCEPT", "REJECT", "REVISE", "SUPERSEDE", "ABANDON"]] = (
+        Field(description="Review actions compatible with the current run posture.")
+    )
+    review_summary: DpmAiWorkflowReviewSummary = Field(
+        description="Bounded review progression summary."
+    )
+    review_required: bool = Field(description="Whether human review is required.")
+    provider_mode: str = Field(min_length=1, description="Provider mode recorded for the run.")
+    stubbed: bool = Field(description="Whether the workflow run is stub-backed.")
+    structured_output_keys: list[str] = Field(
+        description="Structured-output keys recorded by lotus-ai."
+    )
+    evidence_descriptors: list[DpmAiExecutionEvidenceDescriptor] = Field(
+        description="Reference-oriented evidence recorded with the run."
+    )
+    artifact_refs: list[DpmAiArtifactReference] = Field(
+        description="Governed artifact metadata linked to the run."
+    )
+    supersedes_run_id: str | None = Field(
+        default=None, description="Prior run superseded by this run."
+    )
+    superseded_by_run_id: str | None = Field(
+        default=None,
+        description="Newer run that superseded this run.",
+    )
+    replacement_run_id: str | None = Field(
+        default=None,
+        description="Replacement run for a revised or superseded run.",
+    )
+    recovery_lineage: DpmAiRecoveryLineage | None = Field(
+        default=None,
+        description="Retry or replay lineage when the run was recovered.",
+    )
+    created_at: str = Field(min_length=1, description="Run creation timestamp.")
+    completed_at: str | None = Field(
+        default=None,
+        description="Timestamp when the run reached its terminal runtime state.",
+    )
+    last_updated_at: str = Field(min_length=1, description="Latest run update timestamp.")

--- a/src/app/contracts/dpm_exception_summary.py
+++ b/src/app/contracts/dpm_exception_summary.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 
+from app.contracts.dpm_ai_workflow_execution import DpmAiWorkflowExecution
 from app.contracts.dpm_command_center_core import DpmCommandCenterSupportability
 
 
@@ -107,9 +108,11 @@ class DpmExceptionSummaryGatewayResponse(BaseModel):
             }
         ],
     )
-    data: dict[str, object] = Field(
+    data: DpmAiWorkflowExecution = Field(
         description=(
-            "Authoritative lotus-ai workflow-pack execution response, including execution audit, "
-            "workflow-pack run posture, review state, and guardrail-supported structured output."
+            "Validated lotus-ai workflow execution with structured exception output, distinct "
+            "runtime and review posture, safety evidence, governed artifacts, freshness, and "
+            "lineage. Raw generated messages, prompts, storage locations, and telemetry attributes "
+            "are not exposed."
         ),
     )

--- a/src/app/contracts/dpm_outcome_review.py
+++ b/src/app/contracts/dpm_outcome_review.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 
+from app.contracts.dpm_ai_workflow_execution import DpmAiWorkflowExecution
 from app.contracts.dpm_exception_summary import (
     DpmExceptionSummaryGatewayResponse as DpmExceptionSummaryGatewayResponse,
 )
@@ -222,10 +223,12 @@ class DpmOutcomeReviewNarrativeGatewayResponse(BaseModel):
             }
         ],
     )
-    data: dict[str, object] = Field(
+    data: DpmAiWorkflowExecution = Field(
         description=(
-            "Authoritative lotus-ai workflow-pack execution response, including execution audit, "
-            "workflow-pack run posture, review state, and guardrail-supported structured output."
+            "Validated lotus-ai workflow execution with structured outcome-review output, distinct "
+            "runtime and review posture, safety evidence, governed artifacts, freshness, and "
+            "lineage. Raw generated messages, prompts, storage locations, and telemetry attributes "
+            "are not exposed."
         ),
     )
 

--- a/src/app/contracts/dpm_pm_operating_quality.py
+++ b/src/app/contracts/dpm_pm_operating_quality.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, Field, field_validator
 
+from app.contracts.dpm_ai_workflow_execution import DpmAiWorkflowExecution
+
 PM_QUALITY_SUMMARY_ALLOWED_OUTPUTS = {
     "score_run_summary",
     "governance_summary",
@@ -261,9 +263,11 @@ class DpmPmOperatingQualitySummaryGatewayResponse(BaseModel):
             }
         ],
     )
-    data: dict[str, object] = Field(
+    data: DpmAiWorkflowExecution = Field(
         description=(
-            "Authoritative lotus-ai workflow-pack execution response, including execution audit, "
-            "workflow-pack run posture, review state, and guardrail-supported structured output."
+            "Validated lotus-ai workflow execution with structured PM quality output, distinct "
+            "runtime and review posture, safety evidence, governed artifacts, freshness, and "
+            "lineage. Raw generated messages, prompts, storage locations, and telemetry attributes "
+            "are not exposed."
         ),
     )

--- a/src/app/contracts/dpm_proof_packs.py
+++ b/src/app/contracts/dpm_proof_packs.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, Field
 
+from app.contracts.dpm_ai_workflow_execution import DpmAiWorkflowExecution
+
 
 class DpmProofPackGenerateRequest(BaseModel):
     idempotency_key: str = Field(
@@ -204,10 +206,12 @@ class DpmProofPackMemoGatewayResponse(BaseModel):
             }
         ],
     )
-    data: dict[str, object] = Field(
+    data: DpmAiWorkflowExecution = Field(
         description=(
-            "Authoritative lotus-ai workflow-pack execution response, including execution audit, "
-            "workflow-pack run posture, review state, and guardrail-supported structured output."
+            "Validated lotus-ai workflow execution with structured output, runtime and review "
+            "posture, safety evidence, governed artifact metadata, freshness, and replacement "
+            "lineage. Raw generated messages, prompts, storage locations, and telemetry attributes "
+            "are not exposed."
         ),
     )
 

--- a/src/app/contracts/dpm_wave_ai.py
+++ b/src/app/contracts/dpm_wave_ai.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 
+from app.contracts.dpm_ai_workflow_execution import DpmAiWorkflowExecution
 from app.contracts.dpm_wave_supportability import DpmWaveSupportability
 
 
@@ -123,10 +124,11 @@ class DpmWaveMemoGatewayResponse(BaseModel):
             }
         ],
     )
-    data: dict[str, object] = Field(
+    data: DpmAiWorkflowExecution = Field(
         description=(
-            "lotus-ai workflow-pack execution response. Gateway preserves the AI authority "
-            "payload and does not post-process generated memo content into execution actions."
+            "Validated lotus-ai workflow execution with structured memo output, distinct runtime "
+            "and review posture, safety evidence, governed artifacts, freshness, and lineage. "
+            "Gateway does not expose raw generated messages or turn the result into an action."
         )
     )
 
@@ -185,9 +187,11 @@ class DpmOperationsHandoffSummaryGatewayResponse(BaseModel):
             }
         ],
     )
-    data: dict[str, object] = Field(
+    data: DpmAiWorkflowExecution = Field(
         description=(
-            "lotus-ai workflow-pack execution response. Gateway preserves the AI authority "
-            "payload and does not post-process generated handoff text into execution actions."
+            "Validated lotus-ai workflow execution with structured handoff output, distinct "
+            "runtime and review posture, safety evidence, governed artifacts, freshness, and "
+            "lineage. "
+            "Gateway does not expose raw generated messages or turn the result into an action."
         )
     )

--- a/src/app/services/dpm_ai_workflow_execution.py
+++ b/src/app/services/dpm_ai_workflow_execution.py
@@ -1,0 +1,91 @@
+"""Validate lotus-ai workflow execution before exposing it through DPM routes."""
+
+from dataclasses import dataclass
+from typing import Any, NoReturn
+
+from fastapi import HTTPException, status
+from pydantic import ValidationError
+
+from app.contracts.dpm_ai_workflow_execution import DpmAiWorkflowExecution
+
+
+@dataclass(frozen=True, slots=True)
+class DpmAiWorkflowExecutionExpectation:
+    """Source identities expected for one governed DPM workflow handoff."""
+
+    pack_id: str
+    workflow_surface: str
+    pack_version: str = "v1"
+    workflow_authority_owner: str = "lotus-manage"
+
+
+DPM_PROOF_PACK_PM_MEMO_EXECUTION = DpmAiWorkflowExecutionExpectation(
+    pack_id="dpm_pm_memo.pack",
+    workflow_surface="dpm-proof-pack-ai-evidence",
+)
+DPM_WAVE_PM_MEMO_EXECUTION = DpmAiWorkflowExecutionExpectation(
+    pack_id="dpm_wave_pm_memo.pack",
+    workflow_surface="dpm-wave-ai-evidence",
+)
+DPM_OPERATIONS_HANDOFF_EXECUTION = DpmAiWorkflowExecutionExpectation(
+    pack_id="dpm_operations_handoff_summary.pack",
+    workflow_surface="dpm-operations-handoff-ai-evidence",
+)
+DPM_EXCEPTION_SUMMARY_EXECUTION = DpmAiWorkflowExecutionExpectation(
+    pack_id="dpm_exception_summary.pack",
+    workflow_surface="dpm-exception-summary-ai-evidence",
+)
+DPM_OUTCOME_REVIEW_NARRATIVE_EXECUTION = DpmAiWorkflowExecutionExpectation(
+    pack_id="outcome_review_narrative.pack",
+    workflow_surface="dpm-outcome-review-ai-evidence",
+)
+DPM_PM_OPERATING_QUALITY_EXECUTION = DpmAiWorkflowExecutionExpectation(
+    pack_id="pm_quality_summary.pack",
+    workflow_surface="dpm-pm-quality-ai-evidence",
+)
+
+
+def validate_dpm_ai_workflow_execution(
+    payload: dict[str, Any],
+    *,
+    upstream_status: int,
+    correlation_id: str,
+    expectation: DpmAiWorkflowExecutionExpectation,
+) -> DpmAiWorkflowExecution:
+    """Return a safe typed projection or fail closed on source-contract drift."""
+
+    try:
+        execution = DpmAiWorkflowExecution.model_validate(payload)
+    except ValidationError:
+        _raise_invalid_contract(upstream_status)
+
+    run = execution.workflow_pack_run
+    audit = execution.execution.audit
+    if (
+        execution.eligibility.allowed is not True
+        or audit.authorization.allowed is not True
+        or audit.authorization.caller_identity_bound is not True
+        or run.pack_id != expectation.pack_id
+        or run.pack_version != expectation.pack_version
+        or run.registration_ref != f"{expectation.pack_id}@{expectation.pack_version}"
+        or run.caller_app != "lotus-gateway"
+        or run.correlation_id != correlation_id
+        or run.workflow_surface != expectation.workflow_surface
+        or run.workflow_authority_owner != expectation.workflow_authority_owner
+        or audit.authorization.caller_app != "lotus-gateway"
+        or audit.authorization.authenticated_caller_app != "lotus-gateway"
+    ):
+        _raise_invalid_contract(upstream_status)
+    return execution
+
+
+def _raise_invalid_contract(upstream_status: int) -> NoReturn:
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail={
+            "source_service": "lotus-ai",
+            "upstream_status": upstream_status,
+            "error_code": "AI_WORKFLOW_EXECUTION_CONTRACT_INVALID",
+            "detail": "AI workflow output could not be safely verified.",
+        },
+    )

--- a/src/app/services/dpm_command_center_exception_summary.py
+++ b/src/app/services/dpm_command_center_exception_summary.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
-from typing import Any, NoReturn
+from typing import NoReturn
 
 from fastapi import HTTPException, status
 
 from app.config import settings
+from app.contracts.dpm_ai_workflow_execution import DpmAiWorkflowExecution
 from app.contracts.dpm_command_center import (
     DpmCommandCenterSupportability,
     DpmExceptionSummaryGatewayResponse,
@@ -11,6 +12,10 @@ from app.contracts.dpm_command_center import (
 )
 from app.services import dpm_command_center_ai_context, dpm_command_center_supportability
 from app.services.ai_client_protocols import LotusAiWorkflowClient
+from app.services.dpm_ai_workflow_execution import (
+    DPM_EXCEPTION_SUMMARY_EXECUTION,
+    validate_dpm_ai_workflow_execution,
+)
 from app.services.dpm_client_protocols import DpmCommandCenterClient
 from app.services.dpm_command_center_errors import raise_manage_command_center_error
 from app.services.lotus_ai_workflow import (
@@ -106,7 +111,7 @@ class DpmCommandCenterExceptionSummaryMixin:
         exception_id: str,
         summary_context: DpmExceptionSummaryContext,
         correlation_id: str,
-    ) -> tuple[int, dict[str, Any]]:
+    ) -> tuple[int, DpmAiWorkflowExecution]:
         task_payload = dpm_command_center_ai_context.exception_summary_task_payload(
             exception_summary_input=summary_context.exception_summary_input,
             summary_request=summary_context.summary_request,
@@ -140,13 +145,18 @@ class DpmCommandCenterExceptionSummaryMixin:
                 default_detail="lotus-ai exception summary request failed",
             )
 
-        return ai_status, ai_payload
+        return ai_status, validate_dpm_ai_workflow_execution(
+            ai_payload,
+            upstream_status=ai_status,
+            correlation_id=correlation_id,
+            expectation=DPM_EXCEPTION_SUMMARY_EXECUTION,
+        )
 
     def _compose_exception_summary_response(
         self,
         summary_context: DpmExceptionSummaryContext,
         ai_status: int,
-        ai_payload: dict[str, Any],
+        ai_payload: DpmAiWorkflowExecution,
         correlation_id: str,
     ) -> DpmExceptionSummaryGatewayResponse:
         return DpmExceptionSummaryGatewayResponse(

--- a/src/app/services/dpm_command_center_outcome_narrative.py
+++ b/src/app/services/dpm_command_center_outcome_narrative.py
@@ -4,6 +4,7 @@ from typing import Any
 from fastapi import status
 
 from app.config import settings
+from app.contracts.dpm_ai_workflow_execution import DpmAiWorkflowExecution
 from app.contracts.dpm_command_center import (
     DpmOutcomeReviewNarrativeGatewayResponse,
     DpmOutcomeReviewNarrativeRequest,
@@ -11,6 +12,10 @@ from app.contracts.dpm_command_center import (
 )
 from app.services import dpm_command_center_ai_context, dpm_command_center_supportability
 from app.services.ai_client_protocols import LotusAiWorkflowClient
+from app.services.dpm_ai_workflow_execution import (
+    DPM_OUTCOME_REVIEW_NARRATIVE_EXECUTION,
+    validate_dpm_ai_workflow_execution,
+)
 from app.services.dpm_client_protocols import DpmCommandCenterClient
 from app.services.dpm_command_center_errors import raise_manage_command_center_error
 from app.services.lotus_ai_workflow import (
@@ -47,7 +52,7 @@ class DpmCommandCenterOutcomeNarrativeMixin:
             request=request,
             correlation_id=correlation_id,
         )
-        ai_status, ai_payload = await self._execute_outcome_review_narrative_pack(
+        ai_status, ai_execution = await self._execute_outcome_review_narrative_pack(
             lotus_ai_client=lotus_ai_client,
             outcome_review_id=outcome_review_id,
             correlation_id=correlation_id,
@@ -62,7 +67,7 @@ class DpmCommandCenterOutcomeNarrativeMixin:
             supportability=context.supportability,
             ai_evidence_input=context.ai_evidence_input,
             narrative_request=context.narrative_request,
-            data=ai_payload,
+            data=ai_execution,
         )
 
     async def _build_outcome_review_narrative_context(
@@ -110,7 +115,7 @@ class DpmCommandCenterOutcomeNarrativeMixin:
         outcome_review_id: str,
         correlation_id: str,
         context: DpmOutcomeReviewNarrativeContext,
-    ) -> tuple[int, dict[str, Any]]:
+    ) -> tuple[int, DpmAiWorkflowExecution]:
         ai_status, ai_payload = await lotus_ai_client.execute_workflow_pack(
             pack_id="outcome_review_narrative.pack",
             version="v1",
@@ -136,4 +141,9 @@ class DpmCommandCenterOutcomeNarrativeMixin:
                 error_code="AI_OUTCOME_REVIEW_NARRATIVE_UPSTREAM_ERROR",
                 default_detail="lotus-ai outcome-review narrative request failed",
             )
-        return ai_status, ai_payload
+        return ai_status, validate_dpm_ai_workflow_execution(
+            ai_payload,
+            upstream_status=ai_status,
+            correlation_id=correlation_id,
+            expectation=DPM_OUTCOME_REVIEW_NARRATIVE_EXECUTION,
+        )

--- a/src/app/services/dpm_pm_operating_quality_summary_service.py
+++ b/src/app/services/dpm_pm_operating_quality_summary_service.py
@@ -4,6 +4,7 @@ from typing import Any
 from fastapi import HTTPException, status
 
 from app.config import settings
+from app.contracts.dpm_ai_workflow_execution import DpmAiWorkflowExecution
 from app.contracts.dpm_command_center import (
     DpmPmOperatingQualitySummaryGatewayResponse,
     DpmPmOperatingQualitySummaryRequest,
@@ -11,6 +12,10 @@ from app.contracts.dpm_command_center import (
 )
 from app.services import dpm_command_center_ai_context, dpm_command_center_supportability
 from app.services.ai_client_protocols import LotusAiWorkflowClient
+from app.services.dpm_ai_workflow_execution import (
+    DPM_PM_OPERATING_QUALITY_EXECUTION,
+    validate_dpm_ai_workflow_execution,
+)
 from app.services.dpm_command_center_errors import raise_manage_command_center_error
 from app.services.dpm_pm_operating_quality_client_protocols import (
     DpmPmOperatingQualityClientAccessMixin,
@@ -47,7 +52,7 @@ class DpmPmOperatingQualitySummaryServiceMixin(DpmPmOperatingQualityClientAccess
             correlation_id=correlation_id,
         )
 
-        ai_status, ai_payload = await self._execute_pm_operating_quality_summary_workflow(
+        ai_status, ai_execution = await self._execute_pm_operating_quality_summary_workflow(
             lotus_ai_client=lotus_ai_client,
             score_run_id=score_run_id,
             correlation_id=correlation_id,
@@ -57,7 +62,7 @@ class DpmPmOperatingQualitySummaryServiceMixin(DpmPmOperatingQualityClientAccess
             correlation_id=correlation_id,
             summary_context=summary_context,
             ai_status=ai_status,
-            ai_payload=ai_payload,
+            ai_execution=ai_execution,
         )
 
     async def _load_pm_operating_quality_summary_context(
@@ -135,7 +140,7 @@ class DpmPmOperatingQualitySummaryServiceMixin(DpmPmOperatingQualityClientAccess
         score_run_id: str,
         correlation_id: str,
         summary_context: DpmPmOperatingQualitySummaryContext,
-    ) -> tuple[int, dict[str, Any]]:
+    ) -> tuple[int, DpmAiWorkflowExecution]:
         ai_status, ai_payload = await lotus_ai_client.execute_workflow_pack(
             pack_id="pm_quality_summary.pack",
             version="v1",
@@ -163,7 +168,12 @@ class DpmPmOperatingQualitySummaryServiceMixin(DpmPmOperatingQualityClientAccess
                 error_code="AI_PM_OPERATING_QUALITY_SUMMARY_UPSTREAM_ERROR",
                 default_detail="lotus-ai PM operating quality summary request failed",
             )
-        return ai_status, ai_payload
+        return ai_status, validate_dpm_ai_workflow_execution(
+            ai_payload,
+            upstream_status=ai_status,
+            correlation_id=correlation_id,
+            expectation=DPM_PM_OPERATING_QUALITY_EXECUTION,
+        )
 
     def _compose_pm_operating_quality_summary_response(
         self,
@@ -171,7 +181,7 @@ class DpmPmOperatingQualitySummaryServiceMixin(DpmPmOperatingQualityClientAccess
         correlation_id: str,
         summary_context: DpmPmOperatingQualitySummaryContext,
         ai_status: int,
-        ai_payload: dict[str, Any],
+        ai_execution: DpmAiWorkflowExecution,
     ) -> DpmPmOperatingQualitySummaryGatewayResponse:
         return DpmPmOperatingQualitySummaryGatewayResponse(
             correlation_id=correlation_id,
@@ -181,5 +191,5 @@ class DpmPmOperatingQualitySummaryServiceMixin(DpmPmOperatingQualityClientAccess
             supportability=summary_context.supportability,
             score_run=summary_context.score_run,
             summary_request=summary_context.summary_request,
-            data=ai_payload,
+            data=ai_execution,
         )

--- a/src/app/services/dpm_proof_pack_ai_handoff.py
+++ b/src/app/services/dpm_proof_pack_ai_handoff.py
@@ -1,0 +1,154 @@
+"""Compose the governed proof-pack PM memo handoff to lotus-ai."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import status
+
+from app.config import settings
+from app.contracts.dpm_ai_workflow_execution import DpmAiWorkflowExecution
+from app.contracts.dpm_proof_packs import (
+    DpmProofPackMemoGatewayResponse,
+    DpmProofPackMemoRequest,
+    DpmProofPackSupportability,
+)
+from app.services.ai_client_protocols import LotusAiWorkflowClient
+from app.services.dpm_ai_workflow_execution import (
+    DPM_PROOF_PACK_PM_MEMO_EXECUTION,
+    validate_dpm_ai_workflow_execution,
+)
+from app.services.lotus_ai_workflow import build_workflow_pack_task_request
+from app.services.upstream_envelope import raise_product_safe_service_error
+
+_BLOCKED_ACTIONS = [
+    "place_orders",
+    "approve_rebalance",
+    "override_controls",
+    "invent_missing_evidence",
+    "contact_client",
+]
+_UNSUPPORTED_CLAIMS = [
+    "client_contact",
+    "trade_approval",
+    "portfolio_manager_scoring",
+    "execution_instruction",
+]
+
+
+@dataclass(frozen=True)
+class ProofPackAiEvidenceInput:
+    """Manage-owned input and posture for a proof-pack AI handoff."""
+
+    upstream_status: int
+    payload: dict[str, Any]
+    supportability: DpmProofPackSupportability
+
+
+def build_proof_pack_pm_memo_request(
+    request: DpmProofPackMemoRequest,
+) -> dict[str, object]:
+    """Return the bounded business request passed to the governed task."""
+
+    return {
+        "requested_outputs": request.requested_outputs,
+        "audience": request.audience,
+    }
+
+
+async def execute_proof_pack_pm_memo_workflow(
+    *,
+    lotus_ai_client: LotusAiWorkflowClient,
+    proof_pack_id: str,
+    correlation_id: str,
+    ai_evidence_input: ProofPackAiEvidenceInput,
+    memo_request: dict[str, object],
+) -> tuple[int, DpmAiWorkflowExecution]:
+    """Execute and validate the proof-pack PM memo workflow."""
+
+    ai_status, ai_payload = await lotus_ai_client.execute_workflow_pack(
+        pack_id="dpm_pm_memo.pack",
+        version="v1",
+        environment="DEVELOPMENT",
+        caller_identity_class="INTERNAL_SERVICE",
+        workflow_surface="dpm-proof-pack-ai-evidence",
+        task_request=build_workflow_pack_task_request(
+            correlation_id=correlation_id,
+            summary=(
+                "Generate review-gated proof-pack PM memo from bounded AI evidence "
+                f"for {proof_pack_id}."
+            ),
+            payload=_task_payload(ai_evidence_input, memo_request),
+            source_refs=_source_refs(ai_evidence_input.payload, proof_pack_id),
+        ),
+        correlation_id=correlation_id,
+    )
+    if ai_status >= status.HTTP_400_BAD_REQUEST:
+        raise_product_safe_service_error(
+            ai_status,
+            ai_payload,
+            source_service="lotus-ai",
+            error_code="AI_PROOF_PACK_PM_MEMO_UPSTREAM_ERROR",
+            default_detail="lotus-ai proof-pack PM memo request failed",
+        )
+    return ai_status, validate_dpm_ai_workflow_execution(
+        ai_payload,
+        upstream_status=ai_status,
+        correlation_id=correlation_id,
+        expectation=DPM_PROOF_PACK_PM_MEMO_EXECUTION,
+    )
+
+
+def build_proof_pack_pm_memo_response(
+    *,
+    correlation_id: str,
+    ai_evidence_input: ProofPackAiEvidenceInput,
+    memo_request: dict[str, object],
+    ai_upstream_status: int,
+    data: DpmAiWorkflowExecution,
+) -> DpmProofPackMemoGatewayResponse:
+    """Return the Workbench-facing proof-pack memo execution envelope."""
+
+    return DpmProofPackMemoGatewayResponse(
+        correlation_id=correlation_id,
+        contract_version=settings.contract_version,
+        manage_upstream_status=ai_evidence_input.upstream_status,
+        ai_upstream_status=ai_upstream_status,
+        supportability=ai_evidence_input.supportability,
+        ai_evidence_input=ai_evidence_input.payload,
+        memo_request=memo_request,
+        data=data,
+    )
+
+
+def _task_payload(
+    ai_evidence_input: ProofPackAiEvidenceInput,
+    memo_request: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "ai_evidence_input": ai_evidence_input.payload,
+        "memo_request": memo_request,
+        "supportability": {
+            "source_state": ai_evidence_input.supportability.state,
+            "reason_codes": ai_evidence_input.supportability.reason_codes,
+            "blocked_actions": _BLOCKED_ACTIONS,
+            "requires_human_review": True,
+            "unsupported_claims": _UNSUPPORTED_CLAIMS,
+        },
+    }
+
+
+def _source_refs(payload: dict[str, Any], proof_pack_id: str) -> list[str]:
+    source_refs: list[str] = []
+    for key in ("source_refs", "sourceRefs"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            source_refs.extend(str(item) for item in value if item)
+
+    evidence_ref = payload.get("evidence_ref") or payload.get("ai_evidence_input_ref")
+    if evidence_ref:
+        source_refs.append(f"lotus-manage:proof-pack-ai-evidence:{evidence_ref}")
+    payload_proof_pack_id = payload.get("proof_pack_id")
+    if payload_proof_pack_id:
+        source_refs.append(f"lotus-manage:proof-pack:{payload_proof_pack_id}")
+    source_refs.append(f"lotus-manage:proof-pack-ai-evidence:{proof_pack_id}")
+    return sorted(set(source_refs))

--- a/src/app/services/dpm_proof_pack_service.py
+++ b/src/app/services/dpm_proof_pack_service.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Any
 
 from fastapi import status
@@ -10,41 +9,21 @@ from app.contracts.dpm_proof_packs import (
     DpmProofPackMarkdownResponse,
     DpmProofPackMemoGatewayResponse,
     DpmProofPackMemoRequest,
-    DpmProofPackSupportability,
 )
 from app.services.ai_client_protocols import LotusAiWorkflowClient
 from app.services.dpm_client_protocols import DpmProofPackClient
-from app.services.dpm_proof_pack_supportability import build_dpm_proof_pack_supportability
-from app.services.lotus_ai_workflow import (
-    build_workflow_pack_task_request,
-    require_lotus_ai_client,
+from app.services.dpm_proof_pack_ai_handoff import (
+    ProofPackAiEvidenceInput,
+    build_proof_pack_pm_memo_request,
+    build_proof_pack_pm_memo_response,
+    execute_proof_pack_pm_memo_workflow,
 )
+from app.services.dpm_proof_pack_supportability import build_dpm_proof_pack_supportability
+from app.services.lotus_ai_workflow import require_lotus_ai_client
 from app.services.upstream_envelope import (
     build_product_safe_upstream_status_gateway_envelope,
-    raise_product_safe_service_error,
     raise_product_safe_upstream_error,
 )
-
-_PROOF_PACK_PM_MEMO_BLOCKED_ACTIONS = [
-    "place_orders",
-    "approve_rebalance",
-    "override_controls",
-    "invent_missing_evidence",
-    "contact_client",
-]
-_PROOF_PACK_PM_MEMO_UNSUPPORTED_CLAIMS = [
-    "client_contact",
-    "trade_approval",
-    "portfolio_manager_scoring",
-    "execution_instruction",
-]
-
-
-@dataclass(frozen=True)
-class ProofPackAiEvidenceInput:
-    upstream_status: int
-    payload: dict[str, Any]
-    supportability: DpmProofPackSupportability
 
 
 class DpmProofPackService:
@@ -136,8 +115,8 @@ class DpmProofPackService:
             proof_pack_id=proof_pack_id,
             correlation_id=correlation_id,
         )
-        memo_request = _proof_pack_pm_memo_request_payload(request)
-        ai_status, ai_payload = await _execute_proof_pack_pm_memo_workflow(
+        memo_request = build_proof_pack_pm_memo_request(request)
+        ai_status, ai_payload = await execute_proof_pack_pm_memo_workflow(
             lotus_ai_client=lotus_ai_client,
             proof_pack_id=proof_pack_id,
             correlation_id=correlation_id,
@@ -145,7 +124,7 @@ class DpmProofPackService:
             memo_request=memo_request,
         )
 
-        return _proof_pack_pm_memo_response(
+        return build_proof_pack_pm_memo_response(
             correlation_id=correlation_id,
             ai_evidence_input=ai_evidence_input,
             memo_request=memo_request,
@@ -187,122 +166,6 @@ class DpmProofPackService:
             error_code="MANAGE_PROOF_PACK_UPSTREAM_ERROR",
             default_detail="lotus-manage proof-pack request failed",
         )
-
-
-def _proof_pack_pm_memo_request_payload(
-    request: DpmProofPackMemoRequest,
-) -> dict[str, object]:
-    return {
-        "requested_outputs": request.requested_outputs,
-        "audience": request.audience,
-    }
-
-
-def _proof_pack_pm_memo_task_payload(
-    *,
-    ai_evidence_input: ProofPackAiEvidenceInput,
-    memo_request: dict[str, object],
-) -> dict[str, object]:
-    return {
-        "ai_evidence_input": ai_evidence_input.payload,
-        "memo_request": memo_request,
-        "supportability": _proof_pack_pm_memo_supportability_payload(
-            ai_evidence_input.supportability
-        ),
-    }
-
-
-async def _execute_proof_pack_pm_memo_workflow(
-    *,
-    lotus_ai_client: LotusAiWorkflowClient,
-    proof_pack_id: str,
-    correlation_id: str,
-    ai_evidence_input: ProofPackAiEvidenceInput,
-    memo_request: dict[str, object],
-) -> tuple[int, dict[str, Any]]:
-    ai_status, ai_payload = await lotus_ai_client.execute_workflow_pack(
-        pack_id="dpm_pm_memo.pack",
-        version="v1",
-        environment="DEVELOPMENT",
-        caller_identity_class="INTERNAL_SERVICE",
-        workflow_surface="dpm-proof-pack-ai-evidence",
-        task_request=build_workflow_pack_task_request(
-            correlation_id=correlation_id,
-            summary=(
-                "Generate review-gated proof-pack PM memo from bounded AI evidence "
-                f"for {proof_pack_id}."
-            ),
-            payload=_proof_pack_pm_memo_task_payload(
-                ai_evidence_input=ai_evidence_input,
-                memo_request=memo_request,
-            ),
-            source_refs=_proof_pack_ai_source_refs(
-                ai_evidence_input.payload,
-                proof_pack_id,
-            ),
-        ),
-        correlation_id=correlation_id,
-    )
-    if ai_status >= status.HTTP_400_BAD_REQUEST:
-        raise_product_safe_service_error(
-            ai_status,
-            ai_payload,
-            source_service="lotus-ai",
-            error_code="AI_PROOF_PACK_PM_MEMO_UPSTREAM_ERROR",
-            default_detail="lotus-ai proof-pack PM memo request failed",
-        )
-    return ai_status, ai_payload
-
-
-def _proof_pack_pm_memo_response(
-    *,
-    correlation_id: str,
-    ai_evidence_input: ProofPackAiEvidenceInput,
-    memo_request: dict[str, object],
-    ai_upstream_status: int,
-    data: dict[str, Any],
-) -> DpmProofPackMemoGatewayResponse:
-    return DpmProofPackMemoGatewayResponse(
-        correlation_id=correlation_id,
-        contract_version=settings.contract_version,
-        manage_upstream_status=ai_evidence_input.upstream_status,
-        ai_upstream_status=ai_upstream_status,
-        supportability=ai_evidence_input.supportability,
-        ai_evidence_input=ai_evidence_input.payload,
-        memo_request=memo_request,
-        data=data,
-    )
-
-
-def _proof_pack_ai_source_refs(payload: dict[str, Any], proof_pack_id: str) -> list[str]:
-    source_refs: list[str] = []
-    for key in ("source_refs", "sourceRefs"):
-        value = payload.get(key)
-        if isinstance(value, list):
-            source_refs.extend(str(item) for item in value if item)
-
-    evidence_ref = payload.get("evidence_ref") or payload.get("ai_evidence_input_ref")
-    if evidence_ref:
-        source_refs.append(f"lotus-manage:proof-pack-ai-evidence:{evidence_ref}")
-
-    payload_proof_pack_id = payload.get("proof_pack_id")
-    if payload_proof_pack_id:
-        source_refs.append(f"lotus-manage:proof-pack:{payload_proof_pack_id}")
-    source_refs.append(f"lotus-manage:proof-pack-ai-evidence:{proof_pack_id}")
-
-    return sorted(set(source_refs))
-
-
-def _proof_pack_pm_memo_supportability_payload(
-    supportability: DpmProofPackSupportability,
-) -> dict[str, object]:
-    return {
-        "source_state": supportability.state,
-        "reason_codes": supportability.reason_codes,
-        "blocked_actions": _PROOF_PACK_PM_MEMO_BLOCKED_ACTIONS,
-        "requires_human_review": True,
-        "unsupported_claims": _PROOF_PACK_PM_MEMO_UNSUPPORTED_CLAIMS,
-    }
 
 
 def _raise_manage_upstream_error(upstream_status: int, payload: dict[str, Any]) -> None:

--- a/src/app/services/dpm_wave_ai_handoff.py
+++ b/src/app/services/dpm_wave_ai_handoff.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from fastapi import status
 
+from app.contracts.dpm_ai_workflow_execution import DpmAiWorkflowExecution
 from app.contracts.dpm_waves import (
     DpmOperationsHandoffSummaryGatewayResponse,
     DpmOperationsHandoffSummaryRequest,
@@ -10,6 +11,11 @@ from app.contracts.dpm_waves import (
     DpmWaveMemoRequest,
 )
 from app.services.ai_client_protocols import LotusAiWorkflowClient
+from app.services.dpm_ai_workflow_execution import (
+    DPM_OPERATIONS_HANDOFF_EXECUTION,
+    DPM_WAVE_PM_MEMO_EXECUTION,
+    validate_dpm_ai_workflow_execution,
+)
 from app.services.dpm_wave_ai_payloads import (
     WaveReportInput,
     operations_handoff_summary_request_payload,
@@ -69,7 +75,7 @@ class DpmWaveAiHandoffMixin:
         correlation_id: str,
         report_input: WaveReportInput,
         memo_request: dict[str, object],
-    ) -> tuple[int, dict[str, Any]]:
+    ) -> tuple[int, DpmAiWorkflowExecution]:
         lotus_ai_client = require_lotus_ai_client(self._lotus_ai_client)
         ai_status, ai_payload = await lotus_ai_client.execute_workflow_pack(
             pack_id="dpm_wave_pm_memo.pack",
@@ -99,7 +105,12 @@ class DpmWaveAiHandoffMixin:
                 error_code="AI_WAVE_PM_MEMO_UPSTREAM_ERROR",
                 default_detail="lotus-ai wave PM memo request failed",
             )
-        return ai_status, ai_payload
+        return ai_status, validate_dpm_ai_workflow_execution(
+            ai_payload,
+            upstream_status=ai_status,
+            correlation_id=correlation_id,
+            expectation=DPM_WAVE_PM_MEMO_EXECUTION,
+        )
 
     async def request_operations_handoff_summary(
         self,
@@ -134,7 +145,7 @@ class DpmWaveAiHandoffMixin:
         correlation_id: str,
         report_input: WaveReportInput,
         handoff_summary_request: dict[str, object],
-    ) -> tuple[int, dict[str, Any]]:
+    ) -> tuple[int, DpmAiWorkflowExecution]:
         lotus_ai_client = require_lotus_ai_client(self._lotus_ai_client)
         ai_status, ai_payload = await lotus_ai_client.execute_workflow_pack(
             pack_id="dpm_operations_handoff_summary.pack",
@@ -164,7 +175,12 @@ class DpmWaveAiHandoffMixin:
                 error_code="AI_OPERATIONS_HANDOFF_SUMMARY_UPSTREAM_ERROR",
                 default_detail="lotus-ai operations handoff summary request failed",
             )
-        return ai_status, ai_payload
+        return ai_status, validate_dpm_ai_workflow_execution(
+            ai_payload,
+            upstream_status=ai_status,
+            correlation_id=correlation_id,
+            expectation=DPM_OPERATIONS_HANDOFF_EXECUTION,
+        )
 
     async def _load_wave_report_input(
         self,

--- a/src/app/services/dpm_wave_ai_payloads.py
+++ b/src/app/services/dpm_wave_ai_payloads.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from app.config import settings
+from app.contracts.dpm_ai_workflow_execution import DpmAiWorkflowExecution
 from app.contracts.dpm_waves import (
     DpmOperationsHandoffSummaryGatewayResponse,
     DpmOperationsHandoffSummaryRequest,
@@ -154,7 +155,7 @@ def wave_pm_memo_response(
     report_input: WaveReportInput,
     memo_request: dict[str, object],
     ai_upstream_status: int,
-    data: dict[str, Any],
+    data: DpmAiWorkflowExecution,
 ) -> DpmWaveMemoGatewayResponse:
     return DpmWaveMemoGatewayResponse(
         correlation_id=correlation_id,
@@ -195,7 +196,7 @@ def operations_handoff_summary_response(
     report_input: WaveReportInput,
     handoff_summary_request: dict[str, object],
     ai_upstream_status: int,
-    data: dict[str, Any],
+    data: DpmAiWorkflowExecution,
 ) -> DpmOperationsHandoffSummaryGatewayResponse:
     return DpmOperationsHandoffSummaryGatewayResponse(
         correlation_id=correlation_id,

--- a/tests/contract/test_dpm_ai_workflow_execution_contract.py
+++ b/tests/contract/test_dpm_ai_workflow_execution_contract.py
@@ -1,0 +1,73 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_all_dpm_ai_handoffs_publish_one_typed_execution_contract() -> None:
+    schemas = TestClient(app).get("/openapi.json").json()["components"]["schemas"]
+    execution_ref = "#/components/schemas/DpmAiWorkflowExecution"
+
+    for response_schema in (
+        "DpmProofPackMemoGatewayResponse",
+        "DpmWaveMemoGatewayResponse",
+        "DpmOperationsHandoffSummaryGatewayResponse",
+        "DpmExceptionSummaryGatewayResponse",
+        "DpmOutcomeReviewNarrativeGatewayResponse",
+        "DpmPmOperatingQualitySummaryGatewayResponse",
+    ):
+        data_schema = schemas[response_schema]["properties"]["data"]
+        assert data_schema["$ref"] == execution_ref
+        assert data_schema["description"]
+
+
+def test_dpm_ai_execution_openapi_preserves_product_evidence_and_excludes_raw_fields() -> None:
+    schemas = TestClient(app).get("/openapi.json").json()["components"]["schemas"]
+
+    execution_properties = schemas["DpmAiWorkflowExecution"]["properties"]
+    run_properties = schemas["DpmAiWorkflowPackRun"]["properties"]
+    result_properties = schemas["DpmAiTaskResult"]["properties"]
+    audit_properties = schemas["DpmAiTaskAudit"]["properties"]
+    evidence_properties = schemas["DpmAiExecutionEvidenceDescriptor"]["properties"]
+    artifact_properties = schemas["DpmAiArtifactReference"]["properties"]
+
+    for field in ("eligibility", "execution", "workflow_pack_run", "summary"):
+        assert field in execution_properties
+    for field in (
+        "runtime_state",
+        "review_state",
+        "supportability_status",
+        "review_required",
+        "review_summary",
+        "evidence_descriptors",
+        "artifact_refs",
+        "supersedes_run_id",
+        "superseded_by_run_id",
+        "replacement_run_id",
+        "recovery_lineage",
+        "created_at",
+        "completed_at",
+        "last_updated_at",
+    ):
+        assert field in run_properties
+
+    assert set(result_properties) == {"structured_output"}
+    assert "prompt_version" not in audit_properties
+    assert "prompt_selection" not in audit_properties
+    assert "attributes" not in evidence_properties
+    assert "output_preview" not in run_properties
+    assert "storage_reference" not in artifact_properties
+    assert "storage_backend" not in artifact_properties
+    assert "created_by" not in artifact_properties
+
+    for schema_name in (
+        "DpmAiWorkflowExecution",
+        "DpmAiTaskExecution",
+        "DpmAiTaskAudit",
+        "DpmAiWorkflowPackRun",
+        "DpmAiWorkflowReviewSummary",
+        "DpmAiExecutionEvidenceDescriptor",
+        "DpmAiArtifactReference",
+        "DpmAiRecoveryLineage",
+    ):
+        for property_schema in schemas[schema_name]["properties"].values():
+            assert property_schema.get("description")

--- a/tests/contract/test_dpm_command_center_contract.py
+++ b/tests/contract/test_dpm_command_center_contract.py
@@ -10,6 +10,7 @@ from app.contracts.dpm_command_center import (
     DpmPortfolioMemoryGatewayResponse,
 )
 from app.main import app
+from tests.support.lotus_ai_workflow_pack import lotus_ai_workflow_pack_execution_v1
 
 
 def test_dpm_outcome_review_gateway_response_contract_shape() -> None:
@@ -295,10 +296,11 @@ def test_dpm_outcome_review_narrative_gateway_response_contract_shape() -> None:
             },
         },
         narrative_request={"requested_outputs": ["pm_summary"], "audience": ["pm"]},
-        data={
-            "execution": {"status": "COMPLETED"},
-            "workflow_pack_run": {"workflow_authority_owner": "lotus-manage"},
-        },
+        data=lotus_ai_workflow_pack_execution_v1(
+            pack_id="outcome_review_narrative.pack",
+            workflow_surface="dpm-outcome-review-ai-evidence",
+            correlation_id="corr-1",
+        ),
     )
 
     assert response.source_service == "lotus-ai"
@@ -307,7 +309,7 @@ def test_dpm_outcome_review_narrative_gateway_response_contract_shape() -> None:
     assert response.ai_evidence_input["client_communication_boundary"]["boundary_id"] == (
         "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY"
     )
-    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    assert response.data.workflow_pack_run.workflow_authority_owner == "lotus-manage"
 
 
 def test_dpm_exception_summary_gateway_response_contract_shape() -> None:
@@ -329,17 +331,18 @@ def test_dpm_exception_summary_gateway_response_contract_shape() -> None:
             "requested_outputs": ["exception_summary", "recommended_triage"],
             "audience": ["portfolio_manager", "operations"],
         },
-        data={
-            "execution": {"status": "COMPLETED"},
-            "workflow_pack_run": {"workflow_authority_owner": "lotus-manage"},
-        },
+        data=lotus_ai_workflow_pack_execution_v1(
+            pack_id="dpm_exception_summary.pack",
+            workflow_surface="dpm-exception-summary-ai-evidence",
+            correlation_id="corr-exception-summary-1",
+        ),
     )
 
     assert response.source_service == "lotus-ai"
     assert response.evidence_source_service == "lotus-manage"
     assert response.supportability.authority == "lotus-manage:RFC-0038"
     assert response.exception_summary_input["redaction_policy"] == "NO_RAW_PAYLOADS"
-    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    assert response.data.workflow_pack_run.workflow_authority_owner == "lotus-manage"
 
 
 def test_dpm_pm_operating_quality_summary_gateway_response_contract_shape() -> None:
@@ -374,10 +377,11 @@ def test_dpm_pm_operating_quality_summary_gateway_response_contract_shape() -> N
             "requested_outputs": ["score_run_summary", "support_references"],
             "audience": ["portfolio_manager", "investment_control"],
         },
-        data={
-            "execution": {"status": "COMPLETED"},
-            "workflow_pack_run": {"workflow_authority_owner": "lotus-manage"},
-        },
+        data=lotus_ai_workflow_pack_execution_v1(
+            pack_id="pm_quality_summary.pack",
+            workflow_surface="dpm-pm-quality-ai-evidence",
+            correlation_id="corr-pmq-summary-1",
+        ),
     )
 
     assert response.source_service == "lotus-ai"
@@ -388,7 +392,7 @@ def test_dpm_pm_operating_quality_summary_gateway_response_contract_shape() -> N
         "score_run_summary",
         "support_references",
     ]
-    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    assert response.data.workflow_pack_run.workflow_authority_owner == "lotus-manage"
 
 
 def test_dpm_command_center_openapi_contract_registered() -> None:

--- a/tests/contract/test_dpm_proof_pack_contract.py
+++ b/tests/contract/test_dpm_proof_pack_contract.py
@@ -5,6 +5,7 @@ from app.contracts.dpm_proof_packs import (
     DpmProofPackMemoGatewayResponse,
 )
 from app.main import app
+from tests.support.lotus_ai_workflow_pack import lotus_ai_workflow_pack_execution_v1
 
 
 def test_dpm_proof_pack_gateway_response_contract_shape() -> None:
@@ -50,13 +51,17 @@ def test_dpm_proof_pack_pm_memo_gateway_response_contract_shape() -> None:
             "content_hash": "sha256:ai-evidence",
         },
         memo_request={"requested_outputs": ["pm_memo"], "audience": ["portfolio_manager"]},
-        data={"workflow_pack_run": {"workflow_authority_owner": "lotus-manage"}},
+        data=lotus_ai_workflow_pack_execution_v1(
+            pack_id="dpm_pm_memo.pack",
+            workflow_surface="dpm-proof-pack-ai-evidence",
+            correlation_id="corr-proof-pack-memo-1",
+        ),
     )
 
     assert response.source_service == "lotus-ai"
     assert response.evidence_source_service == "lotus-manage"
     assert response.supportability.authority == "lotus-manage:RFC-0040"
-    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    assert response.data.workflow_pack_run.workflow_authority_owner == "lotus-manage"
 
 
 def test_dpm_proof_pack_openapi_contract_registered() -> None:

--- a/tests/contract/test_dpm_wave_contract.py
+++ b/tests/contract/test_dpm_wave_contract.py
@@ -7,6 +7,7 @@ from app.contracts.dpm_waves import (
     DpmWaveMemoGatewayResponse,
 )
 from app.main import app
+from tests.support.lotus_ai_workflow_pack import lotus_ai_workflow_pack_execution_v1
 
 
 def test_dpm_wave_gateway_response_contract_shape() -> None:
@@ -50,13 +51,18 @@ def test_dpm_wave_memo_gateway_response_contract_shape() -> None:
             "requested_outputs": ["wave_pm_memo", "approval_checklist"],
             "audience": ["portfolio_manager", "investment_control"],
         },
-        data={"run_id": "wf_run_wave_memo_001", "status": "REVIEW_REQUIRED"},
+        data=lotus_ai_workflow_pack_execution_v1(
+            pack_id="dpm_wave_pm_memo.pack",
+            workflow_surface="dpm-wave-ai-evidence",
+            correlation_id="corr-wave-ai-memo",
+        ),
     )
 
     assert response.source_service == "lotus-ai"
     assert response.evidence_source_service == "lotus-manage"
     assert response.supportability.authority == "lotus-manage:RFC-0041"
     assert response.wave_report_input["wave_id"] == "dwv_001"
+    assert response.data.workflow_pack_run.review_state == "AWAITING_REVIEW"
 
 
 def test_dpm_operations_handoff_summary_gateway_response_contract_shape() -> None:
@@ -74,13 +80,18 @@ def test_dpm_operations_handoff_summary_gateway_response_contract_shape() -> Non
             "requested_outputs": ["operations_summary", "blocking_conditions"],
             "audience": ["operations", "portfolio_manager"],
         },
-        data={"run_id": "wf_run_handoff_001", "status": "REVIEW_REQUIRED"},
+        data=lotus_ai_workflow_pack_execution_v1(
+            pack_id="dpm_operations_handoff_summary.pack",
+            workflow_surface="dpm-operations-handoff-ai-evidence",
+            correlation_id="corr-wave-handoff-summary",
+        ),
     )
 
     assert response.source_service == "lotus-ai"
     assert response.evidence_source_service == "lotus-manage"
     assert response.supportability.authority == "lotus-manage:RFC-0041"
     assert response.wave_report_input["external_execution_claimed"] is False
+    assert response.data.workflow_pack_run.review_required is True
 
 
 def test_dpm_campaign_workflow_gateway_response_contract_shape() -> None:

--- a/tests/integration/test_dpm_command_center_router.py
+++ b/tests/integration/test_dpm_command_center_router.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 
 from app.main import app
+from tests.support.lotus_ai_workflow_pack import lotus_ai_workflow_pack_execution_v1
 
 
 def test_dpm_command_center_summary_passes_filters_and_preserves_manage_truth(monkeypatch) -> None:
@@ -1192,22 +1193,15 @@ def test_dpm_command_center_outcome_review_ai_narrative_executes_lotus_ai(monkey
     async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN003
         _ = self
         captured["ai"] = kwargs
-        return 200, {
-            "execution": {
-                "status": "COMPLETED",
-                "audit": {"workflow_pack_run_id": "packrun_or_1"},
-                "result": {
-                    "structured_output": {
-                        "outcome_review_narrative_status": "REVIEW_REQUIRED",
-                        "evidence_content_hash": "sha256:or_1-ai-evidence",
-                    }
-                },
+        return 200, lotus_ai_workflow_pack_execution_v1(
+            pack_id="outcome_review_narrative.pack",
+            workflow_surface="dpm-outcome-review-ai-evidence",
+            correlation_id="corr-ai-router-1",
+            structured_output={
+                "outcome_review_narrative_status": "REVIEW_REQUIRED",
+                "evidence_content_hash": "sha256:or_1-ai-evidence",
             },
-            "workflow_pack_run": {
-                "run_id": "packrun_or_1",
-                "workflow_authority_owner": "lotus-manage",
-            },
-        }
+        )
 
     monkeypatch.setattr(
         "app.clients.dpm_client.DpmClient.get_outcome_review_ai_evidence_input",
@@ -1258,22 +1252,15 @@ def test_dpm_command_center_exception_summary_executes_lotus_ai(monkeypatch) -> 
     async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN003
         _ = self
         captured["ai"] = kwargs
-        return 200, {
-            "execution": {
-                "status": "COMPLETED",
-                "audit": {"workflow_pack_run_id": "packrun_exception_1"},
-                "result": {
-                    "structured_output": {
-                        "exception_summary_status": "REVIEW_REQUIRED",
-                        "exception_count": 1,
-                    }
-                },
+        return 200, lotus_ai_workflow_pack_execution_v1(
+            pack_id="dpm_exception_summary.pack",
+            workflow_surface="dpm-exception-summary-ai-evidence",
+            correlation_id="corr-exception-router-1",
+            structured_output={
+                "exception_summary_status": "REVIEW_REQUIRED",
+                "exception_count": 1,
             },
-            "workflow_pack_run": {
-                "run_id": "packrun_exception_1",
-                "workflow_authority_owner": "lotus-manage",
-            },
-        }
+        )
 
     monkeypatch.setattr(
         "app.clients.dpm_client.DpmClient.list_monitoring_exceptions",
@@ -1346,22 +1333,15 @@ def test_dpm_command_center_pm_quality_summary_executes_lotus_ai(monkeypatch) ->
     async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN003
         _ = self
         captured["ai"] = kwargs
-        return 200, {
-            "execution": {
-                "status": "COMPLETED",
-                "audit": {"workflow_pack_run_id": "packrun_pmq_1"},
-                "result": {
-                    "structured_output": {
-                        "workflow_pack_family": "pm_quality_summary",
-                        "summary_status": "REVIEW_REQUIRED",
-                    }
-                },
+        return 200, lotus_ai_workflow_pack_execution_v1(
+            pack_id="pm_quality_summary.pack",
+            workflow_surface="dpm-pm-quality-ai-evidence",
+            correlation_id="corr-pmq-summary-router",
+            structured_output={
+                "workflow_pack_family": "pm_quality_summary",
+                "summary_status": "REVIEW_REQUIRED",
             },
-            "workflow_pack_run": {
-                "run_id": "packrun_pmq_1",
-                "workflow_authority_owner": "lotus-manage",
-            },
-        }
+        )
 
     monkeypatch.setattr(
         "app.clients.dpm_client.DpmClient.get_pm_operating_quality_score_run",

--- a/tests/integration/test_dpm_proof_pack_router.py
+++ b/tests/integration/test_dpm_proof_pack_router.py
@@ -1,6 +1,10 @@
 from fastapi.testclient import TestClient
 
 from app.main import app
+from tests.support.lotus_ai_workflow_pack import (
+    UNSAFE_UPSTREAM_MARKER,
+    lotus_ai_workflow_pack_execution_v1,
+)
 
 
 def test_dpm_proof_pack_generate_preserves_manage_truth(monkeypatch) -> None:
@@ -166,44 +170,17 @@ def test_dpm_proof_pack_pm_memo_executes_lotus_ai_workflow_pack(monkeypatch) -> 
             "proof_pack_id": proof_pack_id,
             "correlation_id": correlation_id,
         }
-        return 200, {
-            "contract_version": "DpmProofPackAiEvidenceInput.v1",
-            "proof_pack_id": proof_pack_id,
-            "proof_pack_content_hash": "sha256:proof-pack",
-            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-            "as_of_date": "2026-05-03",
-            "permitted_use": ["pm_memo_support"],
-            "forbidden_actions": [
-                "place_orders",
-                "approve_rebalance",
-                "override_controls",
-                "invent_missing_evidence",
-                "contact_client",
-            ],
-            "forbidden_fields_removed": ["client_name"],
-            "decision_summary": {"decision": "rebalance_ready"},
-            "supportability_status": "SUPPORTED",
-            "reason_codes": ["AI_EVIDENCE_INPUT_READY"],
-            "sections": [{"section_id": "mandate", "state": "READY"}],
-            "source_refs": ["lotus-manage:proof-pack:dpp_rr_001"],
-            "evidence_ref": "ai-evidence:dpp_rr_001",
-            "content_hash": "sha256:ai-evidence",
-        }
+        return 200, _proof_pack_ai_evidence_payload(proof_pack_id)
 
     async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN003
         _ = self
         captured["ai"] = kwargs
-        return 200, {
-            "execution": {
-                "audit": {"workflow_pack_run_id": "packrun_dpp_rr_001"},
-                "result": {"dpm_pm_memo_status": "REVIEW_REQUIRED"},
-            },
-            "workflow_pack_run": {
-                "run_id": "packrun_dpp_rr_001",
-                "workflow_authority_owner": "lotus-manage",
-                "review_state": "AWAITING_REVIEW",
-            },
-        }
+        return 200, lotus_ai_workflow_pack_execution_v1(
+            pack_id="dpm_pm_memo.pack",
+            workflow_surface="dpm-proof-pack-ai-evidence",
+            correlation_id="corr-proof-pack-memo-router-1",
+            structured_output={"dpm_pm_memo_status": "REVIEW_REQUIRED"},
+        )
 
     monkeypatch.setattr(
         "app.clients.dpm_client.DpmClient.get_proof_pack_ai_evidence_input",
@@ -242,6 +219,51 @@ def test_dpm_proof_pack_pm_memo_executes_lotus_ai_workflow_pack(monkeypatch) -> 
     assert payload["evidence_source_service"] == "lotus-manage"
     assert payload["ai_evidence_input"]["content_hash"] == "sha256:ai-evidence"
     assert payload["data"]["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    assert "output_preview" not in payload["data"]["workflow_pack_run"]
+    assert "storage_reference" not in response.text
+    assert UNSAFE_UPSTREAM_MARKER not in response.text
+
+
+def test_dpm_proof_pack_pm_memo_rejects_malformed_ai_contract_without_leakage(
+    monkeypatch,
+) -> None:
+    async def _fake_ai_input(self, proof_pack_id, correlation_id):  # noqa: ANN001
+        _ = self, correlation_id
+        return 200, _proof_pack_ai_evidence_payload(proof_pack_id)
+
+    async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN003
+        _ = self, kwargs
+        payload = lotus_ai_workflow_pack_execution_v1(
+            pack_id="dpm_pm_memo.pack",
+            workflow_surface="dpm-proof-pack-ai-evidence",
+            correlation_id="corr-proof-pack-invalid-ai-contract",
+        )
+        payload["workflow_pack_run"].pop("review_state")
+        return 200, payload
+
+    monkeypatch.setattr(
+        "app.clients.dpm_client.DpmClient.get_proof_pack_ai_evidence_input",
+        _fake_ai_input,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_ai_client.LotusAiClient.execute_workflow_pack",
+        _fake_execute_workflow_pack,
+    )
+
+    response = TestClient(app).post(
+        "/api/v1/dpm/command-center/proof-packs/dpp_rr_001/ai-pm-memo",
+        json={"requested_outputs": ["pm_memo"], "audience": ["portfolio_manager"]},
+        headers={"X-Correlation-Id": "corr-proof-pack-invalid-ai-contract"},
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == {
+        "source_service": "lotus-ai",
+        "upstream_status": 200,
+        "error_code": "AI_WORKFLOW_EXECUTION_CONTRACT_INVALID",
+        "detail": "AI workflow output could not be safely verified.",
+    }
+    assert UNSAFE_UPSTREAM_MARKER not in response.text
 
 
 def _proof_pack_payload() -> dict[str, object]:
@@ -254,4 +276,30 @@ def _proof_pack_payload() -> dict[str, object]:
             "sections": [{"section_id": "mandate", "state": "READY"}],
         },
         "markdown_url": "/api/v1/rebalance/proof-packs/dpp_rr_001/summary.md",
+    }
+
+
+def _proof_pack_ai_evidence_payload(proof_pack_id: str) -> dict[str, object]:
+    return {
+        "contract_version": "DpmProofPackAiEvidenceInput.v1",
+        "proof_pack_id": proof_pack_id,
+        "proof_pack_content_hash": "sha256:proof-pack",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "as_of_date": "2026-05-03",
+        "permitted_use": ["pm_memo_support"],
+        "forbidden_actions": [
+            "place_orders",
+            "approve_rebalance",
+            "override_controls",
+            "invent_missing_evidence",
+            "contact_client",
+        ],
+        "forbidden_fields_removed": ["client_name"],
+        "decision_summary": {"decision": "rebalance_ready"},
+        "supportability_status": "SUPPORTED",
+        "reason_codes": ["AI_EVIDENCE_INPUT_READY"],
+        "sections": [{"section_id": "mandate", "state": "READY"}],
+        "source_refs": [f"lotus-manage:proof-pack:{proof_pack_id}"],
+        "evidence_ref": f"ai-evidence:{proof_pack_id}",
+        "content_hash": "sha256:ai-evidence",
     }

--- a/tests/integration/test_dpm_wave_router.py
+++ b/tests/integration/test_dpm_wave_router.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from tests.support.lotus_ai_workflow_pack import lotus_ai_workflow_pack_execution_v1
 
 
 def test_dpm_wave_preview_preserves_manage_supportability(monkeypatch) -> None:
@@ -1111,7 +1112,11 @@ def test_dpm_wave_ai_pm_memo_uses_lotus_ai_workflow_pack(monkeypatch) -> None:
     async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN001, ANN003
         _ = self
         captured["ai_kwargs"] = kwargs
-        return 200, {"run_id": "wf_run_wave_memo_001", "status": "REVIEW_REQUIRED"}
+        return 200, lotus_ai_workflow_pack_execution_v1(
+            pack_id="dpm_wave_pm_memo.pack",
+            workflow_surface="dpm-wave-ai-evidence",
+            correlation_id="corr-wave-router-ai-memo",
+        )
 
     monkeypatch.setattr(
         "app.clients.dpm_client.DpmClient.get_wave_report_input",
@@ -1163,7 +1168,11 @@ def test_dpm_wave_operations_handoff_summary_uses_lotus_ai_workflow_pack(monkeyp
     async def _fake_execute_workflow_pack(self, **kwargs):  # noqa: ANN001, ANN003
         _ = self
         captured["ai_kwargs"] = kwargs
-        return 200, {"run_id": "wf_run_handoff_001", "status": "REVIEW_REQUIRED"}
+        return 200, lotus_ai_workflow_pack_execution_v1(
+            pack_id="dpm_operations_handoff_summary.pack",
+            workflow_surface="dpm-operations-handoff-ai-evidence",
+            correlation_id="corr-wave-router-handoff-summary",
+        )
 
     monkeypatch.setattr(
         "app.clients.dpm_client.DpmClient.get_wave_report_input",

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable test builders for source-owned Gateway contracts."""

--- a/tests/support/lotus_ai_workflow_pack.py
+++ b/tests/support/lotus_ai_workflow_pack.py
@@ -1,0 +1,184 @@
+"""Versioned lotus-ai WorkflowPackExecutionResponse fixture builders."""
+
+from typing import Any
+
+LOTUS_AI_WORKFLOW_PACK_EXECUTION_FIXTURE_VERSION = "WorkflowPackExecutionResponse.v1"
+UNSAFE_UPSTREAM_MARKER = "unsafe-upstream-generated-content"
+
+
+def lotus_ai_workflow_pack_execution_v1(
+    *,
+    pack_id: str,
+    workflow_surface: str,
+    correlation_id: str,
+    structured_output: dict[str, object] | None = None,
+    runtime_state: str = "COMPLETED",
+    review_state: str = "AWAITING_REVIEW",
+    supportability_status: str = "ACTION_REQUIRED",
+    review_required: bool = True,
+    stubbed: bool = True,
+    supersedes_run_id: str | None = None,
+    superseded_by_run_id: str | None = None,
+    replacement_run_id: str | None = None,
+    recovery_lineage: dict[str, object] | None = None,
+) -> dict[str, Any]:
+    """Build the bounded peer-service success shape published by lotus-ai."""
+
+    pack_family = pack_id.removesuffix(".pack")
+    run_id = f"packrun_{pack_family}_001"
+    request_id = f"air_{pack_family}_001"
+    provider_mode = "disabled" if stubbed else "openai"
+    provider_id = "text.stub" if stubbed else "text.openai"
+    adapter_kind = "STUB" if stubbed else "OPENAI"
+    output = structured_output or {
+        "workflow_pack_family": pack_family,
+        "state": "REVIEW_REQUIRED",
+        "scope": "support_only",
+    }
+    allowed_review_actions = (
+        ["ACCEPT", "REJECT", "REVISE", "SUPERSEDE", "ABANDON"]
+        if review_required and review_state == "AWAITING_REVIEW"
+        else []
+    )
+    return {
+        "service": "lotus-ai",
+        "version": "0.1.0",
+        "eligibility": {
+            "service": "lotus-ai",
+            "version": "0.1.0",
+            "pack_id": pack_id,
+            "requested_version": "v1",
+            "eligibility_result": "ALLOWED",
+            "allowed": True,
+            "evaluated_registration_ref": f"{pack_id}@v1",
+            "caller_app": "lotus-gateway",
+            "environment": "DEVELOPMENT",
+            "caller_identity_class": "INTERNAL_SERVICE",
+            "tenant_scope_applied": False,
+            "workflow_surface_applied": True,
+            "denial_reasons": [],
+            "status_summary": ["Workflow execution is eligible."],
+        },
+        "execution": {
+            "status": "COMPLETED" if runtime_state != "FAILED" else "FAILED",
+            "task_id": "explain.v1",
+            "category": "explain",
+            "output_label": "EXPLANATION_ONLY",
+            "result": {
+                "message": UNSAFE_UPSTREAM_MARKER,
+                "structured_output": output,
+            },
+            "audit": {
+                "request_id": request_id,
+                "workflow_pack_run_id": run_id,
+                "task_id": "explain.v1",
+                "output_label": "EXPLANATION_ONLY",
+                "prompt_version": "foundation.explain.v1",
+                "prompt_selection": {"unsafe_prompt_detail": UNSAFE_UPSTREAM_MARKER},
+                "provider_mode": provider_mode,
+                "provider_id": provider_id,
+                "adapter_kind": adapter_kind,
+                "model_id": None if stubbed else "gpt-5.4",
+                "model_version": None if stubbed else "2026-06-01",
+                "safety": {
+                    "safety_mode": "documented_only",
+                    "output_label": "EXPLANATION_ONLY",
+                    "redaction_posture": "MINIMIZATION_REQUIRED",
+                    "disposition": "DOCUMENTED_ONLY",
+                    "runtime_redaction_active": False,
+                    "enforced_controls": ["response_labeling", "correlation_and_audit"],
+                    "control_results": [{"control_id": "raw", "summary": UNSAFE_UPSTREAM_MARKER}],
+                    "decision_summary": UNSAFE_UPSTREAM_MARKER,
+                },
+                "authorization": {
+                    "caller_app": "lotus-gateway",
+                    "authenticated_caller_app": "lotus-gateway",
+                    "caller_identity_source": "trusted_http_header",
+                    "caller_identity_bound": True,
+                    "capability_type": "task_execution",
+                    "outcome": "ALLOWED",
+                    "allowed": True,
+                    "tenant_policy_mode": "OPTIONAL",
+                    "task_id": "explain.v1",
+                    "requested_source_ids": [],
+                    "effective_source_ids": [],
+                    "summary": UNSAFE_UPSTREAM_MARKER,
+                },
+                "generated_at": "2026-08-04T18:12:19Z",
+                "stubbed": stubbed,
+            },
+            "evidence": {
+                "descriptors": [
+                    {
+                        "evidence_type": "task_contract",
+                        "summary": "The bounded task contract supported this execution.",
+                        "attributes": {"raw_attribute": UNSAFE_UPSTREAM_MARKER},
+                    }
+                ]
+            },
+        },
+        "workflow_pack_run": {
+            "run_id": run_id,
+            "pack_id": pack_id,
+            "pack_family": pack_family,
+            "pack_version": "v1",
+            "registration_ref": f"{pack_id}@v1",
+            "task_id": "explain.v1",
+            "request_id": request_id,
+            "caller_app": "lotus-gateway",
+            "correlation_id": correlation_id,
+            "tenant_id": "tenant-sg-001",
+            "workflow_surface": workflow_surface,
+            "workflow_authority_owner": "lotus-manage",
+            "runtime_state": runtime_state,
+            "review_state": review_state,
+            "supportability_status": supportability_status,
+            "allowed_review_actions": allowed_review_actions,
+            "review_summary": {
+                "latest_review_event_at": None,
+                "latest_review_actor": None,
+                "review_transition_count": 0,
+                "has_review_history": False,
+            },
+            "review_required": review_required,
+            "provider_mode": provider_mode,
+            "stubbed": stubbed,
+            "output_preview": UNSAFE_UPSTREAM_MARKER,
+            "structured_output_keys": sorted(output),
+            "evidence_descriptors": [
+                {
+                    "evidence_type": "task_contract",
+                    "summary": "The bounded task contract supported this execution.",
+                    "attributes": {"raw_attribute": UNSAFE_UPSTREAM_MARKER},
+                }
+            ],
+            "artifact_refs": [
+                {
+                    "artifact_id": f"artifact_{pack_family}_001",
+                    "domain": "workflow_pack",
+                    "artifact_type": "run_output_summary",
+                    "source_object_kind": "workflow_pack_run",
+                    "source_object_id": run_id,
+                    "lifecycle_status": "runtime_generated",
+                    "retention_posture": "retained_for_review",
+                    "media_type": "application/json",
+                    "byte_size": 512,
+                    "checksum_sha256": "a" * 64,
+                    "storage_backend": "memory",
+                    "storage_reference": f"memory://{UNSAFE_UPSTREAM_MARKER}",
+                    "lineage_parent_artifact_id": None,
+                    "superseded_by_artifact_id": None,
+                    "created_at": "2026-08-04T18:12:19Z",
+                    "created_by": UNSAFE_UPSTREAM_MARKER,
+                }
+            ],
+            "supersedes_run_id": supersedes_run_id,
+            "superseded_by_run_id": superseded_by_run_id,
+            "replacement_run_id": replacement_run_id,
+            "recovery_lineage": recovery_lineage,
+            "created_at": "2026-08-04T18:12:19Z",
+            "completed_at": "2026-08-04T18:12:19Z",
+            "last_updated_at": "2026-08-04T18:12:19Z",
+        },
+        "summary": ["The governed workflow pack completed and requires review."],
+    }

--- a/tests/unit/test_dpm_ai_workflow_execution.py
+++ b/tests/unit/test_dpm_ai_workflow_execution.py
@@ -1,0 +1,335 @@
+from copy import deepcopy
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.services.dpm_ai_workflow_execution import (
+    DPM_EXCEPTION_SUMMARY_EXECUTION,
+    DPM_OPERATIONS_HANDOFF_EXECUTION,
+    DPM_OUTCOME_REVIEW_NARRATIVE_EXECUTION,
+    DPM_PM_OPERATING_QUALITY_EXECUTION,
+    DPM_PROOF_PACK_PM_MEMO_EXECUTION,
+    DPM_WAVE_PM_MEMO_EXECUTION,
+    DpmAiWorkflowExecutionExpectation,
+    validate_dpm_ai_workflow_execution,
+)
+from tests.support.lotus_ai_workflow_pack import (
+    UNSAFE_UPSTREAM_MARKER,
+    lotus_ai_workflow_pack_execution_v1,
+)
+
+_EXPECTATIONS = (
+    DPM_PROOF_PACK_PM_MEMO_EXECUTION,
+    DPM_WAVE_PM_MEMO_EXECUTION,
+    DPM_OPERATIONS_HANDOFF_EXECUTION,
+    DPM_EXCEPTION_SUMMARY_EXECUTION,
+    DPM_OUTCOME_REVIEW_NARRATIVE_EXECUTION,
+    DPM_PM_OPERATING_QUALITY_EXECUTION,
+)
+
+
+@pytest.mark.parametrize("expectation", _EXPECTATIONS)
+def test_validate_dpm_ai_execution_preserves_each_governed_family(
+    expectation: DpmAiWorkflowExecutionExpectation,
+) -> None:
+    correlation_id = f"corr-{expectation.pack_id}"
+    payload = lotus_ai_workflow_pack_execution_v1(
+        pack_id=expectation.pack_id,
+        workflow_surface=expectation.workflow_surface,
+        correlation_id=correlation_id,
+        structured_output={"state": "REVIEW_REQUIRED", "scope": "support_only"},
+    )
+
+    execution = validate_dpm_ai_workflow_execution(
+        payload,
+        upstream_status=200,
+        correlation_id=correlation_id,
+        expectation=expectation,
+    )
+
+    assert execution.workflow_pack_run.pack_id == expectation.pack_id
+    assert execution.workflow_pack_run.runtime_state == "COMPLETED"
+    assert execution.workflow_pack_run.review_state == "AWAITING_REVIEW"
+    assert execution.workflow_pack_run.review_required is True
+    assert execution.workflow_pack_run.stubbed is True
+    assert execution.execution.result.structured_output["scope"] == "support_only"
+
+
+def test_validate_dpm_ai_execution_strips_untrusted_non_product_fields() -> None:
+    payload = lotus_ai_workflow_pack_execution_v1(
+        pack_id=DPM_PROOF_PACK_PM_MEMO_EXECUTION.pack_id,
+        workflow_surface=DPM_PROOF_PACK_PM_MEMO_EXECUTION.workflow_surface,
+        correlation_id="corr-safe-projection",
+    )
+
+    execution = validate_dpm_ai_workflow_execution(
+        payload,
+        upstream_status=200,
+        correlation_id="corr-safe-projection",
+        expectation=DPM_PROOF_PACK_PM_MEMO_EXECUTION,
+    )
+    serialized = execution.model_dump_json()
+
+    assert UNSAFE_UPSTREAM_MARKER not in serialized
+    assert "output_preview" not in serialized
+    assert "prompt_selection" not in serialized
+    assert "storage_reference" not in serialized
+    assert "attributes" not in serialized
+    assert execution.execution.result.structured_output["scope"] == "support_only"
+
+
+def test_validate_dpm_ai_execution_preserves_live_provider_and_recovery_lineage() -> None:
+    payload = lotus_ai_workflow_pack_execution_v1(
+        pack_id=DPM_OPERATIONS_HANDOFF_EXECUTION.pack_id,
+        workflow_surface=DPM_OPERATIONS_HANDOFF_EXECUTION.workflow_surface,
+        correlation_id="corr-live-replay",
+        stubbed=False,
+        recovery_lineage={
+            "recovery_action_type": "REPLAY",
+            "source_queue_item_id": "queue-item-001",
+            "recovery_decision_event_id": "queue-event-001",
+            "recovery_attempt_number": 2,
+            "source_workflow_pack_run_id": "packrun-original-001",
+            "requested_by": "operations-control",
+            "evidence_ref": "replay-evidence-001",
+        },
+    )
+
+    execution = validate_dpm_ai_workflow_execution(
+        payload,
+        upstream_status=200,
+        correlation_id="corr-live-replay",
+        expectation=DPM_OPERATIONS_HANDOFF_EXECUTION,
+    )
+
+    assert execution.execution.audit.stubbed is False
+    assert execution.execution.audit.model_id == "gpt-5.4"
+    assert execution.workflow_pack_run.recovery_lineage is not None
+    assert execution.workflow_pack_run.recovery_lineage.recovery_action_type == "REPLAY"
+
+
+def test_validate_dpm_ai_execution_preserves_superseded_replacement_posture() -> None:
+    payload = lotus_ai_workflow_pack_execution_v1(
+        pack_id=DPM_OUTCOME_REVIEW_NARRATIVE_EXECUTION.pack_id,
+        workflow_surface=DPM_OUTCOME_REVIEW_NARRATIVE_EXECUTION.workflow_surface,
+        correlation_id="corr-superseded-run",
+        runtime_state="SUPERSEDED",
+        review_state="SUPERSEDED",
+        supportability_status="HISTORICAL",
+        superseded_by_run_id="packrun-replacement-001",
+        replacement_run_id="packrun-replacement-001",
+    )
+
+    execution = validate_dpm_ai_workflow_execution(
+        payload,
+        upstream_status=200,
+        correlation_id="corr-superseded-run",
+        expectation=DPM_OUTCOME_REVIEW_NARRATIVE_EXECUTION,
+    )
+
+    assert execution.workflow_pack_run.runtime_state == "SUPERSEDED"
+    assert execution.workflow_pack_run.review_state == "SUPERSEDED"
+    assert execution.workflow_pack_run.supportability_status == "HISTORICAL"
+    assert execution.workflow_pack_run.replacement_run_id == "packrun-replacement-001"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        pytest.param(lambda payload: payload.pop("workflow_pack_run"), id="missing-run"),
+        pytest.param(
+            lambda payload: payload["workflow_pack_run"].pop("review_state"),
+            id="missing-review-state",
+        ),
+        pytest.param(
+            lambda payload: payload["execution"].update({"task_id": "wrong-task"}),
+            id="execution-audit-task",
+        ),
+        pytest.param(
+            lambda payload: payload["execution"].update({"output_label": "WRONG"}),
+            id="execution-audit-label",
+        ),
+        pytest.param(
+            lambda payload: payload["execution"]["audit"]["safety"].update(
+                {"output_label": "WRONG"}
+            ),
+            id="execution-safety-label",
+        ),
+        pytest.param(
+            lambda payload: payload["execution"]["audit"]["authorization"].update(
+                {"task_id": "wrong-task"}
+            ),
+            id="execution-authorization-task",
+        ),
+        pytest.param(
+            lambda payload: payload["execution"]["audit"].update(
+                {"workflow_pack_run_id": "wrong-run"}
+            ),
+            id="audit-run",
+        ),
+        pytest.param(
+            lambda payload: payload["workflow_pack_run"].update({"task_id": "wrong-task"}),
+            id="execution-run-task",
+        ),
+        pytest.param(
+            lambda payload: payload["workflow_pack_run"].update({"request_id": "wrong-request"}),
+            id="audit-run-request",
+        ),
+        pytest.param(
+            lambda payload: payload["workflow_pack_run"].update({"stubbed": False}),
+            id="audit-run-stub",
+        ),
+        pytest.param(
+            lambda payload: payload["workflow_pack_run"].update(
+                {"provider_mode": "wrong-provider"}
+            ),
+            id="audit-run-provider",
+        ),
+        pytest.param(
+            lambda payload: payload["eligibility"].update({"pack_id": "wrong.pack"}),
+            id="eligibility-run-pack",
+        ),
+        pytest.param(
+            lambda payload: payload["eligibility"].update({"requested_version": "v2"}),
+            id="eligibility-run-version",
+        ),
+        pytest.param(
+            lambda payload: payload["eligibility"].update({"caller_app": "wrong-caller"}),
+            id="eligibility-run-caller",
+        ),
+        pytest.param(
+            lambda payload: payload["eligibility"].update(
+                {"evaluated_registration_ref": "wrong.pack@v1"}
+            ),
+            id="eligibility-run-registration",
+        ),
+        pytest.param(
+            lambda payload: payload["eligibility"].update({"version": "wrong-version"}),
+            id="eligibility-service-version",
+        ),
+        pytest.param(
+            lambda payload: payload["workflow_pack_run"].update(
+                {"structured_output_keys": ["wrong_key"]}
+            ),
+            id="run-structured-output-keys",
+        ),
+        pytest.param(
+            lambda payload: payload["eligibility"].update({"allowed": False}),
+            id="eligibility-denied",
+        ),
+        pytest.param(
+            lambda payload: payload["execution"]["audit"]["authorization"].update(
+                {"allowed": False}
+            ),
+            id="authorization-denied",
+        ),
+        pytest.param(
+            lambda payload: (
+                payload["eligibility"].update(
+                    {
+                        "pack_id": "wrong.pack",
+                        "evaluated_registration_ref": "wrong.pack@v1",
+                    }
+                ),
+                payload["workflow_pack_run"].update(
+                    {"pack_id": "wrong.pack", "registration_ref": "wrong.pack@v1"}
+                ),
+            ),
+            id="unexpected-pack",
+        ),
+        pytest.param(
+            lambda payload: (
+                payload["eligibility"].update(
+                    {
+                        "requested_version": "v2",
+                        "evaluated_registration_ref": (
+                            f"{DPM_EXCEPTION_SUMMARY_EXECUTION.pack_id}@v2"
+                        ),
+                    }
+                ),
+                payload["workflow_pack_run"].update(
+                    {
+                        "pack_version": "v2",
+                        "registration_ref": f"{DPM_EXCEPTION_SUMMARY_EXECUTION.pack_id}@v2",
+                    }
+                ),
+            ),
+            id="unexpected-pack-version",
+        ),
+        pytest.param(
+            lambda payload: (
+                payload["eligibility"].update({"evaluated_registration_ref": "wrong.pack@v1"}),
+                payload["workflow_pack_run"].update({"registration_ref": "wrong.pack@v1"}),
+            ),
+            id="unexpected-registration",
+        ),
+        pytest.param(
+            lambda payload: (
+                payload["eligibility"].update({"caller_app": "wrong-caller"}),
+                payload["workflow_pack_run"].update({"caller_app": "wrong-caller"}),
+            ),
+            id="unexpected-caller",
+        ),
+        pytest.param(
+            lambda payload: payload["workflow_pack_run"].update(
+                {"correlation_id": "wrong-correlation"}
+            ),
+            id="unexpected-correlation",
+        ),
+        pytest.param(
+            lambda payload: payload["workflow_pack_run"].update(
+                {"workflow_surface": "wrong-surface"}
+            ),
+            id="unexpected-workflow-surface",
+        ),
+        pytest.param(
+            lambda payload: payload["workflow_pack_run"].update(
+                {"workflow_authority_owner": "wrong-authority"}
+            ),
+            id="unexpected-authority",
+        ),
+        pytest.param(
+            lambda payload: payload["execution"]["audit"]["authorization"].update(
+                {"caller_app": "wrong-caller"}
+            ),
+            id="unexpected-authorized-caller",
+        ),
+        pytest.param(
+            lambda payload: payload["execution"]["audit"]["authorization"].update(
+                {"authenticated_caller_app": "wrong-caller"}
+            ),
+            id="unexpected-authenticated-caller",
+        ),
+        pytest.param(
+            lambda payload: payload["execution"]["audit"]["authorization"].update(
+                {"caller_identity_bound": False}
+            ),
+            id="caller-identity-unbound",
+        ),
+    ),
+)
+def test_validate_dpm_ai_execution_fails_closed_without_leaking_source_payload(mutation) -> None:
+    payload = lotus_ai_workflow_pack_execution_v1(
+        pack_id=DPM_EXCEPTION_SUMMARY_EXECUTION.pack_id,
+        workflow_surface=DPM_EXCEPTION_SUMMARY_EXECUTION.workflow_surface,
+        correlation_id="corr-invalid-contract",
+    )
+    malformed = deepcopy(payload)
+    mutation(malformed)
+
+    with pytest.raises(HTTPException) as raised:
+        validate_dpm_ai_workflow_execution(
+            malformed,
+            upstream_status=200,
+            correlation_id="corr-invalid-contract",
+            expectation=DPM_EXCEPTION_SUMMARY_EXECUTION,
+        )
+
+    assert raised.value.status_code == status.HTTP_502_BAD_GATEWAY
+    assert raised.value.detail == {
+        "source_service": "lotus-ai",
+        "upstream_status": 200,
+        "error_code": "AI_WORKFLOW_EXECUTION_CONTRACT_INVALID",
+        "detail": "AI workflow output could not be safely verified.",
+    }
+    assert UNSAFE_UPSTREAM_MARKER not in str(raised.value.detail)

--- a/tests/unit/test_dpm_command_center_service.py
+++ b/tests/unit/test_dpm_command_center_service.py
@@ -9,6 +9,7 @@ from app.contracts.dpm_command_center import (
     DpmPmOperatingQualitySummaryRequest,
 )
 from app.services.dpm_command_center_service import DpmCommandCenterService
+from tests.support.lotus_ai_workflow_pack import lotus_ai_workflow_pack_execution_v1
 
 
 class _FakeDpmClient:
@@ -1576,22 +1577,15 @@ async def test_dpm_pm_operating_quality_summary_uses_manage_score_run_and_lotus_
     ai_client = _FakeLotusAiClient(
         (
             200,
-            {
-                "execution": {
-                    "status": "COMPLETED",
-                    "audit": {"workflow_pack_run_id": "packrun_pmq_1"},
-                    "result": {
-                        "structured_output": {
-                            "workflow_pack_family": "pm_quality_summary",
-                            "summary_status": "REVIEW_REQUIRED",
-                        }
-                    },
+            lotus_ai_workflow_pack_execution_v1(
+                pack_id="pm_quality_summary.pack",
+                workflow_surface="dpm-pm-quality-ai-evidence",
+                correlation_id="corr-pmq-summary",
+                structured_output={
+                    "workflow_pack_family": "pm_quality_summary",
+                    "summary_status": "REVIEW_REQUIRED",
                 },
-                "workflow_pack_run": {
-                    "run_id": "packrun_pmq_1",
-                    "workflow_authority_owner": "lotus-manage",
-                },
-            },
+            ),
         )
     )
     service = DpmCommandCenterService(
@@ -1643,7 +1637,7 @@ async def test_dpm_pm_operating_quality_summary_uses_manage_score_run_and_lotus_
     assert "compensation_decision" in payload["supportability"]["unsupported_claims"]
     assert payload["portfolio_memory_context"] == manage_payload["portfolio_memory_context"]
     assert "lotus-manage:pm-quality-score-run:pmq_run_001" in task_request["context"]["source_refs"]
-    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    assert response.data.workflow_pack_run.workflow_authority_owner == "lotus-manage"
 
 
 @pytest.mark.asyncio
@@ -1692,22 +1686,15 @@ async def test_dpm_command_center_requests_ai_narrative_from_manage_evidence_onl
     ai_client = _FakeLotusAiClient(
         (
             200,
-            {
-                "execution": {
-                    "status": "COMPLETED",
-                    "audit": {"workflow_pack_run_id": "packrun_outcome_1"},
-                    "result": {
-                        "structured_output": {
-                            "outcome_review_narrative_status": "REVIEW_REQUIRED",
-                            "evidence_content_hash": "sha256:outcome-ai-evidence-001",
-                        }
-                    },
+            lotus_ai_workflow_pack_execution_v1(
+                pack_id="outcome_review_narrative.pack",
+                workflow_surface="dpm-outcome-review-ai-evidence",
+                correlation_id="corr-ai-narrative-1",
+                structured_output={
+                    "outcome_review_narrative_status": "REVIEW_REQUIRED",
+                    "evidence_content_hash": "sha256:outcome-ai-evidence-001",
                 },
-                "workflow_pack_run": {
-                    "run_id": "packrun_outcome_1",
-                    "workflow_authority_owner": "lotus-manage",
-                },
-            },
+            ),
         )
     )
     service = DpmCommandCenterService(
@@ -1732,7 +1719,7 @@ async def test_dpm_command_center_requests_ai_narrative_from_manage_evidence_onl
     assert response.ai_evidence_input["client_communication_boundary"] == (
         _client_communication_boundary()
     )
-    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    assert response.data.workflow_pack_run.workflow_authority_owner == "lotus-manage"
     assert dpm_client.calls == [
         {
             "method": "ai_evidence",
@@ -1834,22 +1821,15 @@ async def test_dpm_command_center_requests_exception_summary_from_manage_excepti
     ai_client = _FakeLotusAiClient(
         (
             200,
-            {
-                "execution": {
-                    "status": "COMPLETED",
-                    "audit": {"workflow_pack_run_id": "packrun_exception_1"},
-                    "result": {
-                        "structured_output": {
-                            "exception_summary_status": "REVIEW_REQUIRED",
-                            "exception_count": 1,
-                        }
-                    },
+            lotus_ai_workflow_pack_execution_v1(
+                pack_id="dpm_exception_summary.pack",
+                workflow_surface="dpm-exception-summary-ai-evidence",
+                correlation_id="corr-exception-summary-1",
+                structured_output={
+                    "exception_summary_status": "REVIEW_REQUIRED",
+                    "exception_count": 1,
                 },
-                "workflow_pack_run": {
-                    "run_id": "packrun_exception_1",
-                    "workflow_authority_owner": "lotus-manage",
-                },
-            },
+            ),
         )
     )
     service = DpmCommandCenterService(
@@ -1879,7 +1859,7 @@ async def test_dpm_command_center_requests_exception_summary_from_manage_excepti
     assert response.exception_summary_input["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
     assert response.exception_summary_input["exception_count"] == 1
     assert response.exception_summary_input["redaction_policy"] == "NO_RAW_PAYLOADS"
-    assert response.data["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    assert response.data.workflow_pack_run.workflow_authority_owner == "lotus-manage"
     assert dpm_client.calls == [
         {
             "method": "list_exceptions",

--- a/tests/unit/test_dpm_proof_pack_service.py
+++ b/tests/unit/test_dpm_proof_pack_service.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException
 
 from app.contracts.dpm_proof_packs import DpmProofPackMemoRequest
 from app.services.dpm_proof_pack_service import DpmProofPackService
+from tests.support.lotus_ai_workflow_pack import lotus_ai_workflow_pack_execution_v1
 
 
 class _FakeDpmClient:
@@ -223,17 +224,12 @@ async def test_dpm_proof_pack_pm_memo_executes_lotus_ai_with_manage_evidence() -
         "evidence_ref": "ai-evidence:dpp_rr_001",
         "content_hash": "sha256:ai-evidence",
     }
-    ai_payload = {
-        "execution": {
-            "audit": {"workflow_pack_run_id": "packrun_dpp_rr_001"},
-            "result": {"dpm_pm_memo_status": "REVIEW_REQUIRED"},
-        },
-        "workflow_pack_run": {
-            "run_id": "packrun_dpp_rr_001",
-            "workflow_authority_owner": "lotus-manage",
-            "review_state": "AWAITING_REVIEW",
-        },
-    }
+    ai_payload = lotus_ai_workflow_pack_execution_v1(
+        pack_id="dpm_pm_memo.pack",
+        workflow_surface="dpm-proof-pack-ai-evidence",
+        correlation_id="corr-proof-pack-memo-1",
+        structured_output={"dpm_pm_memo_status": "REVIEW_REQUIRED"},
+    )
     dpm_client = _FakeDpmClient((200, manage_payload))
     ai_client = _FakeLotusAiClient((200, ai_payload))
     service = DpmProofPackService(
@@ -260,8 +256,7 @@ async def test_dpm_proof_pack_pm_memo_executes_lotus_ai_with_manage_evidence() -
         "requested_outputs": ["pm_memo", "evidence_gaps"],
         "audience": ["portfolio_manager"],
     }
-    workflow_pack_run = cast(dict[str, Any], response.data["workflow_pack_run"])
-    assert workflow_pack_run["workflow_authority_owner"] == "lotus-manage"
+    assert response.data.workflow_pack_run.workflow_authority_owner == "lotus-manage"
     [ai_call] = ai_client.calls
     assert ai_call["pack_id"] == "dpm_pm_memo.pack"
     assert ai_call["version"] == "v1"

--- a/tests/unit/test_dpm_wave_service.py
+++ b/tests/unit/test_dpm_wave_service.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException
 
 from app.contracts.dpm_waves import DpmOperationsHandoffSummaryRequest, DpmWaveMemoRequest
 from app.services.dpm_wave_service import DpmWaveService
+from tests.support.lotus_ai_workflow_pack import lotus_ai_workflow_pack_execution_v1
 
 
 class _FakeDpmClient:
@@ -957,10 +958,12 @@ async def test_dpm_wave_pm_memo_uses_manage_report_input_and_lotus_ai_pack() -> 
             "item_count": 1,
         },
     }
-    ai_payload = {
-        "run_id": "wf_run_wave_memo_001",
-        "output": {"review_required": True, "memo_sections": ["PM summary"]},
-    }
+    ai_payload = lotus_ai_workflow_pack_execution_v1(
+        pack_id="dpm_wave_pm_memo.pack",
+        workflow_surface="dpm-wave-ai-evidence",
+        correlation_id="corr-wave-ai-memo",
+        structured_output={"review_required": True, "memo_sections": ["PM summary"]},
+    )
     dpm_client = _FakeDpmClient((200, manage_payload))
     ai_client = _FakeLotusAiClient((200, ai_payload))
     service = DpmWaveService(
@@ -986,7 +989,8 @@ async def test_dpm_wave_pm_memo_uses_manage_report_input_and_lotus_ai_pack() -> 
         "requested_outputs": ["wave_pm_memo", "approval_checklist"],
         "audience": ["portfolio_manager", "investment_control"],
     }
-    assert response.data == ai_payload
+    assert response.data.workflow_pack_run.review_state == "AWAITING_REVIEW"
+    assert response.data.execution.result.structured_output["memo_sections"] == ["PM summary"]
     ai_call = ai_client.calls[0]
     assert ai_call["pack_id"] == "dpm_wave_pm_memo.pack"
     assert ai_call["version"] == "v1"
@@ -1045,10 +1049,12 @@ async def test_dpm_wave_pm_memo_ai_errors_are_product_safe() -> None:
 @pytest.mark.asyncio
 async def test_dpm_operations_handoff_summary_uses_manage_handoff_evidence_and_lotus_ai() -> None:
     manage_payload = _wave_report_input_with_handoff()
-    ai_payload = {
-        "run_id": "wf_run_operations_handoff_001",
-        "output": {"review_required": True, "sections": ["Operations summary"]},
-    }
+    ai_payload = lotus_ai_workflow_pack_execution_v1(
+        pack_id="dpm_operations_handoff_summary.pack",
+        workflow_surface="dpm-operations-handoff-ai-evidence",
+        correlation_id="corr-operations-handoff-summary",
+        structured_output={"review_required": True, "sections": ["Operations summary"]},
+    )
     dpm_client = _FakeDpmClient((200, manage_payload))
     ai_client = _FakeLotusAiClient((200, ai_payload))
     service = DpmWaveService(
@@ -1074,7 +1080,8 @@ async def test_dpm_operations_handoff_summary_uses_manage_handoff_evidence_and_l
         "requested_outputs": ["operations_summary", "blocking_conditions"],
         "audience": ["operations", "portfolio_manager"],
     }
-    assert response.data == ai_payload
+    assert response.data.workflow_pack_run.review_state == "AWAITING_REVIEW"
+    assert response.data.execution.result.structured_output["sections"] == ["Operations summary"]
     assert dpm_client.calls == [
         {
             "method": "get_wave_report_input",

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -386,6 +386,58 @@ Operational behavior:
 3. this route family is a prerequisite for Workbench product proof but does not by itself certify
    the Workbench UI or demo screenshots.
 
+## DPM Governed AI Workflow Execution Boundary
+
+Status: implementation-backed in Gateway for the six DPM workflow-pack handoff families.
+
+Business outcome:
+
+1. portfolio managers, operations users, and supervisors receive one consistent execution-evidence
+   contract for proof-pack PM memos, wave PM memos, operations handoff summaries, exception
+   summaries, outcome-review narratives, and PM operating-quality summaries,
+2. Workbench can distinguish workflow runtime, human-review, supportability, evidence, freshness,
+   and replacement posture without treating request acceptance as output availability,
+3. support teams receive stable source and correlation evidence without exposing raw prompts,
+   ungoverned generated text, internal storage locations, or provider telemetry.
+
+Supported routes:
+
+1. `POST /api/v1/dpm/command-center/proof-packs/{proof_pack_id}/ai-pm-memo`
+2. `POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`
+3. `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`
+4. `POST /api/v1/dpm/command-center/exceptions/{exception_id}/ai-summary`
+5. `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`
+6. `POST /api/v1/dpm/command-center/pm-operating-quality/score-runs/{score_run_id}/ai-summary`
+
+Authority and contract boundary:
+
+1. `lotus-ai` remains workflow-pack eligibility, execution, run, review, evidence, artifact,
+   provider, and recovery-lineage authority; `lotus-manage` remains consequence-bearing DPM
+   workflow and source-evidence authority,
+2. Gateway validates the canonical source envelope and returns the bounded
+   `DpmAiWorkflowExecution` projection across all six routes,
+3. Gateway preserves runtime state separately from review state and supportability, including
+   review requirement, allowed review actions, source evidence descriptors, safe artifact
+   metadata, completion/update timestamps, supersession, replacement, and retry/replay lineage,
+4. Gateway verifies pack, version, registration, caller, authenticated caller binding,
+   correlation id, workflow surface, and workflow authority for the requested DPM family,
+5. malformed or cross-boundary source output fails closed with product-safe
+   `AI_WORKFLOW_EXECUTION_CONTRACT_INVALID` detail and no raw upstream payload leakage.
+
+Production-readiness controls:
+
+1. raw prompt selection, raw model message and output preview, evidence attributes, internal
+   storage backend/reference, and creator/provider control narratives are excluded,
+2. only the governed task `structured_output` is returned as generated content; Workbench must use
+   a task-specific adapter and must not interpret arbitrary unknown keys,
+3. eligibility, runtime completion, evidence availability, human review, freshness, and client-use
+   suitability remain independent product decisions; no single state or badge implies all six,
+4. missing or invalid source fields are an upstream-contract failure, not permission for Gateway
+   or Workbench to invent a fallback result,
+5. shared fixtures and contract tests pin the complete canonical envelope, live and stub provider
+   posture, review-required and historical/superseded runs, safe projection, and malformed-source
+   rejection.
+
 ## DPM Command Center Construction Alternatives
 
 Status: implementation-backed in Gateway for RFC39-WTBD-001.


### PR DESCRIPTION
## Outcome

Publishes one typed, fail-closed DPM AI workflow execution boundary across all six Workbench-facing handoff families.

Closes #520

## What changed

- added focused execution audit/evidence, workflow run/lineage, and aggregate execution contracts,
- bound service, pack, version, registration, caller, authenticated identity, correlation, workflow surface, task, run, provider, authorization, eligibility, authority owner, and structured-output keys,
- applied the reusable validator to proof-pack memo, wave memo, operations handoff, exception summary, outcome-review narrative, and PM-quality summary responses,
- retained governed structured output, runtime/review/supportability, safe evidence/artifact metadata, timestamps, replacement, and recovery lineage,
- excluded raw prompt selection, free-text model output/preview, evidence attributes, storage locations, creator fields, and unbounded upstream telemetry,
- extracted proof-pack AI handoff orchestration, reducing its facade from the gate-rejected 325 lines to 178 lines.

## Failure posture

Malformed or cross-boundary lotus-ai success payloads fail with product-safe `502 AI_WORKFLOW_EXECUTION_CONTRACT_INVALID`; validation details and raw source content are not returned.

## Validation

- focused DPM and architecture pack: 215 passed,
- new execution envelope and validator: 100% line and branch coverage,
- `make check`: 1,584 unit/contract tests passed,
- `make ci`: 249 integration + 1,857 combined tests passed; 94.51% aggregate coverage,
- dependency audit: no known vulnerabilities (governed compatible exception remains unchanged),
- `make ci-local-docker`: 1,608 unit/contract + 249 integration tests passed on Python 3.11,
- refactor thresholds, MyPy across 723 sources, OpenAPI, migration no-schema, monetary-float, workflow, folder, and diff gates passed,
- wiki pre-publication check shows only the expected one-file authored-source delta.

## Durable truth

Updated repository context, supported-features wiki source, and the codebase review ledger. The independent CI-local Compose cleanup isolation finding is tracked in #521 and is not claimed here.