### PR TITLE
Complete performance deadline transport enforcement

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -170,12 +170,17 @@ Current repository posture:
 17. performance workspace-summary orchestration uses
     `PERFORMANCE_SUMMARY_DEADLINE_SECONDS=30` as an end-to-end monotonic budget across submission
     and polling, while `PERFORMANCE_ANALYTICS_TIMEOUT_SECONDS=15` remains a per-call ceiling.
-    Result reads are limited to the remaining budget, wait for the accepted response's minimum
-    source polling cadence before the first read, preserve one calculation identity and caller
-    context, and emit bounded `async_poll_deadline_exhausted` telemetry. Deadline exhaustion becomes
-    the specific Workbench `PERFORMANCE_WORKSPACE_SUMMARY_DEADLINE_EXHAUSTED` partial-readiness
-    response and suppresses follow-on execution or lineage evidence reads; it is not masked by a
-    replacement calculation or treated as successful because a later warm retry completes.
+    Submission and result reads are limited to the remaining budget both through HTTPX
+    per-operation timeouts and a complete-await cancellation guard. Typed transient transport
+    failures continue through the outer elapsed-time polling loop while actual upstream HTTP
+    failures remain terminal. Polling waits for the accepted response's minimum source cadence
+    before the first read, preserves one calculation identity and caller context after acceptance,
+    and emits bounded `async_poll_deadline_exhausted` telemetry. When submission acceptance is
+    unknown, the deadline response omits calculation identity and result path. Deadline exhaustion
+    becomes the specific Workbench `PERFORMANCE_WORKSPACE_SUMMARY_DEADLINE_EXHAUSTED`
+    partial-readiness response and suppresses follow-on execution or lineage evidence reads; it is
+    not masked by a replacement calculation or treated as successful because a later warm retry
+    completes.
 
 ## Architecture And Module Map
 

--- a/docs/standards/scalability-availability.md
+++ b/docs/standards/scalability-availability.md
@@ -29,16 +29,23 @@ This repository adopts the platform-wide standard defined in lotus-platform/Scal
   budget to the `lotus-performance` workspace-summary submission and result polling flow. The
   budget is configured by `PERFORMANCE_SUMMARY_DEADLINE_SECONDS`; the separate
   `PERFORMANCE_ANALYTICS_TIMEOUT_SECONDS` remains the maximum for one upstream request.
-- Result reads use the smaller of the per-request timeout and the remaining completion budget.
+- Submission and result reads use the smaller of the per-request timeout and the remaining
+  completion budget. Gateway also wraps each complete HTTP await in the remaining monotonic
+  budget, so multiple transport phases and slow response-byte trickles cannot extend the
+  caller-visible deadline beyond the configured allowance.
   Gateway waits for the accepted response's `recommended_poll_after_seconds` minimum cadence
   before the first result read and honors refreshed guidance after each pending result. Polling is
   bounded by elapsed time, not an attempt count. Result reads do not add nested transport retries
-  because the outer polling loop owns the remaining budget and next-read decision.
+  because the outer polling loop owns the remaining budget and next-read decision. Typed transient
+  transport and timeout outcomes continue through that outer loop while budget remains; an actual
+  upstream HTTP error response remains terminal and is not reclassified as a transport failure.
 - One calculation identity, caller correlation, trace, and authorization context are preserved
   from submission through result retrieval. Gateway does not respond to an identity conflict by
   submitting another financial calculation.
 - If the budget expires, the analytics client returns reason code
-  `ASYNC_RESULT_DEADLINE_EXHAUSTED` with the original result identity. The Workbench experience API
+  `ASYNC_RESULT_DEADLINE_EXHAUSTED`. It includes the original calculation identity and result path
+  only after the source has published an accepted response; if submission acceptance is unknown,
+  Gateway omits that identity rather than inventing retrievability. The Workbench experience API
   converts that source failure into the specific
   `PERFORMANCE_WORKSPACE_SUMMARY_DEADLINE_EXHAUSTED` partial-readiness warning and preserves the
   source error code. It does not start execution or lineage evidence reads after the budget has

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -17,11 +17,14 @@
 4. portfolio 360 composition.
 
 Performance-summary cold calculations use a governed 30-second elapsed deadline across source
-submission and polling. Gateway preserves one source calculation identity, waits for the accepted
-response's minimum polling cadence before the first result read, and returns specific
-deadline-exhausted partial-readiness posture if the calculation remains pending. Gateway does not
-start execution or lineage evidence reads after the budget expires, and support is not inferred
-from a successful warm retry.
+submission and polling. The remaining budget governs each complete HTTP operation as well as its
+per-operation transport timeout, including slow multi-phase or response-trickle behavior. Gateway
+preserves one source calculation identity after acceptance, continues bounded polling through
+typed transient transport failures, waits for the accepted response's minimum polling cadence
+before the first result read, and returns specific deadline-exhausted partial-readiness posture if
+the calculation remains pending. If submission acceptance is unknown, Gateway omits calculation
+identity rather than claiming a retrievable result. Gateway does not start execution or lineage
+evidence reads after the budget expires, and support is not inferred from a successful warm retry.
 
 ## Advisory And Proposals
 

--- a/src/app/clients/analytics_poll_budget.py
+++ b/src/app/clients/analytics_poll_budget.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+RequestResultT = TypeVar("RequestResultT")
+
+
+class AnalyticsRequestDeadlineExceeded(TimeoutError):
+    """Raised when one complete analytics request exhausts its elapsed budget."""
+
+
+@dataclass(frozen=True)
+class AnalyticsPollBudget:
+    """Elapsed-time policy for one analytics submission and its result reads."""
+
+    deadline_at: float | None
+
+    @classmethod
+    def from_timeout(cls, timeout_seconds: float | None) -> AnalyticsPollBudget:
+        deadline_at = None if timeout_seconds is None else time.monotonic() + timeout_seconds
+        return cls(deadline_at=deadline_at)
+
+    @classmethod
+    def unbounded(cls) -> AnalyticsPollBudget:
+        return cls(deadline_at=None)
+
+    def remaining_seconds(self) -> float | None:
+        if self.deadline_at is None:
+            return None
+        return self.deadline_at - time.monotonic()
+
+    @property
+    def is_expired(self) -> bool:
+        remaining_seconds = self.remaining_seconds()
+        return remaining_seconds is not None and remaining_seconds <= 0
+
+    @property
+    def is_bounded(self) -> bool:
+        return self.deadline_at is not None
+
+    def request_max_retries(self, default_retries: int) -> int:
+        return 0 if self.is_bounded else default_retries
+
+    def request_timeout(self, default_seconds: float) -> float:
+        remaining_seconds = self.remaining_seconds()
+        if remaining_seconds is None:
+            return default_seconds
+        return min(default_seconds, max(remaining_seconds, 0.001))
+
+    def poll_interval(self, *, payload: dict[str, Any], fallback_seconds: float) -> float:
+        interval_seconds = _recommended_poll_interval(payload, fallback_seconds)
+        remaining_seconds = self.remaining_seconds()
+        if remaining_seconds is None:
+            return interval_seconds
+        return min(interval_seconds, max(remaining_seconds, 0.0))
+
+    async def run_request(
+        self,
+        request_factory: Callable[[], Awaitable[RequestResultT]],
+    ) -> RequestResultT:
+        remaining_seconds = self.remaining_seconds()
+        if remaining_seconds is None:
+            return await request_factory()
+        if remaining_seconds <= 0:
+            raise AnalyticsRequestDeadlineExceeded
+        try:
+            async with asyncio.timeout(remaining_seconds):
+                return await request_factory()
+        except TimeoutError as exc:
+            raise AnalyticsRequestDeadlineExceeded from exc
+
+
+def _recommended_poll_interval(payload: dict[str, Any], fallback_seconds: float) -> float:
+    recommended = payload.get("recommended_poll_after_seconds")
+    if isinstance(recommended, bool) or not isinstance(recommended, int | float):
+        return fallback_seconds
+    resolved = float(recommended)
+    if not math.isfinite(resolved) or resolved <= 0:
+        return fallback_seconds
+    return resolved

