### PR TITLE
ci: dispatch main releasability after merged PRs

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -1,8 +1,6 @@
 name: Main Releasability Gate
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -1,0 +1,23 @@
+name: Merged PR Main Releasability Dispatch
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch-main-releasability:
+    name: Dispatch Main Releasability
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Dispatch main releasability gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref main

--- a/README.md
+++ b/README.md
@@ -336,6 +336,10 @@ PR auto-merge is rebase-only for linear history. The `Queue Auto Merge` helper u
 `LOTUS_AUTOMERGE_TOKEN` with `gh pr merge --auto --rebase --delete-branch`; when that token is not
 available, the helper emits a warning and exits successfully so an authorized human or release actor
 can perform the rebase merge without leaving a false red CI check.
+Merged PRs into `main` also trigger `Merged PR Main Releasability Dispatch`, a bounded
+`pull_request_target` closed-event workflow that dispatches `main-releasability.yml` against
+`main`. This preserves exact-main release evidence when a PR is merged by an authorized human or
+release actor rather than the auto-merge helper.
 
 The Quality Baseline workflow is intentionally report-only. It publishes complexity,
 maintainability, dead-code, dependency, security, import-boundary, documentation, coverage, and

--- a/README.md
+++ b/README.md
@@ -340,6 +340,9 @@ Merged PRs into `main` also trigger `Merged PR Main Releasability Dispatch`, a b
 `pull_request_target` closed-event workflow that dispatches `main-releasability.yml` against
 `main`. This preserves exact-main release evidence when a PR is merged by an authorized human or
 release actor rather than the auto-merge helper.
+The main releasability workflow is intentionally `workflow_dispatch`-only; the merged-PR
+dispatcher owns the automatic post-merge path so human or release-actor merges do not start both a
+push-triggered run and a dispatched run for the same main SHA.
 
 The Quality Baseline workflow is intentionally report-only. It publishes complexity,
 maintainability, dead-code, dependency, security, import-boundary, documentation, coverage, and

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -288,7 +288,9 @@ Important validation expectations:
    rebase merge without leaving a false red helper check,
 7. `.github/workflows/merged-pr-main-releasability.yml` dispatches `main-releasability.yml` after
    a pull request is merged into `main`, preserving exact-main release evidence for authorized
-   human or release-actor merges as well as token-backed auto-merge,
+   human or release-actor merges as well as token-backed auto-merge; `main-releasability.yml` is
+   intentionally `workflow_dispatch`-only so this dispatcher remains the single automatic
+   post-merge path and does not duplicate a push-triggered release run,
 8. `make demo-certification` is the current app-level Gateway demo-readiness command; it calls real
    FastAPI routes with deterministic synthetic upstream fixtures, writes
    `output/demo-certification/gateway-demo-certification.json`, and remains report-only in Quality

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -286,22 +286,25 @@ Important validation expectations:
    `LOTUS_AUTOMERGE_TOKEN` and `gh pr merge --auto --rebase --delete-branch`, and skips cleanly
    with a warning when the token is absent so an authorized human or release actor can perform the
    rebase merge without leaving a false red helper check,
-7. `make demo-certification` is the current app-level Gateway demo-readiness command; it calls real
+7. `.github/workflows/merged-pr-main-releasability.yml` dispatches `main-releasability.yml` after
+   a pull request is merged into `main`, preserving exact-main release evidence for authorized
+   human or release-actor merges as well as token-backed auto-merge,
+8. `make demo-certification` is the current app-level Gateway demo-readiness command; it calls real
    FastAPI routes with deterministic synthetic upstream fixtures, writes
    `output/demo-certification/gateway-demo-certification.json`, and remains report-only in Quality
    Baseline until repeated low-noise evidence and exception policy justify blocking promotion,
