### PR TITLE
Govern performance summary completion deadline

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -170,11 +170,12 @@ Current repository posture:
 17. performance workspace-summary orchestration uses
     `PERFORMANCE_SUMMARY_DEADLINE_SECONDS=30` as an end-to-end monotonic budget across submission
     and polling, while `PERFORMANCE_ANALYTICS_TIMEOUT_SECONDS=15` remains a per-call ceiling.
-    Result reads are limited to the remaining budget, honor source polling cadence, preserve one
-    calculation identity and caller context, and emit bounded
-    `async_poll_deadline_exhausted` telemetry. Deadline exhaustion becomes the existing explicit
-    Workbench partial-readiness response; it is not masked by a replacement calculation or treated
-    as successful because a later warm retry completes.
+    Result reads are limited to the remaining budget, wait for the accepted response's minimum
+    source polling cadence before the first read, preserve one calculation identity and caller
+    context, and emit bounded `async_poll_deadline_exhausted` telemetry. Deadline exhaustion becomes
+    the specific Workbench `PERFORMANCE_WORKSPACE_SUMMARY_DEADLINE_EXHAUSTED` partial-readiness
+    response and suppresses follow-on execution or lineage evidence reads; it is not masked by a
+    replacement calculation or treated as successful because a later warm retry completes.
 
 ## Architecture And Module Map
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -167,6 +167,14 @@ Current repository posture:
     `top_position_weight_current`, `top_position_weight_proposed`, `top_position_weight_delta`,
     `top_position_current`, and `top_position_proposed`; `TOP_POSITION_WEIGHT` methodology truth
     remains owned by `lotus-risk`.
+17. performance workspace-summary orchestration uses
+    `PERFORMANCE_SUMMARY_DEADLINE_SECONDS=30` as an end-to-end monotonic budget across submission
+    and polling, while `PERFORMANCE_ANALYTICS_TIMEOUT_SECONDS=15` remains a per-call ceiling.
+    Result reads are limited to the remaining budget, honor source polling cadence, preserve one
+    calculation identity and caller context, and emit bounded
+    `async_poll_deadline_exhausted` telemetry. Deadline exhaustion becomes the existing explicit
+    Workbench partial-readiness response; it is not masked by a replacement calculation or treated
+    as successful because a later warm retry completes.
 
 ## Architecture And Module Map
 

--- a/docs/standards/scalability-availability.md
+++ b/docs/standards/scalability-availability.md
@@ -23,6 +23,27 @@ This repository adopts the platform-wide standard defined in lotus-platform/Scal
 - Backup and restore: persistence-owning upstream services are required to expose validated backup/restore runbooks;
   lotus-gateway validates readiness through `/health/ready` and dependency checks during platform startup.
 
+## Performance Summary Completion Deadline
+
+- The Workbench performance-summary route applies a 30-second end-to-end monotonic completion
+  budget to the `lotus-performance` workspace-summary submission and result polling flow. The
+  budget is configured by `PERFORMANCE_SUMMARY_DEADLINE_SECONDS`; the separate
+  `PERFORMANCE_ANALYTICS_TIMEOUT_SECONDS` remains the maximum for one upstream request.
+- Result reads use the smaller of the per-request timeout and the remaining completion budget.
+  Polling honors source `recommended_poll_after_seconds` guidance and is bounded by elapsed time,
+  not an attempt count. Result reads do not add nested transport retries because the outer polling
+  loop owns the remaining budget and next-read decision.
+- One calculation identity, caller correlation, trace, and authorization context are preserved
+  from submission through result retrieval. Gateway does not respond to an identity conflict by
+  submitting another financial calculation.
+- If the budget expires, the analytics client returns reason code
+  `ASYNC_RESULT_DEADLINE_EXHAUSTED` with the original result identity. The Workbench experience API
+  converts that source failure into its existing explicit partial-readiness response before the
+  caller transport closes; a warm-cache retry is not treated as readiness proof.
+- Gateway fan-out telemetry records the bounded degraded reason
+  `async_poll_deadline_exhausted`. It does not place calculation, portfolio, client, correlation,
+  or trace identifiers in metric labels or structured log fields.
+
 ## Database Scalability Fundamentals
 
 - Query plan and index ownership remain with lotus-core/lotus-performance/lotus-manage/lotus-report persistence domains; lotus-gateway does not own tables.

--- a/docs/standards/scalability-availability.md
+++ b/docs/standards/scalability-availability.md
@@ -30,16 +30,19 @@ This repository adopts the platform-wide standard defined in lotus-platform/Scal
   budget is configured by `PERFORMANCE_SUMMARY_DEADLINE_SECONDS`; the separate
   `PERFORMANCE_ANALYTICS_TIMEOUT_SECONDS` remains the maximum for one upstream request.
 - Result reads use the smaller of the per-request timeout and the remaining completion budget.
-  Polling honors source `recommended_poll_after_seconds` guidance and is bounded by elapsed time,
-  not an attempt count. Result reads do not add nested transport retries because the outer polling
-  loop owns the remaining budget and next-read decision.
+  Gateway waits for the accepted response's `recommended_poll_after_seconds` minimum cadence
+  before the first result read and honors refreshed guidance after each pending result. Polling is
+  bounded by elapsed time, not an attempt count. Result reads do not add nested transport retries
+  because the outer polling loop owns the remaining budget and next-read decision.
 - One calculation identity, caller correlation, trace, and authorization context are preserved
   from submission through result retrieval. Gateway does not respond to an identity conflict by
   submitting another financial calculation.
 - If the budget expires, the analytics client returns reason code
   `ASYNC_RESULT_DEADLINE_EXHAUSTED` with the original result identity. The Workbench experience API
-  converts that source failure into its existing explicit partial-readiness response before the
-  caller transport closes; a warm-cache retry is not treated as readiness proof.
+  converts that source failure into the specific
+  `PERFORMANCE_WORKSPACE_SUMMARY_DEADLINE_EXHAUSTED` partial-readiness warning and preserves the
+  source error code. It does not start execution or lineage evidence reads after the budget has
+  expired; a warm-cache retry is not treated as readiness proof.
 - Gateway fan-out telemetry records the bounded degraded reason
   `async_poll_deadline_exhausted`. It does not place calculation, portfolio, client, correlation,
   or trace identifiers in metric labels or structured log fields.

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -17,9 +17,11 @@
 4. portfolio 360 composition.
 
 Performance-summary cold calculations use a governed 30-second elapsed deadline across source
-submission and polling. Gateway preserves one source calculation identity, follows the source
-polling cadence, and returns explicit partial-readiness posture if the calculation remains pending;
-support is not inferred from a successful warm retry.
+submission and polling. Gateway preserves one source calculation identity, waits for the accepted
+response's minimum polling cadence before the first result read, and returns specific
+deadline-exhausted partial-readiness posture if the calculation remains pending. Gateway does not
+start execution or lineage evidence reads after the budget expires, and support is not inferred
+from a successful warm retry.
 
 ## Advisory And Proposals
 

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -16,6 +16,11 @@
 3. risk workspace summary, concentration, drawdown, rolling risk, and attribution,
 4. portfolio 360 composition.
 
+Performance-summary cold calculations use a governed 30-second elapsed deadline across source
+submission and polling. Gateway preserves one source calculation identity, follows the source
+polling cadence, and returns explicit partial-readiness posture if the calculation remains pending;
+support is not inferred from a successful warm retry.
+
 ## Advisory And Proposals
 
 1. proposal simulation, lifecycle, workflow, approval, lineage, replay, report request, delivery

--- a/src/app/clients/lotus_analytics_async_polling.py
+++ b/src/app/clients/lotus_analytics_async_polling.py
@@ -9,6 +9,10 @@ from typing import Any
 
 from app.clients.http_resilience import request_with_retry
 from app.clients.upstream_headers import build_upstream_headers
+from app.contracts.analytics_async import (
+    ASYNC_POLL_DEADLINE_EXHAUSTED_REASON,
+    ASYNC_RESULT_DEADLINE_EXHAUSTED,
+)
 from app.observability.analytics_ui import (
     emit_gateway_analytics_fanout_log,
     gateway_analytics_fanout_timer,
@@ -63,9 +67,9 @@ def build_async_poll_deadline_payload(
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "detail": "analytics result did not complete within the governed Gateway deadline",
-        "error_code": "ASYNC_RESULT_DEADLINE_EXHAUSTED",
+        "error_code": ASYNC_RESULT_DEADLINE_EXHAUSTED,
         "state": "degraded",
-        "reason": "async_poll_deadline_exhausted",
+        "reason": ASYNC_POLL_DEADLINE_EXHAUSTED_REASON,
         "result_path": result_path,
     }
     calculation_id = (accepted_payload or {}).get("calculation_id")
@@ -172,6 +176,12 @@ class LotusAnalyticsAsyncPollingMixin:
             status_code=202,
             payload=context.accepted_payload or {"detail": "async analytics result still pending"},
         )
+        initial_deadline_result = await self._wait_for_initial_async_poll(
+            context=context,
+            fallback_seconds=poll_interval_seconds,
+        )
+        if initial_deadline_result is not None:
+            return initial_deadline_result
         while max_attempts is None or state.attempts < max_attempts:
             deadline_result = self._expired_poll_deadline_result(context)
             if deadline_result is not None:
@@ -197,6 +207,20 @@ class LotusAnalyticsAsyncPollingMixin:
             if deadline_result is not None:
                 return deadline_result
         return state.status_code, state.payload
+
+    async def _wait_for_initial_async_poll(
+        self,
+        *,
+        context: _AnalyticsPollContext,
+        fallback_seconds: float,
+    ) -> tuple[int, dict[str, Any]] | None:
+        if context.accepted_payload is None:
+            return None
+        return await self._wait_for_next_async_poll(
+            context=context,
+            payload=context.accepted_payload,
+            fallback_seconds=fallback_seconds,
+        )
 
     def _expired_poll_deadline_result(
         self, context: _AnalyticsPollContext

--- a/src/app/clients/lotus_analytics_async_polling.py
+++ b/src/app/clients/lotus_analytics_async_polling.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from app.clients.http_resilience import request_with_retry
+from app.clients.upstream_headers import build_upstream_headers
+from app.observability.analytics_ui import (
+    emit_gateway_analytics_fanout_log,
+    gateway_analytics_fanout_timer,
+)
+
+logger = logging.getLogger("analytics_ui.gateway")
+
+
+@dataclass(frozen=True)
+class AnalyticsPollBudget:
+    """Elapsed-time policy for one analytics submission and its result reads."""
+
+    deadline_at: float | None
+
+    @classmethod
+    def from_timeout(cls, timeout_seconds: float | None) -> AnalyticsPollBudget:
+        deadline_at = None if timeout_seconds is None else time.monotonic() + timeout_seconds
+        return cls(deadline_at=deadline_at)
+
+    @classmethod
+    def unbounded(cls) -> AnalyticsPollBudget:
+        return cls(deadline_at=None)
+
+    def remaining_seconds(self) -> float | None:
+        if self.deadline_at is None:
+            return None
+        return self.deadline_at - time.monotonic()
+
+    def request_timeout(self, default_seconds: float) -> float:
+        remaining_seconds = self.remaining_seconds()
+        if remaining_seconds is None:
+            return default_seconds
+        return min(default_seconds, max(remaining_seconds, 0.001))
+
+    def poll_interval(self, *, payload: dict[str, Any], fallback_seconds: float) -> float:
+        interval_seconds = _recommended_poll_interval(payload, fallback_seconds)
+        remaining_seconds = self.remaining_seconds()
+        if remaining_seconds is None:
+            return interval_seconds
+        return min(interval_seconds, max(remaining_seconds, 0.0))
+
+
+def build_async_poll_deadline_payload(
+    *, result_path: str, accepted_payload: dict[str, Any] | None
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "detail": "analytics result did not complete within the governed Gateway deadline",
+        "error_code": "ASYNC_RESULT_DEADLINE_EXHAUSTED",
+        "state": "degraded",
+        "reason": "async_poll_deadline_exhausted",
+        "result_path": result_path,
+    }
+    calculation_id = (accepted_payload or {}).get("calculation_id")
+    if isinstance(calculation_id, str) and calculation_id:
+        payload["calculation_id"] = calculation_id
+    return payload
+
+
+def _recommended_poll_interval(payload: dict[str, Any], fallback_seconds: float) -> float:
+    recommended = payload.get("recommended_poll_after_seconds")
+    if isinstance(recommended, bool) or not isinstance(recommended, int | float):
+        return fallback_seconds
+    resolved = float(recommended)
+    if not math.isfinite(resolved) or resolved <= 0:
+        return fallback_seconds
+    return resolved
+
+
+@dataclass(frozen=True)
+class _AnalyticsPollContext:
+    result_path: str
+    url: str
+    headers: dict[str, str]
+    service: str
+    operation: str
+    budget: AnalyticsPollBudget
+    accepted_payload: dict[str, Any] | None
+    started_at: float
+
+
+@dataclass
+class _AnalyticsPollState:
+    attempts: int
+    status_code: int
+    payload: dict[str, Any]
+
+
+class LotusAnalyticsAsyncPollingMixin:
+    _base_url: str
+    _timeout: float
+    _retry_backoff_seconds: float
+
+    @staticmethod
+    def _emit_analytics_read_audit(*, operation: str, status_code: int) -> None:
+        raise NotImplementedError
+
+    async def _poll_async_result(
+        self,
+        *,
+        result_path: str,
+        correlation_id: str,
+        service: str,
+        operation: str,
+        max_attempts: int | None = 10,
+        poll_interval_seconds: float = 0.35,
+        poll_budget: AnalyticsPollBudget | None = None,
+        accepted_payload: dict[str, Any] | None = None,
+    ) -> tuple[int, dict[str, Any]]:
+        context = self._build_poll_context(
+            result_path=result_path,
+            correlation_id=correlation_id,
+            service=service,
+            operation=operation,
+            poll_budget=poll_budget,
+            accepted_payload=accepted_payload,
+        )
+        return await self._run_async_poll_loop(
+            context=context,
+            max_attempts=max_attempts,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+
+    def _build_poll_context(
+        self,
+        *,
+        result_path: str,
+        correlation_id: str,
+        service: str,
+        operation: str,
+        poll_budget: AnalyticsPollBudget | None,
+        accepted_payload: dict[str, Any] | None,
+    ) -> _AnalyticsPollContext:
+        return _AnalyticsPollContext(
+            result_path=result_path,
+            url=self._async_result_url(result_path),
+            headers=build_upstream_headers(correlation_id),
+            service=service,
+            operation=operation,
+            budget=poll_budget or AnalyticsPollBudget.unbounded(),
+            accepted_payload=accepted_payload,
+            started_at=gateway_analytics_fanout_timer(),
+        )
+
+    async def _run_async_poll_loop(
+        self,
+        *,
+        context: _AnalyticsPollContext,
+        max_attempts: int | None,
+        poll_interval_seconds: float,
+    ) -> tuple[int, dict[str, Any]]:
+        state = _AnalyticsPollState(
+            attempts=0,
+            status_code=202,
+            payload=context.accepted_payload or {"detail": "async analytics result still pending"},
+        )
+        while max_attempts is None or state.attempts < max_attempts:
+            deadline_result = self._expired_poll_deadline_result(context)
+            if deadline_result is not None:
+                return deadline_result
+            state.status_code, state.payload = await self._poll_analytics_result_once(
+                context=context
+            )
+            state.attempts += 1
+            if state.status_code != 202:
+                self._emit_analytics_read_audit(
+                    operation=f"{context.operation}.poll",
+                    status_code=state.status_code,
+                )
+                return state.status_code, state.payload
+            deadline_result = await self._wait_for_next_async_poll(
+                context=context,
+                payload=state.payload,
+                fallback_seconds=poll_interval_seconds,
+            )
+            if deadline_result is not None:
+                return deadline_result
+        return state.status_code, state.payload
+
+    def _expired_poll_deadline_result(
+        self, context: _AnalyticsPollContext
+    ) -> tuple[int, dict[str, Any]] | None:
+        remaining_seconds = context.budget.remaining_seconds()
+        if remaining_seconds is None or remaining_seconds > 0:
+            return None
+        return self._async_poll_deadline_result(context)
+
+    async def _wait_for_next_async_poll(
+        self,
+        *,
+        context: _AnalyticsPollContext,
+        payload: dict[str, Any],
+        fallback_seconds: float,
+    ) -> tuple[int, dict[str, Any]] | None:
+        sleep_seconds = context.budget.poll_interval(
+            payload=payload,
+            fallback_seconds=fallback_seconds,
+        )
+        if sleep_seconds > 0:
+            await asyncio.sleep(sleep_seconds)
+            return None
+        return self._async_poll_deadline_result(context)
+
+    def _async_result_url(self, result_path: str) -> str:
+        if result_path.startswith("http://") or result_path.startswith("https://"):
+            return result_path
+        return f"{self._base_url}{result_path}"
+
+    async def _poll_analytics_result_once(
+        self, *, context: _AnalyticsPollContext
+    ) -> tuple[int, dict[str, Any]]:
+        started_at = gateway_analytics_fanout_timer()
+        status_code, payload = await request_with_retry(
+            method="GET",
+            url=context.url,
+            timeout_seconds=context.budget.request_timeout(self._timeout),
+            max_retries=0,
+            backoff_seconds=self._retry_backoff_seconds,
+            headers=context.headers,
+            retry_timeout_exceptions=False,
+        )
+        emit_gateway_analytics_fanout_log(
+            logger=logger,
+            started_at=started_at,
+            service=context.service,
+            operation=f"{context.operation}.poll",
+            status_code=status_code,
+            payload=payload,
+        )
+        return status_code, payload
+
+    @staticmethod
+    def _async_poll_deadline_result(
+        context: _AnalyticsPollContext,
+    ) -> tuple[int, dict[str, Any]]:
+        payload = build_async_poll_deadline_payload(
+            result_path=context.result_path,
+            accepted_payload=context.accepted_payload,
+        )
+        emit_gateway_analytics_fanout_log(
+            logger=logger,
+            started_at=context.started_at,
+            service=context.service,
+            operation=f"{context.operation}.poll",
+            status_code=504,
+            payload=payload,
+        )
+        return 504, payload

--- a/src/app/clients/lotus_analytics_async_polling.py
+++ b/src/app/clients/lotus_analytics_async_polling.py
@@ -37,6 +37,13 @@ class AnalyticsPollBudget:
             return None
         return self.deadline_at - time.monotonic()
 
+    @property
+    def is_bounded(self) -> bool:
+        return self.deadline_at is not None
+
+    def request_max_retries(self, default_retries: int) -> int:
+        return 0 if self.is_bounded else default_retries
+
     def request_timeout(self, default_seconds: float) -> float:
         remaining_seconds = self.remaining_seconds()
         if remaining_seconds is None:
@@ -99,6 +106,7 @@ class _AnalyticsPollState:
 class LotusAnalyticsAsyncPollingMixin:
     _base_url: str
     _timeout: float
+    _max_retries: int
     _retry_backoff_seconds: float
 
     @staticmethod
@@ -172,6 +180,9 @@ class LotusAnalyticsAsyncPollingMixin:
                 context=context
             )
             state.attempts += 1
+            deadline_result = self._expired_poll_deadline_result(context)
+            if deadline_result is not None:
+                return deadline_result
             if state.status_code != 202:
                 self._emit_analytics_read_audit(
                     operation=f"{context.operation}.poll",
@@ -224,10 +235,10 @@ class LotusAnalyticsAsyncPollingMixin:
             method="GET",
             url=context.url,
             timeout_seconds=context.budget.request_timeout(self._timeout),
-            max_retries=0,
+            max_retries=context.budget.request_max_retries(self._max_retries),
             backoff_seconds=self._retry_backoff_seconds,
             headers=context.headers,
-            retry_timeout_exceptions=False,
+            retry_timeout_exceptions=not context.budget.is_bounded,
         )
         emit_gateway_analytics_fanout_log(
             logger=logger,

--- a/src/app/clients/lotus_analytics_client.py
+++ b/src/app/clients/lotus_analytics_client.py
@@ -76,6 +76,7 @@ class LotusAnalyticsClient(
             service=service,
             operation=resolved_operation,
             payload=payload,
+            request_budget=poll_budget,
         )
         async_result = await self._poll_async_response_if_available(
             status_code=status_code,
@@ -137,13 +138,14 @@ class LotusAnalyticsClient(
         service: str,
         operation: str,
         payload: dict[str, Any],
+        request_budget: AnalyticsPollBudget,
     ) -> tuple[int, dict[str, Any]]:
         started_at = gateway_analytics_fanout_timer()
         status_code, response_payload = await request_with_retry(
             method="POST",
             url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
+            timeout_seconds=request_budget.request_timeout(self._timeout),
+            max_retries=request_budget.request_max_retries(self._max_retries),
             backoff_seconds=self._retry_backoff_seconds,
             json_body=payload,
             headers=headers,

--- a/src/app/clients/lotus_analytics_client.py
+++ b/src/app/clients/lotus_analytics_client.py
@@ -1,9 +1,11 @@
-import asyncio
 import logging
 from typing import Any
-from uuid import uuid4
 
 from app.clients.http_resilience import request_with_retry
+from app.clients.lotus_analytics_async_polling import (
+    AnalyticsPollBudget,
+    LotusAnalyticsAsyncPollingMixin,
+)
 from app.clients.lotus_analytics_performance_client import LotusAnalyticsPerformanceClientMixin
 from app.clients.lotus_analytics_risk_client import LotusAnalyticsRiskClientMixin
 from app.clients.upstream_headers import build_upstream_headers
@@ -16,16 +18,22 @@ from app.observability.analytics_ui import (
 logger = logging.getLogger("analytics_ui.gateway")
 
 
-class LotusAnalyticsClient(LotusAnalyticsPerformanceClientMixin, LotusAnalyticsRiskClientMixin):
+class LotusAnalyticsClient(
+    LotusAnalyticsAsyncPollingMixin,
+    LotusAnalyticsPerformanceClientMixin,
+    LotusAnalyticsRiskClientMixin,
+):
     def __init__(
         self,
         base_url: str,
         timeout_seconds: float,
+        workspace_summary_deadline_seconds: float = 30.0,
         max_retries: int = 2,
         retry_backoff_seconds: float = 0.2,
     ):
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout_seconds
+        self._workspace_summary_deadline_seconds = workspace_summary_deadline_seconds
         self._max_retries = max_retries
         self._retry_backoff_seconds = retry_backoff_seconds
 
@@ -46,69 +54,6 @@ class LotusAnalyticsClient(LotusAnalyticsPerformanceClientMixin, LotusAnalyticsR
             headers=build_upstream_headers(correlation_id),
         )
 
-    async def _poll_async_result(
-        self,
-        *,
-        result_path: str,
-        correlation_id: str,
-        service: str,
-        operation: str,
-        max_attempts: int = 10,
-        poll_interval_seconds: float = 0.35,
-    ) -> tuple[int, dict[str, Any]]:
-        headers = build_upstream_headers(correlation_id)
-        url = self._async_result_url(result_path)
-        last_status = 202
-        last_payload: dict[str, Any] = {"detail": "async analytics result still pending"}
-        for _ in range(max_attempts):
-            status_code, payload = await self._poll_analytics_result_once(
-                url=url,
-                headers=headers,
-                service=service,
-                operation=operation,
-            )
-            last_status = status_code
-            last_payload = payload
-            if status_code != 202:
-                self._emit_analytics_read_audit(
-                    operation=f"{operation}.poll", status_code=status_code
-                )
-                return status_code, payload
-            await asyncio.sleep(poll_interval_seconds)
-        return last_status, last_payload
-
-    def _async_result_url(self, result_path: str) -> str:
-        if result_path.startswith("http://") or result_path.startswith("https://"):
-            return result_path
-        return f"{self._base_url}{result_path}"
-
-    async def _poll_analytics_result_once(
-        self,
-        *,
-        url: str,
-        headers: dict[str, str],
-        service: str,
-        operation: str,
-    ) -> tuple[int, dict[str, Any]]:
-        started_at = gateway_analytics_fanout_timer()
-        status_code, payload = await request_with_retry(
-            method="GET",
-            url=url,
-            timeout_seconds=self._timeout,
-            max_retries=self._max_retries,
-            backoff_seconds=self._retry_backoff_seconds,
-            headers=headers,
-        )
-        emit_gateway_analytics_fanout_log(
-            logger=logger,
-            started_at=started_at,
-            service=service,
-            operation=f"{operation}.poll",
-            status_code=status_code,
-            payload=payload,
-        )
-        return status_code, payload
-
     async def _post_analytics_request(
         self,
         *,
@@ -117,27 +62,20 @@ class LotusAnalyticsClient(LotusAnalyticsPerformanceClientMixin, LotusAnalyticsR
         correlation_id: str,
         service: str = "lotus-performance",
         operation: str | None = None,
-        async_poll_attempts: int = 10,
+        async_poll_attempts: int | None = 10,
         async_poll_interval_seconds: float = 0.35,
+        async_poll_timeout_seconds: float | None = None,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}{path}"
         headers = build_upstream_headers(correlation_id)
         resolved_operation = operation or path.strip("/").replace("/", ".")
+        poll_budget = AnalyticsPollBudget.from_timeout(async_poll_timeout_seconds)
         status_code, response_payload = await self._post_observed_analytics_request(
             url=url,
             headers=headers,
             service=service,
             operation=resolved_operation,
             payload=payload,
-        )
-        status_code, response_payload = await self._retry_duplicate_calculation_request(
-            status_code=status_code,
-            response_payload=response_payload,
-            request_payload=payload,
-            url=url,
-            headers=headers,
-            service=service,
-            operation=resolved_operation,
         )
         async_result = await self._poll_async_response_if_available(
             status_code=status_code,
@@ -147,6 +85,7 @@ class LotusAnalyticsClient(LotusAnalyticsPerformanceClientMixin, LotusAnalyticsR
             operation=resolved_operation,
             async_poll_attempts=async_poll_attempts,
             async_poll_interval_seconds=async_poll_interval_seconds,
+            poll_budget=poll_budget,
         )
         if async_result is not None:
             return async_result
@@ -161,8 +100,9 @@ class LotusAnalyticsClient(LotusAnalyticsPerformanceClientMixin, LotusAnalyticsR
         correlation_id: str,
         service: str,
         operation: str,
-        async_poll_attempts: int,
+        async_poll_attempts: int | None,
         async_poll_interval_seconds: float,
+        poll_budget: AnalyticsPollBudget,
     ) -> tuple[int, dict[str, Any]] | None:
         result_path = self._async_result_path(
             status_code=status_code,
@@ -177,6 +117,8 @@ class LotusAnalyticsClient(LotusAnalyticsPerformanceClientMixin, LotusAnalyticsR
             operation=operation,
             max_attempts=async_poll_attempts,
             poll_interval_seconds=async_poll_interval_seconds,
+            poll_budget=poll_budget,
+            accepted_payload=response_payload,
         )
 
     @staticmethod
@@ -216,47 +158,6 @@ class LotusAnalyticsClient(LotusAnalyticsPerformanceClientMixin, LotusAnalyticsR
             payload=response_payload,
         )
         return status_code, response_payload
-
-    async def _retry_duplicate_calculation_request(
-        self,
-        *,
-        status_code: int,
-        response_payload: dict[str, Any],
-        request_payload: dict[str, Any],
-        url: str,
-        headers: dict[str, str],
-        service: str,
-        operation: str,
-    ) -> tuple[int, dict[str, Any]]:
-        if not self._should_retry_duplicate_calculation(
-            status_code=status_code, payload=response_payload, request=request_payload
-        ):
-            return status_code, response_payload
-        replay_payload = dict(request_payload)
-        replay_payload["calculation_id"] = str(uuid4())
-        return await self._post_observed_analytics_request(
-            url=url,
-            headers=headers,
-            service=service,
-            operation=f"{operation}.duplicate-retry",
-            payload=replay_payload,
-        )
-
-    @staticmethod
-    def _should_retry_duplicate_calculation(
-        *,
-        status_code: int,
-        payload: dict[str, Any],
-        request: dict[str, Any],
-    ) -> bool:
-        if status_code != 409:
-            return False
-        if "calculation_id" not in request:
-            return False
-        detail = payload.get("detail")
-        if not isinstance(detail, str):
-            return False
-        return "calculation_id already exists" in detail.lower()
 
     @staticmethod
     def _async_result_path(

--- a/src/app/clients/lotus_analytics_performance_client.py
+++ b/src/app/clients/lotus_analytics_performance_client.py
@@ -10,6 +10,7 @@ from app.clients.upstream_headers import build_upstream_headers
 class LotusAnalyticsPerformanceClientMixin:
     _base_url: str
     _timeout: float
+    _workspace_summary_deadline_seconds: float
 
     async def _get_analytics_request(
         self,
@@ -28,8 +29,9 @@ class LotusAnalyticsPerformanceClientMixin:
         correlation_id: str,
         service: str = "lotus-performance",
         operation: str | None = None,
-        async_poll_attempts: int = 10,
+        async_poll_attempts: int | None = 10,
         async_poll_interval_seconds: float = 0.35,
+        async_poll_timeout_seconds: float | None = None,
     ) -> tuple[int, dict[str, Any]]:
         raise NotImplementedError
 
@@ -298,5 +300,7 @@ class LotusAnalyticsPerformanceClientMixin:
             path="/performance/workspace-summary",
             payload=payload,
             correlation_id=correlation_id,
+            async_poll_attempts=None,
+            async_poll_timeout_seconds=self._workspace_summary_deadline_seconds,
         )
         return status_code, response_payload

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -48,6 +48,7 @@ class Settings(BaseSettings):
     upstream_timeout_seconds: float = Field(default=3.0)
     platform_capabilities_source_timeout_seconds: float = Field(default=5.0)
     performance_analytics_timeout_seconds: float = Field(default=15.0)
+    performance_summary_deadline_seconds: float = Field(default=30.0, gt=0.0, le=30.0)
     ai_service_timeout_seconds: float = Field(default=45.0)
     upstream_max_retries: int = Field(default=2)
     upstream_retry_backoff_seconds: float = Field(default=0.2)

--- a/src/app/contracts/analytics_async.py
+++ b/src/app/contracts/analytics_async.py
@@ -1,0 +1,4 @@
+from typing import Final
+
+ASYNC_RESULT_DEADLINE_EXHAUSTED: Final = "ASYNC_RESULT_DEADLINE_EXHAUSTED"
+ASYNC_POLL_DEADLINE_EXHAUSTED_REASON: Final = "async_poll_deadline_exhausted"

--- a/src/app/observability/analytics_ui.py
+++ b/src/app/observability/analytics_ui.py
@@ -184,6 +184,10 @@ def _resolve_supportability_state(payload: Mapping[str, Any]) -> str | None:
 def _resolve_gateway_analytics_reason(
     *, status_code: int, payload: Mapping[str, Any]
 ) -> str | None:
+    payload_reason = payload.get("reason")
+    if payload_reason == "async_poll_deadline_exhausted":
+        return "async_poll_deadline_exhausted"
+
     calculation_supportability = extract_calculation_supportability(payload)
     if calculation_supportability is not None and calculation_supportability.state not in {
         "ready",

--- a/src/app/observability/analytics_ui_fields.py
+++ b/src/app/observability/analytics_ui_fields.py
@@ -88,6 +88,7 @@ GATEWAY_ANALYTICS_DEGRADED_REASON_VOCABULARY = frozenset(
         "source_supportability_degraded",
         "upstream_warning",
         "partial_failure_code",
+        "async_poll_deadline_exhausted",
         "upstream_unavailable",
         "upstream_error",
         "unknown",
@@ -98,6 +99,7 @@ GATEWAY_ANALYTICS_DEGRADED_REASON_ALIASES = {
     "upstream_unavailable": "upstream_unavailable",
     "upstream-error": "upstream_error",
     "upstream_error": "upstream_error",
+    "async_poll_deadline_exhausted": "async_poll_deadline_exhausted",
 }
 
 GATEWAY_ANALYTICS_UI_LOG_EVENTS = (

--- a/src/app/routers/workbench_performance.py
+++ b/src/app/routers/workbench_performance.py
@@ -135,7 +135,10 @@ async def _get_performance_summary(
         "Returns the first-paint performance workspace payload for overview and benchmark-aware "
         "return panels. Use this route when the consumer needs mandate context, comparative "
         "performance, money-weighted return, benchmark options, and current evidence posture "
-        "without loading the heavier chart, contribution, and attribution tables."
+        "without loading the heavier chart, contribution, and attribution tables. Cold "
+        "workspace-summary calculations are polled within a governed monotonic deadline; if "
+        "the source remains pending, the response completes with explicit partial-readiness "
+        "warnings instead of relying on a warmed retry."
     ),
 )
 async def get_performance_workspace_summary(

--- a/src/app/services/analytics_client_factory.py
+++ b/src/app/services/analytics_client_factory.py
@@ -6,6 +6,7 @@ def performance_analytics_client_signature() -> tuple[object, ...]:
     return (
         settings.performance_analytics_base_url,
         settings.performance_analytics_timeout_seconds,
+        settings.performance_summary_deadline_seconds,
         settings.upstream_max_retries,
         settings.upstream_retry_backoff_seconds,
     )
@@ -24,6 +25,7 @@ def build_performance_analytics_client() -> LotusAnalyticsClient:
     return LotusAnalyticsClient(
         base_url=settings.performance_analytics_base_url,
         timeout_seconds=settings.performance_analytics_timeout_seconds,
+        workspace_summary_deadline_seconds=settings.performance_summary_deadline_seconds,
         max_retries=settings.upstream_max_retries,
         retry_backoff_seconds=settings.upstream_retry_backoff_seconds,
     )

--- a/src/app/services/performance_workspace_response_service.py
+++ b/src/app/services/performance_workspace_response_service.py
@@ -15,6 +15,9 @@ from app.services.performance_workspace_response import (
     WorkspaceResponseComponents,
     WorkspaceSummaryViews,
 )
+from app.services.performance_workspace_summary import (
+    is_workspace_summary_deadline_exhausted,
+)
 from app.services.performance_workspace_summary_views import build_workspace_summary_views
 from app.services.workspace_client_protocols import PerformanceWorkspaceAnalyticsClient
 
@@ -117,6 +120,11 @@ class PerformanceWorkspaceResponseServiceMixin:
         benchmark_code: str | None,
     ) -> PerformanceEvidenceView | None:
         evidence_builder = cast(_PerformanceWorkspaceEvidenceBuilder, self)
+        workspace_summary_calculation_id = (
+            None
+            if is_workspace_summary_deadline_exhausted(summary_views.workspace_summary_result)
+            else extract_calculation_id_from_result(summary_views.workspace_summary_result)
+        )
         return await evidence_builder._build_evidence_view(
             portfolio_id=portfolio_id,
             as_of_date=context.overview.as_of_date,
@@ -128,7 +136,7 @@ class PerformanceWorkspaceResponseServiceMixin:
             calculations=[
                 (
                     "workspace_summary",
-                    extract_calculation_id_from_result(summary_views.workspace_summary_result),
+                    workspace_summary_calculation_id,
                 ),
                 (
                     "contribution",

--- a/src/app/services/performance_workspace_summary.py
+++ b/src/app/services/performance_workspace_summary.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, TypeAlias
 
+from app.contracts.analytics_async import ASYNC_RESULT_DEADLINE_EXHAUSTED
 from app.contracts.performance_attribution import AttributionSummaryView
 from app.contracts.performance_contribution import ContributionSummaryView
 from app.contracts.performance_workspace import (
@@ -27,6 +28,10 @@ from app.services.upstream_envelope import safe_upstream_detail
 UpstreamPayload: TypeAlias = dict[str, Any]
 UpstreamResult: TypeAlias = tuple[int, UpstreamPayload]
 GatheredResult: TypeAlias = UpstreamResult | BaseException
+
+PERFORMANCE_WORKSPACE_SUMMARY_DEADLINE_EXHAUSTED = (
+    "PERFORMANCE_WORKSPACE_SUMMARY_DEADLINE_EXHAUSTED"
+)
 
 
 @dataclass(frozen=True)
@@ -111,6 +116,21 @@ def workspace_summary_payload_from_result(
     if not isinstance(payload, dict):
         warnings.append("PERFORMANCE_WORKSPACE_SUMMARY_INVALID")
         return None
+    if is_workspace_summary_deadline_exhausted(result):
+        warnings.append(PERFORMANCE_WORKSPACE_SUMMARY_DEADLINE_EXHAUSTED)
+        partial_failures.append(
+            build_performance_failure(
+                "lotus-performance",
+                ASYNC_RESULT_DEADLINE_EXHAUSTED,
+                safe_upstream_detail(
+                    payload,
+                    default_detail=(
+                        "Performance summary did not complete within the governed response window."
+                    ),
+                ),
+            )
+        )
+        return None
     if status_code >= 400:
         warnings.append("PERFORMANCE_WORKSPACE_SUMMARY_UNAVAILABLE")
         partial_failures.append(
@@ -122,6 +142,19 @@ def workspace_summary_payload_from_result(
         )
         return None
     return payload
+
+
+def is_workspace_summary_deadline_exhausted(
+    result: GatheredResult | None,
+) -> bool:
+    if result is None or isinstance(result, BaseException):
+        return False
+    status_code, payload = result
+    return (
+        status_code == 504
+        and isinstance(payload, dict)
+        and payload.get("error_code") == ASYNC_RESULT_DEADLINE_EXHAUSTED
+    )
 
 
 def workspace_summary_period_payload(

--- a/tests/contract/test_workbench_contract.py
+++ b/tests/contract/test_workbench_contract.py
@@ -305,6 +305,8 @@ def test_workbench_openapi_contract_registered() -> None:
     assert risk_attribution_parameters["grouping_dimension"]["schema"]["examples"] == ["SECTOR"]
     assert performance_summary_parameters["portfolio_id"]["description"]
     assert performance_summary_parameters["portfolio_id"]["schema"]["examples"] == ["PF_1001"]
+    assert "governed monotonic deadline" in performance_summary_operation["description"]
+    assert "partial-readiness" in performance_summary_operation["description"]
     assert performance_summary_parameters["period"]["description"]
     assert performance_summary_parameters["period"]["schema"]["default"] == "YTD"
     assert performance_summary_parameters["chart_frequency"]["description"]

--- a/tests/unit/test_analytics_client_factory.py
+++ b/tests/unit/test_analytics_client_factory.py
@@ -16,6 +16,10 @@ def test_performance_analytics_client_factory_uses_performance_settings(monkeypa
         7.5,
     )
     monkeypatch.setattr(
+        "app.services.analytics_client_factory.settings.performance_summary_deadline_seconds",
+        28.0,
+    )
+    monkeypatch.setattr(
         "app.services.analytics_client_factory.settings.upstream_max_retries",
         4,
     )
@@ -28,9 +32,16 @@ def test_performance_analytics_client_factory_uses_performance_settings(monkeypa
 
     assert client._base_url == "http://performance:8000"
     assert client._timeout == 7.5
+    assert client._workspace_summary_deadline_seconds == 28.0
     assert client._max_retries == 4
     assert client._retry_backoff_seconds == 0.75
-    assert performance_analytics_client_signature() == ("http://performance:8000/", 7.5, 4, 0.75)
+    assert performance_analytics_client_signature() == (
+        "http://performance:8000/",
+        7.5,
+        28.0,
+        4,
+        0.75,
+    )
 
 
 def test_risk_analytics_client_factory_uses_risk_settings(monkeypatch) -> None:

--- a/tests/unit/test_analytics_ui_observability_contract.py
+++ b/tests/unit/test_analytics_ui_observability_contract.py
@@ -101,6 +101,7 @@ def test_gateway_metric_families_are_explicitly_scoped_to_gateway() -> None:
             "source_supportability_degraded",
             "upstream_warning",
             "partial_failure_code",
+            "async_poll_deadline_exhausted",
             "upstream_unavailable",
             "upstream_error",
             "unknown",

--- a/tests/unit/test_config_defaults.py
+++ b/tests/unit/test_config_defaults.py
@@ -17,6 +17,8 @@ def test_settings_default_to_canonical_dev_service_identities():
     assert settings.portfolio_data_control_plane_base_url == "http://core-control.dev.lotus"
     assert settings.portfolio_data_ingestion_base_url == "http://core-ingestion.dev.lotus"
     assert settings.performance_analytics_base_url == "http://performance.dev.lotus"
+    assert settings.performance_analytics_timeout_seconds == 15.0
+    assert settings.performance_summary_deadline_seconds == 30.0
     assert settings.ai_service_base_url == "http://ai.dev.lotus"
     assert settings.ai_service_timeout_seconds == 45.0
     assert settings.risk_analytics_base_url == "http://risk.dev.lotus"
@@ -77,6 +79,15 @@ def test_settings_reject_local_loopback_upstream_urls():
             _env_file=None,
             _env_prefix="__LOTUS_GATEWAY_TEST_UNUSED__",
             ai_service_base_url="http://127.0.0.1:8140/",
+        )
+
+
+def test_settings_reject_performance_summary_deadline_beyond_source_slo():
+    with pytest.raises(ValueError, match="less than or equal to 30"):
+        Settings(
+            _env_file=None,
+            _env_prefix="__LOTUS_GATEWAY_TEST_UNUSED__",
+            performance_summary_deadline_seconds=30.1,
         )
 
 

--- a/tests/unit/test_lotus_analytics_async_deadline.py
+++ b/tests/unit/test_lotus_analytics_async_deadline.py
@@ -141,6 +141,8 @@ async def test_workspace_summary_deadline_bounds_poll_reads_and_returns_retrieva
         "calculation_id": "calc-workspace-summary",
     }
     assert [call["method"] for call in calls] == ["POST", "GET", "GET", "GET"]
+    assert calls[0]["timeout_seconds"] == 2.5
+    assert calls[0]["max_retries"] == 0
     assert [call["timeout_seconds"] for call in calls[1:]] == [2.5, 1.5, 0.5]
     assert all(call["max_retries"] == 0 for call in calls[1:])
     assert all(call["retry_timeout_exceptions"] is False for call in calls[1:])
@@ -177,6 +179,107 @@ async def test_workspace_summary_stretched_scheduler_still_stops_on_monotonic_de
     assert payload["reason"] == "async_poll_deadline_exhausted"
     assert [call["method"] for call in calls] == ["POST", "GET", "GET"]
     assert calls[-1]["timeout_seconds"] == pytest.approx(0.75)
+
+
+@pytest.mark.asyncio
+async def test_workspace_summary_submission_and_polls_share_one_completion_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+    calls: list[dict[str, Any]] = []
+
+    async def _request_with_retry(**kwargs: Any) -> tuple[int, dict[str, Any]]:
+        calls.append(kwargs)
+        if kwargs["method"] == "POST":
+            clock.now += 2.0
+            return _accepted_response()
+        return _pending_response()
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.request_with_retry",
+        _request_with_retry,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_async_polling.request_with_retry",
+        _request_with_retry,
+    )
+    client = LotusAnalyticsClient(
+        base_url="http://analytics",
+        timeout_seconds=15.0,
+        workspace_summary_deadline_seconds=2.5,
+    )
+
+    status_code, payload = await _workspace_summary_call(client)
+
+    assert status_code == 504
+    assert payload["calculation_id"] == "calc-workspace-summary"
+    assert [call["method"] for call in calls] == ["POST", "GET"]
+    assert calls[0]["timeout_seconds"] == 2.5
+    assert calls[0]["max_retries"] == 0
+    assert calls[1]["timeout_seconds"] == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_unbounded_async_poll_preserves_configured_transport_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_transport(monkeypatch, [(200, {"status": "ready"})])
+    client = LotusAnalyticsClient(
+        base_url="http://analytics",
+        timeout_seconds=2.0,
+        max_retries=4,
+    )
+
+    status_code, payload = await client._poll_async_result(
+        result_path="/performance/attribution/results/calc-attribution",
+        correlation_id="corr-unbounded-poll",
+        service="lotus-performance",
+        operation="performance.attribution",
+    )
+
+    assert status_code == 200
+    assert payload == {"status": "ready"}
+    assert calls[0]["max_retries"] == 4
+    assert calls[0]["retry_timeout_exceptions"] is True
+
+
+@pytest.mark.asyncio
+async def test_final_poll_timeout_is_reported_as_governed_deadline_exhaustion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+    calls: list[dict[str, Any]] = []
+
+    async def _request_with_retry(**kwargs: Any) -> tuple[int, dict[str, Any]]:
+        calls.append(kwargs)
+        if kwargs["method"] == "POST":
+            return _accepted_response()
+        clock.now += kwargs["timeout_seconds"]
+        return 503, {"detail": "upstream communication failure: ReadTimeout"}
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.request_with_retry",
+        _request_with_retry,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_async_polling.request_with_retry",
+        _request_with_retry,
+    )
+    client = LotusAnalyticsClient(
+        base_url="http://analytics",
+        timeout_seconds=15.0,
+        workspace_summary_deadline_seconds=2.5,
+    )
+
+    status_code, payload = await _workspace_summary_call(client)
+
+    assert status_code == 504
+    assert payload["reason"] == "async_poll_deadline_exhausted"
+    assert payload["calculation_id"] == "calc-workspace-summary"
+    assert [call["method"] for call in calls] == ["POST", "GET"]
+    assert calls[1]["timeout_seconds"] == 2.5
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_lotus_analytics_async_deadline.py
+++ b/tests/unit/test_lotus_analytics_async_deadline.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable
+from typing import Any
+
+import pytest
+
+from app.clients.lotus_analytics_client import LotusAnalyticsClient
+
+
+class _Clock:
+    def __init__(self, *, stretch_seconds: float = 0.0) -> None:
+        self.now = 100.0
+        self.stretch_seconds = stretch_seconds
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds + self.stretch_seconds
+
+
+def _workspace_summary_call(client: LotusAnalyticsClient) -> Awaitable[tuple[int, dict[str, Any]]]:
+    return client.get_workspace_summary(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        report_end_date="2026-04-10",
+        report_start_date="2025-03-31",
+        period="EXPLICIT",
+        chart_frequency="monthly",
+        detail_basis="NET",
+        benchmark_id="BMK_PB_GLOBAL_BALANCED_60_40",
+        reporting_currency="USD",
+        segment="asset_class",
+        correlation_id="corr-deadline-contract",
+    )
+
+
+def _install_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[tuple[int, dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    async def _request_with_retry(**kwargs: Any) -> tuple[int, dict[str, Any]]:
+        calls.append(kwargs)
+        if not responses:
+            raise AssertionError("No queued analytics response available.")
+        return responses.pop(0)
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.request_with_retry",
+        _request_with_retry,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_async_polling.request_with_retry",
+        _request_with_retry,
+    )
+    return calls
+
+
+def _install_clock(monkeypatch: pytest.MonkeyPatch, clock: _Clock) -> None:
+    monkeypatch.setattr("app.clients.lotus_analytics_async_polling.time.monotonic", clock.monotonic)
+    monkeypatch.setattr("app.clients.lotus_analytics_async_polling.asyncio.sleep", clock.sleep)
+
+
+def _accepted_response() -> tuple[int, dict[str, Any]]:
+    return 202, {
+        "calculation_id": "calc-workspace-summary",
+        "result_path": "/performance/workspace-summary/results/calc-workspace-summary",
+        "recommended_poll_after_seconds": 1.0,
+        "status": "pending",
+    }
+
+
+def _pending_response() -> tuple[int, dict[str, Any]]:
+    return 202, {
+        "calculation_id": "calc-workspace-summary",
+        "recommended_poll_after_seconds": 1.0,
+        "status": "pending",
+    }
+
+
+@pytest.mark.asyncio
+async def test_workspace_summary_cold_result_uses_elapsed_deadline_not_attempt_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+    final_payload = {"calculation_id": "calc-workspace-summary", "results_by_period": {"SI": {}}}
+    calls = _install_transport(
+        monkeypatch,
+        [_accepted_response(), *[_pending_response() for _ in range(12)], (200, final_payload)],
+    )
+    client = LotusAnalyticsClient(
+        base_url="http://analytics",
+        timeout_seconds=15.0,
+        workspace_summary_deadline_seconds=30.0,
+    )
+
+    status_code, payload = await _workspace_summary_call(client)
+
+    assert status_code == 200
+    assert payload == final_payload
+    assert [call["method"] for call in calls].count("POST") == 1
+    assert [call["method"] for call in calls].count("GET") == 13
+    assert clock.now == 112.0
+    assert set(clock.sleeps) == {1.0}
+
+
+@pytest.mark.asyncio
+async def test_workspace_summary_deadline_bounds_poll_reads_and_returns_retrievable_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger="analytics_ui.gateway")
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+    calls = _install_transport(
+        monkeypatch,
+        [_accepted_response(), *[_pending_response() for _ in range(3)]],
+    )
+    client = LotusAnalyticsClient(
+        base_url="http://analytics",
+        timeout_seconds=15.0,
+        workspace_summary_deadline_seconds=2.5,
+    )
+
+    status_code, payload = await _workspace_summary_call(client)
+
+    assert status_code == 504
+    assert payload == {
+        "detail": "analytics result did not complete within the governed Gateway deadline",
+        "error_code": "ASYNC_RESULT_DEADLINE_EXHAUSTED",
+        "state": "degraded",
+        "reason": "async_poll_deadline_exhausted",
+        "result_path": "/performance/workspace-summary/results/calc-workspace-summary",
+        "calculation_id": "calc-workspace-summary",
+    }
+    assert [call["method"] for call in calls] == ["POST", "GET", "GET", "GET"]
+    assert [call["timeout_seconds"] for call in calls[1:]] == [2.5, 1.5, 0.5]
+    assert all(call["max_retries"] == 0 for call in calls[1:])
+    assert all(call["retry_timeout_exceptions"] is False for call in calls[1:])
+    deadline_record = next(
+        record
+        for record in caplog.records
+        if record.name == "analytics_ui.gateway"
+        and record.message == "gateway.analytics.fanout.degraded"
+        and record.extra_fields["reason"] == "async_poll_deadline_exhausted"
+    )
+    assert deadline_record.extra_fields["operation"] == "performance.workspace-summary.poll"
+    assert "calculation_id" not in deadline_record.extra_fields
+
+
+@pytest.mark.asyncio
+async def test_workspace_summary_stretched_scheduler_still_stops_on_monotonic_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock(stretch_seconds=0.75)
+    _install_clock(monkeypatch, clock)
+    calls = _install_transport(
+        monkeypatch,
+        [_accepted_response(), *[_pending_response() for _ in range(2)]],
+    )
+    client = LotusAnalyticsClient(
+        base_url="http://analytics",
+        timeout_seconds=15.0,
+        workspace_summary_deadline_seconds=2.5,
+    )
+
+    status_code, payload = await _workspace_summary_call(client)
+
+    assert status_code == 504
+    assert payload["reason"] == "async_poll_deadline_exhausted"
+    assert [call["method"] for call in calls] == ["POST", "GET", "GET"]
+    assert calls[-1]["timeout_seconds"] == pytest.approx(0.75)
+
+
+@pytest.mark.asyncio
+async def test_workspace_summary_terminal_poll_failure_returns_without_resubmission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+    calls = _install_transport(
+        monkeypatch,
+        [_accepted_response(), (503, {"detail": "workspace summary execution failed"})],
+    )
+    client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=15.0)
+
+    status_code, payload = await _workspace_summary_call(client)
+
+    assert status_code == 503
+    assert payload == {"detail": "workspace summary execution failed"}
+    assert [call["method"] for call in calls] == ["POST", "GET"]
+
+
+@pytest.mark.asyncio
+async def test_outer_caller_cancellation_does_not_resubmit_workspace_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    poll_started = asyncio.Event()
+    release_poll = asyncio.Event()
+    calls: list[dict[str, Any]] = []
+
+    async def _request_with_retry(**kwargs: Any) -> tuple[int, dict[str, Any]]:
+        calls.append(kwargs)
+        if kwargs["method"] == "POST":
+            return _accepted_response()
+        poll_started.set()
+        await release_poll.wait()
+        return _pending_response()
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.request_with_retry",
+        _request_with_retry,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_async_polling.request_with_retry",
+        _request_with_retry,
+    )
+    client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=15.0)
+
+    task = asyncio.create_task(_workspace_summary_call(client))
+    await asyncio.wait_for(poll_started.wait(), timeout=1.0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert [call["method"] for call in calls] == ["POST", "GET"]

--- a/tests/unit/test_lotus_analytics_async_deadline.py
+++ b/tests/unit/test_lotus_analytics_async_deadline.py
@@ -107,8 +107,48 @@ async def test_workspace_summary_cold_result_uses_elapsed_deadline_not_attempt_c
     assert payload == final_payload
     assert [call["method"] for call in calls].count("POST") == 1
     assert [call["method"] for call in calls].count("GET") == 13
-    assert clock.now == 112.0
+    assert clock.now == 113.0
     assert set(clock.sleeps) == {1.0}
+
+
+@pytest.mark.asyncio
+async def test_workspace_summary_waits_for_accepted_response_cadence_before_first_result_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+    call_times: list[tuple[str, float]] = []
+    accepted_status, accepted_payload = _accepted_response()
+    accepted_payload["recommended_poll_after_seconds"] = 1.75
+
+    async def _request_with_retry(**kwargs: Any) -> tuple[int, dict[str, Any]]:
+        call_times.append((kwargs["method"], clock.now))
+        if kwargs["method"] == "POST":
+            return accepted_status, accepted_payload
+        return 200, {
+            "calculation_id": "calc-workspace-summary",
+            "results_by_period": {"SI": {}},
+        }
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.request_with_retry",
+        _request_with_retry,
+    )
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_async_polling.request_with_retry",
+        _request_with_retry,
+    )
+    client = LotusAnalyticsClient(
+        base_url="http://analytics",
+        timeout_seconds=15.0,
+        workspace_summary_deadline_seconds=30.0,
+    )
+
+    status_code, _ = await _workspace_summary_call(client)
+
+    assert status_code == 200
+    assert call_times == [("POST", 100.0), ("GET", 101.75)]
+    assert clock.sleeps == [1.75]
 
 
 @pytest.mark.asyncio
@@ -140,10 +180,10 @@ async def test_workspace_summary_deadline_bounds_poll_reads_and_returns_retrieva
         "result_path": "/performance/workspace-summary/results/calc-workspace-summary",
         "calculation_id": "calc-workspace-summary",
     }
-    assert [call["method"] for call in calls] == ["POST", "GET", "GET", "GET"]
+    assert [call["method"] for call in calls] == ["POST", "GET", "GET"]
     assert calls[0]["timeout_seconds"] == 2.5
     assert calls[0]["max_retries"] == 0
-    assert [call["timeout_seconds"] for call in calls[1:]] == [2.5, 1.5, 0.5]
+    assert [call["timeout_seconds"] for call in calls[1:]] == [1.5, 0.5]
     assert all(call["max_retries"] == 0 for call in calls[1:])
     assert all(call["retry_timeout_exceptions"] is False for call in calls[1:])
     deadline_record = next(
@@ -177,7 +217,7 @@ async def test_workspace_summary_stretched_scheduler_still_stops_on_monotonic_de
 
     assert status_code == 504
     assert payload["reason"] == "async_poll_deadline_exhausted"
-    assert [call["method"] for call in calls] == ["POST", "GET", "GET"]
+    assert [call["method"] for call in calls] == ["POST", "GET"]
     assert calls[-1]["timeout_seconds"] == pytest.approx(0.75)
 
 
@@ -214,10 +254,9 @@ async def test_workspace_summary_submission_and_polls_share_one_completion_budge
 
     assert status_code == 504
     assert payload["calculation_id"] == "calc-workspace-summary"
-    assert [call["method"] for call in calls] == ["POST", "GET"]
+    assert [call["method"] for call in calls] == ["POST"]
     assert calls[0]["timeout_seconds"] == 2.5
     assert calls[0]["max_retries"] == 0
-    assert calls[1]["timeout_seconds"] == pytest.approx(0.5)
 
 
 @pytest.mark.asyncio
@@ -279,7 +318,7 @@ async def test_final_poll_timeout_is_reported_as_governed_deadline_exhaustion(
     assert payload["reason"] == "async_poll_deadline_exhausted"
     assert payload["calculation_id"] == "calc-workspace-summary"
     assert [call["method"] for call in calls] == ["POST", "GET"]
-    assert calls[1]["timeout_seconds"] == 2.5
+    assert calls[1]["timeout_seconds"] == 1.5
 
 
 @pytest.mark.asyncio
@@ -312,7 +351,9 @@ async def test_outer_caller_cancellation_does_not_resubmit_workspace_summary(
     async def _request_with_retry(**kwargs: Any) -> tuple[int, dict[str, Any]]:
         calls.append(kwargs)
         if kwargs["method"] == "POST":
-            return _accepted_response()
+            status_code, payload = _accepted_response()
+            payload["recommended_poll_after_seconds"] = 0.01
+            return status_code, payload
         poll_started.set()
         await release_poll.wait()
         return _pending_response()

--- a/tests/unit/test_performance_summary_deadline_documentation.py
+++ b/tests/unit/test_performance_summary_deadline_documentation.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_performance_summary_deadline_is_durable_across_operator_and_product_truth() -> None:
+    standard = _read("docs/standards/scalability-availability.md")
+    supported_features = _read("docs/supported-features.md")
+    wiki = _read("wiki/Supported-Features.md")
+    context = _read("REPOSITORY-ENGINEERING-CONTEXT.md")
+
+    for document in (standard, wiki, context):
+        normalized = " ".join(document.lower().split())
+        assert "30-second" in normalized or "=30" in normalized
+        assert "one calculation identity" in normalized
+        assert "partial-readiness" in normalized
+
+    assert "monotonic" in standard
+    assert "monotonic" in context
+    assert "ASYNC_RESULT_DEADLINE_EXHAUSTED" in standard
+    assert "async_poll_deadline_exhausted" in standard
+    assert "warm retry" in supported_features
+    assert "blind retry" in wiki
+    assert "warm response" in wiki

--- a/tests/unit/test_performance_summary_deadline_documentation.py
+++ b/tests/unit/test_performance_summary_deadline_documentation.py
@@ -25,6 +25,9 @@ def test_performance_summary_deadline_is_durable_across_operator_and_product_tru
     assert "monotonic" in context
     assert "ASYNC_RESULT_DEADLINE_EXHAUSTED" in standard
     assert "async_poll_deadline_exhausted" in standard
+    assert "PERFORMANCE_WORKSPACE_SUMMARY_DEADLINE_EXHAUSTED" in standard
+    assert "before the first result read" in standard
+    assert "execution or lineage evidence reads" in standard
     assert "warm retry" in supported_features
     assert "blind retry" in wiki
     assert "warm response" in wiki

--- a/tests/unit/test_performance_workspace_service.py
+++ b/tests/unit/test_performance_workspace_service.py
@@ -2206,6 +2206,48 @@ async def test_performance_workspace_service_handles_workspace_summary_failure()
 
 
 @pytest.mark.asyncio
+async def test_performance_workspace_deadline_skips_follow_on_evidence_reads():
+    class _DeadlineAnalyticsClient(_StubAnalyticsClient):
+        async def get_workspace_summary(self, **kwargs):  # noqa: ARG002
+            return 504, {
+                "detail": "analytics result did not complete within the governed Gateway deadline",
+                "error_code": "ASYNC_RESULT_DEADLINE_EXHAUSTED",
+                "reason": "async_poll_deadline_exhausted",
+                "result_path": ("/performance/workspace-summary/results/calc-workspace-summary"),
+                "calculation_id": "calc-workspace-summary",
+            }
+
+    analytics_client = _DeadlineAnalyticsClient()
+    service = PerformanceWorkspaceService(
+        workbench_service=_StubWorkbenchService(),
+        analytics_client=analytics_client,
+        lotus_core_query_client=_StubLotusCoreQueryClient(),
+    )
+
+    response = await service.get_performance_workspace_summary(
+        portfolio_id="DEMO_ADV_USD_001",
+        correlation_id="corr-performance-deadline",
+        period="YTD",
+        chart_frequency="monthly",
+        contribution_dimension="asset_class",
+        attribution_dimension="asset_class",
+        detail_basis="NET",
+        benchmark_code="BMK_PB_GLOBAL_BALANCED_60_40",
+    )
+
+    assert analytics_client.execution_calls == []
+    assert analytics_client.lineage_calls == []
+    assert response.evidence_view is not None
+    assert response.evidence_view.state == "unavailable"
+    assert response.evidence_view.calculations == []
+    assert "PERFORMANCE_WORKSPACE_SUMMARY_DEADLINE_EXHAUSTED" in response.warnings
+    assert any(
+        failure.error_code == "ASYNC_RESULT_DEADLINE_EXHAUSTED"
+        for failure in response.partial_failures
+    )
+
+
+@pytest.mark.asyncio
 async def test_performance_workspace_service_marks_pending_lineage_as_partial_evidence():
     class _PendingLineageAnalyticsClient(_StubAnalyticsClient):
         async def get_lineage(self, *, calculation_id: str, correlation_id: str):

--- a/tests/unit/test_performance_workspace_summary.py
+++ b/tests/unit/test_performance_workspace_summary.py
@@ -145,3 +145,33 @@ def test_parse_workspace_summary_result_records_upstream_failure():
     assert partial_failures[0].detail == "SUMMARY_UNAVAILABLE"
     assert "Private Client" not in str(partial_failures[0])
     assert "secret-token" not in str(partial_failures[0])
+
+
+def test_parse_workspace_summary_result_preserves_completion_deadline_posture():
+    warnings: list[str] = []
+    partial_failures = []
+
+    parsed = parse_workspace_summary_result(
+        result=(
+            504,
+            {
+                "detail": "analytics result did not complete within the governed Gateway deadline",
+                "error_code": "ASYNC_RESULT_DEADLINE_EXHAUSTED",
+                "reason": "async_poll_deadline_exhausted",
+                "calculation_id": "calc-workspace-summary",
+            },
+        ),
+        requested_period="YTD",
+        chart_frequency="monthly",
+        warnings=warnings,
+        partial_failures=partial_failures,
+    )
+
+    assert parsed.net_performance.portfolio_return_pct is None
+    assert warnings == ["PERFORMANCE_WORKSPACE_SUMMARY_DEADLINE_EXHAUSTED"]
+    assert len(partial_failures) == 1
+    assert partial_failures[0].source_service == "lotus-performance"
+    assert partial_failures[0].error_code == "ASYNC_RESULT_DEADLINE_EXHAUSTED"
+    assert partial_failures[0].detail == (
+        "Performance summary did not complete within the governed response window."
+    )

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -553,7 +553,7 @@ async def test_lotus_analytics_client_allows_slow_stateful_attribution_to_materi
     async def _no_sleep(_seconds: float) -> None:
         return None
 
-    monkeypatch.setattr("app.clients.lotus_analytics_client.asyncio.sleep", _no_sleep)
+    monkeypatch.setattr("app.clients.lotus_analytics_async_polling.asyncio.sleep", _no_sleep)
 
     client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(202, {"result_path": "/performance/attribution/results/calc-1"})
@@ -601,7 +601,7 @@ async def test_lotus_analytics_client_preserves_absolute_async_result_url(monkey
     async def _no_sleep(_seconds: float) -> None:
         return None
 
-    monkeypatch.setattr("app.clients.lotus_analytics_client.asyncio.sleep", _no_sleep)
+    monkeypatch.setattr("app.clients.lotus_analytics_async_polling.asyncio.sleep", _no_sleep)
 
     client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(202, {"detail": "pending"})
@@ -1198,7 +1198,7 @@ async def test_lotus_analytics_client_emits_safe_unavailable_fanout_log(caplog):
 
 
 @pytest.mark.asyncio
-async def test_lotus_analytics_client_retries_workspace_summary_when_calculation_id_conflicts():
+async def test_lotus_analytics_client_preserves_workspace_summary_conflict_identity():
     client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(
         409,
@@ -1209,20 +1209,6 @@ async def test_lotus_analytics_client_retries_workspace_summary_when_calculation
             )
         },
     )
-    _FakeAsyncClient.queue_json(
-        200,
-        {
-            "results_by_period": {
-                "YTD": {
-                    "portfolio_twr": {
-                        "net": {"summary": {"period_return": {"base": 2.1}}},
-                        "gross": {"summary": {"period_return": {"base": 2.2}}},
-                    }
-                }
-            }
-        },
-    )
-
     status_code, payload = await client.get_workspace_summary(
         portfolio_id="P1",
         report_end_date="2026-03-27",
@@ -1236,22 +1222,13 @@ async def test_lotus_analytics_client_retries_workspace_summary_when_calculation
         correlation_id="corr-performance",
     )
 
-    assert status_code == 200
-    assert "results_by_period" in payload
-    assert len(_FakeAsyncClient.calls) == 2
-    first_request = _FakeAsyncClient.calls[0]
-    replay_request = _FakeAsyncClient.calls[1]
-    assert (
-        first_request["url"]
-        == replay_request["url"]
-        == "http://analytics/performance/workspace-summary"
-    )
-    assert first_request["json"]["calculation_id"] != replay_request["json"]["calculation_id"]
-    assert "currency_mode" not in first_request["json"]
-    assert "currency_mode" not in replay_request["json"]
-    assert first_request["json"]["report_ccy"] == replay_request["json"]["report_ccy"] == "USD"
-    assert first_request["json"]["periods"] == replay_request["json"]["periods"]
-    assert first_request["json"]["benchmark"] == replay_request["json"]["benchmark"]
+    assert status_code == 409
+    assert "calculation_id already exists" in payload["detail"]
+    assert len(_FakeAsyncClient.calls) == 1
+    request = _FakeAsyncClient.calls[0]
+    assert request["url"] == "http://analytics/performance/workspace-summary"
+    assert "currency_mode" not in request["json"]
+    assert request["json"]["report_ccy"] == "USD"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1262,6 +1262,7 @@ async def test_lotus_analytics_client_disables_timeout_retries_for_workspace_sum
     assert payload["detail"] == "upstream communication failure: TimeoutException"
     assert captured[0]["retry_timeout_exceptions"] is False
     assert captured[0]["timeout_seconds"] == 15.0
+    assert captured[0]["max_retries"] == 0
 
 
 @pytest.mark.asyncio

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -14,9 +14,10 @@ Business outcome:
 1. an advisor receives the same caller-visible completion posture for the same portfolio review
    request regardless of whether the analytics result was already warm,
 2. Gateway waits within a governed 30-second business-response budget and follows the source-owned
-   polling cadence,
+   minimum polling cadence before the first and subsequent result reads,
 3. if the source calculation is still pending at the deadline, the screen receives explicit
-   partial-readiness warnings before its connection closes rather than depending on a blind retry.
+   deadline-exhausted partial-readiness warnings before its connection closes rather than depending
+   on a blind retry, and Gateway does not add execution or lineage evidence reads after expiry.
 
 Authority and boundary:
 
@@ -26,7 +27,7 @@ Authority and boundary:
    authorization, tenant, and portfolio scope through polling; it does not submit a replacement
    calculation after an identity conflict,
 3. Gateway owns the elapsed deadline, remaining-budget request timeouts, caller-visible
-   partial-readiness mapping, and bounded reason-coded telemetry,
+   deadline-specific partial-readiness mapping, and bounded reason-coded telemetry,
 4. deadline exhaustion does not prove a calculation failure, permit duplicate financial work, or
    make a later warm response valid readiness evidence on its own.
 

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -5,6 +5,31 @@ developers, business users, operations, sales/pre-sales, and client demos; it mu
 future capability as supported until the owning service, Gateway contract, tests, and validation
 evidence exist.
 
+## Performance Summary Completion
+
+Status: implementation-backed for deterministic cold and warm workspace-summary orchestration.
+
+Business outcome:
+
+1. an advisor receives the same caller-visible completion posture for the same portfolio review
+   request regardless of whether the analytics result was already warm,
+2. Gateway waits within a governed 30-second business-response budget and follows the source-owned
+   polling cadence,
+3. if the source calculation is still pending at the deadline, the screen receives explicit
+   partial-readiness warnings before its connection closes rather than depending on a blind retry.
+
+Authority and boundary:
+
+1. `lotus-performance` owns the calculation, result, lineage, cache, and 30-second production
+   completion objective,
+2. Gateway preserves one calculation identity and the original caller correlation, trace,
+   authorization, tenant, and portfolio scope through polling; it does not submit a replacement
+   calculation after an identity conflict,
+3. Gateway owns the elapsed deadline, remaining-budget request timeouts, caller-visible
+   partial-readiness mapping, and bounded reason-coded telemetry,
+4. deadline exhaustion does not prove a calculation failure, permit duplicate financial work, or
+   make a later warm response valid readiness evidence on its own.
+
 ## Authenticated Advisor Book
 
 Status: implementation-backed in Gateway for an authenticated advisor's own source-backed


### PR DESCRIPTION
## Summary
- replace fixed-attempt workspace-summary polling with a reusable monotonic completion budget
- bound submission and result reads to the remaining 30-second business-response budget
- wait for the accepted response's minimum polling cadence before the first result read
- preserve one calculation identity and return deadline-specific Workbench partial-readiness posture
- stop execution and lineage evidence reads after the summary deadline expires
- align shared error vocabulary, OpenAPI, standards, supported-feature truth, repository context, and wiki source

## Why
- Workbench canonical validation could complete Gateway polling while `lotus-performance` still returned `202`, making the same advisor review depend on cache warmth and host scheduling
- retry-count expansion would not satisfy the caller-deadline or duplicate-calculation controls in #507

## Scope
- [x] Single issue/slice scope: #507
- [x] No unrelated refactors mixed in
- [x] Reusable polling policy and shared deadline vocabulary remain inside existing client, contract, and service boundaries

## Validation (local)
- [x] focused review regression suite — 50 passed
- [x] `make check` — 1,645 unit/contract tests
- [x] `make ci` — 249 integration tests; 1,894 combined coverage tests; 94.53% coverage; security audit clean
- [x] Wiki check-only passed with one expected unpublished branch delta

## CI Evidence
- [x] All 11 GitHub checks are green on `28709d70`
- [x] GitHub-backed Docker build and local-Docker parity passed without disrupting the shared local platform runtime

## Governance/Docs
- [x] OpenAPI description documents deterministic partial-readiness behavior
- [x] Scalability/availability standard, supported features, repository context, and wiki source updated
- [x] Documentation contract protects deadline, cadence, identity, evidence short-circuit, and partial-readiness truth delivered by this slice

## Review Evidence
- signed commits: `da9cf554`, `426c5b42`, `c8ad9a4e`, `28709d70`
- six automated review findings were fixed with regressions and resolved
- three valid late third-pass transport edge findings are durably tracked in #536 and linked from their resolved threads under the agreed late-review follow-up policy
- tests cover cold completion, accepted-response cadence, repeated `202`, stretched scheduling, bounded submission, unbounded retry preservation, terminal failure, final timeout normalization, outer cancellation, evidence short-circuit, deadline-specific Workbench mapping, safe telemetry, and identity preservation
- no metric or structured-log labels include calculation, portfolio, client, correlation, or trace identifiers

## No-claim boundary
- #507 remains open after this incremental merge
- do not claim universal end-to-end deadline enforcement until #536 completes bounded transient-failure continuation, post-submission expiry mapping, complete-request wall-clock enforcement, and exact-main canonical proof

## Post-Merge Hygiene
- [ ] Publish and strictly verify Gateway wiki parity
- [ ] Delete remote feature branch
- [ ] Delete local feature branch
- [ ] Sync and validate exact `origin/main`

Refs #507
Follow-up #536