--- a/src/app/clients/http_json_resilience.py
+++ b/src/app/clients/http_json_resilience.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+import httpx
+
+from app.clients.http_response_payloads import (
+    communication_failure_result,
+    response_payload,
+    unsupported_method_payload,
+)
+from app.clients.http_retry_policy import (
+    retry_attempts,
+    retry_delay,
+    should_retry_request_error,
+    should_retry_status,
+)
+
+_JSON_REQUEST_METHODS = frozenset({"GET", "POST", "PUT"})
+
+
+class RequestFailureKind(StrEnum):
+    TRANSPORT = "transport"
+    TIMEOUT = "timeout"
+    UNSUPPORTED_METHOD = "unsupported_method"
+    RETRIES_EXHAUSTED = "retries_exhausted"
+
+
+@dataclass(frozen=True)
+class JsonRequestOutcome:
+    status_code: int
+    payload: dict[str, Any]
+    failure_kind: RequestFailureKind | None = None
+
+    @property
+    def is_transient_transport_failure(self) -> bool:
+        return self.failure_kind in {
+            RequestFailureKind.TRANSPORT,
+            RequestFailureKind.TIMEOUT,
+        }
+
+    def as_result(self) -> tuple[int, dict[str, Any]]:
+        return self.status_code, self.payload
+
+
+async def _send_json_request(
+    *,
+    client: httpx.AsyncClient,
+    request_method: str,
+    url: str,
+    params: dict[str, Any] | None,
+    headers: dict[str, str] | None,
+    json_body: dict[str, Any] | None,
+    data: dict[str, Any] | None,
+    files: dict[str, Any] | None,
+) -> httpx.Response:
+    if request_method == "GET":
+        return await client.get(url, params=params, headers=headers)
+    if request_method == "PUT":
+        return await client.put(url, headers=headers, json=json_body)
+    return await client.post(
+        url,
+        params=params,
+        headers=headers,
+        json=json_body,
+        data=data,
+        files=files,
+    )
+
+
+async def _send_json_request_once(
+    *,
+    request_method: str,
+    url: str,
+    timeout_seconds: float,
+    params: dict[str, Any] | None,
+    headers: dict[str, str] | None,
+    json_body: dict[str, Any] | None,
+    data: dict[str, Any] | None,
+    files: dict[str, Any] | None,
+) -> httpx.Response:
+    async with httpx.AsyncClient(
+        timeout=timeout_seconds,
+        follow_redirects=True,
+    ) as client:
+        return await _send_json_request(
+            client=client,
+            request_method=request_method,
+            url=url,
+            params=params,
+            headers=headers,
+            json_body=json_body,
+            data=data,
+            files=files,
+        )
+
+
+async def _retry_or_return_json_response(
+    *,
+    response: httpx.Response,
+    retry_status_codes: set[int] | None,
+    attempt: int,
+    max_retries: int,
+    backoff_seconds: float,
+) -> JsonRequestOutcome | None:
+    if should_retry_status(
+        response_status_code=response.status_code,
+        retry_status_codes=retry_status_codes,
+        attempt=attempt,
+        max_retries=max_retries,
+    ):
+        await _sleep_before_retry(backoff_seconds, attempt)
+        return None
+    return JsonRequestOutcome(response.status_code, response_payload(response))
+
+
+def _request_error_failure_kind(exc: httpx.RequestError) -> RequestFailureKind:
+    if isinstance(exc, httpx.TimeoutException):
+        return RequestFailureKind.TIMEOUT
+    return RequestFailureKind.TRANSPORT
+
+
+async def _retry_or_return_request_error(
+    *,
+    exc: httpx.RequestError,
+    retry_timeout_exceptions: bool,
+    attempt: int,
+    max_retries: int,
+    backoff_seconds: float,
+) -> JsonRequestOutcome | None:
+    if should_retry_request_error(
+        exc=exc,
+        retry_timeout_exceptions=retry_timeout_exceptions,
+        attempt=attempt,
+        max_retries=max_retries,
+    ):
+        await _sleep_before_retry(backoff_seconds, attempt)
+        return None
+    status_code, payload = communication_failure_result(exc.__class__.__name__)
+    return JsonRequestOutcome(
+        status_code=status_code,
+        payload=payload,
+        failure_kind=_request_error_failure_kind(exc),
+    )
+
+
+async def _send_json_retry_attempt(
+    *,
+    request_kwargs: dict[str, Any],
+    retry_status_codes: set[int] | None,
+    retry_timeout_exceptions: bool,
+    attempt: int,
+    max_retries: int,
+    backoff_seconds: float,
+) -> JsonRequestOutcome | None:
+    try:
+        response = await _send_json_request_once(**request_kwargs)
+        return await _retry_or_return_json_response(
+            response=response,
+            retry_status_codes=retry_status_codes,
+            attempt=attempt,
+            max_retries=max_retries,
+            backoff_seconds=backoff_seconds,
+        )
+    except httpx.RequestError as exc:
+        return await _retry_or_return_request_error(
+            exc=exc,
+            retry_timeout_exceptions=retry_timeout_exceptions,
+            attempt=attempt,
+            max_retries=max_retries,
+            backoff_seconds=backoff_seconds,
+        )
+
+
+async def _sleep_before_retry(backoff_seconds: float, attempt: int) -> None:
+    await asyncio.sleep(retry_delay(backoff_seconds, attempt))
+
+
+def _json_request_kwargs(
+    *,
+    request_method: str,
+    url: str,
+    timeout_seconds: float,
+    params: dict[str, Any] | None,
+    headers: dict[str, str] | None,
+    json_body: dict[str, Any] | None,
+    data: dict[str, Any] | None,
+    files: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "request_method": request_method,
+        "url": url,
+        "timeout_seconds": timeout_seconds,
+        "params": params,
+        "headers": headers,
+        "json_body": json_body,
+        "data": data,
+        "files": files,
+    }
+
+
+async def _execute_json_request(
+    *,
+    request_kwargs: dict[str, Any],
+    retry_status_codes: set[int] | None,
+    retry_timeout_exceptions: bool,
+    max_retries: int,
+    backoff_seconds: float,
+) -> JsonRequestOutcome:
+    for attempt in range(retry_attempts(max_retries)):
+        result = await _send_json_retry_attempt(
+            request_kwargs=request_kwargs,
+            retry_status_codes=retry_status_codes,
+            retry_timeout_exceptions=retry_timeout_exceptions,
+            attempt=attempt,
+            max_retries=max_retries,
+            backoff_seconds=backoff_seconds,
+        )
+        if result is not None:
+            return result
+    status_code, payload = communication_failure_result("exhausted retries")
+    return JsonRequestOutcome(
+        status_code=status_code,
+        payload=payload,
+        failure_kind=RequestFailureKind.RETRIES_EXHAUSTED,
+    )
+
+
+async def request_with_retry_outcome(
+    *,
+    method: str,
+    url: str,
+    timeout_seconds: float,
+    max_retries: int = 2,
+    backoff_seconds: float = 0.2,
+    retry_status_codes: set[int] | None = None,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    json_body: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None,
+    files: dict[str, Any] | None = None,
+    retry_timeout_exceptions: bool = True,
+) -> JsonRequestOutcome:
+    request_method = method.upper()
+    if request_method not in _JSON_REQUEST_METHODS:
+        return JsonRequestOutcome(
+            status_code=503,
+            payload=unsupported_method_payload(method),
+            failure_kind=RequestFailureKind.UNSUPPORTED_METHOD,
+        )
+    request_kwargs = _json_request_kwargs(
+        request_method=request_method,
+        url=url,
+        timeout_seconds=timeout_seconds,
+        params=params,
+        headers=headers,
+        json_body=json_body,
+        data=data,
+        files=files,
+    )
+    return await _execute_json_request(
+        request_kwargs=request_kwargs,
+        retry_status_codes=retry_status_codes,
+        retry_timeout_exceptions=retry_timeout_exceptions,
+        max_retries=max_retries,
+        backoff_seconds=backoff_seconds,
+    )

