### PR TITLE
Stabilize advisor-book and contribution readiness

### DIFF
--- a/src/app/clients/lotus_analytics_performance_client.py
+++ b/src/app/clients/lotus_analytics_performance_client.py
@@ -226,6 +226,7 @@ class LotusAnalyticsPerformanceClientMixin:
             path="/performance/contribution",
             payload=payload,
             correlation_id=correlation_id,
+            async_poll_attempts=40,
         )
 
     async def get_attribution_analytics(

--- a/src/app/services/advisor_book_service.py
+++ b/src/app/services/advisor_book_service.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import date
-from typing import Literal, cast
+from typing import Literal
 
 from pydantic import ValidationError
 
@@ -30,6 +30,9 @@ _SUPPORTED_PORTFOLIO_TYPES: tuple[AdvisorBookMandateType, ...] = (
     "ADVISORY",
     "DISCRETIONARY",
 )
+_SUPPORTED_PORTFOLIO_TYPE_BY_SOURCE_VALUE: dict[str, AdvisorBookMandateType] = {
+    value: value for value in _SUPPORTED_PORTFOLIO_TYPES
+}
 
 
 @dataclass(frozen=True)
@@ -108,7 +111,9 @@ def _validate_source_scope(
         or any(
             member.booking_center_code != caller.booking_center_code for member in source.members
         )
-        or any(member.portfolio_type not in _SUPPORTED_PORTFOLIO_TYPES for member in source.members)
+        or any(
+            _canonical_portfolio_type(member.portfolio_type) is None for member in source.members
+        )
         or len({member.portfolio_id for member in source.members}) != len(source.members)
     ):
         raise _source_contract_invalid()
@@ -163,8 +168,9 @@ def _project_response(
 
 
 def _matches(member: SourceAdvisorBookMember, query: AdvisorBookQuery) -> bool:
+    mandate_type = _canonical_portfolio_type(member.portfolio_type)
     return (query.client_id is None or member.client_id == query.client_id) and (
-        query.mandate_type is None or member.portfolio_type == query.mandate_type
+        query.mandate_type is None or mandate_type == query.mandate_type
     )
 
 
@@ -172,18 +178,21 @@ def _sort_value(member: SourceAdvisorBookMember, sort_by: AdvisorBookSortField) 
     if sort_by == "client_id":
         return member.client_id
     if sort_by == "mandate_type":
-        return member.portfolio_type
+        return _canonical_portfolio_type(member.portfolio_type) or member.portfolio_type
     return member.portfolio_id
 
 
 def _portfolio(member: SourceAdvisorBookMember) -> AdvisorBookPortfolio:
+    mandate_type = _canonical_portfolio_type(member.portfolio_type)
+    if mandate_type is None:
+        raise _source_contract_invalid()
     return AdvisorBookPortfolio(
         portfolio_id=member.portfolio_id,
         display_name=member.portfolio_id,
         client_id=member.client_id,
         base_currency=member.base_currency,
         booking_center_code=member.booking_center_code,
-        mandate_type=cast(AdvisorBookMandateType, member.portfolio_type),
+        mandate_type=mandate_type,
         status=member.status,
         opened_on=member.open_date,
         closed_on=member.close_date,
@@ -195,6 +204,10 @@ def _portfolio(member: SourceAdvisorBookMember) -> AdvisorBookPortfolio:
             else "legacy_advisor_projection"
         ),
     )
+
+
+def _canonical_portfolio_type(value: str) -> AdvisorBookMandateType | None:
+    return _SUPPORTED_PORTFOLIO_TYPE_BY_SOURCE_VALUE.get(value.strip().upper())
 
 
 def _empty_response(

--- a/tests/unit/test_advisor_book_service.py
+++ b/tests/unit/test_advisor_book_service.py
@@ -120,6 +120,37 @@ async def test_service_requests_authenticated_own_book_and_projects_governed_mem
 
 
 @pytest.mark.asyncio
+async def test_service_normalizes_supported_source_portfolio_type_casing() -> None:
+    payload = _payload(
+        members=[
+            _member(
+                "PB_SG_GLOBAL_BAL_001",
+                client_id="CIF_SG_000184",
+                portfolio_type="discretionary",
+            )
+        ],
+        tenant_id=None,
+    )
+    service = AdvisorBookService(membership_client=_MembershipClient(payload=payload))
+
+    response = await service.get_advisor_book(
+        caller=_caller(),
+        query=AdvisorBookQuery(
+            as_of_date=date(2026, 4, 10),
+            mandate_type="DISCRETIONARY",
+            sort_by="mandate_type",
+        ),
+        correlation_id="corr-lowercase-core-portfolio-type",
+    )
+
+    assert response.page.total_count == 1
+    assert response.items[0].portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert response.items[0].mandate_type == "DISCRETIONARY"
+    assert response.items[0].membership_basis == "governed_role_assignment"
+    assert response.supportability.reason_code == "advisor_book_tenant_scope_not_reported"
+
+
+@pytest.mark.asyncio
 async def test_service_filters_sorts_and_pages_source_memberships_deterministically() -> None:
     members = [
         _member("PB_003", client_id="CIF_002", portfolio_type="DISCRETIONARY"),

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -429,6 +429,34 @@ async def test_lotus_analytics_client_performance_workspace_requests_use_owned_c
 
 
 @pytest.mark.asyncio
+async def test_lotus_analytics_client_uses_extended_contribution_async_poll_budget(
+    monkeypatch,
+) -> None:
+    client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)
+    captured: dict[str, object] = {}
+
+    async def _capture_post_analytics_request(**kwargs):
+        captured.update(kwargs)
+        return 200, {"results_by_period": {"YTD": {}}}
+
+    monkeypatch.setattr(client, "_post_analytics_request", _capture_post_analytics_request)
+
+    status_code, _ = await client.get_contribution_analytics(
+        portfolio_id="P1",
+        report_start_date="2026-01-01",
+        report_end_date="2026-02-24",
+        period="YTD",
+        metric_basis="NET",
+        dimension="asset_class",
+        correlation_id="corr-performance",
+    )
+
+    assert status_code == 200
+    assert captured["path"] == "/performance/contribution"
+    assert captured["async_poll_attempts"] == 40
+
+
+@pytest.mark.asyncio
 async def test_lotus_analytics_client_calls_composite_performance_routes():
     client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(


### PR DESCRIPTION
## Summary
- Normalizes supported Core advisor-book portfolio type casing at the Gateway boundary.
- Extends performance contribution async polling to align details readiness with summary/advisor-proof timing.
- Keeps unsupported source contract values fail-closed.

## Issues
- Addresses sgajbi/lotus-gateway#531.
- Addresses sgajbi/lotus-gateway#532.
- Keep issues open until merged-main validation and QA lifecycle closure are recorded.

## Validation
- Unit/integration advisor-book: `python -m pytest tests/unit/test_advisor_book_service.py tests/unit/test_advisor_book_source_contract.py tests/integration/test_advisor_book_router.py -q` => 28 passed.
- Unit/integration focused: `python -m pytest tests/unit/test_upstream_clients.py::test_lotus_analytics_client_uses_extended_contribution_async_poll_budget tests/unit/test_upstream_clients.py::test_lotus_analytics_client_performance_workspace_requests_use_owned_contract_keys tests/unit/test_advisor_book_service.py tests/unit/test_advisor_book_source_contract.py tests/integration/test_advisor_book_router.py -q` => 30 passed.
- Static: `ruff check` and `ruff format --check` on touched files passed.
- Repo gate: `make check` => passed, 1632 tests.
- Runtime: rebuilt lotus-gateway; live advisor-book endpoint returned `PB_SG_GLOBAL_BAL_001` with `mandate_type=DISCRETIONARY`; live performance details endpoint returned supported contribution details with completed contribution lineage.

## Governance
- Tiering: draft PR; required GitHub PR checks must pass before merge.
- Post-merge mainline proof: pending after merge.
- Wiki: no repo wiki source changed.
- Non-degradation: fixes bounded Gateway integration normalization/readiness; no ownership movement from Core or Performance.