-8. Docker parity matters because the gateway is a live integration boundary,
-9. Gateway Docker images are tagged with the Git SHA, stamped with non-secret build-time OCI
+9. Docker parity matters because the gateway is a live integration boundary,
+10. Gateway Docker images are tagged with the Git SHA, stamped with non-secret build-time OCI
    labels, scanned with Trivy before any main-lane push, inventoried with an SBOM, and recorded in a
    release manifest. Main Releasability is the only lane that pushes to GHCR; it captures the
    digest after push, signs the digest-pinned image, creates provenance attestation evidence, and
    requires Kubernetes deployment by digest while preserving the same image for environment
    promotion,
-10. `/version` exposes the same non-secret build and deployment metadata expected in release
+11. `/version` exposes the same non-secret build and deployment metadata expected in release
     manifests: Git commit SHA, branch, build timestamp, repo URL, image digest, CI run ID, and
     version. Image digest is deployment/runtime metadata captured after push and must not be baked
     into Docker build args, ENV, or OCI labels as `unknown`,
-11. README and wiki updates should preserve truthful endpoint-specific parameter conventions, and
+12. README and wiki updates should preserve truthful endpoint-specific parameter conventions, and
    mixed query, body, or multipart shapes should be backed by executable examples in the wiki.
 
 ## Standards And RFCs That Govern This Repository

--- a/docs/operations/development-workflow-and-ci-strategy.md
+++ b/docs/operations/development-workflow-and-ci-strategy.md
@@ -18,3 +18,8 @@ PR auto-merge is rebase-only for linear history. The `Queue Auto Merge` helper u
 `LOTUS_AUTOMERGE_TOKEN` with `gh pr merge --auto --rebase --delete-branch`; when that token is not
 available, the helper emits a warning and exits successfully so an authorized human or release actor
 can perform the rebase merge without leaving a false red CI check.
+
+Merged PRs into `main` are followed by the `Merged PR Main Releasability Dispatch` workflow, which
+dispatches `main-releasability.yml` against `main` after GitHub reports a closed pull request as
+merged. This preserves exact-main Main Releasability evidence across both automated and authorized
+manual rebase merges.

