### PR TITLE
feat(advisor-brief): preserve source review evidence

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -174,6 +174,10 @@ Current repository posture:
     `top_position_weight_current`, `top_position_weight_proposed`, `top_position_weight_delta`,
     `top_position_current`, and `top_position_proposed`; `TOP_POSITION_WEIGHT` methodology truth
     remains owned by `lotus-risk`.
+    Advisor-brief workflow-pack mapping preserves Lotus AI's source-recorded latest review actor,
+    latest review event time, transition count, and history flag. Consumers must fail closed when
+    that evidence is absent or malformed; terminal `review_state` is not sufficient evidence of a
+    recorded human decision.
 17. performance workspace-summary orchestration uses
     `PERFORMANCE_SUMMARY_DEADLINE_SECONDS=30` as an end-to-end monotonic budget across submission
     and polling, while `PERFORMANCE_ANALYTICS_TIMEOUT_SECONDS=15` remains a per-call ceiling.

--- a/src/app/contracts/advisor_brief_examples.py
+++ b/src/app/contracts/advisor_brief_examples.py
@@ -145,6 +145,10 @@ ADVISOR_BRIEF_RESPONSE_EXAMPLE: dict[str, Any] = {
         "run_id": "packrun_advisor_brief_air_123",
         "runtime_state": "COMPLETED",
         "review_state": "AWAITING_REVIEW",
+        "latest_review_event_at": None,
+        "latest_review_actor": None,
+        "review_transition_count": 0,
+        "has_review_history": False,
         "allowed_review_actions": [
             "ACCEPT",
             "REJECT",

--- a/src/app/contracts/advisor_brief_workflow.py
+++ b/src/app/contracts/advisor_brief_workflow.py
@@ -61,6 +61,38 @@ class AdvisorBriefWorkflowPackRun(BaseModel):
         description="Current lotus-ai review state for the workflow-pack run.",
         examples=["AWAITING_REVIEW"],
     )
+    latest_review_event_at: str | None = Field(
+        default=None,
+        description=(
+            "UTC timestamp of the latest source-recorded lotus-ai review transition, when "
+            "review history is available."
+        ),
+        examples=["2026-04-21T03:22:00Z"],
+    )
+    latest_review_actor: str | None = Field(
+        default=None,
+        description=(
+            "Actor recorded by lotus-ai on the latest review transition, when review history "
+            "is available."
+        ),
+        examples=["advisor_1"],
+    )
+    review_transition_count: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Source-reported count of review-state transitions linked to the workflow-pack run."
+        ),
+        examples=[1],
+    )
+    has_review_history: bool | None = Field(
+        default=None,
+        description=(
+            "Source-reported indication that lotus-ai retains review-transition history for "
+            "the run."
+        ),
+        examples=[True],
+    )
     allowed_review_actions: list[str] = Field(
         default_factory=list,
         description=(

--- a/src/app/services/advisor_brief_workflow_pack.py
+++ b/src/app/services/advisor_brief_workflow_pack.py
@@ -118,6 +118,10 @@ def _parse_workflow_pack_run_profile(
         run_id=_safe_str(operator_payload.get("run_id")) or profile.run_id,
         runtime_state=_safe_str(operator_payload.get("runtime_state")) or "UNKNOWN",
         review_state=_safe_str(operator_payload.get("review_state")) or "UNKNOWN",
+        latest_review_event_at=_safe_str(review.get("latest_review_event_at")),
+        latest_review_actor=_safe_str(review.get("latest_review_actor")),
+        review_transition_count=_safe_non_negative_int(review.get("review_transition_count")),
+        has_review_history=_safe_bool(review.get("has_review_history")),
         allowed_review_actions=[
             action
             for action in (_safe_str(value) for value in _safe_list(review.get("allowed_actions")))
@@ -198,3 +202,13 @@ def _safe_str(value: Any) -> str | None:
     if isinstance(value, str) and value.strip():
         return value.strip()
     return None
+
+
+def _safe_non_negative_int(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _safe_bool(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None

--- a/src/app/services/advisor_brief_workflow_pack.py
+++ b/src/app/services/advisor_brief_workflow_pack.py
@@ -25,6 +25,14 @@ class _WorkflowPackRunProfile:
     operator_payload: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class _ReviewEvidence:
+    latest_event_at: str | None = None
+    latest_actor: str | None = None
+    transition_count: int | None = None
+    has_history: bool | None = None
+
+
 def assert_advisor_brief_review_action_allowed(
     *,
     workflow_pack_run: AdvisorBriefWorkflowPackRun | None,
@@ -106,6 +114,7 @@ def _parse_workflow_pack_run_profile(
     profile: _WorkflowPackRunProfile,
 ) -> AdvisorBriefWorkflowPackRun:
     review = _safe_dict(profile.consumer_payload.get("review"))
+    review_evidence = _parse_review_evidence(review)
     lineage = _safe_dict(profile.consumer_payload.get("lineage"))
     operator_payload = profile.operator_payload
     findings = [
@@ -120,10 +129,10 @@ def _parse_workflow_pack_run_profile(
         run_id=_safe_str(operator_payload.get("run_id")) or profile.run_id,
         runtime_state=_safe_str(operator_payload.get("runtime_state")) or "UNKNOWN",
         review_state=_safe_str(operator_payload.get("review_state")) or "UNKNOWN",
-        latest_review_event_at=_safe_utc_timestamp(review.get("latest_review_event_at")),
-        latest_review_actor=_safe_str(review.get("latest_review_actor")),
-        review_transition_count=_safe_non_negative_int(review.get("review_transition_count")),
-        has_review_history=_safe_bool(review.get("has_review_history")),
+        latest_review_event_at=review_evidence.latest_event_at,
+        latest_review_actor=review_evidence.latest_actor,
+        review_transition_count=review_evidence.transition_count,
+        has_review_history=review_evidence.has_history,
         allowed_review_actions=[
             action
             for action in (_safe_str(value) for value in _safe_list(review.get("allowed_actions")))
@@ -222,6 +231,44 @@ def _safe_utc_timestamp(value: Any) -> str | None:
     except ValueError:
         return None
     return timestamp if parsed.utcoffset() == timedelta(0) else None
+
+
+def _parse_review_evidence(review: dict[str, Any]) -> _ReviewEvidence:
+    raw_values = (
+        review.get("latest_review_event_at"),
+        review.get("latest_review_actor"),
+        review.get("review_transition_count"),
+        review.get("has_review_history"),
+    )
+    if all(value is None for value in raw_values):
+        return _ReviewEvidence()
+
+    latest_event_at = _safe_utc_timestamp(raw_values[0])
+    latest_actor = _safe_str(raw_values[1])
+    transition_count = _safe_non_negative_int(raw_values[2])
+    has_history = _safe_bool(raw_values[3])
+
+    if (
+        has_history is True
+        and latest_event_at is not None
+        and latest_actor is not None
+        and transition_count is not None
+        and transition_count > 0
+    ):
+        return _ReviewEvidence(
+            latest_event_at=latest_event_at,
+            latest_actor=latest_actor,
+            transition_count=transition_count,
+            has_history=True,
+        )
+    if (
+        has_history is False
+        and latest_event_at is None
+        and latest_actor is None
+        and transition_count == 0
+    ):
+        return _ReviewEvidence(transition_count=0, has_history=False)
+    return _ReviewEvidence()
 
 
 def _safe_non_negative_int(value: Any) -> int | None:

--- a/src/app/services/advisor_brief_workflow_pack.py
+++ b/src/app/services/advisor_brief_workflow_pack.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Any
 
 from fastapi import HTTPException, status
@@ -118,7 +120,7 @@ def _parse_workflow_pack_run_profile(
         run_id=_safe_str(operator_payload.get("run_id")) or profile.run_id,
         runtime_state=_safe_str(operator_payload.get("runtime_state")) or "UNKNOWN",
         review_state=_safe_str(operator_payload.get("review_state")) or "UNKNOWN",
-        latest_review_event_at=_safe_str(review.get("latest_review_event_at")),
+        latest_review_event_at=_safe_utc_timestamp(review.get("latest_review_event_at")),
         latest_review_actor=_safe_str(review.get("latest_review_actor")),
         review_transition_count=_safe_non_negative_int(review.get("review_transition_count")),
         has_review_history=_safe_bool(review.get("has_review_history")),
@@ -202,6 +204,24 @@ def _safe_str(value: Any) -> str | None:
     if isinstance(value, str) and value.strip():
         return value.strip()
     return None
+
+
+def _safe_utc_timestamp(value: Any) -> str | None:
+    timestamp = _safe_str(value)
+    if (
+        timestamp is None
+        or re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:Z|\+00:00)",
+            timestamp,
+        )
+        is None
+    ):
+        return None
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return timestamp if parsed.utcoffset() == timedelta(0) else None
 
 
 def _safe_non_negative_int(value: Any) -> int | None:

--- a/tests/integration/test_workbench_router.py
+++ b/tests/integration/test_workbench_router.py
@@ -2305,6 +2305,8 @@ def test_workbench_performance_advisor_brief_openapi_contract():
     assert response_schema["example"]["supportability"][1]["value"] == "Unavailable"
     assert response_schema["example"]["ai_audit"]["model_id"] == "qwen3:8b"
     assert response_schema["example"]["workflow_pack_run"]["review_state"] == "AWAITING_REVIEW"
+    assert response_schema["example"]["workflow_pack_run"]["review_transition_count"] == 0
+    assert response_schema["example"]["workflow_pack_run"]["has_review_history"] is False
     assert (
         response_schema["example"]["workflow_pack_run"]["findings"][0]["finding_id"]
         == "review_pending"

--- a/tests/unit/test_advisor_brief_service.py
+++ b/tests/unit/test_advisor_brief_service.py
@@ -124,6 +124,10 @@ class _StubLotusAiClient:
             "run_id": "packrun_advisor_brief_req-1",
             "review": {
                 "allowed_actions": ["ACCEPT", "REJECT", "REVISE", "SUPERSEDE", "ABANDON"],
+                "latest_review_event_at": None,
+                "latest_review_actor": None,
+                "review_transition_count": 0,
+                "has_review_history": False,
             },
             "lineage": {"workflow_authority_owner": "lotus-gateway"},
         }
@@ -242,6 +246,16 @@ class _StubLotusAiClient:
             request_payload = kwargs["request_payload"]
             replacement_run_id = request_payload.get("replacement_run_id")
             action_type = request_payload["action_type"]
+            self.consumer_view_payload = {
+                **self.consumer_view_payload,
+                "review": {
+                    **self.consumer_view_payload["review"],
+                    "latest_review_event_at": "2026-04-21T03:22:00Z",
+                    "latest_review_actor": request_payload["reviewed_by"],
+                    "review_transition_count": 1,
+                    "has_review_history": True,
+                },
+            }
             if action_type == "ACCEPT":
                 self.operator_profile_payload = {
                     **self.operator_profile_payload,
@@ -1112,6 +1126,10 @@ async def test_advisor_brief_service_applies_review_action_and_returns_updated_r
     assert response.workflow_pack_run.review_state == "ACCEPTED"
     assert response.workflow_pack_run.supportability_status == "READY"
     assert response.workflow_pack_run.review_pending is False
+    assert response.workflow_pack_run.latest_review_event_at == "2026-04-21T03:22:00Z"
+    assert response.workflow_pack_run.latest_review_actor == "advisor_1"
+    assert response.workflow_pack_run.review_transition_count == 1
+    assert response.workflow_pack_run.has_review_history is True
     assert (
         response.workflow_pack_run.current_summary_note
         == "Run accepted for bounded downstream workflow use."

--- a/tests/unit/test_advisor_brief_workflow_pack.py
+++ b/tests/unit/test_advisor_brief_workflow_pack.py
@@ -44,7 +44,13 @@ class _AdvisorBriefAiClientStub:
         return (
             200,
             {
-                "review": {"allowed_actions": ["ACCEPT"]},
+                "review": {
+                    "allowed_actions": ["ACCEPT"],
+                    "latest_review_event_at": "2026-06-01T00:05:00Z",
+                    "latest_review_actor": "advisor_1",
+                    "review_transition_count": 1,
+                    "has_review_history": True,
+                },
                 "lineage": {"workflow_authority_owner": "lotus-ai"},
             },
         )
@@ -161,8 +167,47 @@ async def test_load_advisor_brief_workflow_pack_run_preserves_review_posture() -
     assert run is not None
     assert run.run_id == "packrun-advisor-brief-1"
     assert run.allowed_review_actions == ["ACCEPT"]
+    assert run.latest_review_event_at == "2026-06-01T00:05:00Z"
+    assert run.latest_review_actor == "advisor_1"
+    assert run.review_transition_count == 1
+    assert run.has_review_history is True
     assert run.workflow_authority_owner == "lotus-ai"
     assert run.findings[0].finding_id == "finding-1"
+
+
+@pytest.mark.asyncio
+async def test_load_advisor_brief_workflow_pack_run_fails_malformed_review_evidence_closed() -> (
+    None
+):
+    client = _AdvisorBriefAiClientStub()
+
+    async def _malformed_consumer_view(**kwargs: Any) -> tuple[int, dict[str, Any]]:
+        return (
+            200,
+            {
+                "review": {
+                    "allowed_actions": ["ACCEPT"],
+                    "latest_review_event_at": 123,
+                    "latest_review_actor": " ",
+                    "review_transition_count": True,
+                    "has_review_history": "true",
+                },
+                "lineage": {"workflow_authority_owner": "lotus-ai"},
+            },
+        )
+
+    client.get_workflow_pack_run_consumer_view = _malformed_consumer_view  # type: ignore[method-assign]
+    run = await load_advisor_brief_workflow_pack_run(
+        lotus_ai_client=client,
+        ai_audit={"workflow_pack_run_id": "packrun-advisor-brief-1"},
+        correlation_id="corr-1",
+    )
+
+    assert run is not None
+    assert run.latest_review_event_at is None
+    assert run.latest_review_actor is None
+    assert run.review_transition_count is None
+    assert run.has_review_history is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_advisor_brief_workflow_pack.py
+++ b/tests/unit/test_advisor_brief_workflow_pack.py
@@ -175,10 +175,19 @@ async def test_load_advisor_brief_workflow_pack_run_preserves_review_posture() -
     assert run.findings[0].finding_id == "finding-1"
 
 
+@pytest.mark.parametrize(
+    "review_timestamp",
+    [
+        "not-a-date",
+        "2026-06-01T00:05:00",
+        "2026-06-01T08:05:00+08:00",
+        "2026-02-30T00:05:00Z",
+    ],
+)
 @pytest.mark.asyncio
-async def test_load_advisor_brief_workflow_pack_run_fails_malformed_review_evidence_closed() -> (
-    None
-):
+async def test_load_advisor_brief_workflow_pack_run_fails_malformed_review_evidence_closed(
+    review_timestamp: str,
+) -> None:
     client = _AdvisorBriefAiClientStub()
 
     async def _malformed_consumer_view(**kwargs: Any) -> tuple[int, dict[str, Any]]:
@@ -187,7 +196,7 @@ async def test_load_advisor_brief_workflow_pack_run_fails_malformed_review_evide
             {
                 "review": {
                     "allowed_actions": ["ACCEPT"],
-                    "latest_review_event_at": 123,
+                    "latest_review_event_at": review_timestamp,
                     "latest_review_actor": " ",
                     "review_transition_count": True,
                     "has_review_history": "true",

--- a/tests/unit/test_advisor_brief_workflow_pack.py
+++ b/tests/unit/test_advisor_brief_workflow_pack.py
@@ -176,19 +176,32 @@ async def test_load_advisor_brief_workflow_pack_run_preserves_review_posture() -
 
 
 @pytest.mark.parametrize(
-    "review_timestamp",
+    ("evidence_field", "malformed_value"),
     [
-        "not-a-date",
-        "2026-06-01T00:05:00",
-        "2026-06-01T08:05:00+08:00",
-        "2026-02-30T00:05:00Z",
+        ("latest_review_event_at", "not-a-date"),
+        ("latest_review_event_at", "2026-06-01T00:05:00"),
+        ("latest_review_event_at", "2026-06-01T08:05:00+08:00"),
+        ("latest_review_event_at", "2026-02-30T00:05:00Z"),
+        ("latest_review_actor", " "),
+        ("review_transition_count", True),
+        ("review_transition_count", 0),
+        ("has_review_history", "true"),
+        ("has_review_history", False),
     ],
 )
 @pytest.mark.asyncio
 async def test_load_advisor_brief_workflow_pack_run_fails_malformed_review_evidence_closed(
-    review_timestamp: str,
+    evidence_field: str,
+    malformed_value: Any,
 ) -> None:
     client = _AdvisorBriefAiClientStub()
+    review_evidence: dict[str, Any] = {
+        "latest_review_event_at": "2026-06-01T00:05:00Z",
+        "latest_review_actor": "advisor_1",
+        "review_transition_count": 1,
+        "has_review_history": True,
+    }
+    review_evidence[evidence_field] = malformed_value
 
     async def _malformed_consumer_view(**kwargs: Any) -> tuple[int, dict[str, Any]]:
         return (
@@ -196,10 +209,7 @@ async def test_load_advisor_brief_workflow_pack_run_fails_malformed_review_evide
             {
                 "review": {
                     "allowed_actions": ["ACCEPT"],
-                    "latest_review_event_at": review_timestamp,
-                    "latest_review_actor": " ",
-                    "review_transition_count": True,
-                    "has_review_history": "true",
+                    **review_evidence,
                 },
                 "lineage": {"workflow_authority_owner": "lotus-ai"},
             },
@@ -217,6 +227,41 @@ async def test_load_advisor_brief_workflow_pack_run_fails_malformed_review_evide
     assert run.latest_review_actor is None
     assert run.review_transition_count is None
     assert run.has_review_history is None
+
+
+@pytest.mark.asyncio
+async def test_load_advisor_brief_workflow_pack_run_preserves_coherent_no_history_evidence() -> (
+    None
+):
+    client = _AdvisorBriefAiClientStub()
+
+    async def _no_history_consumer_view(**kwargs: Any) -> tuple[int, dict[str, Any]]:
+        return (
+            200,
+            {
+                "review": {
+                    "allowed_actions": ["ACCEPT"],
+                    "latest_review_event_at": None,
+                    "latest_review_actor": None,
+                    "review_transition_count": 0,
+                    "has_review_history": False,
+                },
+                "lineage": {"workflow_authority_owner": "lotus-ai"},
+            },
+        )
+
+    client.get_workflow_pack_run_consumer_view = _no_history_consumer_view  # type: ignore[method-assign]
+    run = await load_advisor_brief_workflow_pack_run(
+        lotus_ai_client=client,
+        ai_audit={"workflow_pack_run_id": "packrun-advisor-brief-1"},
+        correlation_id="corr-1",
+    )
+
+    assert run is not None
+    assert run.latest_review_event_at is None
+    assert run.latest_review_actor is None
+    assert run.review_transition_count == 0
+    assert run.has_review_history is False
 
 
 @pytest.mark.asyncio

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -293,6 +293,10 @@ or governed ingress endpoints without embedding environment-specific hostnames i
 - Workbench advisor-brief reads emit bounded analytics read audit records with
   `operation=advisor_brief.summary` and `panel=advisor-brief`; upstream authorization denials are
   recorded as permission-blocked without restricted identifiers or raw entitlement text
+- Workbench advisor-brief workflow-pack posture preserves Lotus AI's bounded review evidence:
+  latest review actor, latest review event time, transition count, and review-history state.
+  Missing or malformed evidence remains absent; a terminal review state alone is not proof of a
+  source-recorded human decision
 - legal-hold summary is returned as metadata for support posture; gateway retrieval does not expose
   legal-hold mutation, purge, retention mutation, or access-event routes
 - intake upload routes accept camelCase multipart aliases such as `entityType`, `sampleSize`, and


### PR DESCRIPTION
## Summary
- preserve source-owned Advisor Brief review provenance through the Gateway contract
- fail closed when review-event evidence is malformed or absent
- align service, integration, OpenAPI example, repository context, and wiki truth

## Why
- Workbench must distinguish a source-persisted human review from a terminal-looking workflow state
- review actor, event time, transition count, and history posture are required to prevent unsupported client-ready claims

## Scope
- [x] Single RFC/slice scope
- [x] No unrelated refactors mixed in

## Validation (local)
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test-unit`
- [x] Full `make check` passed: mypy 732 source files and 1,679 unit/contract tests
- [x] Gateway wiki source check passed with expected unpublished branch delta

## CI Expectations
- [ ] Fast PR gates are green
- [ ] Heavy gates run in scheduled/manual tier where applicable

## Governance/Docs
- [x] RFC/docs updated where behavior or standards changed
- [x] API/OpenAPI/vocabulary updates included if contract changed
- [x] Repository engineering context and `wiki/API-Surface.md` updated

## Post-Merge Hygiene
- [ ] Publish and verify Gateway wiki parity
- [ ] Delete remote feature branch
- [ ] Delete local feature branch
- [ ] Sync local main with origin/main (`local = remote = main`)

Closes #547