--- a/src/app/clients/http_resilience.py
+++ b/src/app/clients/http_resilience.py
@@ -3,9 +3,9 @@ from typing import Any
 
 import httpx
 
+from app.clients.http_json_resilience import request_with_retry_outcome
 from app.clients.http_response_payloads import (
     binary_communication_failure_result,
-    communication_failure_result,
     response_payload,
     unsupported_method_payload,
 )
@@ -17,59 +17,39 @@ from app.clients.http_retry_policy import (
 )
 
 _BINARY_REQUEST_METHODS = frozenset({"GET", "POST"})
-_JSON_REQUEST_METHODS = frozenset({"GET", "POST", "PUT"})
 
 
-async def _send_json_request(
+async def request_with_retry(
     *,
-    client: httpx.AsyncClient,
-    request_method: str,
-    url: str,
-    params: dict[str, Any] | None,
-    headers: dict[str, str] | None,
-    json_body: dict[str, Any] | None,
-    data: dict[str, Any] | None,
-    files: dict[str, Any] | None,
-) -> httpx.Response:
-    if request_method == "GET":
-        return await client.get(url, params=params, headers=headers)
-    if request_method == "PUT":
-        return await client.put(url, headers=headers, json=json_body)
-    return await client.post(
-        url,
-        params=params,
-        headers=headers,
-        json=json_body,
-        data=data,
-        files=files,
-    )
-
-
-async def _send_json_request_once(
-    *,
-    request_method: str,
+    method: str,
     url: str,
     timeout_seconds: float,
-    params: dict[str, Any] | None,
-    headers: dict[str, str] | None,
-    json_body: dict[str, Any] | None,
-    data: dict[str, Any] | None,
-    files: dict[str, Any] | None,
-) -> httpx.Response:
-    async with httpx.AsyncClient(
-        timeout=timeout_seconds,
-        follow_redirects=True,
-    ) as client:
-        return await _send_json_request(
-            client=client,
-            request_method=request_method,
-            url=url,
-            params=params,
-            headers=headers,
-            json_body=json_body,
-            data=data,
-            files=files,
-        )
+    max_retries: int = 2,
+    backoff_seconds: float = 0.2,
+    retry_status_codes: set[int] | None = None,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    json_body: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None,
+    files: dict[str, Any] | None = None,
+    retry_timeout_exceptions: bool = True,
+) -> tuple[int, dict[str, Any]]:
+    """Preserve the stable tuple API while the typed outcome API serves policy-aware callers."""
+    outcome = await request_with_retry_outcome(
+        method=method,
+        url=url,
+        timeout_seconds=timeout_seconds,
+        max_retries=max_retries,
+        backoff_seconds=backoff_seconds,
+        retry_status_codes=retry_status_codes,
+        params=params,
+        headers=headers,
+        json_body=json_body,
+        data=data,
+        files=files,
+        retry_timeout_exceptions=retry_timeout_exceptions,
+    )
+    return outcome.as_result()
 
 
 async def _send_binary_request_once(
@@ -91,72 +71,6 @@ async def _send_binary_request_once(
 
 async def _sleep_before_retry(backoff_seconds: float, attempt: int) -> None:
     await asyncio.sleep(retry_delay(backoff_seconds, attempt))
-
-
-async def _retry_or_return_json_response(
-    *,
-    response: httpx.Response,
-    retry_status_codes: set[int] | None,
-    attempt: int,
-    max_retries: int,
-    backoff_seconds: Any,
-) -> tuple[int, dict[str, Any]] | None:
-    if should_retry_status(
-        response_status_code=response.status_code,
-        retry_status_codes=retry_status_codes,
-        attempt=attempt,
-        max_retries=max_retries,
-    ):
-        await _sleep_before_retry(backoff_seconds, attempt)
-        return None
-    return response.status_code, response_payload(response)
-
-
-async def _retry_or_return_request_error(
-    *,
-    exc: httpx.RequestError,
-    retry_timeout_exceptions: bool,
-    attempt: int,
-    max_retries: int,
-    backoff_seconds: Any,
-) -> tuple[int, dict[str, str]] | None:
-    if not should_retry_request_error(
-        exc=exc,
-        retry_timeout_exceptions=retry_timeout_exceptions,
-        attempt=attempt,
-        max_retries=max_retries,
-    ):
-        return communication_failure_result(exc.__class__.__name__)
-    await _sleep_before_retry(backoff_seconds, attempt)
-    return None
-
-
-async def _send_json_retry_attempt(
-    *,
-    request_kwargs: dict[str, Any],
-    retry_status_codes: set[int] | None,
-    retry_timeout_exceptions: bool,
-    attempt: int,
-    max_retries: int,
-    backoff_seconds: Any,
-) -> tuple[int, dict[str, Any]] | None:
-    try:
-        response = await _send_json_request_once(**request_kwargs)
-        return await _retry_or_return_json_response(
-            response=response,
-            retry_status_codes=retry_status_codes,
-            attempt=attempt,
-            max_retries=max_retries,
-            backoff_seconds=backoff_seconds,
-        )
-    except httpx.RequestError as exc:
-        return await _retry_or_return_request_error(
-            exc=exc,
-            retry_timeout_exceptions=retry_timeout_exceptions,
-            attempt=attempt,
-            max_retries=max_retries,
-            backoff_seconds=backoff_seconds,
-        )
 
 
 async def _retry_or_return_binary_response(
@@ -226,51 +140,6 @@ async def _send_binary_retry_attempt(
             max_retries=max_retries,
             backoff_seconds=backoff_seconds,
         )
-
-
-async def request_with_retry(
-    *,
-    method: str,
-    url: str,
-    timeout_seconds: float,
-    max_retries: int = 2,
-    backoff_seconds: float = 0.2,
-    retry_status_codes: set[int] | None = None,
-    params: dict[str, Any] | None = None,
-    headers: dict[str, str] | None = None,
-    json_body: dict[str, Any] | None = None,
-    data: dict[str, Any] | None = None,
-    files: dict[str, Any] | None = None,
-    retry_timeout_exceptions: bool = True,
-) -> tuple[int, dict[str, Any]]:
-    request_method = method.upper()
-    if request_method not in _JSON_REQUEST_METHODS:
-        return 503, unsupported_method_payload(method)
-
-    request_kwargs = {
-        "request_method": request_method,
-        "url": url,
-        "timeout_seconds": timeout_seconds,
-        "params": params,
-        "headers": headers,
-        "json_body": json_body,
-        "data": data,
-        "files": files,
-    }
-    attempts = retry_attempts(max_retries)
-    for attempt in range(attempts):
-        result = await _send_json_retry_attempt(
-            request_kwargs=request_kwargs,
-            retry_status_codes=retry_status_codes,
-            retry_timeout_exceptions=retry_timeout_exceptions,
-            attempt=attempt,
-            max_retries=max_retries,
-            backoff_seconds=backoff_seconds,
-        )
-        if result is not None:
-            return result
-
-    return communication_failure_result("exhausted retries")
 
 
 async def request_binary_with_retry(

--- a/src/app/clients/lotus_analytics_async_polling.py
+++ b/src/app/clients/lotus_analytics_async_polling.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import math
-import time
 from dataclasses import dataclass
 from typing import Any
 
-from app.clients.http_resilience import request_with_retry
+from app.clients.analytics_poll_budget import (
+    AnalyticsPollBudget,
+    AnalyticsRequestDeadlineExceeded,
+)
+from app.clients.http_json_resilience import (
+    JsonRequestOutcome,
+    request_with_retry_outcome,
+)
 from app.clients.upstream_headers import build_upstream_headers
 from app.contracts.analytics_async import (
     ASYNC_POLL_DEADLINE_EXHAUSTED_REASON,
@@ -21,71 +26,21 @@ from app.observability.analytics_ui import (
 logger = logging.getLogger("analytics_ui.gateway")
 
 
-@dataclass(frozen=True)
-class AnalyticsPollBudget:
-    """Elapsed-time policy for one analytics submission and its result reads."""
-
-    deadline_at: float | None
-
-    @classmethod
-    def from_timeout(cls, timeout_seconds: float | None) -> AnalyticsPollBudget:
-        deadline_at = None if timeout_seconds is None else time.monotonic() + timeout_seconds
-        return cls(deadline_at=deadline_at)
-
-    @classmethod
-    def unbounded(cls) -> AnalyticsPollBudget:
-        return cls(deadline_at=None)
-
-    def remaining_seconds(self) -> float | None:
-        if self.deadline_at is None:
-            return None
-        return self.deadline_at - time.monotonic()
-
-    @property
-    def is_bounded(self) -> bool:
-        return self.deadline_at is not None
-
-    def request_max_retries(self, default_retries: int) -> int:
-        return 0 if self.is_bounded else default_retries
-
-    def request_timeout(self, default_seconds: float) -> float:
-        remaining_seconds = self.remaining_seconds()
-        if remaining_seconds is None:
-            return default_seconds
-        return min(default_seconds, max(remaining_seconds, 0.001))
-
-    def poll_interval(self, *, payload: dict[str, Any], fallback_seconds: float) -> float:
-        interval_seconds = _recommended_poll_interval(payload, fallback_seconds)
-        remaining_seconds = self.remaining_seconds()
-        if remaining_seconds is None:
-            return interval_seconds
-        return min(interval_seconds, max(remaining_seconds, 0.0))
-
-
 def build_async_poll_deadline_payload(
-    *, result_path: str, accepted_payload: dict[str, Any] | None
+    *, result_path: str | None, accepted_payload: dict[str, Any] | None
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "detail": "analytics result did not complete within the governed Gateway deadline",
         "error_code": ASYNC_RESULT_DEADLINE_EXHAUSTED,
         "state": "degraded",
         "reason": ASYNC_POLL_DEADLINE_EXHAUSTED_REASON,
-        "result_path": result_path,
     }
+    if result_path:
+        payload["result_path"] = result_path
     calculation_id = (accepted_payload or {}).get("calculation_id")
     if isinstance(calculation_id, str) and calculation_id:
         payload["calculation_id"] = calculation_id
     return payload
-
-
-def _recommended_poll_interval(payload: dict[str, Any], fallback_seconds: float) -> float:
-    recommended = payload.get("recommended_poll_after_seconds")
-    if isinstance(recommended, bool) or not isinstance(recommended, int | float):
-        return fallback_seconds
-    resolved = float(recommended)
-    if not math.isfinite(resolved) or resolved <= 0:
-        return fallback_seconds
-    return resolved
 
 
 @dataclass(frozen=True)
@@ -186,27 +141,46 @@ class LotusAnalyticsAsyncPollingMixin:
             deadline_result = self._expired_poll_deadline_result(context)
             if deadline_result is not None:
                 return deadline_result
-            state.status_code, state.payload = await self._poll_analytics_result_once(
-                context=context
-            )
+            try:
+                outcome = await self._poll_analytics_result_once(context=context)
+            except AnalyticsRequestDeadlineExceeded:
+                return self._async_poll_deadline_result(context)
+            state.status_code = outcome.status_code
+            state.payload = outcome.payload
             state.attempts += 1
             deadline_result = self._expired_poll_deadline_result(context)
             if deadline_result is not None:
                 return deadline_result
-            if state.status_code != 202:
-                self._emit_analytics_read_audit(
-                    operation=f"{context.operation}.poll",
-                    status_code=state.status_code,
-                )
-                return state.status_code, state.payload
-            deadline_result = await self._wait_for_next_async_poll(
+            poll_result = await self._result_after_poll_outcome(
                 context=context,
-                payload=state.payload,
+                outcome=outcome,
                 fallback_seconds=poll_interval_seconds,
             )
-            if deadline_result is not None:
-                return deadline_result
+            if poll_result is not None:
+                return poll_result
         return state.status_code, state.payload
+
+    async def _result_after_poll_outcome(
+        self,
+        *,
+        context: _AnalyticsPollContext,
+        outcome: JsonRequestOutcome,
+        fallback_seconds: float,
+    ) -> tuple[int, dict[str, Any]] | None:
+        should_continue = outcome.status_code == 202 or (
+            context.budget.is_bounded and outcome.is_transient_transport_failure
+        )
+        if should_continue:
+            return await self._wait_for_next_async_poll(
+                context=context,
+                payload=outcome.payload,
+                fallback_seconds=fallback_seconds,
+            )
+        self._emit_analytics_read_audit(
+            operation=f"{context.operation}.poll",
+            status_code=outcome.status_code,
+        )
+        return outcome.as_result()
 
     async def _wait_for_initial_async_poll(
         self,
@@ -253,26 +227,28 @@ class LotusAnalyticsAsyncPollingMixin:
 
     async def _poll_analytics_result_once(
         self, *, context: _AnalyticsPollContext
-    ) -> tuple[int, dict[str, Any]]:
+    ) -> JsonRequestOutcome:
         started_at = gateway_analytics_fanout_timer()
-        status_code, payload = await request_with_retry(
-            method="GET",
-            url=context.url,
-            timeout_seconds=context.budget.request_timeout(self._timeout),
-            max_retries=context.budget.request_max_retries(self._max_retries),
-            backoff_seconds=self._retry_backoff_seconds,
-            headers=context.headers,
-            retry_timeout_exceptions=not context.budget.is_bounded,
+        outcome = await context.budget.run_request(
+            lambda: request_with_retry_outcome(
+                method="GET",
+                url=context.url,
+                timeout_seconds=context.budget.request_timeout(self._timeout),
+                max_retries=context.budget.request_max_retries(self._max_retries),
+                backoff_seconds=self._retry_backoff_seconds,
+                headers=context.headers,
+                retry_timeout_exceptions=not context.budget.is_bounded,
+            )
         )
         emit_gateway_analytics_fanout_log(
             logger=logger,
             started_at=started_at,
             service=context.service,
             operation=f"{context.operation}.poll",
-            status_code=status_code,
-            payload=payload,
+            status_code=outcome.status_code,
+            payload=outcome.payload,
         )
-        return status_code, payload
+        return outcome
 
     @staticmethod
     def _async_poll_deadline_result(

--- a/src/app/clients/lotus_analytics_client.py
+++ b/src/app/clients/lotus_analytics_client.py
@@ -1,10 +1,16 @@
 import logging
 from typing import Any
 
+from app.clients.http_json_resilience import (
+    JsonRequestOutcome,
+    request_with_retry_outcome,
+)
 from app.clients.http_resilience import request_with_retry
 from app.clients.lotus_analytics_async_polling import (
     AnalyticsPollBudget,
+    AnalyticsRequestDeadlineExceeded,
     LotusAnalyticsAsyncPollingMixin,
+    build_async_poll_deadline_payload,
 )
 from app.clients.lotus_analytics_performance_client import LotusAnalyticsPerformanceClientMixin
 from app.clients.lotus_analytics_risk_client import LotusAnalyticsRiskClientMixin
@@ -141,25 +147,53 @@ class LotusAnalyticsClient(
         request_budget: AnalyticsPollBudget,
     ) -> tuple[int, dict[str, Any]]:
         started_at = gateway_analytics_fanout_timer()
-        status_code, response_payload = await request_with_retry(
-            method="POST",
-            url=url,
-            timeout_seconds=request_budget.request_timeout(self._timeout),
-            max_retries=request_budget.request_max_retries(self._max_retries),
-            backoff_seconds=self._retry_backoff_seconds,
-            json_body=payload,
-            headers=headers,
-            retry_timeout_exceptions=False,
-        )
+        try:
+            outcome = await request_budget.run_request(
+                lambda: request_with_retry_outcome(
+                    method="POST",
+                    url=url,
+                    timeout_seconds=request_budget.request_timeout(self._timeout),
+                    max_retries=request_budget.request_max_retries(self._max_retries),
+                    backoff_seconds=self._retry_backoff_seconds,
+                    json_body=payload,
+                    headers=headers,
+                    retry_timeout_exceptions=False,
+                )
+            )
+        except AnalyticsRequestDeadlineExceeded:
+            outcome = self._submission_deadline_outcome()
+        if request_budget.is_expired and outcome.status_code != 504:
+            outcome = self._submission_deadline_outcome(outcome)
         emit_gateway_analytics_fanout_log(
             logger=logger,
             started_at=started_at,
             service=service,
             operation=operation,
-            status_code=status_code,
-            payload=response_payload,
+            status_code=outcome.status_code,
+            payload=outcome.payload,
         )
-        return status_code, response_payload
+        return outcome.as_result()
+
+    @classmethod
+    def _submission_deadline_outcome(
+        cls,
+        accepted_outcome: JsonRequestOutcome | None = None,
+    ) -> JsonRequestOutcome:
+        result_path = None
+        accepted_payload = None
+        if accepted_outcome is not None and accepted_outcome.status_code == 202:
+            accepted_payload = accepted_outcome.payload
+            result_path = cls._async_result_path(
+                status_code=accepted_outcome.status_code,
+                response_payload=accepted_outcome.payload,
+            )
+        return JsonRequestOutcome(
+            status_code=504,
+            payload=build_async_poll_deadline_payload(
+                result_path=result_path,
+                accepted_payload=accepted_payload,
+            ),
+        )
 
     @staticmethod
     def _async_result_path(

--- a/tests/unit/test_http_resilience.py
+++ b/tests/unit/test_http_resilience.py
@@ -5,6 +5,10 @@ from pathlib import Path
 import httpx
 import pytest
 
+from app.clients.http_json_resilience import (
+    RequestFailureKind,
+    request_with_retry_outcome,
+)
 from app.clients.http_resilience import request_binary_with_retry, request_with_retry
 from app.clients.http_response_payloads import (
     binary_communication_failure_result,
@@ -380,6 +384,41 @@ async def test_request_with_retry_returns_503_after_network_error(monkeypatch):
 
     assert status == 503
     assert payload["detail"] == "upstream communication failure: NetworkError"
+
+
+@pytest.mark.asyncio
+async def test_request_outcome_classifies_transport_failure_without_parsing_payload(monkeypatch):
+    monkeypatch.setattr("httpx.AsyncClient", _NetworkErrorAsyncClient)
+
+    outcome = await request_with_retry_outcome(
+        method="GET",
+        url="http://service/health",
+        timeout_seconds=1.0,
+        max_retries=0,
+        backoff_seconds=0.0,
+    )
+
+    assert outcome.status_code == 503
+    assert outcome.failure_kind == RequestFailureKind.TRANSPORT
+    assert outcome.is_transient_transport_failure is True
+
+
+@pytest.mark.asyncio
+async def test_request_outcome_keeps_source_503_distinct_from_transport_failure(monkeypatch):
+    monkeypatch.setattr("httpx.AsyncClient", _RetryStatusAsyncClient)
+    _RetryStatusAsyncClient.calls = 0
+
+    outcome = await request_with_retry_outcome(
+        method="GET",
+        url="http://service/health",
+        timeout_seconds=1.0,
+        max_retries=0,
+        backoff_seconds=0.0,
+    )
+
+    assert outcome.status_code == 503
+    assert outcome.failure_kind is None
+    assert outcome.is_transient_transport_failure is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_lotus_analytics_async_deadline.py
+++ b/tests/unit/test_lotus_analytics_async_deadline.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Awaitable
 from typing import Any
 
 import pytest
 
+from app.clients.analytics_poll_budget import AnalyticsPollBudget
+from app.clients.http_json_resilience import JsonRequestOutcome, RequestFailureKind
 from app.clients.lotus_analytics_client import LotusAnalyticsClient
 
 
@@ -41,29 +44,32 @@ def _workspace_summary_call(client: LotusAnalyticsClient) -> Awaitable[tuple[int
 
 def _install_transport(
     monkeypatch: pytest.MonkeyPatch,
-    responses: list[tuple[int, dict[str, Any]]],
+    responses: list[tuple[int, dict[str, Any]] | JsonRequestOutcome],
 ) -> list[dict[str, Any]]:
     calls: list[dict[str, Any]] = []
 
-    async def _request_with_retry(**kwargs: Any) -> tuple[int, dict[str, Any]]:
+    async def _request_with_retry(**kwargs: Any) -> JsonRequestOutcome:
         calls.append(kwargs)
         if not responses:
             raise AssertionError("No queued analytics response available.")
-        return responses.pop(0)
+        response = responses.pop(0)
+        if isinstance(response, JsonRequestOutcome):
+            return response
+        return JsonRequestOutcome(*response)
 
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.request_with_retry",
+        "app.clients.lotus_analytics_client.request_with_retry_outcome",
         _request_with_retry,
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_async_polling.request_with_retry",
+        "app.clients.lotus_analytics_async_polling.request_with_retry_outcome",
         _request_with_retry,
     )
     return calls
 
 
 def _install_clock(monkeypatch: pytest.MonkeyPatch, clock: _Clock) -> None:
-    monkeypatch.setattr("app.clients.lotus_analytics_async_polling.time.monotonic", clock.monotonic)
+    monkeypatch.setattr("app.clients.analytics_poll_budget.time.monotonic", clock.monotonic)
     monkeypatch.setattr("app.clients.lotus_analytics_async_polling.asyncio.sleep", clock.sleep)
 
 
@@ -121,21 +127,24 @@ async def test_workspace_summary_waits_for_accepted_response_cadence_before_firs
     accepted_status, accepted_payload = _accepted_response()
     accepted_payload["recommended_poll_after_seconds"] = 1.75
 
-    async def _request_with_retry(**kwargs: Any) -> tuple[int, dict[str, Any]]:
+    async def _request_with_retry(**kwargs: Any) -> JsonRequestOutcome:
         call_times.append((kwargs["method"], clock.now))
         if kwargs["method"] == "POST":
-            return accepted_status, accepted_payload
-        return 200, {
-            "calculation_id": "calc-workspace-summary",
-            "results_by_period": {"SI": {}},
-        }
+            return JsonRequestOutcome(accepted_status, accepted_payload)
+        return JsonRequestOutcome(
+            200,
+            {
+                "calculation_id": "calc-workspace-summary",
+                "results_by_period": {"SI": {}},
+            },
+        )
 
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.request_with_retry",
+        "app.clients.lotus_analytics_client.request_with_retry_outcome",
         _request_with_retry,
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_async_polling.request_with_retry",
+        "app.clients.lotus_analytics_async_polling.request_with_retry_outcome",
         _request_with_retry,
     )
     client = LotusAnalyticsClient(
@@ -229,19 +238,19 @@ async def test_workspace_summary_submission_and_polls_share_one_completion_budge
     _install_clock(monkeypatch, clock)
     calls: list[dict[str, Any]] = []
 
-    async def _request_with_retry(**kwargs: Any) -> tuple[int, dict[str, Any]]:
+    async def _request_with_retry(**kwargs: Any) -> JsonRequestOutcome:
         calls.append(kwargs)
         if kwargs["method"] == "POST":
             clock.now += 2.0
-            return _accepted_response()
-        return _pending_response()
+            return JsonRequestOutcome(*_accepted_response())
+        return JsonRequestOutcome(*_pending_response())
 
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.request_with_retry",
+        "app.clients.lotus_analytics_client.request_with_retry_outcome",
         _request_with_retry,
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_async_polling.request_with_retry",
+        "app.clients.lotus_analytics_async_polling.request_with_retry_outcome",
         _request_with_retry,
     )
     client = LotusAnalyticsClient(
@@ -291,19 +300,23 @@ async def test_final_poll_timeout_is_reported_as_governed_deadline_exhaustion(
     _install_clock(monkeypatch, clock)
     calls: list[dict[str, Any]] = []
 
-    async def _request_with_retry(**kwargs: Any) -> tuple[int, dict[str, Any]]:
+    async def _request_with_retry(**kwargs: Any) -> JsonRequestOutcome:
         calls.append(kwargs)
         if kwargs["method"] == "POST":
-            return _accepted_response()
+            return JsonRequestOutcome(*_accepted_response())
         clock.now += kwargs["timeout_seconds"]
-        return 503, {"detail": "upstream communication failure: ReadTimeout"}
+        return JsonRequestOutcome(
+            503,
+            {"detail": "upstream communication failure: ReadTimeout"},
+            RequestFailureKind.TIMEOUT,
+        )
 
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.request_with_retry",
+        "app.clients.lotus_analytics_client.request_with_retry_outcome",
         _request_with_retry,
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_async_polling.request_with_retry",
+        "app.clients.lotus_analytics_async_polling.request_with_retry_outcome",
         _request_with_retry,
     )
     client = LotusAnalyticsClient(
@@ -341,6 +354,192 @@ async def test_workspace_summary_terminal_poll_failure_returns_without_resubmiss
 
 
 @pytest.mark.asyncio
+async def test_bounded_poll_continues_after_typed_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+    final_payload = {
+        "calculation_id": "calc-workspace-summary",
+        "results_by_period": {"YTD": {}},
+    }
+    calls = _install_transport(
+        monkeypatch,
+        [
+            _accepted_response(),
+            JsonRequestOutcome(
+                503,
+                {"detail": "upstream communication failure: NetworkError"},
+                RequestFailureKind.TRANSPORT,
+            ),
+            (200, final_payload),
+        ],
+    )
+    client = LotusAnalyticsClient(
+        base_url="http://analytics",
+        timeout_seconds=15.0,
+        workspace_summary_deadline_seconds=5.0,
+    )
+
+    status_code, payload = await _workspace_summary_call(client)
+
+    assert status_code == 200
+    assert payload == final_payload
+    assert [call["method"] for call in calls] == ["POST", "GET", "GET"]
+    assert clock.sleeps == [1.0, 0.35]
+
+
+@pytest.mark.asyncio
+async def test_bounded_poll_transport_failures_stop_at_elapsed_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+    transport_failure = JsonRequestOutcome(
+        503,
+        {"detail": "upstream communication failure: RemoteProtocolError"},
+        RequestFailureKind.TRANSPORT,
+    )
+    calls = _install_transport(
+        monkeypatch,
+        [_accepted_response(), transport_failure, transport_failure, transport_failure],
+    )
+    client = LotusAnalyticsClient(
+        base_url="http://analytics",
+        timeout_seconds=15.0,
+        workspace_summary_deadline_seconds=2.0,
+    )
+
+    status_code, payload = await _workspace_summary_call(client)
+
+    assert status_code == 504
+    assert payload["error_code"] == "ASYNC_RESULT_DEADLINE_EXHAUSTED"
+    assert payload["calculation_id"] == "calc-workspace-summary"
+    assert [call["method"] for call in calls] == ["POST", "GET", "GET", "GET"]
+    assert clock.now == pytest.approx(102.0)
+
+
+@pytest.mark.asyncio
+async def test_source_503_remains_terminal_for_bounded_poll(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+    calls = _install_transport(
+        monkeypatch,
+        [_accepted_response(), (503, {"detail": "calculation failed"})],
+    )
+    client = LotusAnalyticsClient(
+        base_url="http://analytics",
+        timeout_seconds=15.0,
+        workspace_summary_deadline_seconds=5.0,
+    )
+
+    status_code, payload = await _workspace_summary_call(client)
+
+    assert status_code == 503
+    assert payload == {"detail": "calculation failed"}
+    assert [call["method"] for call in calls] == ["POST", "GET"]
+
+
+@pytest.mark.asyncio
+async def test_submission_timeout_after_budget_expiry_maps_to_deadline_without_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+    calls: list[dict[str, Any]] = []
+
+    async def _request_with_retry(**kwargs: Any) -> JsonRequestOutcome:
+        calls.append(kwargs)
+        clock.now += 2.5
+        return JsonRequestOutcome(
+            503,
+            {"detail": "upstream communication failure: ReadTimeout"},
+            RequestFailureKind.TIMEOUT,
+        )
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.request_with_retry_outcome",
+        _request_with_retry,
+    )
+    client = LotusAnalyticsClient(
+        base_url="http://analytics",
+        timeout_seconds=15.0,
+        workspace_summary_deadline_seconds=2.5,
+    )
+
+    status_code, payload = await _workspace_summary_call(client)
+
+    assert status_code == 504
+    assert payload["error_code"] == "ASYNC_RESULT_DEADLINE_EXHAUSTED"
+    assert "calculation_id" not in payload
+    assert "result_path" not in payload
+    assert [call["method"] for call in calls] == ["POST"]
+
+
+@pytest.mark.asyncio
+async def test_submission_complete_await_is_bounded_by_wall_clock_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _slow_request(**kwargs: Any) -> JsonRequestOutcome:  # noqa: ARG001
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+        return JsonRequestOutcome(*_accepted_response())
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_client.request_with_retry_outcome",
+        _slow_request,
+    )
+    client = LotusAnalyticsClient(
+        base_url="http://analytics",
+        timeout_seconds=15.0,
+        workspace_summary_deadline_seconds=0.04,
+    )
+
+    started_at = time.perf_counter()
+    status_code, payload = await _workspace_summary_call(client)
+    elapsed_seconds = time.perf_counter() - started_at
+
+    assert status_code == 504
+    assert payload["error_code"] == "ASYNC_RESULT_DEADLINE_EXHAUSTED"
+    assert elapsed_seconds < 0.15
+
+
+@pytest.mark.asyncio
+async def test_poll_complete_await_is_bounded_by_wall_clock_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _slow_request(**kwargs: Any) -> JsonRequestOutcome:  # noqa: ARG001
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+        return JsonRequestOutcome(200, {"status": "ready"})
+
+    monkeypatch.setattr(
+        "app.clients.lotus_analytics_async_polling.request_with_retry_outcome",
+        _slow_request,
+    )
+    client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=15.0)
+    poll_budget = AnalyticsPollBudget.from_timeout(0.04)
+
+    started_at = time.perf_counter()
+    status_code, payload = await client._poll_async_result(
+        result_path="/performance/workspace-summary/results/calc-workspace-summary",
+        correlation_id="corr-wall-clock",
+        service="lotus-performance",
+        operation="performance.workspace-summary",
+        poll_budget=poll_budget,
+        accepted_payload=None,
+    )
+    elapsed_seconds = time.perf_counter() - started_at
+
+    assert status_code == 504
+    assert payload["error_code"] == "ASYNC_RESULT_DEADLINE_EXHAUSTED"
+    assert payload["result_path"].endswith("calc-workspace-summary")
+    assert elapsed_seconds < 0.15
+
+
+@pytest.mark.asyncio
 async def test_outer_caller_cancellation_does_not_resubmit_workspace_summary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -348,22 +547,22 @@ async def test_outer_caller_cancellation_does_not_resubmit_workspace_summary(
     release_poll = asyncio.Event()
     calls: list[dict[str, Any]] = []
 
-    async def _request_with_retry(**kwargs: Any) -> tuple[int, dict[str, Any]]:
+    async def _request_with_retry(**kwargs: Any) -> JsonRequestOutcome:
         calls.append(kwargs)
         if kwargs["method"] == "POST":
             status_code, payload = _accepted_response()
             payload["recommended_poll_after_seconds"] = 0.01
-            return status_code, payload
+            return JsonRequestOutcome(status_code, payload)
         poll_started.set()
         await release_poll.wait()
-        return _pending_response()
+        return JsonRequestOutcome(*_pending_response())
 
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.request_with_retry",
+        "app.clients.lotus_analytics_client.request_with_retry_outcome",
         _request_with_retry,
     )
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_async_polling.request_with_retry",
+        "app.clients.lotus_analytics_async_polling.request_with_retry_outcome",
         _request_with_retry,
     )
     client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=15.0)

--- a/tests/unit/test_performance_summary_deadline_documentation.py
+++ b/tests/unit/test_performance_summary_deadline_documentation.py
@@ -14,6 +14,8 @@ def test_performance_summary_deadline_is_durable_across_operator_and_product_tru
     supported_features = _read("docs/supported-features.md")
     wiki = _read("wiki/Supported-Features.md")
     context = _read("REPOSITORY-ENGINEERING-CONTEXT.md")
+    standard_normalized = " ".join(standard.lower().split())
+    wiki_normalized = " ".join(wiki.lower().split())
 
     for document in (standard, wiki, context):
         normalized = " ".join(document.lower().split())
@@ -28,6 +30,11 @@ def test_performance_summary_deadline_is_durable_across_operator_and_product_tru
     assert "PERFORMANCE_WORKSPACE_SUMMARY_DEADLINE_EXHAUSTED" in standard
     assert "before the first result read" in standard
     assert "execution or lineage evidence reads" in standard
+    assert "complete http await" in standard_normalized
+    assert "typed transient transport" in standard_normalized
+    assert "submission acceptance is unknown" in standard_normalized
     assert "warm retry" in supported_features
+    assert "slow multi-phase or response-trickle" in supported_features
     assert "blind retry" in wiki
+    assert "complete-await cancellation" in wiki_normalized
     assert "warm response" in wiki

--- a/tests/unit/test_upstream_clients.py
+++ b/tests/unit/test_upstream_clients.py
@@ -1233,14 +1233,21 @@ async def test_lotus_analytics_client_preserves_workspace_summary_conflict_ident
 
 @pytest.mark.asyncio
 async def test_lotus_analytics_client_disables_timeout_retries_for_workspace_summary(monkeypatch):
+    from app.clients.http_json_resilience import JsonRequestOutcome, RequestFailureKind
+
     captured: list[dict] = []
 
     async def _fake_request_with_retry(**kwargs):
         captured.append(kwargs)
-        return 503, {"detail": "upstream communication failure: TimeoutException"}
+        return JsonRequestOutcome(
+            503,
+            {"detail": "upstream communication failure: TimeoutException"},
+            RequestFailureKind.TIMEOUT,
+        )
 
     monkeypatch.setattr(
-        "app.clients.lotus_analytics_client.request_with_retry", _fake_request_with_retry
+        "app.clients.lotus_analytics_client.request_with_retry_outcome",
+        _fake_request_with_retry,
     )
 
     client = LotusAnalyticsClient(base_url="http://analytics", timeout_seconds=15.0)

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -17,7 +17,11 @@ Business outcome:
    minimum polling cadence before the first and subsequent result reads,
 3. if the source calculation is still pending at the deadline, the screen receives explicit
    deadline-exhausted partial-readiness warnings before its connection closes rather than depending
-   on a blind retry, and Gateway does not add execution or lineage evidence reads after expiry.
+   on a blind retry, and Gateway does not add execution or lineage evidence reads after expiry,
+4. the complete submission and result-read awaits stay inside the elapsed budget even when a
+   connection uses multiple transport phases or returns a slow trickle of response bytes; bounded
+   transient transport failures can be retried by the polling loop without hiding source HTTP
+   failures.
 
 Authority and boundary:
 
@@ -27,9 +31,11 @@ Authority and boundary:
    authorization, tenant, and portfolio scope through polling; it does not submit a replacement
    calculation after an identity conflict,
 3. Gateway owns the elapsed deadline, remaining-budget request timeouts, caller-visible
-   deadline-specific partial-readiness mapping, and bounded reason-coded telemetry,
+   deadline-specific partial-readiness mapping, typed transport outcome handling, complete-await
+   cancellation, and bounded reason-coded telemetry,
 4. deadline exhaustion does not prove a calculation failure, permit duplicate financial work, or
-   make a later warm response valid readiness evidence on its own.
+   make a later warm response valid readiness evidence on its own; if the source has not published
+   acceptance, Gateway omits calculation identity and result location instead of inventing them.
 
 ## Authenticated Advisor Book
 


### PR DESCRIPTION
## Outcome

Completes the transport-edge correctness follow-up from PR #534 for the governed performance-summary completion deadline.

## Changes

- adds typed JSON transport outcomes without parsing synthetic error text
- wraps complete bounded POST and GET awaits in the remaining monotonic budget
- keeps bounded transient transport failures in the outer polling loop while budget remains
- preserves terminal source HTTP failures
- reclassifies post-submission deadline exhaustion truthfully and omits unknown calculation identity
- updates standards, supported-feature truth, repository context, and wiki source

## Validation

- focused deadline/resilience/upstream/documentation suite: 233 passed
- `make check`: 1,653 passed
- `make ci`: 249 integration passed; 1,902 combined passed; 94.54% coverage
- dependency audit: no known vulnerabilities under governed PYSEC-2026-161 compatibility exception
- wiki pre-merge check: one intentional unpublished source change

## Issue posture

Implements #536. Issue #536 remains open pending merge, wiki publication, and exact-main canonical proof. Parent #507 remains open until canonical proof closes the full program.