--- a/docs/operations/development-workflow-and-ci-strategy.md
+++ b/docs/operations/development-workflow-and-ci-strategy.md
@@ -23,3 +23,6 @@ Merged PRs into `main` are followed by the `Merged PR Main Releasability Dispatc
 dispatches `main-releasability.yml` against `main` after GitHub reports a closed pull request as
 merged. This preserves exact-main Main Releasability evidence across both automated and authorized
 manual rebase merges.
+The main releasability workflow is intentionally `workflow_dispatch`-only; the merged-PR dispatcher
+is the single automatic post-merge path and prevents duplicate push-triggered and dispatch-triggered
+main releasability runs for the same merge.

--- a/tests/unit/test_main_releasability_dispatch_workflow.py
+++ b/tests/unit/test_main_releasability_dispatch_workflow.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+
+def test_merged_pr_main_releasability_dispatcher_targets_main_gate() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8")
+
+    assert "name: Merged PR Main Releasability Dispatch" in text
+    assert "pull_request_target:" in text
+    assert "types: [closed]" in text
+    assert "actions: write" in text
+    assert "contents: read" in text
+    assert "github.event.pull_request.merged == true" in text
+    assert "github.event.pull_request.base.ref == 'main'" in text
+    assert "timeout-minutes: 10" in text
+    assert 'gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref main' in text
+
+
+def test_main_releasability_gate_remains_dispatchable_and_main_bound() -> None:
+    workflow = WORKFLOW_DIR / "main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8")
+
+    assert "name: Main Releasability Gate" in text
+    assert "workflow_dispatch:" in text
+    assert "push:" in text
+    assert "branches: [ main ]" in text

--- a/tests/unit/test_main_releasability_dispatch_workflow.py
+++ b/tests/unit/test_main_releasability_dispatch_workflow.py
@@ -25,5 +25,5 @@ def test_main_releasability_gate_remains_dispatchable_and_main_bound() -> None:
 
     assert "name: Main Releasability Gate" in text
     assert "workflow_dispatch:" in text
-    assert "push:" in text
-    assert "branches: [ main ]" in text
+    assert "  push:\n" not in text
+    assert "branches: [ main ]" not in text

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -48,6 +48,11 @@ PR auto-merge is rebase-only for linear history. The `Queue Auto Merge` helper u
 available, the helper emits a warning and exits successfully so an authorized human or release actor
 can perform the rebase merge without leaving a false red CI check.
 
+Merged PRs into `main` also trigger the `Merged PR Main Releasability Dispatch` workflow. It listens
+only to closed pull-request events, verifies that the pull request was merged into `main`, and then
+dispatches `main-releasability.yml` against `main`. That keeps exact-main release evidence
+available for authorized human merges and release-actor merges, not only token-backed auto-merge.
+
 ## What the gates protect
 
 - workbench-facing contract integrity

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -52,6 +52,8 @@ Merged PRs into `main` also trigger the `Merged PR Main Releasability Dispatch` 
 only to closed pull-request events, verifies that the pull request was merged into `main`, and then
 dispatches `main-releasability.yml` against `main`. That keeps exact-main release evidence
 available for authorized human merges and release-actor merges, not only token-backed auto-merge.
+`main-releasability.yml` is intentionally `workflow_dispatch`-only so this dispatcher is the single
+automatic post-merge path and does not race or cancel a duplicate push-triggered release run.
 
 ## What the gates protect
 


### PR DESCRIPTION
## Summary
- Add a bounded merged-PR dispatcher workflow for `main-releasability.yml`.
- Keep `main-releasability.yml` `workflow_dispatch`-only so the merged-PR dispatcher is the single automatic post-merge path and does not duplicate/cancel push-triggered runs.
- Add workflow contract tests for trigger, permissions, main-branch guard, timeout, dispatch target, and no duplicate push trigger.
- Update README, repo context, operations docs, and wiki source with current release-evidence posture.

Issue: #552

## Validation
- `python -m pytest tests/unit/test_main_releasability_dispatch_workflow.py tests/unit/test_workflow_action_runtime.py -q` => 19 passed
- `python scripts/check_workflow_action_runtime.py` => passed
- `git diff --check` => passed
- `make check` after review fix => 1690 passed
- `make ci` final PR head after review fix => passed; 254 integration tests, 1944 coverage tests, 94.58% total coverage against 84% gate, dependency security audit passed
- `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-gateway -AllowUnpublishedSourceChanges` => expected DiffCount 1 because this branch changes repo-authored wiki source
- `python C:\Users\Sandeep\projects\lotus-platform\automation\validate_branch_commit_budget.py --repo-root . --base-ref origin/main --head-ref HEAD` => within budget, 2 commits

## Governance evidence
- Lane placement: dispatcher is separate from PR Merge Gate and triggers the existing Main Releasability Gate after merged PRs to `main`.
- Deduplication: `main-releasability.yml` no longer has a direct `push` trigger; manual `workflow_dispatch` remains for operator reruns.
- Permissions: dispatcher uses `actions: write`, `contents: read`; no repo contents write permission.
- Stranded truth: `git branch -r --no-merged origin/main` returned no unmerged remote branches for `lotus-gateway` before implementation.
- Wiki: repo-authored wiki source changed; publish after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-gateway`, then strict check-only parity.
- Non-degradation: no runtime/API contract behavior changed; existing OpenAPI, migration, integration, coverage, security, and workflow governance gates passed.
- Skill/context decision: no platform skill change in this repo PR; reviewer feedback is captured in sgajbi/lotus-platform#688 to tighten the platform template/validator so future rollouts do not keep both automatic paths.

## Post-merge requirements
- Verify exact-main Main Releasability Gate for the merge SHA.
- Update issue #552 to `status/merged-main` after exact-main proof, wiki publication/parity, and branch cleanup evidence.
- Remove `lotus-gateway` from the platform auto-merge releasability exception register in a follow-up platform PR after this PR lands and exact-main proof passes.
